### PR TITLE
Fix Javascript error

### DIFF
--- a/app/views/submissions/_submission_warning.js.erb
+++ b/app/views/submissions/_submission_warning.js.erb
@@ -13,7 +13,7 @@ function show_confirmation(evt) {
     # he intends to navigate away and cancels the request if
     # 'Cancel' is pressed by the user.
     %>
-    evt.returnValue = '<%= I18n.t('uncommitted_changes_warning') %>';
+    evt.returnValue = "<%= I18n.t('uncommitted_changes_warning') %>";
   }
 }
 


### PR DESCRIPTION
Strings between single quotes while it should be double quotes.
