### PR TITLE
Grade Distribution Graph fix

### DIFF
--- a/app/models/assignment_stat.rb
+++ b/app/models/assignment_stat.rb
@@ -16,7 +16,7 @@ class AssignmentStat < ActiveRecord::Base
       return self.grade_distribution_percentage.parse_csv.map{ |x| x.to_i }.to_json
     else
       # Default, empty distribution
-      return [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+      return "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
     end
   end
 end

--- a/app/views/main/_grade_distribution_graph.html.erb
+++ b/app/views/main/_grade_distribution_graph.html.erb
@@ -22,11 +22,7 @@
     <% else %>
         legend = '<%= I18n.t("students.students") %>'
     <% end %>
-    g.data(legend,
-        <% assignment.assignment_stat.grade_distribution_array.each do |d| -%>
-            <%= d -%>,
-        <% end -%>
-        '');
+    g.data(legend, <%= assignment.assignment_stat.grade_distribution_array %> );
 
     // Create the labels
     var intervals = 20;


### PR DESCRIPTION
Fix for issue #657. The problem was bad data input for the graph library. It would return a list if there was no grade information, and a json list (in string format as json wont to be). This change makes it always return a json string, and uses that string as data input directly with no processing.

Unfortunately, since releasing marks doesn't seem to work right now I can't test how it looks like with a real distribution of data. 
