### PR TITLE
FIX for issue 1024

### DIFF
--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -256,7 +256,7 @@ module AutomatedTestsHelper
     list_run_scripts = scripts_to_run(assignment, call_on)
     arg_list = ""
     list_run_scripts.each do |script|
-      arg_list = arg_list + "#{script.script_name} #{script.halts_testing} "
+      arg_list = arg_list + "#{script.script_name.gsub(/\s/, "\\ ")} #{script.halts_testing} "
     end
     
     # Run script

--- a/automated-tests-files/test_runner/testrunner.rb
+++ b/automated-tests-files/test_runner/testrunner.rb
@@ -49,7 +49,7 @@ def runTest(fileName)
     # basic timeout check
     # if the test_suite runs for over N seconds, it times out
     Timeout.timeout($TIME_LIMIT) do
-      @pipe = IO.popen("./#{fileName}")
+      @pipe = IO.popen("./'#{fileName}'")
       Process.wait @pipe.pid
     end
   rescue Timeout::Error
@@ -102,7 +102,7 @@ def getNext(useSTD)
     return s
   else
     # return the next 2 arguments, which will be (fileName, tag)
-    args = "#{ARGV[$LAST_ARG]} #{ARGV[$LAST_ARG+1]}"
+    args = "#{ARGV[$LAST_ARG]}:#{ARGV[$LAST_ARG+1]}"
     $LAST_ARG = $LAST_ARG + 2
     return args
   end
@@ -171,14 +171,14 @@ def main()
   
   files = []
   flags = []
-  #using stdin can return nil, and using cmd line can return " ", but not nil
-  while(nextFile != nil && nextFile != " ") do
-    filedata = nextFile.split(' ')
+  #using stdin can return nil, and using cmd line can return ":", but not nil
+  while(nextFile != nil && nextFile != ":") do
+    filedata = nextFile.split(':')
 
     #extract the test script data
-    files.push(filedata[0])
+    files.push(filedata[0].gsub(/\s/, "\ "))
     flags.push(getBool(filedata[1]))
-    
+
     #get the next script
     nextFile = getNext(useSTD)
   end


### PR DESCRIPTION
The automated test script can now handle a file with a space in the name.

Instead of joining and splitting the argument list with a space, I decided to use a colon (:). Colons can't be used in filenames on Windows and Mac operating systems so there is unlikely to be an issue in the filename getting split up as there was with splitting on whitespace.
