### PR TITLE
Fix: post-markus-review would fail 

### DIFF
--- a/lib/tools/post-markus-review
+++ b/lib/tools/post-markus-review
@@ -68,7 +68,7 @@ function create_diff {
 		echo "done."
 	fi
 	DIFF_FILE_TEMP=".current_feature.$$.diff"
-	exec_safe "git diff --full-index master $FEATURE_BRANCH" > $DIFF_FILE_TEMP
+	exec_safe "git diff --full-index master $FEATURE_BRANCH --" > $DIFF_FILE_TEMP
 }
 
 


### PR DESCRIPTION
post-markus-review would fail  with a master directory in the root directory.

Reviewed by Severin here : http://review.markusproject.org/r/1083/
