### PR TITLE
Fixed issue #868. Assignment.rb graded_submissions method returns only 1 graded submission from each grouping

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -785,17 +785,14 @@ class Assignment < ActiveRecord::Base
 
   # Returns all the submissions that have been graded (completed)
   def graded_submissions
-		results = []
-		groupings.each do |grouping|
-			if grouping.marking_completed?
-		    submission = grouping.current_submission_used
-		    unless submission.nil?
-		      result = submission.get_latest_result
-					results.push(result)
-				end	
-			end
-		end
-		return results
+    results = []
+    groupings.each do |grouping|
+      if grouping.marking_completed?
+        submission = grouping.current_submission_used
+        results.push(submission.get_latest_result) unless submission.nil?
+      end
+    end
+    results
   end
 
   def groups_submitted


### PR DESCRIPTION
Modified assignment.rb graded_submissions method to return only 1 graded submission from each grouping
