### PR TITLE
Downgrade to Machinist 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :development, :test do
   gem "rdoc"
   gem "rcov"
   gem "shoulda"
-  gem "machinist"
+  gem "machinist", "< 2"
   gem "faker"
   gem "railroady"
   gem "time-warp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     json (1.7.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
-    machinist (2.0)
+    machinist (1.0.6)
     mail (2.2.19)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -132,7 +132,7 @@ DEPENDENCIES
   faker
   fastercsv
   i18n
-  machinist
+  machinist (< 2)
   mocha
   mongrel_cluster
   mysql2 (< 0.3)


### PR DESCRIPTION
I made a mistake. I pushed a Gemfile.lock with machinist2 inside it. Tests are not starting anymore.

Sorry for that.

Here is the fix

Tests must be modified in order to support machinist2.
See https://github.com/notahat/machinist/wiki/machinist-2 and #765
