### PR TITLE
Fix for issue-860: assignments in the admin dashboard are now sorted by their latest due date in ASC order

### DIFF
--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -25,7 +25,8 @@
 <div class="wrapLeft">
 <p><%= I18n.t(:welcome_to_markus, {:user_name => @current_user.first_name}) %></p>
 
-  <% @assignments.each do |a| %>
+  <% # Display assignments and sort them in ASC order by their latest due date %>
+  <% @assignments.sort_by{|a| a.latest_due_date()}.each do |a| %>
     <%= render :partial => "assignment_summary", :locals => { :assignment => a } %>
   <% end %>
 


### PR DESCRIPTION
Completed in reference to https://github.com/MarkUsProject/Markus/issues/860
