### PR TITLE
Fix for issue 577: Display modal on failed ajax calls from expired sessions

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -6,8 +6,8 @@
 
   <%= render :partial => 'layouts/head' %>
 
-
   <%= render :partial => "boot.js.erb" %>
+
   <script type="text/javascript">
   //<![CDATA[
 
@@ -72,16 +72,6 @@
   }
 
   document.observe("dom:loaded", function() {
-    Ajax.Responders.register({
-      onComplete: function(requester, xhr, json_response) {
-        if(xhr.status == 403) { // forbidden
-          // go back to home page
-          window.location = "<%= root_url %>";
-        }
-      }
-    });
-
-
     modalCreate = new Control.Modal($('create_group_dialog'),
     {
       overlayOpacity: 0.75,

--- a/app/views/layouts/_redirect.html.erb
+++ b/app/views/layouts/_redirect.html.erb
@@ -1,0 +1,8 @@
+<div id="redirect_dialog" style="display:none;">
+  <%= form_tag do %>
+    <p><strong><%= I18n.t(:session_expired)%></strong></p>
+    <br />
+    <%= button_to_function I18n.t(:log_in), 'redirectToLogin()' %>
+    <%= button_to_function I18n.t(:cancel), 'redirect_modal.close()' %>
+  <% end %>
+</div>

--- a/app/views/layouts/_redirect.js.erb
+++ b/app/views/layouts/_redirect.js.erb
@@ -1,0 +1,15 @@
+<script type="text/javascript">
+//<![CDATA[
+
+function redirectToLogin() {
+  window.location = "<%= root_url %>";
+}
+
+jQuery(document).ajaxError(function(event, xhr, settings, exception) {
+  if (xhr.status == 403) {
+    redirect_modal.open();
+  }
+});
+
+//]]>
+</script>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -32,6 +32,7 @@
     <%= render :partial => 'layouts/sub_sub_menu' %>
     <%= render :partial => 'layouts/about' %>
     <%= render :partial => 'layouts/role_switch' %>
+    <%= render :partial => 'layouts/redirect' %>
     <div id="container">
       <div id="content">
         <%= render :partial => 'layouts/noscript'%>
@@ -44,5 +45,6 @@
   <script type="text/javascript">
     jQuery.noConflict();
   </script>
+  <%= render 'layouts/redirect.js.erb' %>
 </body>
 </html>

--- a/app/views/layouts/no_menu_header.html.erb
+++ b/app/views/layouts/no_menu_header.html.erb
@@ -23,6 +23,7 @@
   <%= render :partial => 'layouts/menu' unless controller.action_name == 'login' %>
   <%= render :partial => 'layouts/sub_menu', :locals =>{:no_menu_header => 'true'}%>
   <%= render :partial => 'layouts/about' %>
+  <%= render :partial => 'layouts/redirect' %>
 
   <div id="container">
     <div id="content">
@@ -30,6 +31,8 @@
     </div><!-- Content -->
   </div><!-- Container -->
 </div>
+
+<%= render 'layouts/redirect.js.erb' %>
 
 </body>
 </html>

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -66,13 +66,9 @@
       $('working').show();
       window.onbeforeunload = check_working;
     },
-    onComplete: function(requester, xhr, json_response) {
+    onComplete: function() {
       $('working').hide();
       window.onbeforeunload = null;
-      if(xhr.status == 403) { // forbidden
-        // go back to home page
-        window.location = "<%= root_url %>";
-      }
     }
   });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -306,6 +306,7 @@ Markus::Application.routes.draw do
       get 'about'
       post 'login_as'
       get 'role_switch'
+      get 'redirect'
       get 'clear_role_switch_session'
       post 'reset_api_key'
     end

--- a/public/javascripts/layouts.js
+++ b/public/javascripts/layouts.js
@@ -4,5 +4,6 @@ jQuery(document).ready(function () {
   window.dialog_modal = new ModalMarkus('#about_dialog');
   window.dialog_modal.modal_dialog.dialog( "option", "height", 670 );
   window.dialog_modal.modal_dialog.dialog( "option", "width", 600 );
+  window.redirect_modal = new ModalMarkus('#redirect_dialog');
 
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1113,6 +1113,11 @@ input#extra_mark_description{
    border-radius: 5px;
 }
 
+#redirect_dialog {
+   background: white;
+   padding: 20px;
+}
+
 #about_dialog {
   background: white;
   border: 1px solid #000000;


### PR DESCRIPTION
This is in reference to https://github.com/MarkUsProject/Markus/pull/981 and https://github.com/MarkUsProject/Markus/issues/577

Rather than simply log the user out, a modal is displayed warning the user that the session has expired. From the modal, they can either close it to return to the page and look at what changes will be lost, or return to the login page. It has also been applied to all main pages. Refer to the screenshot attached.

![login-required](https://f.cloud.github.com/assets/817212/1069633/adf9cf28-1426-11e3-9d91-5d378a29be37.png)
