### PR TITLE
Fix for issue-63: Added config directive to enable/disable the MarkusLogger

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -188,6 +188,8 @@ Markus::Application.configure do
   ###################################################################
   # Logging Options
   ###################################################################
+  # If set to true then the MarkusLogger will be enabled
+  MARKUS_LOGGING_ENABLED = true
   # If set to true then the rotation of the logfiles will be defined
   # by MARKUS_LOGGING_ROTATE_INTERVAL instead of the size of the file
   MARKUS_LOGGING_ROTATE_BY_INTERVAL = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -216,6 +216,8 @@ Markus::Application.configure do
   ###################################################################
   # Logging Options
   ###################################################################
+  # If set to true then the MarkusLogger will be enabled
+  MARKUS_LOGGING_ENABLED = true
   # If set to true then the rotation of the logfiles will be defined
   # by MARKUS_LOGGING_ROTATE_INTERVAL instead of the size of the file
   MARKUS_LOGGING_ROTATE_BY_INTERVAL = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -186,6 +186,9 @@ Markus::Application.configure do
   ###################################################################
   # Logging Options
   ###################################################################
+  # If set to true then the MarkusLogger will be enabled
+  # MarkusLogger-related tests will fail if set to false
+  MARKUS_LOGGING_ENABLED = true
   # If set to true then the rotation of the logfiles will be defined
   # by MARKUS_LOGGING_ROTATE_INTERVAL instead of the size of the file
   MARKUS_LOGGING_ROTATE_BY_INTERVAL = false

--- a/lib/classes/markus_logger.rb
+++ b/lib/classes/markus_logger.rb
@@ -94,19 +94,21 @@ class MarkusLogger
   #=== Exceptions
   # When the log level is not known then an exception of type ArgumentError is raised
   def log(msg, level=INFO)
-    case level
-    when INFO
-      @__logger__.info(msg)
-    when DEBUG
-      @__logger__.debug(msg)
-    when WARN
-      @__logger__.warn(msg)
-    when ERROR
-      @__errorLogger__.error(msg)
-    when FATAL
-      @__errorLogger__.fatal(msg)
-    else
-      raise ArgumentError,('Logger: Unknown loglevel')
+    if MarkusConfigurator.markus_config_logging_enabled?
+      case level
+      when INFO
+        @__logger__.info(msg)
+      when DEBUG
+        @__logger__.debug(msg)
+      when WARN
+        @__logger__.warn(msg)
+      when ERROR
+        @__errorLogger__.error(msg)
+      when FATAL
+        @__errorLogger__.fatal(msg)
+      else
+        raise ArgumentError,('Logger: Unknown loglevel')
+      end
     end
   end
 

--- a/lib/markus_configurator.rb
+++ b/lib/markus_configurator.rb
@@ -164,6 +164,15 @@ module MarkusConfigurator
   ######################################
   # MarkusLogger configuration
   ######################################
+  def markus_config_logging_enabled?
+    if defined? MARKUS_LOGGING_ENABLED
+      return MARKUS_LOGGING_ENABLED
+    else
+      #If not defined, default to true
+      return true
+    end
+  end
+  
   def markus_config_validate_file
     if defined? VALIDATE_FILE
       return VALIDATE_FILE


### PR DESCRIPTION
Fix in reference to https://github.com/MarkUsProject/Markus/issues/63
Uses a config directive and only writes to the logs if that directive is set to true.
