### PR TITLE
Better inline JS integration

### DIFF
--- a/app/views/admins/_boot.js.erb
+++ b/app/views/admins/_boot.js.erb
@@ -1,4 +1,6 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
+
 document.observe("dom:loaded", function() {
 
   users_table = new FilterTable({
@@ -22,4 +24,5 @@ document.observe("dom:loaded", function() {
   <%= remote_function :url => {:action => 'populate'}, :complete => "$('loading_list').hide();"%>
 });
 
+//]]>
 </script>

--- a/app/views/annotation_categories/_boot.js.erb
+++ b/app/views/annotation_categories/_boot.js.erb
@@ -1,3 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
+//]]>
 </script>

--- a/app/views/annotation_categories/index.html.erb
+++ b/app/views/annotation_categories/index.html.erb
@@ -9,6 +9,8 @@
 	:cache => "livepipe_cache" %>
 
 <script type="text/javascript">
+//<![CDATA[
+
    var modalUpload = null;
    var modalDownload = null;
 
@@ -37,7 +39,8 @@
        fade: false
 
      });
-   })
+   });
+//]]>
 </script>
 
 

--- a/app/views/assignments/_add_file_link.html.erb
+++ b/app/views/assignments/_add_file_link.html.erb
@@ -1,7 +1,9 @@
 <div id="add_file_link">
   <input type="text" id="new_assignment_filename" name="new_assignment_filename">
   <%= button_to_remote "Add Required File", :url => { :action => "add_assignment_file", :id => @assignment.id}, :with => "'new_assignment_filename=' + $F('new_assignment_filename')"%>
-  <script>
+  <script type="text/javascript">
+  //<![CDATA[
+
    $('new_assignment_filename').observe('keydown', function(event) {
       if (event.keyCode == Event.KEY_RETURN) {
   <%= remote_function :url => { :action => "add_assignment_file", :id => @assignment.id}, :with => "'new_assignment_filename=' + $F('new_assignment_filename')", :success => "Event.element(event).value = ''; Event.element(event).enable();Event.element(event).activate();"%>
@@ -10,6 +12,7 @@
    }
     
    });
+   //]]>
    </script>
 </div>
 

--- a/app/views/assignments/_boot.js.erb
+++ b/app/views/assignments/_boot.js.erb
@@ -1,4 +1,5 @@
-<script language="Javascript" type="text/javascript">
+<script type="text/javascript">
+//<![CDATA[
   var past_due_date_edit_warning = "<%= t(:past_due_date_edit_warning) %>";
 
   var grace_periods = null;
@@ -25,4 +26,5 @@
     <% end %>
     
   });
+//]]>
 </script>

--- a/app/views/assignments/student_interface.html.erb
+++ b/app/views/assignments/student_interface.html.erb
@@ -4,6 +4,8 @@
 	:cache => "livepipe_cache" %>
 
 <script type="text/javascript">
+//<![CDATA[
+
   var invite_modal = null;
 
   function invite(){
@@ -19,7 +21,8 @@
       className: 'invite_modal',
       fade: false
     });
-  })
+  });
+//]]>
 </script>
 
 <div id="title_bar">

--- a/app/views/flexible_criteria/index.html.erb
+++ b/app/views/flexible_criteria/index.html.erb
@@ -9,6 +9,7 @@
 	:cache => "livepipe_cache" %>
 
 <script type="text/javascript">
+//<![CDATA[
 
   var modalUpload = null;
   var modalDownload = null;
@@ -41,6 +42,7 @@
     });
 
   });
+//]]>
 </script>
 
 <% if @assignment.past_due_date?%>

--- a/app/views/grade_entry_forms/grades.html.erb
+++ b/app/views/grade_entry_forms/grades.html.erb
@@ -4,7 +4,8 @@
 <%= javascript_include_tag "livepipe/livepipe.js" %>
 <%= javascript_include_tag "livepipe/window.js" %>
 
-<script>
+<script type="text/javascript">
+//<![CDATA[
 
   var modalUpload = null;
  
@@ -22,6 +23,8 @@
       fade: false
     });
   });
+
+//]]>
 </script>
 
 <div id="title_bar">

--- a/app/views/graders/_boot.js.erb
+++ b/app/views/graders/_boot.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
 var groupings_table = null;
 
@@ -198,4 +199,5 @@ document.observe("dom:loaded", function() {
   <% end %>
 });
 
+//]]>
 </script>

--- a/app/views/graders/manage.html.erb
+++ b/app/views/graders/manage.html.erb
@@ -7,6 +7,7 @@
 
 <%= render :partial => "boot.js.erb" %>
 <script type="text/javascript">
+//<![CDATA[
 
 var modalCreate = null;
 var modalAssignmentGroupReUse = null;
@@ -65,6 +66,7 @@ document.observe("dom:loaded", function(){
 
 
 
+//]]>
 </script>
 
 <div id="title_bar">

--- a/app/views/groups/_boot.js.erb
+++ b/app/views/groups/_boot.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
 var groupings_table = null;
 
@@ -128,4 +129,5 @@ document.observe("dom:loaded", function() {
   <%= remote_function :url => {:action => 'populate_students', :id => @assignment.id}, :complete => "$('loading_students_list').hide();"%>
 });
 
+//]]>
 </script>

--- a/app/views/groups/manage.html.erb
+++ b/app/views/groups/manage.html.erb
@@ -7,6 +7,7 @@
 
 <%= render :partial => "boot.js.erb" %>
 <script type="text/javascript">
+//<![CDATA[
 
 var modalCreate = null;
 var modalAssignmentGroupReUse = null;
@@ -116,11 +117,12 @@ document.observe("dom:loaded", function(){
     className: 'modalAssignmentGroupReUse',
     fade:false
   });
-})
+});
 
 
 
 
+//]]>
 </script>
 
 <% if @assignment.past_due_date? %>

--- a/app/views/groups/student_interface.html.erb
+++ b/app/views/groups/student_interface.html.erb
@@ -9,6 +9,7 @@
 	:cache => "livepipe_cache" %>
 
 <script type="text/javascript">
+//<![CDATA[
 
 var modal = null;
 
@@ -39,7 +40,8 @@ document.observe("dom:loaded", function(){
     fade:false
 
   });
-})
+});
+//]]>
 </script>
 
 

--- a/app/views/layouts/_about.html.erb
+++ b/app/views/layouts/_about.html.erb
@@ -1,6 +1,8 @@
 <%= javascript_include_tag "livepipe/livepipe.js"%>
 <%= javascript_include_tag "livepipe/window.js"%>
-<script type="text/javascript">   
+<script type="text/javascript">
+//<![CDATA[
+  
  var about_modal = null;
 
  document.observe("dom:loaded", function(){
@@ -9,7 +11,8 @@
       className: 'about_modal',
       fade: false
     });
- } )
+ });
+//]]>
 </script>
 <!-- about scaffold -->
 <div id="about_dialog" style="display: none;">

--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -28,5 +28,7 @@
 
 <%# Try to put focus on the login text field on load %>
 <script type="text/javascript">
+//<![CDATA[
   try{ document.getElementById('user_login').focus(); } catch(e) {}
+//]]>
 </script>

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -1,4 +1,5 @@
-<script language="Javascript" type="text/javascript">
+<script type="text/javascript">
+//<![CDATA[
 var selected_markable_id = null;
 var selected_extra_mark_id = null;
 var positions = null;
@@ -251,4 +252,5 @@ function hide_image_annotations() {
   if(annotation_manager == null){ return;}
   annotation_manager.getAnnotationTextDisplayer().hideShowing();
 }
+//]]>
 </script>

--- a/app/views/results/common/_image_codeviewer.html.erb
+++ b/app/views/results/common/_image_codeviewer.html.erb
@@ -12,7 +12,8 @@
   <input id="annotation_grid"type="hidden" value="<%=h(@file.get_annotation_grid.to_json)%>"></input>
   <input id="enable_annotations?"type="hidden" value=<%=(@current_user.ta? || @current_user.admin?) && !@result.released_to_students%>></input>
 
-  <script language="javascript">
+  <script type="text/javascript">
+  //<![CDATA[
     source_code_ready_for_image();
     <% if (defined? annots) %>
       <% annots.each do |annot| %>
@@ -20,6 +21,6 @@
           '<%=simple_format(h(escape_javascript(CGI.unescape(annot.annotation_text.content.to_s))))%>');
       <% end %>
     <% end %>
-
+  //]]>
   </script>
 </div>

--- a/app/views/results/common/_test_result_window.html.erb
+++ b/app/views/results/common/_test_result_window.html.erb
@@ -1,4 +1,6 @@
 <script type="text/javascript">
+//<![CDATA[
+
   function load_test_result(test_result_id) {
     $('loading_test_result').show();
     $('select_test_result_id').disable();
@@ -7,4 +9,5 @@
     $('loading_test_result').hide();
     $('select_test_result_id').enable();
   }
+//]]>
 </script>

--- a/app/views/results/common/_text_codeviewer.html.erb
+++ b/app/views/results/common/_text_codeviewer.html.erb
@@ -6,7 +6,9 @@
 <%=h file_contents %>
 </pre>
 
-<script language="javascript">
+
+<script type="text/javascript">
+//<![CDATA[
     dp.SyntaxHighlighter.ClipboardSwf = '/javascripts/syntaxhighlighter/clipboard.swf';
     dp.SyntaxHighlighter.HighlightAll('code');
     $('standby_highlighting').hide();
@@ -29,6 +31,6 @@
     <% if !@focus_line.nil? %>
       focus_source_code_line(<%=@focus_line%>);
     <% end %>
-
+//]]>
 </script>
 

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -54,6 +54,8 @@
 <%= javascript_include_tag "Grader/tabs_boot.js"%>
 
 <script type="text/javascript">
+//<![CDATA[
+
   var modalNotesGroup = null;
   document.observe("dom:loaded", function(){
     modalNotesGroup = new Control.Modal($('notes_dialog'),
@@ -82,6 +84,7 @@ function check_working() {
   return '<%=t(:still_working_warning)%>';
 }
 
+//]]>
 </script>
 
 <%

--- a/app/views/results/marker/_boot.js.erb
+++ b/app/views/results/marker/_boot.js.erb
@@ -1,4 +1,5 @@
-<script language="Javascript" text="text/javascript">
+<script type="text/javascript">
+//<![CDATA[
 document.observe("dom:loaded", function() {
   //After DOM is loaded, load up the first submitted file
   <% if !first_file.nil? %>
@@ -26,4 +27,5 @@ Event.observe(window, 'load', function() {
   <% end %>
 <% end %>
 });
+//]]>
 </script>

--- a/app/views/results/marker/_marker_flexible_criterion_li.html.erb
+++ b/app/views/results/marker/_marker_flexible_criterion_li.html.erb
@@ -17,10 +17,13 @@ class="mark_criterion_title_div_level float_left">
     <%= text_field_tag('mark_' + mark.id.to_s, mark.mark,:size=>4, :class=>'mark_grade_input') %>
 	/&nbsp; <span id="mark_flexible_max_<%=mark.id%>"><%= mark_criterion.max.to_s%> </span>
 	<script type="text/javascript">
+	//<![CDATA[
+
 	  // Prevents click from expanding/collapsing Criterion
 	  $('mark_<%=mark.id.to_s%>').observe('click', function(event){
 	    event.stop();
 	  });
+        //]]>
 	</script>
     <%= observe_field 'mark_' + mark.id.to_s,
                           :url => {:action => :update_mark, :mark_id=>mark.id},

--- a/app/views/results/marker/_setup_annotation_categories.js.erb
+++ b/app/views/results/marker/_setup_annotation_categories.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
 /** Begin Annotation Category dropdown code **/
 
@@ -9,4 +10,5 @@ function setup_annotation_categories() {
   <% end %>
 }
 
+//]]>
 </script>

--- a/app/views/results/student/_boot.js.erb
+++ b/app/views/results/student/_boot.js.erb
@@ -1,4 +1,5 @@
-<script language="Javascript" text="text/javascript">
+<script text="text/javascript">
+//<![CDATA[
 //After DOM is loaded, load up the first submitted file
 document.observe("dom:loaded", function() {
 
@@ -12,4 +13,5 @@ document.observe("dom:loaded", function() {
   setup_divider($('code_pane'), $('pane_divider'));
         
 });
+//]]>
 </script>

--- a/app/views/rubrics/index.html.erb
+++ b/app/views/rubrics/index.html.erb
@@ -6,6 +6,7 @@
 	:cache => "livepipe_cache" %>
 
 <script type="text/javascript">
+//<![CDATA[
 
   var modalUpload = null;
   var modalDownload = null;
@@ -38,6 +39,7 @@
     });
     
   });
+//]]>
 </script>
 
 <% if @assignment.past_due_date?%>

--- a/app/views/students/_boot.js.erb
+++ b/app/views/students/_boot.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 document.observe("dom:loaded", function() {
 
   users_table = new FilterTable({
@@ -53,4 +54,5 @@ document.observe("dom:loaded", function() {
   <%= remote_function :url => {:action => 'populate'}, :complete => "$('loading_list').hide();"%>
 });
 
+//]]>
 </script>

--- a/app/views/students/_student_form_actions.js.erb
+++ b/app/views/students/_student_form_actions.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
   function before_form_submit()
   {
     $('apply_bulk_action').setValue('<%= I18n.t('students.processing') %>');
@@ -14,4 +15,5 @@
     $('apply_bulk_action2').setValue('<%= I18n.t('apply') %>');
     $('apply_bulk_action2').enable();
   }
+//]]>
 </script>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -4,7 +4,9 @@
 <%= render :partial => "boot.js.erb"%>
 <%= render :partial => "student_form_actions.js.erb"%>
 
-<script>
+<script type="text/javascript">
+//<![CDATA[
+
 document.observe("dom:loaded", function(){
 
   modalNotesGroup = new Control.Modal($('notes_dialog'),
@@ -30,7 +32,8 @@ document.observe("dom:loaded", function(){
     fade:false
 
   });
-})
+});
+//]]>
 </script>
 
 <div id="title_bar"><h1><%=h I18n.t("students.manage_students") %></h1>

--- a/app/views/submissions/_file_manager_boot.js.erb
+++ b/app/views/submissions/_file_manager_boot.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
 var files_table = null;
 
@@ -34,4 +35,5 @@ document.observe("dom:loaded", function() {
 
 });
 
+//]]>
 </script>

--- a/app/views/submissions/_repo_browser_boot.js.erb
+++ b/app/views/submissions/_repo_browser_boot.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 
 var files_table = null;
 
@@ -31,5 +32,5 @@ document.observe("dom:loaded", function() {
   <%= remote_function :url => {:action => 'populate_repo_browser', :id => @grouping.id, :path => @path, :revision_number => @revision_number}, :complete => "$('loading_list').hide();" %>
 
 });
-
+//]]>
 </script>

--- a/app/views/submissions/_submission_warning.js.erb
+++ b/app/views/submissions/_submission_warning.js.erb
@@ -1,4 +1,5 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
 var onbeforeunload_flag = false;
 
 function set_onbeforeunload(value) {
@@ -18,4 +19,5 @@ function show_confirmation(evt) {
 
 // register basic handler
 window.onbeforeunload = show_confirmation;
+//]]>
 </script>

--- a/app/views/tas/_boot.js.erb
+++ b/app/views/tas/_boot.js.erb
@@ -1,4 +1,6 @@
-<script type="text/javascript" language="Javascript">
+<script type="text/javascript">
+//<![CDATA[
+
 document.observe("dom:loaded", function() {
 
   users_table = new FilterTable({
@@ -22,4 +24,5 @@ document.observe("dom:loaded", function() {
   <%= remote_function :url => {:action => 'populate'}, :complete => "$('loading_list').hide();"%>
 });
 
+//]]>
 </script>

--- a/app/views/tas/index.html.erb
+++ b/app/views/tas/index.html.erb
@@ -3,7 +3,9 @@
 
 <%= render :partial => "boot.js" %>
 
-<script>
+<script type="text/javascript">
+//<![CDATA[
+
 document.observe("dom:loaded", function(){
 
   modalUpload = new Control.Modal($('upload_dialog'),
@@ -21,7 +23,8 @@ document.observe("dom:loaded", function(){
     fade:false
 
   });
-})
+});
+//]]>
 </script>
 
 <div id="title_bar"><h1><%=h I18n.t("graders.manage_graders") %></h1>

--- a/app/views/test_framework/_boot.js.erb
+++ b/app/views/test_framework/_boot.js.erb
@@ -1,4 +1,5 @@
-<script language="Javascript" type="text/javascript">
+<script type="text/javascript">
+//<![CDATA[
 
   document.observe('dom:loaded', function() {
 
@@ -7,4 +8,5 @@
     <% end %>
 
   });
+//]]>
 </script>


### PR DESCRIPTION
I fixed all the inline JS integration
- by adding type="text/javascript" (in the script tag) where missing
- by removing language="javascript" (in the script tag) where present (it's deprecated)
- by escaping JS chunks in <![CDATA[…]]> (xHTML is XML, JS is not, therefore it must be escaped)
- by adding semicolons where missing

See http://review.markusproject.org/r/828/
