### PR TITLE
FIX for issue 1022

### DIFF
--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -431,6 +431,9 @@ module AutomatedTestsHelper
     # Array for checking duplicate file names
     file_name_array = []
     
+    #add existing scripts names
+    params.each {|key, value| if(key[/test_script_\d+/] != nil) then file_name_array << value end}
+    
     # Retrieve all test scripts
     testscripts = params[:assignment][:test_scripts_attributes]
 


### PR DESCRIPTION
When a test script and support file gets uploaded the first time it is passed differently in the params hash than when it's created and updated. This caused the check for repeat filenames to not work properly when a a file being created is the same as an existing file. Added a line to add files being updated.
