### PR TITLE
Add hidden credentials file to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ log/
 
 # Temporary and backup files
 *~
+
+# MarkUs Review poster tool credentials file
+.markusdev-creds


### PR DESCRIPTION
This is used by our review poster script. Since usernames are different
per developer, we should ignore this file.

I didn't create a review for this. Feel free to have a look at the diff here :) Thanks!
