### PR TITLE
Closes #156. Extra marks left total mark unchanged

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -312,11 +312,12 @@ class ResultsController < ApplicationController
       if !@extra_mark.update_attributes(params[:extra_mark])
         render :action => 'results/marker/add_extra_mark_error'
       else
+        # need to re-calculate total mark
+        @result.update_total_mark
         render :action => 'results/marker/insert_extra_mark'
       end
       return
     end
-
     render :action => 'results/marker/add_extra_mark'
   end
 
@@ -327,6 +328,7 @@ class ResultsController < ApplicationController
     @extra_mark.destroy
     #need to recalculate total mark
     @result = @extra_mark.result
+    @result.update_total_mark
     render :action => 'results/marker/remove_extra_mark'
   end
 

--- a/app/views/results/marker/_update_mark.rjs
+++ b/app/views/results/marker/_update_mark.rjs
@@ -10,8 +10,7 @@ end
 if result_mark.markable_type == 'FlexibleCriterion'
   page.hide "mark_verify_result_#{result_mark.id.to_s}"
 end
-  page.replace_html "mark_#{result_mark.id.to_s}_summary_mark", result_mark.mark
-  page.replace_html "current_subtotal_div", result_mark.result.get_subtotal
-  page['marking_state'].setValue(Result::MARKING_STATES[:partial])
-  page.call "update_total_mark", result_mark.result.total_mark
-
+page.replace_html "mark_#{result_mark.id.to_s}_summary_mark", result_mark.mark
+page.replace_html "current_subtotal_div", result_mark.result.get_subtotal
+page['marking_state'].setValue(Result::MARKING_STATES[:partial])
+page.call "update_total_mark", result_mark.result.total_mark

--- a/test/functional/results_controller_test.rb
+++ b/test/functional/results_controller_test.rb
@@ -898,24 +898,48 @@ class ResultsControllerTest < AuthenticatedControllerTest
 
           context "without save error" do
             setup do
+              @result.update_total_mark
+              @old_total_mark = @result.total_mark
               post_as @admin, :add_extra_mark, :id => @result.id, :extra_mark => { :extra_mark => 1 }
             end
             should assign_to :result
             should assign_to :extra_mark
             should render_template 'results/marker/insert_extra_mark'
             should respond_with :success
+
+            should "have added the extra mark and updated total mark accordingly" do
+              @result.reload
+              assert_equal @old_total_mark + 1, @result.total_mark
+            end
           end
 
         end
 
         context "GET on :remove_extra_mark" do
           setup do
+            # clear any existing extra marks
+            @result.extra_marks.map{ |mark| mark.destroy }
+            # create and save extra marks
+            (3..4).each do |extra_mark_value|
+              @extra_mark = ExtraMark.new
+              @extra_mark.unit = ExtraMark::UNITS[:points]
+              @extra_mark.result = @result
+              @extra_mark.extra_mark = extra_mark_value
+              assert @extra_mark.save
+            end
+            @result.update_total_mark
+            @old_total_mark = @result.total_mark
             get_as @admin, :remove_extra_mark, :id => @extra_mark.id
           end
           should_not set_the_flash
           should assign_to :result
           should render_template 'results/marker/remove_extra_mark'
           should respond_with :success
+
+          should "have removed the extra mark in question and updated the total mark accordingly" do
+            @result.reload
+            assert_equal @old_total_mark - @extra_mark.extra_mark, @result.total_mark
+          end
         end
 
         context "GET on :expand_criteria" do
@@ -1218,24 +1242,48 @@ class ResultsControllerTest < AuthenticatedControllerTest
 
           context "without save error" do
             setup do
+              @unmarked_result.update_total_mark
+              @old_total_mark = @unmarked_result.total_mark
               post_as @ta, :add_extra_mark, :id => @unmarked_result.id, :extra_mark => { :extra_mark => 1 }
             end
             should assign_to :result
             should assign_to :extra_mark
             should render_template 'results/marker/insert_extra_mark'
             should respond_with :success
+
+            should "have added the extra mark and updated total mark accordingly" do
+              @unmarked_result.reload
+              assert_equal @old_total_mark + 1, @unmarked_result.total_mark
+            end
           end
 
         end
 
         context "GET on :remove_extra_mark" do
           setup do
+            # clear any existing extra marks
+            @result.extra_marks.map{ |mark| mark.destroy }
+            # create and save extra marks
+            (3..4).each do |extra_mark_value|
+              @extra_mark = ExtraMark.new
+              @extra_mark.unit = ExtraMark::UNITS[:points]
+              @extra_mark.result = @result
+              @extra_mark.extra_mark = extra_mark_value
+              assert @extra_mark.save
+            end
+            @result.update_total_mark
+            @old_total_mark = @result.total_mark
             get_as @ta, :remove_extra_mark, :id => @extra_mark.id
           end
           should_not set_the_flash
           should assign_to :result
           should render_template 'results/marker/remove_extra_mark'
           should respond_with :success
+
+          should "have removed the extra mark in question and updated the total mark accordingly" do
+            @result.reload
+            assert_equal @old_total_mark - @extra_mark.extra_mark, @result.total_mark
+          end
         end
 
         context "GET on :expand_criteria" do


### PR DESCRIPTION
When adding/removing extra marks in the "Summary" pane of the grader
view, the total mark was not updated. We missed calls to
result.update_total_mark. Regression tests have been added to account
for this case.

Reviewed by Mike: http://review.markusproject.org/r/1017/

Thanks!
