### PR TITLE
Fix for 1152: Set include_root_in_json to false, and added API functional tests to check for root

### DIFF
--- a/config/initializers/05_new_rails_defaults.rb
+++ b/config/initializers/05_new_rails_defaults.rb
@@ -1,7 +1,8 @@
 # These settings change the behavior of Rails 2 apps and will be defaults
 # for Rails 3. You can remove this initializer when Rails 3 is released.
 
-# Default as of Rails 3.1. Don't use the class name as root for JSON output
+# As of Rails 3.1.0, including the Active Record class name as root for JSON
+# serialized output is disabled by default
 ActiveRecord::Base.include_root_in_json = false
 
 # Store the full class name (including module namespace) in STI type column.

--- a/test/functional/api/assignments_controller_test.rb
+++ b/test/functional/api/assignments_controller_test.rb
@@ -90,12 +90,18 @@ class Api::AssignmentsControllerTest < ActionController::TestCase
     context 'getting a json response' do
       setup do
         @request.env['HTTP_ACCEPT'] = 'application/json'
-        get 'show', :id => 'garbage'
       end
 
       should 'be successful' do
+        get 'show', :id => 'garbage'
         assert_template 'shared/http_status'
         assert_equal @response.content_type, 'application/json'
+      end
+
+      should 'not use the ActiveRecord class name as the root' do
+        assignment = Assignment.make
+        get 'show', :id => assignment.id.to_s
+        assert !@response.body.include?('{"assignment":')
       end
     end
 

--- a/test/functional/api/groups_controller_test.rb
+++ b/test/functional/api/groups_controller_test.rb
@@ -87,12 +87,18 @@ class Api::GroupsControllerTest < ActionController::TestCase
     context 'getting a json response' do
       setup do
         @request.env['HTTP_ACCEPT'] = 'application/json'
-        get 'show', :assignment_id => 'garbage', :id => 'garbage'
       end
 
       should 'be successful' do
+        get 'show', :assignment_id => 'garbage', :id => 'garbage'
         assert_template 'shared/http_status'
         assert_equal @response.content_type, 'application/json'
+      end
+
+      should 'not use the ActiveRecord class name as the root' do
+        grouping = Grouping.make
+        get 'index', :assignment_id => grouping.assignment.id.to_s
+        assert !@response.body.include?('{"group":')
       end
     end
 

--- a/test/functional/api/users_controller_test.rb
+++ b/test/functional/api/users_controller_test.rb
@@ -217,12 +217,18 @@ class Api::UsersControllerTest < ActionController::TestCase
     context 'getting a json response' do
       setup do
         @request.env['HTTP_ACCEPT'] = 'application/json'
-        get 'show', :id => 'garbage'
       end
 
       should 'be successful' do
+        get 'show', :id => 'garbage'
         assert_template 'shared/http_status'
         assert_equal @response.content_type, 'application/json'
+      end
+
+      should 'not use the ActiveRecord class name as the root' do
+        user = Admin.make
+        get 'show', :id => user.id.to_s
+        assert !@response.body.include?('{"admin":')
       end
     end
 


### PR DESCRIPTION
This is in reference to issue https://github.com/MarkUsProject/Markus/issues/1152
