### PR TITLE
Closes #467. Student interface empty for group a.

### DIFF
--- a/app/views/layouts/no_menu_header.html.erb
+++ b/app/views/layouts/no_menu_header.html.erb
@@ -27,7 +27,7 @@
 
   <div id="container">
     <div id="content">
-       <%= @content_for_layout %>
+       <%= yield :layout %>
     </div><!-- Content -->
   </div><!-- Container -->
 </div>


### PR DESCRIPTION
We were using old code, in particular @content_for_layout. This is not
supported anymore and one should use yield :layout instead.

Reviewed by Benjamin: http://review.markusproject.org/r/1077/
