### PR TITLE
Fix url routing with collect and grade this revision in repo browser

### DIFF
--- a/app/views/submissions/update_converted_pdfs.rjs
+++ b/app/views/submissions/update_converted_pdfs.rjs
@@ -6,17 +6,17 @@ if submission_collector.safely_stop_child_exited
     if @converted_count == @pdf_count
     submission_collector.safely_stop_child_exited = false
     submission_collector.save
-      page.redirect_to :controller => 'results', :action => 'edit',
+      page.redirect_to edit_assignment_submission_result_path(
       :assignment_id => @grouping.assignment_id,
       :submission_id => @grouping.current_submission_used.id,
-      :id => @grouping.current_submission_used.result.id
+      :id => @grouping.current_submission_used.result.id)
     end
   else
     submission_collector.safely_stop_child_exited = false
     submission_collector.save
-    page.redirect_to :controller => 'results', :action => 'edit',
+    page.redirect_to edit_assignment_submission_result_path(
       :assignment_id => @grouping.assignment_id,
       :submission_id => @grouping.current_submission_used.id,
-      :id => @grouping.current_submission_used.result.id
+      :id => @grouping.current_submission_used.result.id)
   end
 end


### PR DESCRIPTION
For issue Issue #500, When clicking "Collect and Grade This Revision", the url is given in the format /assignments/:assignment_id/submissions/:submission_id/results/edit?id= instead of /assignments/:assignment_id/submissions/:submission_id/results/:id/edit. This causes issue with path helper functions, causing the submission to be collected but it can't display the marking page
