### PR TITLE
Rdoc must now be added as a Gem in the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 # Other development related required gems. You don't need them
 # for production.
 group :development, :test do
+  gem "rdoc"
   gem "shoulda"
   gem "selenium-client", "~>1.2.15"
   gem "machinist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       activesupport (= 2.3.10)
       rake (>= 0.8.3)
     rake (0.9.0)
+    rdoc (3.6.1)
     routing-filter (0.2.3)
       actionpack
     ruby-debug (0.10.4)
@@ -76,6 +77,7 @@ DEPENDENCIES
   mysql
   pg
   rails (= 2.3.10)
+  rdoc
   routing-filter
   ruby-debug
   rubyzip

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,6 @@ require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'tasks/rails'
 require 'db_populate'


### PR DESCRIPTION
Remove a deprecated warning

Reviewed by Nelle
