### PR TITLE
Notes can now be saved correctly (without visualEffect errors) and are retrieved correctly when clicking Notes on the Users (Manage Students) page

### DIFF
--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,5 +1,6 @@
 <%= javascript_include_tag "FilterTable/FilterTable"%>
 <%= javascript_include_tag "users_manager"%>
+<%= javascript_include_tag "effects.js" %>
 
 <%= render :partial => "boot.js.erb"%>
 <%= render :partial => "student_form_actions.js.erb"%>

--- a/app/views/users/table_row/_filter_table_row.html.erb
+++ b/app/views/users/table_row/_filter_table_row.html.erb
@@ -28,7 +28,7 @@
                 notes_dialog_note_path(
                     :id => user.id,
                     :noteable_id => user.id,
-                    :noteable_type => 'User',
+                    :noteable_type => 'Student',
                     :action_to => 'note_message',
                     :controller_to => 'students',
                     :number_of_notes_field => "num_notes_#{user.id}",


### PR DESCRIPTION
Fixed #850.

Notes can now be saved without "visualEffect" errors and are correctly displayed in the "Existing Notes" box when accessing a specific user's notes.
