### PR TITLE
Correction of errors in functional tests

### DIFF
--- a/test/functional/annotations_controller_test.rb
+++ b/test/functional/annotations_controller_test.rb
@@ -123,7 +123,7 @@ class AnnotationsControllerTest < AuthenticatedControllerTest
     end # End context :create image
 
     should "on :destroy" do
-      anno = TextAnnotation.create({
+      anno = TextAnnotation.make({
         :line_start => 1, :line_end => 1,
         :annotation_text_id => @annotation_text.id,
         :submission_file_id =>  @submission_file.id,
@@ -135,7 +135,7 @@ class AnnotationsControllerTest < AuthenticatedControllerTest
     end # End context :destroy
 
     should "on :update_annotation" do
-      anno = TextAnnotation.create({
+      anno = TextAnnotation.make({
         :line_start => 1, :line_end => 1,
         :annotation_text_id => @annotation_text.id,
         :submission_file_id =>  @submission_file.id})
@@ -199,7 +199,7 @@ class AnnotationsControllerTest < AuthenticatedControllerTest
     end # End context :create image
 
     should "on :destroy" do
-      anno = TextAnnotation.create({
+      anno = TextAnnotation.make({
         :line_start => 1, :line_end => 1,
         :annotation_text_id => @annotation_text.id,
         :submission_file_id =>  @submission_file.id,
@@ -211,7 +211,7 @@ class AnnotationsControllerTest < AuthenticatedControllerTest
     end # End context :destroy
 
     should "on :update_annotation" do
-      anno = TextAnnotation.create({
+      anno = TextAnnotation.make({
         :line_start => 1, :line_end => 1,
         :annotation_text_id => @annotation_text.id,
         :submission_file_id =>  @submission_file.id})


### PR DESCRIPTION
For me, problems were due to the use of `create()` instead of `make()` function.
Exactly, the `is_remark` attribute were missed for the model TextAnnotation.
