### PR TITLE
Display section of a group in the submission view only if it is a "section groups only" assignment

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -558,14 +558,13 @@ class Grouping < ActiveRecord::Base
     end
     return result.map{|a| a.criterion}.uniq
   end
-  
-  # Get the section for this group. Since all students must be in the same section to
-  # be in the same group, return the section name for the first student with a section.
+
+  # Get the section for this group. If assignment restricts member of a groupe
+  # to a section, all students are in the same section. Therefore, return only
+  # the inviters section
   def section
-    self.students.each do |student|
-      if student.has_section?
-        return student.section.name
-      end
+    if !self.inviter.nil? and self.inviter.has_section?
+      return self.inviter.section.name
     end
     return '-'
   end

--- a/app/views/submissions/_submissions_table_sorting_links.html.erb
+++ b/app/views/submissions/_submissions_table_sorting_links.html.erb
@@ -66,6 +66,7 @@
               :sort_by => 'total_mark',
               :desc => (sort_by == 'total_mark' && desc.blank?) %>
     </th>
+    <% if assignment.section_groups_only %>
     <th class="<%="ap_sorting_by" if (sort_by == 'section')%>
     	        <%="ap_sorting_by_desc" if (sort_by == 'section' && !desc.blank?)%>">
       <%= link_to I18n.t("browse_submissions.section"),
@@ -76,6 +77,7 @@
               :sort_by => 'section',
               :desc => (sort_by == 'section' && desc.blank?) %>
     </th>
+    <% end %>
     <th>
       <%= I18n.t("browse_submissions.can_begin_grading") %>
     </th>

--- a/app/views/submissions/submissions_table_row/_table_row.html.erb
+++ b/app/views/submissions/submissions_table_row/_table_row.html.erb
@@ -128,9 +128,14 @@
     <% end %>
   <% end %>
   </td>
+
+  <%# We don't need to display the section of the group unless it is a section group 
+      assignment %>
+  <% if assignment.section_groups_only %>
   <td>
   	<%= h(grouping.section) %>
   </td>
+  <% end %>
   <td>
     <% if Time.now >= assignment.submission_rule.calculate_grouping_collection_time(grouping) %>
       <%= image_tag('icons/tick.png') %>


### PR DESCRIPTION
Small nitpick in the UI of a previous commit.

I'm not even sure we _want_ that information displayed here for most cases (right now, this is used on at ECN). Long term, we might want this to be configurable (through javascript ?)
