### PR TITLE
Fix issue-658, login input now gets focus when opening the "switch role" modal

### DIFF
--- a/app/views/main/_role_switch_content.html.erb
+++ b/app/views/main/_role_switch_content.html.erb
@@ -19,7 +19,7 @@
     <%= button_to_function "Cancel", 'role_switch_modal.close()', :tabindex => 110 %>
   <% end %>
   <script>
-    $('effective_user_login').focus();
     role_switch_modal.open();
+    $('effective_user_login').focus();
   </script>
 </div>


### PR DESCRIPTION
In reference to: https://github.com/MarkUsProject/Markus/issues/658
Focus is now given after the modal is created, rather than trying to do so before.
