### PR TITLE
Closing Bug #355 - fixing alignment of Marking State icon in Submissions 

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1384,7 +1384,7 @@ td a{
   text-transform: none;
 }
 
-td.delete_row, td.marking_state {
+td.delete_row {
   text-align: center;
 }
 


### PR DESCRIPTION
Closing Bug #355 - fixing alignment of Marking State icon in Submissions Table.

Reviewed at http://review.markusproject.org/r/1038/, with Ship-it from jerboaa
