### PR TITLE
Fixing deprecated save calls

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -56,7 +56,7 @@ class ResultsController < ApplicationController
 
       if @old_result
         oldmark = criterion.marks.find_or_create_by_result_id(@old_result.id)
-        oldmark.save(false)
+        oldmark.save(:validate => false)
         @old_marks_map[criterion.id] = oldmark
       end
     end
@@ -343,7 +343,7 @@ class ResultsController < ApplicationController
 
       if @old_result
         oldmark = criterion.marks.find_or_create_by_result_id(@old_result.id)
-        oldmark.save(false)
+        oldmark.save(:validate => false)
         @old_marks_map[criterion.id] = oldmark
       end
     end


### PR DESCRIPTION
save(false) has been deprecated.  I replaced two instances of it with oldmark.save(:validate => false)
