### PR TITLE
Fix for issue 617: Display a modal warning users about functionality in IE, and suggesting switching browsers. Only shown on first visit of any session at the login page

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -57,6 +57,17 @@ class MainController < ApplicationController
       end
     end
 
+    # Check if it's the user's first visit this session
+    # Need to accomodate redirects for local and cookie testing
+    if (params.has_key?(:locale) && !params.has_key?(:cookieTest))
+      if session[:first_visit].nil?
+        @first_visit = true
+        session[:first_visit] = 'false'
+      else
+        @first_visit = false
+      end
+    end
+
     @current_user = current_user
     # redirect to main page if user is already logged in.
     if logged_in? && !request.post?

--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -1,6 +1,9 @@
-<%= javascript_include_tag 'application.js' -%>
-<%= javascript_include_tag 'prototype.js' -%>
-<%= javascript_include_tag 'rails.js' -%>
+<%= javascript_include_tag 'application.js',
+    'prototype.js',
+    'rails.js',
+    'livepipe/livepipe.js',
+    'livepipe/window.js',
+    'livepipe/tabs.js' %>
 <div class="login">
   <div class="login-greeting"><%= I18n.t(:welcome_to) %></div>
 
@@ -33,9 +36,31 @@
   </div>
 </div>
 
-<%# Try to put focus on the login text field on load %>
+<div id="ie_warning_dialog" style="display:none;">
+  <%= I18n.t(:ie_warning)%><br /><br />
+  <a href=\"http://www.mozilla.org/en-US/firefox/\">FireFox</a><br />
+  <a href=\"https://www.google.com/chrome/\">Google Chrome</a><br /><br />
+  <%= button_to_function "Ok", 'ie_warning_modal.close()', :tabindex => 100 %>
+  <div>&nbsp;</div>
+</div>
+
 <script type="text/javascript">
 //<![CDATA[
-  try{ document.getElementById('user_login').focus(); } catch(e) {}
+  <% if @first_visit %>
+    <%# Alert Internet Explorer users of incompatibility %>
+      if (Prototype.Browser.IE) {
+        var ie_warning_modal = null;
+
+        ie_warning_modal = new Control.Modal(
+          $('ie_warning_dialog'),
+          { overlayOpacity: 0.75, className: 'ie_warning_modal', fade: false }
+        );
+
+        ie_warning_modal.open();
+      }
+  <% end %>
+
+  <%# Try to put focus on the login text field on load %>
+  try { document.getElementById('user_login').focus(); } catch(e) { }
 //]]>
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     username_and_password_not_blank: "Your username and password must not be blank."
     session_expired:     "Your session has expired. Please log in"
     please_log_in:       "Please log in"
+    ie_warning: "It appears that you are using Internet Explorer. Please note that some features of MarkUs may not work as expected in your browser. For a better user-experience, we suggest considering:"
 
     # app/views/layouts/_header.html.erb
     log_out:            "Log out"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,6 +22,7 @@ fr:
     username_and_password_not_blank: "Veuillez entrer vos nom d'utilisateur et mot de passe."
     session_expired:     "Votre session a expiré. Merci de vous reconnecter."
     please_log_in:       "Merci de vous connecter."
+    ie_warning: "Il semble que vous utilisez Internet Explorer. Veuillez noter que certaines fonctionnalités de MarkUs ne peuvent pas fonctionner comme prévu dans votre navigateur. Pour une meilleure expérience, nous vous suggérons de considerer: "
 
     # app/views/layouts/_header.html.erb
     log_out:            "Déconnexion"

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1030,10 +1030,14 @@ input#extra_mark_description{
   margin-left: -50px;
 }
 
-#role_switch_dialog {
+#role_switch_dialog, #ie_warning_dialog {
   background-color: #fff;
   padding: 10px;  
   border: 10px solid #333;  
+}
+
+#ie_warning_dialog {
+  width: 400px;
 }
 
 #about_icon, #switch_role_icon {


### PR DESCRIPTION
This is in reference to: https://github.com/MarkUsProject/Markus/issues/617
It uses a modal for consistency, and it's only displayed at the beginning of each session. Otherwise you'd receive the notification on each redirect, including login errors.
