### PR TITLE
Update README.rst and markus-contributors.txt with students from UCOSP Winter 2013

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,19 +132,20 @@ MarkUs' development has been supported by the University of Toronto, École
 Centrale de Nantes, et. al. Kudos to everyone who turned that support into
 working code:
 
-Aaron Lee, Adam Goucher, Aimen Khan, Alexandre Lissy, Alex Krassikov, Amanda
-Manarin, Andrew Louis, Anthony Le Jallé, Anton Braverman, Benjamin Thorent,
+Aaron Lee, Adam Goucher, Aimen Khan, Alexandre Lissy, Alex Krassikov, Alysha Kwok,
+Amanda Manarin, Andrew Louis, Anthony Le Jallé, Anton Braverman, Benjamin Thorent,
 Benjamin Vialle, Bertan Guven, Brian Xu, Bryan Shen, Camille Guérin, Catherine
 Fawcett, Christian Jacques, Christine Yu, Clément Delafargue, Clément Schiano,
-Danesh Dadachanji, Diane Tam, Dina Sabie, Egor Philippov, Erik Traikov, Evan
-Browning, Farah Juma, Fernando Garces, Gabriel Roy-Lortie, Geoffrey Flores,
-Hanson Wu, Horatiu Halmaghi, Ibrahim Shahin, Jay Parekh, Jérôme Gazel, Jiahui
-Xu, Jordan Saleh, Joseph Mate, Joseph Maté, Justin Foong, Karel Kahula, Kurtis
-Schmidt, Luke Kysow, Mélanie Gaudet, Michael Lumbroso, Mike Conley, Mike
-Gunderloy, Misa Sakamoto, Neha Kumar, Nelle Varoquaux, Nicolas Bouillon,
-Nicolas Carougeau, Noé Bedetti, Oloruntobi Ogunbiyi, Razvan Vlaicu, Robert
-Burke, Samuel Gougeon, Sean Budning, Severin Gehwolf, Shion Kashimura, Simon
-Lavigne-Giroux, Tara Clark, Tianhai Hu, Valentin Roger, Veronica Wong, Victoria
-Mui, Victor Ivri, Vivien Suen, Yansong Zang
+Danesh Dadachanji, Daryn Lam, Daniel St. Jules, Dina Sabie, Diane Tam, Egor
+Philippov, Erik Traikov, Evan Browning, Farah Juma, Fernando Garces, Gabriel Roy-
+Lortie, Geoffrey Flores, Ghislain Guiot, Hanson Wu, Horatiu Halmaghi, Ian Smith,
+Ibrahim Shahin, Jay Parekh, Jérôme Gazel, Jiahui Xu, Jordan Saleh, Joseph Mate,
+Joseph Maté, Justin Foong, Karel Kahula, Kurtis Schmidt, Luke Kysow, Marc Bodmer,
+Mélanie Gaudet, Michael Lumbroso, Mike Conley, Mike Gunderloy, Mike Stewart, Mike
+Wu, Misa Sakamoto, Neha Kumar, Nelle Varoquaux, Nicolas Bouillon, Nick Lee, Nicolas
+Carougeau, Noé Bedetti, Oloruntobi Ogunbiyi, Oussama Ben Amar, Razvan Vlaicu, Robert
+Burke, Samuel Gougeon, Sean Budning, Severin Gehwolf, Shion Kashimura, Simon Lavigne-
+Giroux, Tara Clark, Tianhai Hu, Valentin Roger, Veronica Wong, Victoria Mui, Victor
+Ivri, Vivien Suen, Yansong Zang
 
 Supervisors: Karen Reid, Morgan Magnin

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -3,6 +3,7 @@ Adam Goucher
 Aimen Khan
 Alex Krassikov
 Alexandre Lissy
+Alysha Kwok
 Amanda Manarin
 Andrew Louis
 Andrey Kulakevich
@@ -24,6 +25,7 @@ Clément Delafargue
 Clément Schiano
 Danesh Dadachanji
 Daryn Lam
+Daniel St. Jules
 Derek Dowling
 Diane Tam
 Dina Sabie
@@ -39,6 +41,7 @@ Geoffrey Flores
 Ghislain Guiot
 Hanson Wu
 Horatiu Halmaghi
+Ian Smith
 Ibrahim Shahin
 Jay Parekh
 Jeffrey Ling
@@ -54,21 +57,26 @@ Karel Kahula
 Kira McCoan
 Kristian Lejao
 Kurtis Schmidt
-Luke Kysow 
+Luke Kysow
+Marc Bodmer
 Mélanie Gaudet
 Michael Ing
 Michael Lumbroso
 Michael Margel
 Mike Conley
 Mike Gunderloy
+Mike Stewart
+Mike Wu
 Mina Almasry
 Misa Sakamoto
 Neha Kumar
 Nelle Varoquaux
+Nick Lee
 Nicolas Bouillon
 Nicolas Carougeau
 Noé Bedetti
 Oloruntobi Ogunbiyi
+Oussama Ben Amar
 Razvan Vlaicu
 Robert Burke
 Samuel Gougeon


### PR DESCRIPTION
Added Alysha Kwok, Daryn Lam, Daniel St. Jules, Ian Smith, Marc Bodmer, Mike Stewart, Mike Wu, Nick Lee, and Oussama Ben Amar to the list.
