### PR TITLE
Closes #30. Cookie overflow error in file manager.

### DIFF
--- a/app/views/submissions/file_manager.html.erb
+++ b/app/views/submissions/file_manager.html.erb
@@ -54,12 +54,13 @@
   <% end %>
 <% end %>
 
-<% if flash[:update_conflicts] %>
+<% if !@file_manager_errors.nil? && @file_manager_errors[:update_conflicts]
+%>
   <div class="error">
     <h2><%= I18n.t("student.submission.conflicts") %></h2>
     <p><%= I18n.t("student.submission.file_conflicts") %></p>
     <ul>
-    <% flash[:update_conflicts].each do |conflict| %>
+    <% @file_manager_errors[:update_conflicts].each do |conflict| %>
       <li><%= h(conflict.to_s) %></li>
     <% end %>
     </ul>
@@ -71,9 +72,9 @@
     <%=flash[:commit_notice]%>
   </div>
 <% end %>
-<% if flash[:commit_error] %>
+<% if !@file_manager_errors.nil? && @file_manager_errors[:commit_error] %>
   <div class="warning">
-    <%=flash[:commit_error] %>
+    <%=@file_manager_errors[:commit_error] %>
   </div>
 <% end %>
 


### PR DESCRIPTION
When attempting to upload a file with the same filename, which had
already been uploaded, MarkUs threw an Internal Server Error. This was
caused by using the flash (i.e. the cookie) as a vehicle to carry over
state from the update_files action to the file_manager view. Now we
aren't using redirect_to, thus saving a rather expensive redirect, and
just use render instead.

I've updated submission_controller_test.rb accordingly.

Reviewed by Benjamin: http://review.markusproject.org/r/1025/
