### PR TITLE
Fix for issue 769, fix routing issue with grading assignment caused by upgrading to rails 3.0

### DIFF
--- a/app/views/submission_rules/grace_period/_grader_tab.html.erb
+++ b/app/views/submission_rules/grace_period/_grader_tab.html.erb
@@ -2,7 +2,7 @@
   user_deductions = grouping.grace_period_deductions.group_by {|d| d.membership.user}
 %>
 
-<h3><%=t('submission_rules.grace_period_submission_rule.deductions')%></h3>
+<h3><%=I18n.t('submission_rules.grace_period_submission_rule.deductions')%></h3>
 <% user_deductions.each do |u| %>
 <table>
   <thead>
@@ -15,7 +15,7 @@
       <%= u[1].first.deduction %> credits
     </td>
     <td>
-      <%= link_to_remote t('submission_rules.grace_period_submission_rule.remove_deduction'), :url => {:action => 'delete_grace_period_deduction', :id => grouping.id, :deduction_id => u[1].first.id }, :confirm => t('submission_rules.grace_period_submission_rule.confirm_remove_deduction') %>
+      <%=link_to I18n.t('submission_rules.grace_period_submission_rule.remove_deduction'), :url => {:action => 'delete_grace_period_deduction', :id => grouping.id, :deduction_id => u[1].first.id }, :confirm => I18n.t('submission_rules.grace_period_submission_rule.confirm_remove_deduction') %>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This issue is related to issue #475.  link_to_remote is no longer support in rails 3.0.  Also, the bug #769 is the same as #685.
