### PR TITLE
FIX for issue 1015

### DIFF
--- a/app/models/test_script.rb
+++ b/app/models/test_script.rb
@@ -43,8 +43,8 @@
 
 class TestScript < ActiveRecord::Base
   belongs_to :assignment
-  has_many :test_results
-  has_many :test_script_results
+  has_many :test_results, :dependent => :delete_all
+  has_many :test_script_results, :dependent => :delete_all
   
   # Run sanitize_filename before saving to the database
   before_save :sanitize_filename


### PR DESCRIPTION
Deleting a test script should delete all of the associated results because the information about the test script (ie the name of the script and the max marks for the script) is no longer in the database and the results become useless. If the test script is deleted, then we don't need the results from it.
