### PR TITLE
Implementation for "show total" property in grade entry form

### DIFF
--- a/app/views/grade_entry_forms/_form.html.erb
+++ b/app/views/grade_entry_forms/_form.html.erb
@@ -35,6 +35,7 @@
     <%= raw(f.label :description, t(:description)) %>
     <%= raw(f.text_field :description) %><br />
 
+
     <%= raw(f.label :message) %>
     <%= raw(f.text_area :message, :rows => 8, :cols => 65) %><br />
 
@@ -44,6 +45,10 @@
 	                           :locale => I18n.default_locale}) %>
     <%= raw(t(:iso_date_format_example)) %>
 
+<br />
+
+    <%= raw(f.label :show_total, t('grade_entry_forms.show_total')) %>
+    <%= raw(f.check_box :show_total) %><br />
     <br />
 
     <h4><%= t('grade_entry_forms.specify_columns') %></h4>

--- a/app/views/grade_entry_forms/_grades_table.html.erb
+++ b/app/views/grade_entry_forms/_grades_table.html.erb
@@ -41,11 +41,19 @@
                                               :id => @grade_entry_form.id) %></td>
       <% end %>
 
-      <td class="student_total">
-	<div class="total_value" style="display:inline-block"><%= text_field_tag 'total_' + student.id.to_s,
-                                    h(@grade_entry_form.calculate_total_mark(student.id)),
-                                    :size => 4, :disabled => true %></div></td>
-      <td>
+       <% if @grade_entry_form.show_total %>
+	
+		<td class="student_total">
+			<div class="total_value" style="display:inline-block;">
+				<%= text_field_tag 'total_' + student.id.to_s,
+						    h(@grade_entry_form.calculate_total_mark(student.id)),
+
+						    :size => 4, :disabled => true %>
+			</div>
+		</td>
+	<% end %>
+
+	<td>
         <% if grade_entry_student.released_to_student %>
           <%= image_tag('icons/email_go.png')%>
         <% end %>

--- a/app/views/grade_entry_forms/_grades_table_column_names.html.erb
+++ b/app/views/grade_entry_forms/_grades_table_column_names.html.erb
@@ -78,12 +78,18 @@
     </th>
   <% end %>
 
-  <% # Display the total number of marks for this grade entry form
+  <% # Display the total number of marks for this grade entry form only if 
+     # the "show total" option is checked
   %>
-  <th <% if @current_user.admin? or @current_user.ta? %> class="student_total" <% end%> >
-    <%= t('grade_entry_forms.grades.total') + " " + h(@grade_entry_form.out_of_total) %>
-    <br /> <a href="#" onclick="toggleTotalColVisibility()"> <%= t('grade_entry_forms.toggle_column') %> </a>
-  </th>
+  <% if @grade_entry_form.show_total %>
+		<th class="student_total" >
+		<%= t('grade_entry_forms.grades.total') + " " + h(@grade_entry_form.out_of_total) %>
+		<% if @current_user.admin? or @current_user.ta? %>		
+			<br /> <a href="#" onclick="toggleTotalColVisibility()"> <%= t('grade_entry_forms.toggle_column') %> </a>
+		<% end %>
+		</th>
+  <% end %>
+
   <% if @current_user.admin? or @current_user.ta? %>
     <% # Extra column heading for marking state
     %>

--- a/app/views/grade_entry_forms/_list.html.erb
+++ b/app/views/grade_entry_forms/_list.html.erb
@@ -14,8 +14,8 @@
           <th><%=t(:description)%></th>
           <th><%=t(:shortened_date)%></th>
           <% # Note: this hides the results column within the student view %>
-	  <% if !@current_user.student? %>
-		<th><%=t('results.results_name')%></th> <% end %>
+
+		<th><%=t('results.results_name')%></th>
         </tr>
       </thead>
       <tbody>
@@ -38,23 +38,27 @@
                  %>
               <% end %>
             </td>
-	    <% if !@current_user.student? %>
+
             <td class="grade_entry_form_result">
               <% if !@g_id_entries.empty? && !@g_id_entries[grade_entry_form.id].nil? %>
-                <strong><%=t('mark_message')%></strong>
-                <% if grade_entry_form.all_blank_grades?(@g_id_entries[grade_entry_form.id]) %>
-                  <%= t('grade_entry_forms.grades.no_mark') %>
-                <% else %>
-                  <%= # show results
-                    ("%.2f" % (grade_entry_form.calculate_total_percent(@g_id_entries[grade_entry_form.id].user.id).to_s) + "%")
-                  %>
-                <% end %>
-                <%= ("(Class Average: " + ("%.2f" % (grade_entry_form.calculate_released_average)).to_s + "%)") %>
+		<% if grade_entry_form.show_total %>
+		        <strong><%=t('mark_message')%></strong>
+		        <% if grade_entry_form.all_blank_grades?(@g_id_entries[grade_entry_form.id]) %>
+		          <%= t('grade_entry_forms.grades.no_mark') %>
+		        <% else %>
+		          <%= # show results
+		            ("%.2f" % (grade_entry_form.calculate_total_percent(@g_id_entries[grade_entry_form.id].user.id).to_s) + "%")
+		          %>
+		        <% end %>
+		        <%= ("(Class Average: " + ("%.2f" % (grade_entry_form.calculate_released_average)).to_s + "%)") %>
+		<% else %>
+			<strong> <%= t('grade_entry_forms.students.detailed_marks_message') %> </strong>
+		<% end %>
               <% elsif grade_entry_form.date < Time.zone.now.to_date %>
                 <%= t('grade_entry_forms.students.no_results') %>
               <% end %>
             </td>
-	    <% end %>
+
           </tr>
         <% end %>
       </tbody>

--- a/app/views/grade_entry_forms/student_interface.html.erb
+++ b/app/views/grade_entry_forms/student_interface.html.erb
@@ -34,15 +34,16 @@
                 <% end %>
               </td>
           <% end %>
-
-          <td>
-            <% total = @grade_entry_form.calculate_total_mark(@student.id) %>
-            <% if total != "" %>
-              <%= total %>
-            <% else %>
-              <%= t('grade_entry_forms.grades.no_mark') %>
-            <% end %>
-         </td>
+	  <% if @grade_entry_form.show_total %>
+		  <td class=grade>
+		    <% total = @grade_entry_form.calculate_total_mark(@student.id) %>
+		    <% if total != "" %>
+		      <%= total %>
+		    <% else %>
+		      <%= t('grade_entry_forms.grades.no_mark') %>
+		    <% end %>
+		 </td>
+	  <% end %>
         </tr>
      </table>
    <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,6 +401,7 @@ en:
       toggle_column: "hide/show"
       properties: "Marks Spreadsheet Properties"
       required_fields: "Required Fields <span class='required_field'>*</span>"
+      show_total: "Show Total"
       create:
         success: "Successfully created new marks spreadsheet"
         title: "Add Marks Spreadsheet"
@@ -423,6 +424,7 @@ en:
       students:
         title: "Your Term Marks"
         no_results: "There are no marks available yet."
+        detailed_marks_message: "Detailed marks are available."
       csv:
         incomplete_header: "Incomplete grade entry item names or totals."
         incomplete_row: "Contains too little information."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -402,6 +402,7 @@ fr:
       toggle_column: "cacher/montrer"
       properties: "Propriétés de la feuille de note"
       required_fields: "Champs obligatoires <span class='required_field'>*</span>"
+      show_total: "Montrer Totale"
       create:
         success: "Feuille de notes créée"
         title: "Créer une nouvelle feuille de notes"
@@ -423,6 +424,7 @@ fr:
       students:
         title: "Vos feuilles de notes"
         no_results: "Il n'y a pas encore de résultats pour cette feuille de notes."
+        detailed_marks_message: "Marques détaillées sont disponibles."
       csv:
         incomplete_header: "Totaux ou noms manquants."
         incomplete_row: "Ne contient pas assez d'informations."

--- a/db/migrate/20130403002432_add_column_show_total_to_grade_entry_forms_table.rb
+++ b/db/migrate/20130403002432_add_column_show_total_to_grade_entry_forms_table.rb
@@ -1,0 +1,9 @@
+class AddColumnShowTotalToGradeEntryFormsTable < ActiveRecord::Migration
+  def self.up
+    add_column :grade_entry_forms, :show_total, :boolean
+  end
+
+  def self.down
+    remove_column :grade_entry_forms, :show_total
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130219230002) do
+ActiveRecord::Schema.define(:version => 20130403002432) do
 
   create_table "annotation_categories", :force => true do |t|
     t.text     "annotation_category_name"
@@ -153,6 +152,7 @@ ActiveRecord::Schema.define(:version => 20130219230002) do
     t.date     "date"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "show_total"
   end
 
   add_index "grade_entry_forms", ["short_identifier"], :name => "index_grade_entry_forms_on_short_identifier", :unique => true

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -335,6 +335,13 @@ legend {
 }
 
 
+/* Left aligns show total checkbox on 
+   grade entry form properties */
+
+#grade_entry_form_show_total {
+  min-width: 0px;
+}
+
 /* menu */
 
 #menu {


### PR DESCRIPTION
added a new feature in the grades entry form where admins can control whether or not to render the totals column:
- added a new "show total" checkbox that is displayed when creating a new form or editing an existing one
- made relevant database changes
- added internationalization support for new labels
- made CSS changes in the grade entry form view
