### PR TITLE
FIX for issue 446. 'each' for Strings undefined in ruby 1.9

### DIFF
--- a/app/views/flexible_criteria/_new_flexible_criterion_errors.html.erb
+++ b/app/views/flexible_criteria/_new_flexible_criterion_errors.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <%= @errors.each do |error| %>
+  <%= @errors.each_line do |error| %>
     <li><%=error[0]%> <%=error[1]%></li>
   <% end %>
 </ul>


### PR DESCRIPTION
Changed from 'each' to 'each_line' because ruby 1.9.x no longer has 'each' for Strings.

'each' for Strings was removed in ruby 1.9 because it was confusing what you wanted to iterate over (chars, lines, etc).

'each' and 'each line' have the same functionality but 'each_line' is still available in 1.9.X.
