### PR TITLE
FIX for issue 1029, add indicator for new annotations from remarking

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -8,12 +8,14 @@ class AnnotationsController < ApplicationController
     @submission_file_id = params[:submission_file_id]
     @submission_file = SubmissionFile.find(@submission_file_id)
     submission= @submission_file.submission
+    is_remark = submission.has_remark?
     if params[:annotation_type] == 'image' then
       @annotation = ImageAnnotation.new
       @annotation.update_attributes({
         :x1 => Integer(params[:x1]), :x2 => Integer(params[:x2]),
         :y1 => Integer(params[:y1]), :y2 => Integer(params[:y2]),
         :submission_file_id => params[:submission_file_id],
+        :is_remark => is_remark,
         :annotation_number => submission.annotations.count + 1
       })
     else
@@ -22,6 +24,7 @@ class AnnotationsController < ApplicationController
         :line_start => params[:line_start],
         :line_end => params[:line_end],
         :submission_file_id => params[:submission_file_id],
+        :is_remark => is_remark,
         :annotation_number => submission.annotations.count + 1
       })
     end
@@ -39,6 +42,7 @@ class AnnotationsController < ApplicationController
     @submission_file_id = params[:submission_file_id]
     @submission_file = SubmissionFile.find(@submission_file_id)
     submission= @submission_file.submission
+    is_remark = submission.has_remark?
     case params[:annotation_type]
       when 'text'
         @annotation = TextAnnotation.create({
@@ -46,6 +50,7 @@ class AnnotationsController < ApplicationController
           :line_end => params[:line_end],
           :annotation_text_id => @text.id,
           :submission_file_id => params[:submission_file_id],
+          :is_remark => is_remark,
           :annotation_number => submission.annotations.count + 1
         })
       when 'image'
@@ -54,6 +59,7 @@ class AnnotationsController < ApplicationController
           :submission_file_id => params[:submission_file_id],
           :x1 => Integer(params[:x1]), :x2 => Integer(params[:x2]),
           :y1 => Integer(params[:y1]), :y2 => Integer(params[:y2]),
+          :is_remark => is_remark,
           :annotation_number => submission.annotations.count + 1
         })
     end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -5,6 +5,7 @@ class Annotation < ActiveRecord::Base
   validates_presence_of :submission_file
   validates_presence_of :annotation_text
   validates_presence_of :annotation_number
+  validates_inclusion_of :is_remark, :in => [true, false]
 
   validates_associated      :submission_file
   validates_associated      :annotation_text

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -1,7 +1,7 @@
 <% annots.each do |annot| %>
   <li class="<%= cycle('annotations1', 'annotations2') %>">
 
-    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %></p>
+    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
     <div class="annotationContent" id="annotation_text_content_display_<%=(annot.annotation_text.id)%>">
       <%= simple_format(h(annot.annotation_text.content)) %>
     </div>

--- a/app/views/results/student/_annotation_summary.html.erb
+++ b/app/views/results/student/_annotation_summary.html.erb
@@ -1,7 +1,7 @@
 <% annots.each do |annot| %>
   <li class="<%= cycle('annotations1', 'annotations2') %>">
 
-    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %></p>
+    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
     <p class="annotationContent" id="annotation_text_content_display_<%=(annot.annotation_text.id)%>">
     <%=simple_format(h(annot.annotation_text.content))%>
     </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,7 @@ en:
         show_old_marks: "Show Old Mark Summary"
       annotation:
         from_line_to: "%{file_path}: Line %{line_start} to %{line_end}"
+        remark_flag: "(remark)"
         no_annotation_in_this_category: "There are no annotations in this category"
         new_annotation: "Create new annotation"
         annotation_category: "Annotation Category"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -287,6 +287,7 @@ fr:
         show_old_marks: "Afficher la note précédente "
       annotation:
         from_line_to: "%{file_path} : Lignes %{line_start} à %{line_end}"
+        remark_flag: "(retour)"
         no_annotation_in_this_category: "Il n'y a pas d'annotation dans cette catégorie"
         new_annotation: "Nouvelle annotation"
         annotation_category: "Catégorie de l'annotation"

--- a/db/migrate/20130402190548_add_is_remark_to_annotations.rb
+++ b/db/migrate/20130402190548_add_is_remark_to_annotations.rb
@@ -1,0 +1,9 @@
+class AddIsRemarkToAnnotations < ActiveRecord::Migration
+  def self.up
+    add_column :annotations, :is_remark, :boolean
+  end
+
+  def self.down
+    remove_column :annotations, :is_remark
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130219230002) do
+ActiveRecord::Schema.define(:version => 20130402190548) do
 
   create_table "annotation_categories", :force => true do |t|
     t.text     "annotation_category_name"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(:version => 20130219230002) do
     t.integer "y2"
     t.string  "type"
     t.integer "annotation_number"
+    t.boolean "is_remark"
   end
 
   add_index "annotations", ["submission_file_id"], :name => "index_annotations_on_assignmentfile_id"


### PR DESCRIPTION
Added an indicator in "Annotation Summary" tab for annotations that are added during remarking (#1029). The indicator is shown in both the marker's view and the student's view.

The French translation may need to be corrected.

![Screenshot from 2013-04-02 16:17:47](https://f.cloud.github.com/assets/993257/331439/ec7a81a0-9bec-11e2-9da0-287480652b17.png)
