### PR TITLE
Fix for Issue 1202: missing user name in error message when trying to add inactive user to group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -378,7 +378,7 @@ class GroupsController < ApplicationController
 
     begin
       if student.hidden
-        raise I18n.t('add_student.fail.hidden', student.user_name)
+        raise I18n.t('add_student.fail.hidden', :user_name => student.user_name)
       end
       if student.has_accepted_grouping_for?(@assignment.id)
         raise I18n.t('add_student.fail.already_grouped',


### PR DESCRIPTION
In reference to https://github.com/MarkUsProject/Markus/issues/1202

![screen shot 2013-10-02 at 9 58 40 pm](https://f.cloud.github.com/assets/817212/1258900/a17fe9ce-2bcf-11e3-9c58-636b5168c16f.png)
