### PR TITLE
Fix for issue-860: assignments are now sorted by due_date in ascending order by default

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -72,6 +72,9 @@ class Assignment < ActiveRecord::Base
   validate :minimum_number_of_groups, :check_timezone
   after_save :update_assigned_tokens
 
+  # Set the default order of assignments: in ascending order of due_date
+  default_scope order('due_date ASC')
+
   # Export a YAML formatted string created from the assignment rubric criteria.
   def export_rubric_criteria_yml
     criteria = self.rubric_criteria


### PR DESCRIPTION
Completed in reference to: https://github.com/MarkUsProject/Markus/issues/860
I didn't create any tests given that I simply defined a default_scope in the assignment model.
