### PR TITLE
Use Time.zone.now over Time.now.

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -86,7 +86,7 @@ class ResultsController < ApplicationController
     collection_time = @assignment.submission_rule.calculate_collection_time.localtime
 
     groupings.delete_if do |grouping|
-      grouping != @grouping && ((!grouping.has_submission? && (Time.now < collection_time)))
+      grouping != @grouping && ((!grouping.has_submission? && (Time.zone.now < collection_time)))
     end
 
     # We sort by Group name by default
@@ -396,7 +396,7 @@ class ResultsController < ApplicationController
     if !@assignment.past_remark_due_date?
       @submission = Submission.find(params[:id])
       @submission.remark_request = params[:submission][:remark_request]
-      @submission.remark_request_timestamp = Time.now
+      @submission.remark_request_timestamp = Time.zone.now
       @submission.save
       @old_result = @submission.result
       if !(@submission.remark_result)

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -294,7 +294,7 @@ module AutomatedTestsHelper
     FileUtils.cd(pwd)
 
     # File to store build details
-    filename = I18n.l(Time.now, :format => :ant_date) + ".log"
+    filename = I18n.l(Time.zone.now, :format => :ant_date) + ".log"
     # Status of Ant build
     status = ''
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -122,11 +122,11 @@ class Assignment < ActiveRecord::Base
   def past_due_date?
     # If no section due dates
     if !self.section_due_dates_type && self.section_due_dates.empty?
-      return !due_date.nil? && Time.now > due_date
+      return !due_date.nil? && Time.zone.now > due_date
     # If section due dates
     else
       self.section_due_dates.each do |d|
-        if !d.due_date.nil? && Time.now > d.due_date
+        if !d.due_date.nil? && Time.zone.now > d.due_date
           return true
         end
       end
@@ -139,7 +139,7 @@ class Assignment < ActiveRecord::Base
     if self.section_due_dates_type and !grouping.inviter.section.nil?
         section_due_date =
     SectionDueDate.due_date_for(grouping.inviter.section, self)
-        return !section_due_date.nil? && Time.now > section_due_date
+        return !section_due_date.nil? && Time.zone.now > section_due_date
     else
       self.past_due_date?
     end
@@ -171,11 +171,11 @@ class Assignment < ActiveRecord::Base
   end
 
   def past_collection_date?
-    return Time.now > submission_rule.calculate_collection_time
+    return Time.zone.now > submission_rule.calculate_collection_time
   end
 
   def past_remark_due_date?
-    return !remark_due_date.nil? && Time.now > remark_due_date
+    return !remark_due_date.nil? && Time.zone.now > remark_due_date
   end
 
   # Returns a Submission instance for this user depending on whether this

--- a/app/models/grace_period_submission_rule.rb
+++ b/app/models/grace_period_submission_rule.rb
@@ -18,7 +18,7 @@ class GracePeriodSubmissionRule < SubmissionRule
     # We need to know how many grace credits this grouping has left...
     grace_credits_remaining = grouping.available_grace_credits
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.now)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now)
     grace_credits_to_use = calculate_deduction_amount(overtime_hours)
     if grace_credits_remaining < grace_credits_to_use
       # This grouping is out of grace credits.

--- a/app/models/penalty_decay_period_submission_rule.rb
+++ b/app/models/penalty_decay_period_submission_rule.rb
@@ -15,7 +15,7 @@ class PenaltyDecayPeriodSubmissionRule < SubmissionRule
   # after the due date has passed, but before the calculated collection date.
   def overtime_message(grouping)
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.now)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now)
     # Calculate the penalty that the grouping will suffer
     potential_penalty = calculate_penalty(overtime_hours)
 

--- a/app/models/penalty_period_submission_rule.rb
+++ b/app/models/penalty_period_submission_rule.rb
@@ -14,7 +14,7 @@ class PenaltyPeriodSubmissionRule < SubmissionRule
   # after the due date has passed, but before the calculated collection date.
   def overtime_message(grouping)
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.now)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now)
     # Calculate the penalty that the grouping will suffer
     potential_penalty = calculate_penalty(overtime_hours)
 

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -9,7 +9,7 @@ class SubmissionRule < ActiveRecord::Base
 
   def can_collect_now?
     return @can_collect_now if !@can_collect_now.nil?
-    @can_collect_now = Time.now >= get_collection_time
+    @can_collect_now = Time.zone.now >= get_collection_time
   end
 
   # Cache that allows us to quickly get collection time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -254,7 +254,7 @@ class User < ActiveRecord::Base
     digest = Digest::SHA2.new(bitlen=512)
     # generate a unique token
     unique_seed = ActiveSupport::SecureRandom.hex(20)
-    return digest.update("#{unique_seed} SECRET! #{Time.now.to_f}").to_s
+    return digest.update("#{unique_seed} SECRET! #{Time.zone.now.to_f}").to_s
   end
 
   # strip input string

--- a/app/views/assignments/_list.html.erb
+++ b/app/views/assignments/_list.html.erb
@@ -27,22 +27,22 @@
             </td>
             <td>
               <% if !assignment.section_due_dates_type %>
-                <% if assignment.due_date < Time.now %>
+                <% if assignment.due_date < Time.zone.now %>
                   <strong><%= I18n.l(assignment.due_date, :format => :long_date) %></strong>
                 <% else %>
                   <strong><%= I18n.l(assignment.due_date, :format => :long_date) %></strong><br />
                     <%= I18n.t(:days_and_hours_left,
-                    :days => ((((assignment.due_date - Time.now)/(60 * 60 * 24)).floor).to_s),
-                    :hours => ((((assignment.due_date - Time.now)/(60 * 60)) % 24).floor)) %>
+                    :days => ((((assignment.due_date - Time.zone.now)/(60 * 60 * 24)).floor).to_s),
+                    :hours => ((((assignment.due_date - Time.zone.now)/(60 * 60)) % 24).floor)) %>
                 <% end %>
 	      <% else %>
-               <% if assignment.section_due_date(@section) < Time.now %>
+               <% if assignment.section_due_date(@section) < Time.zone.now %>
                 <strong><%= I18n.l(assignment.section_due_date(@section), :format => :long_date) %></strong>
                 <% else %>
                   <strong><%= I18n.l(assignment.section_due_date(@section), :format => :long_date) %></strong><br />
                     <%= I18n.t(:days_and_hours_left,
-                    :days => ((((assignment.due_date - Time.now)/(60 * 60 * 24)).floor).to_s),
-                    :hours => ((((assignment.due_date - Time.now)/(60 * 60)) % 24).floor)) %>
+                    :days => ((((assignment.due_date - Time.zone.now)/(60 * 60 * 24)).floor).to_s),
+                    :hours => ((((assignment.due_date - Time.zone.now)/(60 * 60)) % 24).floor)) %>
                <% end %>
 	      <% end %>
             </td>
@@ -56,7 +56,7 @@
                 <%= simple_format(sanitize(@a_id_results[assignment.id].overall_comment)) %>
               </p>
               <%= link_to h(I18n.t('results.results_name')), :controller => "results", :action => 'view_marks', :id => assignment.id %>
-              <% elsif assignment.due_date < Time.now %>
+              <% elsif assignment.due_date < Time.zone.now %>
                 <%= I18n.t(:no_result) %>
               <% end %>
             </td>

--- a/app/views/grade_entry_forms/_list.html.erb
+++ b/app/views/grade_entry_forms/_list.html.erb
@@ -29,10 +29,10 @@
             </td>
             <td>
             	<strong><%= h l(grade_entry_form.date, :format => :short_date) %></strong>
-              <% if grade_entry_form.date > Time.now.to_date %>
+              <% if grade_entry_form.date > Time.zone.now.to_date %>
                 <br />
                 <%= t(:days_left,
-                      :days => grade_entry_form.date - Time.now.to_date)
+                      :days => grade_entry_form.date - Time.zone.now.to_date)
                  %>
               <% end %>
             </td>
@@ -47,7 +47,7 @@
                   %>
                 <% end %>
                 <%= ("(Class Average: " + ("%.2f" % (grade_entry_form.calculate_released_average)).to_s + "%)") %>
-              <% elsif grade_entry_form.date < Time.now.to_date %>
+              <% elsif grade_entry_form.date < Time.zone.now.to_date %>
                 <%= t('grade_entry_forms.students.no_results') %>
               <% end %>
             </td>

--- a/app/views/submissions/_server_time.html.erb
+++ b/app/views/submissions/_server_time.html.erb
@@ -1,2 +1,2 @@
   <strong><%= I18n.t("server_time") %></strong>
-  <%= I18n.l(Time.now, :format => :long_date)%>
+  <%= I18n.l(Time.zone.now, :format => :long_date)%>

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -2,7 +2,7 @@
 <%= javascript_include_tag "ajax_paginate" %>
 
 <div class="notice">
-  <% if Time.now >= @assignment.submission_rule.calculate_collection_time %>
+  <% if Time.zone.now >= @assignment.submission_rule.calculate_collection_time %>
      <%=h I18n.t("browse_submissions.grading_can_begin") %>
   <% else %>
      <%=h I18n.t("browse_submissions.grading_can_begin_after",

--- a/app/views/submissions/submissions_table_row/_table_row.html.erb
+++ b/app/views/submissions/submissions_table_row/_table_row.html.erb
@@ -14,7 +14,7 @@
 </td>
 <td>
   <% if !grouping.has_submission? %>
-    <% if Time.now >=
+    <% if Time.zone.now >=
     assignment.submission_rule.calculate_grouping_collection_time(grouping) %>
       <%= link_to h(grouping.group.group_name),
                   collect_and_begin_grading_assignment_submission_path(
@@ -137,7 +137,7 @@
   </td>
   <% end %>
   <td>
-    <% if Time.now >= assignment.submission_rule.calculate_grouping_collection_time(grouping) %>
+    <% if Time.zone.now >= assignment.submission_rule.calculate_grouping_collection_time(grouping) %>
       <%= image_tag('icons/tick.png') %>
     <% else %>
       <%= image_tag('icons/cross.png') %>


### PR DESCRIPTION
Since Rails transparently converts DB times to
ActiveSupport::TimeWithZone instances and Time.zone.now returns such an
instance this should be the better approach in particular when it comes
to comparing times.

Units and functional tests continue to pass.
