### PR TITLE
FIX for issue 734, fixed ordering using an OrderedHash

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -75,7 +75,7 @@ class Assignment < ActiveRecord::Base
   # Export a YAML formatted string created from the assignment rubric criteria.
   def export_rubric_criteria_yml
     criteria = self.rubric_criteria
-    final = Hash.new
+    final = ActiveSupport::OrderedHash.new
     criteria.each do |criterion|
       inner = ActiveSupport::OrderedHash.new
       inner["weight"] =  criterion["weight"]


### PR DESCRIPTION
Fixed preservation of ordering of download and upload of yaml rubric by using an OrderedHash. (Issue 734)
