### PR TITLE
Fix warning of duplicate test. Closes #379.

### DIFF
--- a/test/unit/submission_test.rb
+++ b/test/unit/submission_test.rb
@@ -12,7 +12,7 @@ class SubmissionTest < ActiveSupport::TestCase
     assert_equal s.result.marking_state, Result::MARKING_STATES[:unmarked], "Result marking_state should have been automatically set to unmarked"
   end
 
-  should "create a remark result" do
+  should "create a new remark result" do
     s = submissions(:submission_1)
     s.save
     s.create_remark_result


### PR DESCRIPTION
submission_test.rb had two "create a remark result. " tests. One is now
called "create a new remark result" This fixes the issue.

Reviewed by Benjamin: http://review.markusproject.org/r/1049/
