### PR TITLE
Correction of find deprecated

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -6,7 +6,7 @@ class AdminsController < ApplicationController
   end
 
   def populate
-    admins_data = Admin.find(:all, :order => "user_name")
+    admins_data = Admin.all(:order => "user_name")
     # construct_table_rows defined in UsersHelper
     @admins = construct_table_rows(admins_data)
   end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -42,7 +42,7 @@ class GradersController < ApplicationController
 
   def populate_graders
     @assignment = Assignment.find(params[:assignment_id])
-    @graders = Ta.find(:all)
+    @graders = Ta.all
     @table_rows = construct_grader_table_rows(@graders, @assignment)
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -80,7 +80,7 @@ class GroupsController < ApplicationController
 
     # Checking if a group with this name already exists
 
-    if (@groups = Group.find(:first, :conditions => {:group_name =>
+    if (@groups = Group.first(:conditions => {:group_name =>
     [params[:new_groupname]]}))
        existing = true
        groupexist_id = @groups.id
@@ -99,7 +99,7 @@ class GroupsController < ApplicationController
       params[:groupexist_id] = groupexist_id
       params[:assignment_id] = @assignment.id
 
-      if Grouping.find(:all, :conditions => ["assignment_id =
+      if Grouping.all(:conditions => ["assignment_id =
       :assignment_id and group_id = :groupexist_id", {:groupexist_id =>
       groupexist_id, :assignment_id => @assignment.id}])
          flash[:fail_notice] = I18n.t('groups.rename_group.already_in_use')
@@ -141,7 +141,7 @@ class GroupsController < ApplicationController
   def populate_students
     @assignment = Assignment.find(params[:assignment_id],
                                   :include => [:groupings])
-    @students = Student.find(:all)
+    @students = Student.all
     @table_rows = construct_student_table_rows(@students, @assignment)
   end
 

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -150,7 +150,7 @@ class MainController < ApplicationController
       redirect_to :controller => 'assignments', :action => 'index'
       return
     end
-    @assignments = Assignment.find(:all)
+    @assignments = Assignment.all
     render :index, :layout => 'content'
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -12,9 +12,8 @@ class NotesController < ApplicationController
     @highlight_field = params[:highlight_field]
     @number_of_notes_field = params[:number_of_notes_field]
 
-    @notes = Note.find(:all,
-                       :conditions => {:noteable_id => @noteable.id,
-                                       :noteable_type => @noteable.class.name})
+    @notes = Note.all(:conditions => {:noteable_id => @noteable.id,
+                                      :noteable_type => @noteable.class.name})
     render :partial => "notes/modal_dialogs/notes_dialog_script.rjs"
   end
 
@@ -37,7 +36,7 @@ class NotesController < ApplicationController
   end
 
   def index
-    @notes = Note.find(:all, :order => "created_at DESC", :include => [:user, :noteable])
+    @notes = Note.all(:order => "created_at DESC", :include => [:user, :noteable])
     @current_user = current_user
     # Notes are attached to noteables, if there are no noteables, we can't make notes.
     @noteables_available = Note.noteables_exist?
@@ -72,7 +71,7 @@ class NotesController < ApplicationController
   def noteable_object_selector
     case params[:noteable_type]
       when "Student"
-        @students = Student.find(:all, :order => "user_name")
+        @students = Student.all(:order => "user_name")
       when "Assignment"
         @assignments = Assignment.all
       when "Grouping"

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -35,7 +35,8 @@ class ResultsController < ApplicationController
 
     @old_result = nil
     if @submission.remark_submitted?
-      @old_result = Result.find(:all, :conditions => ["submission_id = ?", @submission.id], :order =>["id ASC"])[0]
+      @old_result = Result.all(:conditions => ["submission_id = ?", @submission.id],
+                               :order =>["id ASC"])[0]
     end
 
     @annotation_categories = @assignment.annotation_categories
@@ -74,10 +75,8 @@ class ResultsController < ApplicationController
          m.grouping
        end
     elsif current_user.admin?
-      groupings = @assignment.groupings.find(
-                      :all,
-                      :include => :group,
-                      :order => 'id ASC')
+      groupings = @assignment.groupings.all(:include => :group,
+                                            :order => 'id ASC')
     end
 
     # If a grouping's submission's marking_status is complete, we're not going

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -7,7 +7,7 @@ class SectionsController < ApplicationController
   # Displays sections, and allows to create them
   #TODO Displays metrics concerning users and sections
   def index
-    @sections = Section.find(:all)
+    @sections = Section.all
   end
 
   def new

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -12,22 +12,21 @@ class StudentsController < ApplicationController
   end
 
   def index
-    @students = Student.find(:all, :order => "user_name")
-    @sections = Section.find(:all, :order => "name")
+    @students = Student.all(:order => "user_name")
+    @sections = Section.all(:order => "name")
   end
 
   def populate
-    @students_data = Student.find(:all,
-                                  :order => "user_name",
-                                  :include => [:section,
-                                               :grace_period_deductions])
+    @students_data = Student.all(:order => "user_name",
+                                 :include => [:section,
+                                              :grace_period_deductions])
     # construct_table_rows defined in UsersHelper
     @students = construct_table_rows(@students_data)
   end
 
   def edit
     @user = Student.find_by_id(params[:id])
-    @sections = Section.find(:all, :order => "name")
+    @sections = Section.all(:order => "name")
   end
 
   def update
@@ -36,7 +35,7 @@ class StudentsController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if !@user.update_attributes(attrs)
       flash[:error] = I18n.t("students.update.error")
-      @sections = Section.find(:all, :order => "name")
+      @sections = Section.all(:order => "name")
       render :edit
     else
       flash[:success] = I18n.t("students.update.success",
@@ -76,7 +75,7 @@ class StudentsController < ApplicationController
 
   def new
     @user = Student.new(params[:user])
-    @sections = Section.find(:all, :order => "name")
+    @sections = Section.all(:order => "name")
   end
 
   def create
@@ -89,7 +88,7 @@ class StudentsController < ApplicationController
                                :user_name => @user.user_name)
       redirect_to :action => 'index' # Redirect
     else
-      @sections = Section.find(:all, :order => "name")
+      @sections = Section.all(:order => "name")
       flash[:error] = I18n.t('students.create.error')
       render :new
     end
@@ -105,7 +104,7 @@ class StudentsController < ApplicationController
   #downloads users with the given role as a csv list
   def download_student_list
     #find all the users
-    students = Student.find(:all, :order => "user_name")
+    students = Student.all(:order => "user_name")
     case params[:format]
     when "csv"
       output = User.generate_csv_list(students)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -254,7 +254,7 @@ class SubmissionsController < ApplicationController
       flash[:error] = I18n.t("collect_submissions.could_not_collect",
         :assignment_identifier => assignment.short_identifier)
     else
-      groupings = assignment.groupings.find(:all, :include => :tas, :conditions => ["users.id = ?", current_user.id])
+      groupings = assignment.groupings.all(:include => :tas, :conditions => ["users.id = ?", current_user.id])
       submission_collector = SubmissionCollector.instance
       submission_collector.push_groupings_to_queue(groupings)
       flash[:success] = I18n.t("collect_submissions.collection_job_started",
@@ -316,10 +316,11 @@ class SubmissionsController < ApplicationController
 
     #Eager load all data only for those groupings that will be displayed
     sorted_groupings = @groupings
-    @groupings = Grouping.find(:all, :conditions => {:id => sorted_groupings},
-      :include => [:assignment, :group, :grace_period_deductions,
-        {:current_submission_used => :results},
-        {:accepted_student_memberships => :user}])
+    @groupings = Grouping.all(:conditions => {:id => sorted_groupings},
+                              :include =>
+                                  [:assignment, :group, :grace_period_deductions,
+                                   {:current_submission_used => :results},
+                                   {:accepted_student_memberships => :user}])
 
     #re-sort @groupings by the previous order, because eager loading query
     #messed up the grouping order

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -3,11 +3,11 @@ class TasController < ApplicationController
   before_filter  :authorize_only_for_admin
 
   def index
-    @tas = Ta.find(:all, :order => "user_name")
+    @tas = Ta.all(:order => "user_name")
   end
 
   def populate
-    @tas_data = Ta.find(:all, :order => "user_name")
+    @tas_data = Ta.all(:order => "user_name")
     # construct_table_rows defined in UsersHelper
     @tas = construct_table_rows(@tas_data)
   end
@@ -56,7 +56,7 @@ class TasController < ApplicationController
   #downloads users with the given role as a csv list
   def download_ta_list
     #find all the users
-    tas = Ta.find(:all, :order => "user_name")
+    tas = Ta.all(:order => "user_name")
     case params[:format]
     when "csv"
       output = User.generate_csv_list(tas)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -336,8 +336,8 @@ class Assignment < ActiveRecord::Base
       group.save
     else
       return nil if new_group_name.nil?
-      if Group.find(:first, :conditions => {:group_name => new_group_name})
-        group = Group.find(:first, :conditions => {:group_name =>       new_group_name})
+      if Group.first(:conditions => {:group_name => new_group_name})
+        group = Group.first(:conditions => {:group_name => new_group_name})
         if !self.groupings.find_by_group_id(group.id).nil?
           raise "Group #{new_group_name} already exists"
         end
@@ -358,7 +358,7 @@ class Assignment < ActiveRecord::Base
   # Create all the groupings for an assignment where students don't work
   # in groups.
   def create_groupings_when_students_work_alone
-     @students = Student.find(:all)
+     @students = Student.all
      for student in @students do
        if !student.has_accepted_grouping_for?(self.id)
         student.create_group_for_working_alone_student(self.id)

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -65,7 +65,7 @@ class GradeEntryForm < ActiveRecord::Base
     totalMarks = 0
     numReleased = 0
 
-    grade_entry_students = self.grade_entry_students.find(:all, :conditions => { :released_to_student => true })
+    grade_entry_students = self.grade_entry_students.all(:conditions => { :released_to_student => true })
     grade_entry_students.each do |grade_entry_student|
       totalMark = self.calculate_total_mark(grade_entry_student.user_id)
       if totalMark != BLANK_MARK

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -32,7 +32,7 @@ class Result < ActiveRecord::Base
   #returns the sum of the marks not including bonuses/deductions
   def get_subtotal
     total = 0.0
-    self.marks.find(:all, :include => [:markable]).each do |m|
+    self.marks.all(:include => [:markable]).each do |m|
       total = total + m.get_mark
     end
     return total

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -74,7 +74,7 @@ class Student < User
 
   def memberships_for(aid)
      @student = self
-     @memberships = StudentMembership.find(:all, :conditions => {:user_id => @student.id})
+     @memberships = StudentMembership.all(:conditions => {:user_id => @student.id})
      @memberships.each do |m|
        if m.grouping.assignment_id != aid
          @memberships.delete(m)
@@ -112,7 +112,7 @@ class Student < User
       @assignment = Assignment.find(aid)
       @grouping = Grouping.new
       @grouping.assignment_id = @assignment.id
-      if !Group.find(:first, :conditions => {:group_name => self.user_name}).nil?
+      if !Group.first(:conditions => {:group_name => self.user_name}).nil?
         @group = Group.find(:first, :conditions => {:group_name => self.user_name})
       else
         @group = Group.new(:group_name => self.user_name)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -56,16 +56,16 @@ class Submission < ActiveRecord::Base
   # returns the original result 
   def get_original_result
     if self.remark_result_id.nil?
-      result = Result.find(:first, :conditions => ["submission_id = ?", self.id])
+      result = Result.first(:conditions => ["submission_id = ?", self.id])
     else 
-      result = Result.find(:first, :conditions => ["submission_id = ? AND id != ?", self.id, self.remark_result_id])
+      result = Result.first(:conditions => ["submission_id = ? AND id != ?", self.id, self.remark_result_id])
     end
     return result
   end
 
   # returns the remark result if exists, returns nil if does not exist
   def get_remark_result
-    result = Result.find(:first, :conditions => ["id = ?", self.remark_result_id])
+    result = Result.first(:conditions => ["id = ?", self.remark_result_id])
     return result
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ActiveRecord::Base
   #TODO: make these proper associations. They work fine for now but
   # they'll be slow in production
   def active_groupings
-    self.groupings.find(:all, :conditions => ["memberships.membership_status != :u", { :u => StudentMembership::STATUSES[:rejected]}])
+    self.groupings.all(:conditions => ["memberships.membership_status != :u", { :u => StudentMembership::STATUSES[:rejected]}])
   end
 
   # Helper methods -----------------------------------------------------


### PR DESCRIPTION
find(:first) and find(:all) are deprecated in favour of first and all methods. Support will be removed from Rails 3.2.

I found this link which speaks about it: http://m.onkey.org/active-record-query-interface
