### PR TITLE
Fix for issue 968: Fix notice on dashboard warning users about using non-gecko based browsers

### DIFF
--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -4,10 +4,19 @@
 		"Bluff/excanvas.js" %>
 <% end %>
 
-<% if !@current_user.student? and
-    # If not Firefox display warning
-    (request.env['HTTP_USER_AGENT'].downcase =~ /gecko/i).nil? %>
-   <p class="notice"><%= I18n.t(:firefox_warning) %></p>
+<% if !@current_user.student? %>
+   <p id="firefox_warning" class="notice"><%= I18n.t(:firefox_warning) %></p>
+   
+   <script type="text/javascript">
+    //<![CDATA[
+    $('firefox_warning').hide();
+
+    // Display warning if not using a Gecko-based browser
+    if (!Prototype.Browser.Gecko) { 
+      $('firefox_warning').show();
+    }
+    //]]>
+  </script>
 <% end %>
 
 <div id="title_bar">


### PR DESCRIPTION
This is in reference to https://github.com/MarkUsProject/Markus/issues/968
Uses Prototype's browser detection. Now the notice displays as originally intended in non-gecko browsers.
