### PR TITLE
FIX for issue 912, fixed Assignments Submitted calculation on dashboard

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -735,6 +735,10 @@ class Assignment < ActiveRecord::Base
     return self.submissions.select { |submission| submission.result.marking_state == Result::MARKING_STATES[:complete] }
   end
 
+  def groups_submitted
+    return self.groupings.select { |grouping| grouping.has_submission?}
+  end
+
   private
 
   # Returns true if we are safe to set the repository name

--- a/app/views/main/_assignment_info_summary.html.erb
+++ b/app/views/main/_assignment_info_summary.html.erb
@@ -13,7 +13,7 @@
   <tr>
     <td><%= I18n.t(:assignments_submitted) %></td>
     <td>
-      <%= h( "#{assignment.submissions.size}/#{assignment.groupings.size}" ) %>
+      <%= h( "#{assignment.groups_submitted.size}/#{assignment.groupings.size}" ) %>
     </td>
   </tr>
 

--- a/test/unit/assignment_test.rb
+++ b/test/unit/assignment_test.rb
@@ -208,6 +208,38 @@ class AssignmentTest < ActiveSupport::TestCase
       assert @assignment.graded_submissions.size == 0
     end
 
+    context "with some assignments submitted once" do
+      setup do
+        grouping = Grouping.make(:assignment => @assignment)
+        2.times do
+          grouping = Grouping.make(:assignment => @assignment)
+          sub = Submission.make(:grouping => grouping)
+        end
+      end
+
+      should "have 2 groups submitted" do
+        assert @assignment.groups_submitted.size == 2
+        assert @assignment.submissions.size == 2
+      end
+    end
+
+    context "with some assignments submitted multiple times" do
+      setup do
+        grouping = Grouping.make(:assignment => @assignment)
+        2.times do
+          grouping = Grouping.make(:assignment => @assignment)
+          2.times do
+            sub = Submission.make(:grouping => grouping)
+          end
+        end
+      end
+
+      should "have 2 groups, each submitted 2 times" do
+        assert @assignment.groups_submitted.size == 2
+        assert @assignment.submissions.size == 4
+      end
+    end
+
     context "with some assignments graded" do
       setup do
         grouping = Grouping.make(:assignment => @assignment)


### PR DESCRIPTION
Fixed calculation of the number of assignments submitted (#912). It used to be the number of submissions, including multiple submissions per group. Now it calculates the number of groups with at least one submission. Two unit tests were written.
