### PR TITLE
Fixing routing errors for the results_controller_test functional test

### DIFF
--- a/app/views/assignments/_test_result_window.html.erb
+++ b/app/views/assignments/_test_result_window.html.erb
@@ -4,7 +4,7 @@
   function load_test_result(test_result_id) {
     $('loading_test_result').show();
     $('select_test_result_id').disable();
-    window.open('<%= url_for(:controller => "assignments", :action => "render_test_result", :aid => aid)%>?test_result_id='+test_result_id,
+    window.open('<%= url_for(:controller => "assignments", :action => "render_test_result", :id => @assignment.id, :aid => aid)%>&test_result_id='+test_result_id,
     "Test Results", "width=400,height=250,resizable=yes,scrollbars=yes")
     $('loading_test_result').hide();
     $('select_test_result_id').enable();

--- a/app/views/results/common/_test_selector.html.erb
+++ b/app/views/results/common/_test_selector.html.erb
@@ -3,7 +3,7 @@
 %>
   <%=label_tag "select_test_result_id", h(I18n.t("common.test_results")), :class => "inline_label" %>
 <%= link_to image_tag("icons/cog_go.png", :alt => I18n.t("common.test_code"), :title => I18n.t("common.test_code"), :id => "test_icon"),
-     assignment_automated_test_path(:assignment_id => @assignment.id, :result => @result), :id => "test_select_link", :remote => true %>
+     assignment_automated_tests_path(:assignment_id => @assignment.id, :result => @result), :id => "test_select_link", :remote => true %>
 
     <script type='text/javascript'>
     $("test_select_link").observe('ajax:after', function(evt, status, data, xhr) {


### PR DESCRIPTION
I have inadvertently introduced new errors for the results_controller_test as a part of some of my previous commits ( embarrassed >_< ). These errors should not have affected anyone's work as they only came up during functional testing.

Steps to reproduce: run "rake test:functionals" on the most up-to-date master and note the eight errors.

Solution:
- test_selector partial was calling the wrong helper... assignment_automated_test_path returns a path for a member where as we are really looking for a collection via assignment_automated_test<b>s</b>_path
  - this problem was always there, but somehow only came up recently as an actual error in testing
- for the code in test_result_window partial we need to explicitly pass the id for the url to be generated correctly when the view is rendered through the functional tests
