### PR TITLE
issue 315: config locale fall back to english in production environment.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,10 @@
 # Settings specified here will take precedence over those in config/environment.rb
 Markus::Application.configure do
+  # rails will fallback to en, no matter what is set as config.i18n.default_locale
+  # rails will fallback to config.i18n.default_locale translation
+  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
+
   # The production environment is meant for finished, "live" apps.
   # Code is not reloaded between requests
   config.cache_classes = true


### PR DESCRIPTION
This is my solution to issue #315.

Testing
Manual:
1. Comment out an entry in /config/locales/fr.yml, "welcome_to:" for example.
2. Run Markus in dev mode, go to http://0.0.0.0:3000/fr and note that fall back doesn't happen on the login page("translation missing").
3. Run Markus in production mode(rails s -e production) and go to http://0.0.0.0:3000/fr
4. Fall back to english("Welcome to MarkUs!")
