### PR TITLE
Closes #1120: Grader should go to submissions

### DIFF
--- a/app/views/layouts/_sub_menu.html.erb
+++ b/app/views/layouts/_sub_menu.html.erb
@@ -132,7 +132,9 @@
 </div>
 
 <% end %>
-<% elsif @current_user.ta? and controller.controller_name == 'assignments' %>
+<% elsif @current_user.ta? and (controller.controller_name == 'assignments' ||
+                                controller.controller_name == 'submissions' ||
+                                controller.controller_name == 'results') %>
 <div id="sub_menu">
   <ul id="root" class="level1 horizontal">
    <li class="level1 visible_dropdown">

--- a/test/functional/submissions_controller_test.rb
+++ b/test/functional/submissions_controller_test.rb
@@ -336,7 +336,7 @@ class SubmissionsControllerTest < AuthenticatedControllerTest
        
         should 'per_page and sort_by not defined so cookies are set to default' do
           Assignment.stubs(:find).returns(@assignment)
-          @assignment.expects(:short_identifier).once.returns('a1')
+          @assignment.expects(:short_identifier).twice.returns('a1')
           @assignment.submission_rule.expects(:can_collect_now?).once.returns(true)
 
           @c_per_page = @grader.id.to_s + '_' + @assignment.id.to_s + '_per_page'
@@ -353,7 +353,7 @@ class SubmissionsControllerTest < AuthenticatedControllerTest
         
         should 'per_page and sort_by defined so cookies are set to their values' do
           Assignment.stubs(:find).returns(@assignment)
-          @assignment.expects(:short_identifier).once.returns('a1')
+          @assignment.expects(:short_identifier).twice.returns('a1')
           @assignment.submission_rule.expects(:can_collect_now?).once.returns(true) 
 
           @c_per_page = @grader.id.to_s + '_' + @assignment.id.to_s + '_per_page'


### PR DESCRIPTION
In reference to #1120
- add of the rule for the grader to see the `sub_menu` in `submissions`
  and `results` pages.
- modification of tests which were, for me, obsolete.
