### PR TITLE
Fix issue 799 - Disable bulk action button after clicking to prevent multiple clicks

### DIFF
--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -135,7 +135,7 @@ document.observe("dom:loaded", function(){
 	    <% end %>
 	</select>
       </span>
-      <%= submit_tag t(:apply), :id => 'apply_bulk_action', :name => 'commit' %>
+      <%= submit_tag t(:apply), :id => 'apply_bulk_action', :disable_with => I18n.t('working'), :name => 'commit' %>
 
 
 


### PR DESCRIPTION
Fix issue #799.  Disable the apply button once clicked to prevent multiple clicks.
