### PR TITLE
FIX for issue 729, Apply 30 character limit for Short Description so assignment drop down menu doesn't overflow.

### DIFF
--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -28,9 +28,9 @@
       <%=raw( f.text_field :short_identifier,
                        :onchange =>  "$(
                             'assignment_repository_folder').setValue(
-                                    $(this).getValue())" )%><br />
+                                    $(this).getValue())", :maxlength => 30 )%><br />
     <% else %>
-      <%= raw( f.text_field :short_identifier ) %><br />
+      <%= raw( f.text_field :short_identifier, :maxlength => 30 ) %><br />
     <% end %>
 
     <%= raw( f.label :description, t(:name) ) %>


### PR DESCRIPTION
The Short Description of Assignments runs over the borders of the dropdown menu.  A cap of 30 characters was placed as that is the maximum the drop down menu can hold with out overflowing.
