### PR TITLE
Fix #815: cannot remove Object::Csv

### DIFF
--- a/app/helpers/csv_helper.rb
+++ b/app/helpers/csv_helper.rb
@@ -6,12 +6,19 @@
 require 'fastercsv' unless RUBY_VERSION > '1.9'
 require 'csv'       if     RUBY_VERSION > '1.9'
 
-module CsvHelper
+def class_defined(klass)
   begin
-    class Csv < CSV
-    end
-  rescue
-    class Csv < FasterCSV
-    end
+    klass = Module.const_get(klass)
+    return klass.is_a?(Class)
+  rescue NameError
+    return false
+  end
+end
+
+module CsvHelper
+  if class_defined("CSV")
+    CsvHelper.const_set :Csv, CSV
+  else
+    CsvHelper.const_set :Csv, FasterCSV
   end
 end


### PR DESCRIPTION
My explanation for this is a bit hand-wavy :)

This was caused because of some Rails 3.0.13 implemation specific
side-effect of removing constants. In particular
activesupport-3.0.13/lib/active_support/dependencies.rb (lines 628-635)
were causing this together with our CsvHelper implementation. I think it
attempted to remove Object::Csv because we include the Csv class from
CsvHelper bringing it into the Object namespace. This seems to have
conflicted somehow with Csv being in the CsvHelper module.

In any case this fix aliases CSV on Ruby 1.9.x and FasterCSV on Ruby
1.8.7 respectively to CsvHelper::Csv. This doesn't seem to have the
above conflict.
