### PR TITLE
Closes #1164: Session lost

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -17,7 +17,8 @@
                              'livepipe/livepipe.js',
                              'livepipe/window.js',
                              'livepipe/tabs.js',
-                             'layouts' %>
+                             'layouts',
+                             'prototype-snippet' %>
   <%= stylesheet_link_tag "livepipe/tabs.css", :media => 'all' %>
   <%= csrf_meta_tag %>
   <%= yield :head %>

--- a/public/javascripts/prototype-snippet.js
+++ b/public/javascripts/prototype-snippet.js
@@ -1,0 +1,22 @@
+/*
+ * Registers a callback which copies the csrf token into the
+ * X-CSRF-Token header with each ajax request.  Necessary to 
+ * work with rails applications which have fixed
+ * CVE-2011-0447
+*/
+
+Ajax.Responders.register({
+  onCreate: function(request) {
+    var csrf_meta_tag = $$('meta[name=csrf-token]')[0];
+
+    if (csrf_meta_tag) {
+      var header = 'X-CSRF-Token',
+          token = csrf_meta_tag.readAttribute('content');
+
+      if (!request.options.requestHeaders) {
+        request.options.requestHeaders = {};
+      }
+      request.options.requestHeaders[header] = token;
+    }
+  }
+});


### PR DESCRIPTION
In relation with #1164.
- added `prototype-snippet.js`
- added this JS to `layouts/content`

thx @BenjaminVialle for the [link](http://weblog.rubyonrails.org/2011/2/8/csrf-protection-bypass-in-ruby-on-rails/)

Take cake for the entire migration to jQuery.
