### PR TITLE
closes #721 - add section modal shows error if adding fails

### DIFF
--- a/app/views/students/_student_form.html.erb
+++ b/app/views/students/_student_form.html.erb
@@ -15,8 +15,11 @@ modalAddNewSection = new Control.Modal($('add_new_section_dialog'),
 <div class="section">
   <%= form_for @user, :as => :user do |f| %>
 
-    <%= render :partial => "shared/error_explanation",
-        :locals => { :model => @user, :flash_message => flash[:error] } %>
+    <% if flash[:error] && !flash[:error].empty? %>
+      <div class="notice">
+        <%=flash[:error]%>
+      </div>
+    <% end %>
 
     <%= raw(f.label(:user_name, I18n.t("user.user_name"))) %>
     <%= raw(f.text_field :user_name) %><br />


### PR DESCRIPTION
add section modal shows errors.

The problem was that the template does not have a model error therefore using the error_explanation partial did not work
