### PR TITLE
Put mongrel_cluster gem into it's own group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,10 @@ group :development, :test do
   gem "ruby-debug"
   gem "mocha"
 end
+
+# If you  plan to use clustered mongrel servers for production
+# make sure that this group is included. You don't need this
+# group if you are using Phusion Passenger.
+group :mongrel do
+  gem "mongrel_cluster"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,9 @@ GEM
     activesupport (3.0.10)
     arel (2.0.10)
     builder (2.1.2)
+    cgi_multipart_eof_fix (2.5.0)
     columnize (0.3.4)
+    daemons (1.1.4)
     db_populate (0.2.6)
     dynamic_form (1.1.4)
     erubis (2.6.6)
@@ -45,6 +47,8 @@ GEM
     faker (0.9.5)
       i18n (~> 0.4)
     fastercsv (1.5.4)
+    fastthread (1.0.7)
+    gem_plugin (0.2.3)
     i18n (0.5.0)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
@@ -56,6 +60,14 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.16)
     mocha (0.9.12)
+    mongrel (1.1.5)
+      cgi_multipart_eof_fix (>= 2.4)
+      daemons (>= 1.0.3)
+      fastthread (>= 1.0.1)
+      gem_plugin (>= 0.2.3)
+    mongrel_cluster (1.0.5)
+      gem_plugin (>= 0.2.3)
+      mongrel (>= 1.0.2)
     mysql (2.8.1)
     pg (0.11.0)
     polyglot (0.3.2)
@@ -116,6 +128,7 @@ DEPENDENCIES
   i18n
   machinist
   mocha
+  mongrel_cluster
   mysql
   pg
   prototype_legacy_helper (= 0.0.0)!

--- a/config/mongrel_cluster.yml
+++ b/config/mongrel_cluster.yml
@@ -8,7 +8,7 @@
 #
 # Logfiles go to log/mongrel_<portnumber>.log
 #
-log_file: /home/markus/sandbox/markus_trunk/log/mongrel.log
+log_file: log/mongrel.log
 #
 # Use port 8000 and upwards for the number of mongrels
 # to start
@@ -21,7 +21,7 @@ environment: production
 address: 127.0.0.1
 #
 # Location and filenames as to where to put PID files
-pid_file: /home/markus/sandbox/markus_trunk/tmp/pids/mongrel.pid
+pid_file: tmp/pids/mongrel.pid
 #
 # Number of mongrel servers to start
 servers: 3
@@ -33,8 +33,8 @@ user: markus
 group: markus
 # 
 # Document root of static HTML files (you shouldn't change this)
-docroot: /home/markus/sandbox/markus_trunk/public
+docroot: public
 #
 # Directory into which to change before starting mongrel servers
 # This shouldn't be changed.
-chdir: /home/markus/sandbox/markus_trunk
+chdir: ./


### PR DESCRIPTION
Update to Gemfile and Gemfile.lock so that developers and users can
opt-in to use mongrel.

Reviewed by Benjamin: http://review.markusproject.org/r/1072/
