### PR TITLE
Fix for issue-1182: Fixed Edit button style to be consistent with others

### DIFF
--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -6,7 +6,7 @@
       <%= simple_format(annot.annotation_text.content) %>
     </div>
 
-    <%= link_to_function I18n.t("edit"),
+    <%= button_to I18n.t("edit"),
          "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",
          {:class => "float_left edit_remove_annotation_button"} %>
     <%= button_to I18n.t("remove"),


### PR DESCRIPTION
link to the issue: https://github.com/MarkUsProject/Markus/issues/1182

``` ruby
<%= link_to_function I18n.t("edit"),
         "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",
         {:class => "float_left edit_remove_annotation_button"} %>
    <%= button_to I18n.t("remove"),
         annotations_path(:id => annot.id, :submission_file_id => @submission_file_id),
         :method => :delete, :class => "edit_remove_annotation_button",
         :confirm => I18n.t("marker.annotation.sure_to_remove"), :remote => true %>
```

The "Edit" and "Remove" buttons are actually of the same style, but "Edit" is implemented as a link while "Remove" is a button. Changing "link_to_function" to "button_to" on "Edit" did the trick.
