### PR TITLE
Fixed missing template error in Sections.

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -40,6 +40,7 @@ class SectionsController < ApplicationController
       redirect_to :action => 'index'
     else
       flash[:error] = reason_for_error(@section.errors, I18n.t('section.update.error'))
+      redirect_to :action => 'edit'
     end
   end
 end

--- a/test/functional/sections_controller_test.rb
+++ b/test/functional/sections_controller_test.rb
@@ -84,6 +84,17 @@ class SectionsControllerTest < AuthenticatedControllerTest
 
       assert_not_nil Section.find_by_name("no section")
     end
+
+    should "edits a section name to an existing name" do
+      @section = Section.make
+      @section2 = Section.make
+      put_as @admin,
+              :update,
+              :id => @section.id,
+              :section => {:name => @section2.name}
+      assert_response :redirect
+      assert_equal flash[:error], I18n.t('section.update.error') + ' Name has already been taken.'
+    end
   end
 
 end


### PR DESCRIPTION
Closed #269. Fixed missing template error upon renaming a Section to an existing Section name. Added a functional test for it.
