### PR TITLE
Fix for issue-1195: input box width adjusted

### DIFF
--- a/app/views/grade_entry_forms/_grade_entry_item.html.erb
+++ b/app/views/grade_entry_forms/_grade_entry_item.html.erb
@@ -9,7 +9,8 @@
     <%= raw(f.label :name,
                     t('grade_entry_forms.column_name'),
                     :class => "inline_label") %>
-    <%= raw(f.text_field :name) %>
+    <%= raw(f.text_field :name,
+                         :size => 20) %>
 
     <%= raw(f.label :out_of,
                     t('grade_entry_forms.column_out_of'),


### PR DESCRIPTION
Adjusted the width of the Name input box to make all the labels and input boxes fit in the same line.

![screenshot-issue1195-fixed](https://f.cloud.github.com/assets/5225404/1186342/88b45aa8-22f4-11e3-906e-4e01eeddd400.png)
