### PR TITLE
Fix issue-953: gave the annotation category pane a percentage-based width and added a min-width to the body.

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -7,6 +7,7 @@ body {
 	padding: 0;
 	font-family: "Lucida Grande", Verdana, Arial, sans-serif;
 	font-size: 0.8em;
+  min-width: 600px;
 }
 
 .clear {
@@ -236,7 +237,6 @@ legend {
 #header {
   padding: 3px;
   border-bottom: 1px solid #000;
-  min-width: 60em;
 }
 
 #user_info {
@@ -1618,6 +1618,7 @@ div.align_text_right {
 
 #flexible_criteria_pane, #annotation_category_pane	{
    padding: 0px 2%;
+   width: 24%;
 }
 
 #rubric_criteria_pane .criteria_fieldset, #flexible_criteria_pane .criteria_fieldset, #annotation_category_pane .annotation_categories_fieldset{


### PR DESCRIPTION
![Screen shot 2013-01-20 at 11 43 42 PM](https://f.cloud.github.com/assets/817212/82262/160ea92a-6398-11e2-966e-7c32525c0313.png)

In reference to https://github.com/MarkUsProject/Markus/issues/953
The min-width added to the body is less than that which already exists for the header, so I'm not imposing any restrictions not previously done.
