### PR TITLE
Fix for issue 781 "Jump-To" Filter for Marks Spreadsheets is broken

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,7 @@ Markus::Application.routes.draw do
 
     member do
       get 'grades'
-      get 'g_table_paginate'
+      post 'g_table_paginate'
       get 'csv_download'
       post 'csv_upload'
       post 'update_grade'


### PR DESCRIPTION
There was an routing issue using get instead of post
