### PR TITLE
Closes 1104: Indicate to the grader a post deadline submission

### DIFF
--- a/app/views/submissions/submissions_table_row/_table_row.html.erb
+++ b/app/views/submissions/submissions_table_row/_table_row.html.erb
@@ -62,6 +62,9 @@
     <% if !grouping.has_submission? %>
     -
     <% else %>
+      <%= image_tag 'icons/error.png',
+                    :alt => t(:past_due_date_edit_result_warning),
+                    :title => t(:past_due_date_edit_result_warning) if grouping.past_due_date? %>
       <%= I18n.l(grouping.current_submission_used.revision_timestamp :format => :long_date) %>
     <% end %>
     </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,7 @@ en:
     encoding:           "Encoding"
 
     marks_released_notice:  "The marks have been released. You cannot change the grades."
+    commit_after_due_date: "This commit is after the due date."
     past_due_date_edit_warning:  "WARNING:  The due date you have selected is in the past."
     past_due_date_edit_result_warning: "The last commit of this group is after the due date."
     release_marks: "Release Marks"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -228,6 +228,7 @@ fr:
     encoding:           "Codage"
 
     marks_released_notice:  "Les notes sont maintenant affichées. Vous ne pouvez plus les changer."
+    commit_after_due_date: "Ce commit est postérieur à la date de rendu."
     past_due_date_edit_warning:  "ATTENTION ! La date de retour que vous avez choisie est antérieure à la date actuelle."
     past_due_date_edit_result_warning: "La date du dernier rendu de ce groupe est postérieure à la date de retour."
     release_marks: "Afficher les notes aux étudiants"


### PR DESCRIPTION
In reference to #1104
- Adding a warning icon in submission/browse before the date
