### PR TITLE
Removing ruby-debug requires in repositories that were causing production

### DIFF
--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -1,6 +1,5 @@
 require File.join(File.dirname(__FILE__),'/repository')
 require "rubygems"
-require "ruby-debug"
 module Repository
 
 # Implements AbstractRepository for memory repositories

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -2,7 +2,6 @@ require "svn/repos" # load SVN Ruby bindings
 require "svn/client"
 require "md5"
 require "rubygems"    # debugging
-require "ruby-debug"  # debugging
 require File.join(File.dirname(__FILE__),'/repository') # load repository module
 
 module Repository


### PR DESCRIPTION
Removing ruby-debug requires in repositories that were causing production installs to freak out (since ruby-debug is not required in production installs). Referenced by issue #162.
