### PR TITLE
removed annotation hiding code

### DIFF
--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -31,9 +31,6 @@ function source_code_ready() {
 
 //A version of source_code_ready for image files.
 function source_code_ready_for_image() {
-  if ($('annotation_menu') != null) {
-    $('annotation_menu').hide();
-  }
   annotation_manager = null;
 
   var image_event_handler = new ImageEventHandler();


### PR DESCRIPTION
Hi,

Here is an attempt to fix issue #567.

After digging into the code I saw that there were lines of javascript that were hiding the annotation menu. I removed those and now the annotation menu is showing and usable, and annotation categories can be used again. Did that fix it? I am not sure because I cant figure out how to use annotations. Please test and let me know?
