### PR TITLE
Fix routing for issue 500 repo browser

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Markus::Application.routes.draw do
         get 'collect_and_begin_grading'
         post 'manually_collect_and_begin_grading'
         get 'repo_browser'
+        post 'repo_browser'
       end
 
       resources :results do


### PR DESCRIPTION
With a previous update, the config/routes.rb changed 'repo_browser' from post to get.  However, to switch different revision by revision_timestamp/number expects post.
