### PR TITLE
FIX for issue 619, fixed sorting on columns that contain html

### DIFF
--- a/app/views/graders/_boot.js.erb
+++ b/app/views/graders/_boot.js.erb
@@ -67,8 +67,8 @@ document.observe("dom:loaded", function() {
     },
     sorts: {
       nohtml: function(a, b) {
-        return a[FILTERTABLE_SORT].stripTags().toLowerCase() < b[FILTERTABLE_SORT].stripTags().toLowerCase();
-      }
+        return a[FILTERTABLE_SORT].stripTags().toLowerCase() > b[FILTERTABLE_SORT].stripTags().toLowerCase() ? 1 : -1;
+        }
     },
     total_count_id: 'all_groupings_count',
     filter_count_ids: {
@@ -133,11 +133,6 @@ document.observe("dom:loaded", function() {
     filter_count_ids: {
       assigned: 'assigned_graders_count',
       unassigned: 'unassigned_graders_count'
-    },
-    sorts: {
-      nohtml: function(a, b) {
-        return a[FILTERTABLE_SORT].stripTags().toLowerCase() < b[FILTERTABLE_SORT].stripTags().toLowerCase();
-        }
     }
   });
 
@@ -189,7 +184,7 @@ document.observe("dom:loaded", function() {
     total_count_id: 'all_criteria_count',
     sorts: {
       nohtml: function(a, b) {
-        return a[FILTERTABLE_SORT].stripTags().toLowerCase() < b[FILTERTABLE_SORT].stripTags().toLowerCase();
+        return a[FILTERTABLE_SORT].stripTags().toLowerCase() > b[FILTERTABLE_SORT].stripTags().toLowerCase() ? 1 : -1;
         }
     }
   });

--- a/app/views/groups/_boot.js.erb
+++ b/app/views/groups/_boot.js.erb
@@ -63,7 +63,7 @@ document.observe("dom:loaded", function() {
     },
     sorts: {
       nohtml: function(a, b) {
-        return a[FILTERTABLE_SORT].stripTags().toLowerCase() < b[FILTERTABLE_SORT].stripTags().toLowerCase();
+        return a[FILTERTABLE_SORT].stripTags().toLowerCase() > b[FILTERTABLE_SORT].stripTags().toLowerCase() ? 1 : -1;
       }
     },
     total_count_id: 'all_groupings_count',


### PR DESCRIPTION
Fixed improper sorting of columns that contained html with text (ie: checkboxes). Overwritten sort method inequality was reversed and expression was missing logic to change returned value to either 1 or -1. Affected columns: Assignments->Graders->Groups->graders column, Assignments->Graders->Criteria->graders column, Assignments->Groups->All Groups->members column, Assignments->Groups->Valid->members column . (Issue #619) 
