### PR TITLE
Bug 122 new

### DIFF
--- a/app/views/results/common/_image_codeviewer.html.erb
+++ b/app/views/results/common/_image_codeviewer.html.erb
@@ -18,7 +18,7 @@
     <% if (defined? annots) %>
       <% annots.each do |annot| %>
           add_annotation_text(<%=annot.annotation_text.id%>,
-          '<%=simple_format(h(escape_javascript(CGI.unescape(annot.annotation_text.content.to_s))))%>');
+          '<%=simple_format(h(escape_javascript(annot.annotation_text.content.to_s)))%>');
       <% end %>
     <% end %>
   //]]>

--- a/app/views/results/common/_text_codeviewer.html.erb
+++ b/app/views/results/common/_text_codeviewer.html.erb
@@ -20,7 +20,7 @@
     <% if (defined? annots) %>
         <% annots.each do |annot| %>
             add_annotation_text(<%=annot.annotation_text.id%>,
-            '<%=simple_format(h(escape_javascript(CGI.unescape(annot.annotation_text.content.to_s))))%>');
+            '<%=simple_format(h(escape_javascript(annot.annotation_text.content.to_s)))%>');
             add_annotation(<%=annot.id%>, $R(<%= annot.line_start %>, <%= annot.line_end %>),
              '<%=annot.annotation_text.id%>');
 

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -3,7 +3,7 @@
 
     <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %></p>
     <div class="annotationContent" id="annotation_text_content_display_<%=h(annot.annotation_text.id)%>">
-      <%=simple_format(h(CGI.unescape(annot.annotation_text.content)))%>
+      <%=simple_format(h(annot.annotation_text.content))%>
     </div>
     <p class="manageAnnotations"><%=link_to_function I18n.t("edit"), "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();"%>
     &middot;

--- a/app/views/results/student/_annotation_summary.html.erb
+++ b/app/views/results/student/_annotation_summary.html.erb
@@ -3,7 +3,7 @@
 
     <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %></p>
     <p class="annotationContent" id="annotation_text_content_display_<%=h(annot.annotation_text.id)%>">
-    <%=simple_format(h(CGI.unescape(annot.annotation_text.content)))%>
+    <%=simple_format(h(annot.annotation_text.content))%>
     </p>
     
   </li>


### PR DESCRIPTION
For the bug #122 if an annotation contains any %HH url-escaped pattern, it will be stripped out. 

This bug will show up when the marker is marking or when the student is viewing the annotations on his/her source code in two different places, one is 'Source Code' tab and 'Annot. Summary' tab. Under the 'Source Code' tab the bug will show up in the pop-up square when you move your mouse over the code lines, and under the 'Annot. Summary' tab the bug will show up below the Current Annotations.

So for the following four changes I made, the first two fix the bug showing up in the pop-up square under 'Source Code' and the last two fix the bug showing up below the Current Annotations under 'Annot. Summary'
