### PR TITLE
Correction of the error in unit tests

### DIFF
--- a/test/unit/penalty_decay_period_submission_rule_test.rb
+++ b/test/unit/penalty_decay_period_submission_rule_test.rb
@@ -47,7 +47,7 @@ class PenaltyDecayPeriodSubmissionRuleTest < ActiveSupport::TestCase
 
     should "be able to calculate collection time for a grouping" do
       assert Time.now <  @assignment.due_date
-      assert_equal @assignment.due_date, @rule.calculate_grouping_collection_time(@membership.grouping)
+      assert_equal @assignment.due_date.to_a, @rule.calculate_grouping_collection_time(@membership.grouping).to_a
     end
 
     should "not apply decay period deductions for on-time submissions" do


### PR DESCRIPTION
The error seems come from the `usec` of the TimeWithZone.

That is somewhere, when the object TimeWithZone is created, all content is put except `usec`.
I didn't find where is the mistake. I look for on the web and some people who have the same problem say that we can just test equity with `object.to_a`.
