### PR TITLE
Closes #197: Encoding breaks

### DIFF
--- a/app/views/results/common/codeviewer.rjs
+++ b/app/views/results/common/codeviewer.rjs
@@ -2,7 +2,14 @@
   begin
     page['code_pane'].onmousemove = nil
     # Non-binary files
+
     if !SubmissionFile.is_binary?(@file_contents)
+
+      begin
+        @file_contents = Iconv.iconv('utf-8', 'utf-8', @file_contents)
+      rescue Iconv::Failure
+        @file_contents = Iconv.iconv('utf-8', 'ISO-8859-1', @file_contents)
+      end
       page.replace_html 'codeviewer',
         :partial => 'results/common/text_codeviewer',
         :locals => { :uid => params[:uid], :file_contents => @file_contents,


### PR DESCRIPTION
In reference with #197.

My tests work with that modification, but we need to find a better solution.
- added an Iconv encoding to allow possibility unlock codeviewer.

EDIT: Also, in reference with #338. 
