### PR TITLE
Display warning if no group is selected on a global action

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -265,8 +265,8 @@ class GroupsController < ApplicationController
     if params[:groupings].nil? or params[:groupings].size ==  0
 	 #if there is a global action than there should be a group selected
          if params[:global_actions]
-               @warning_no_group_selected = I18n.t("assignment.group.select_a_group")
-               render :warning_no_group_selected
+               @global_action_warning = I18n.t("assignment.group.select_a_group")
+               render :partial => "groups/global_action_warning.rjs"
                return
          end
       #Just do nothing
@@ -296,7 +296,8 @@ class GroupsController < ApplicationController
           add_members(student_ids, grouping_ids[0], @assignment)
           return
         else
-          render :nothing => true
+          @global_action_warning = I18n.t("assignment.group.select_a_student")
+          render :partial => "groups/global_action_warning.rjs"
           return
         end
       when "unassign"

--- a/app/views/groups/_global_action_warning.rjs
+++ b/app/views/groups/_global_action_warning.rjs
@@ -1,0 +1,6 @@
+if @global_action_warning
+    page.replace_html 'global_action_warning_msg', @global_action_warning
+    page.show('global_action_warning') 
+else
+    page.hide('global_action_warning')
+end

--- a/app/views/groups/add_members.rjs
+++ b/app/views/groups/add_members.rjs
@@ -20,13 +20,8 @@ else
   page.hide('warnings_grace')
 end
 
-if @warning_no_group_selected
-  page.replace_html 'warning_no_group_selected_msg', @warning_no_group_selected
-  page.show('warning_no_group_selected') 
-else
-  page.hide('warning_no_group_selected')
-end
 
+page << render(:partial => 'groups/global_action_warning')
 
 page.call 'modify_students', @students_data.to_json
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/delete_groupings.rjs
+++ b/app/views/groups/delete_groupings.rjs
@@ -6,12 +6,7 @@ if !@errors.empty?
   page.show 'errors'
 end
 
-if @warning_no_group_selected
-  page.replace_html 'warning_no_group_selected_msg', @warning_no_group_selected
-  page.show('warning_no_group_selected') 
-else
-  page.hide('warning_no_group_selected')
-end
+page << render(:partial => 'groups/global_action_warning')
 
 ids = []
 @removed_groupings.each do |grouping|

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -200,9 +200,9 @@
     <div id="warnings_grace_msg">
     </div>
   </div>
- <div class="warning" id="warning_no_group_selected" style="display: none; ">
+ <div class="warning" id="global_action_warning" style="display: none; ">
 	<h3><%=h t("groups.warning") %></h3>
-	<div id="warning_no_group_selected_msg">
+	<div id="global_action_warning_msg">
 	</div>
   </div>
 

--- a/app/views/groups/modify_groupings.rjs
+++ b/app/views/groups/modify_groupings.rjs
@@ -1,8 +1,3 @@
-if @warning_no_group_selected
-  page.replace_html 'warning_no_group_selected_msg', @warning_no_group_selected
-  page.show('warning_no_group_selected') 
-else
-  page.hide('warning_no_group_selected')
-end
+page << render(:partial => 'groups/global_action_warning')
 
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/remove_members.rjs
+++ b/app/views/groups/remove_members.rjs
@@ -1,10 +1,4 @@
-if @warning_no_group_selected
-  page.replace_html 'warning_no_group_selected_msg', @warning_no_group_selected
-  page.show('warning_no_group_selected') 
-else
-  page.hide('warning_no_group_selected')
-end
-
+page << render(:partial => 'groups/global_action_warning')
 
 page.call 'modify_students', @students_data.to_json
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/warning_no_group_selected.rjs
+++ b/app/views/groups/warning_no_group_selected.rjs
@@ -1,6 +1,0 @@
-if @warning_no_group_selected
-  page.replace_html 'warning_no_group_selected_msg', @warning_no_group_selected
-  page.show('warning_no_group_selected') 
-else
-  page.hide('warning_no_group_selected')
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,7 @@ en:
             assign_over_limit: "You have assigned more than the maximum number of students to group %{group}"
             grace_day_over_limit: "You have assigned one or more students who has less grace period credits than the amount already used by group %{group} for this assignment"
             select_a_group: "Select a group"
+            select_a_student: "Select a student"
             select_only_one_group: "You may only assign each student to one group."
             deleted: "Group has been deleted"
             work_in_groups:  "Students can work in groups"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -134,6 +134,7 @@ fr:
             assign_over_limit: "Vous avez dépassé le nombre maximal d'étudiants pour le groupe %{group}"
             grace_day_over_limit: "Vous avez assigné un ou plusieurs étudiants ayant un nombre de crédits de grâce inférieur à celui déjà utilisé par le groupe %{group} pour ce devoir."
             select_a_group: "Sélectionner un groupe"
+            select_a_student: "Sélectionner un(e) étudiant(e)"
             select_only_one_group: "Vous ne pouvez assigner un(e) étudiant(e) qu'à un seul groupe."
             deleted: "Le groupe a été supprimé"
             work_in_groups:  "Les étudiants peuvent travailler en groupe"


### PR DESCRIPTION
Will display a warning "No group selected" if the user clicks add/remove (member), validate, invalidate or delete without selecting a group. We should also log one "No student is selected" if they do add (member) to a group, but I will log that as a seperate bug.
