### PR TITLE
Sorting File Names in selector

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -326,7 +326,9 @@ class ResultsController < ApplicationController
 
     @annotation_categories = @assignment.annotation_categories
     @group = @grouping.group
-    @files = @submission.submission_files
+    @files = @submission.submission_files.sort do |a, b|
+      File.join(a.path, a.filename) <=> File.join(b.path, b.filename)
+    end
     @test_result_files = @submission.test_results
     @first_file = @files.first
     @extra_marks_points = @result.extra_marks.points

--- a/app/views/results/common/_file_selector.html.erb
+++ b/app/views/results/common/_file_selector.html.erb
@@ -8,7 +8,6 @@
     <% if files.empty? %>
       <option value=""><%= I18n.t("common.no_file_in_repository") %></option>
     <% end %>
-    <% files.sort! { |a,b| (a.path + a.filename).downcase <=> (b.path + b.filename).downcase }%>
     <% files.each do |file| %>
         <option value="<%= h(file.id) %>">
           <%= h(File.join(file.path, file.filename)) %>


### PR DESCRIPTION
Added a line to sort the file names alphabetically in the file selector, Issue #85.  Manually tested to ensure the file selector is sorted and links work on submission page.
