### PR TITLE
Closes #461. Fix rake db:populate task.

### DIFF
--- a/db/populate/06_repos.rb
+++ b/db/populate/06_repos.rb
@@ -1,7 +1,7 @@
 # Let's populate students repository with nice data
 
 groups = Group.all
-assignment = Assignment.first
+assignment = Assignment.find_by_short_identifier("A1")
 
 file_dir  = File.join(File.dirname(__FILE__), '/data')
 groups.each do |group|


### PR DESCRIPTION
Assignment.first was used instead of finding the correct assignment for
which the groups were created.

Reviewed by Benjamin: http://review.markusproject.org/r/1080/
