### PR TITLE
Fix for issue 1203: rubrics_controller now updates weights

### DIFF
--- a/app/views/rubrics/_criterion_editor.html.erb
+++ b/app/views/rubrics/_criterion_editor.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared/flash_message' %>
 
 <%= form_for criterion,
-	     :as => :flexible_criterion,
+	     :as => :rubric_criterion,
 	     :url => {:action => 'update', :id => criterion.id},
 		   :html => {:remote => true} do |f| %>
 <h2>


### PR DESCRIPTION
This is a fix for https://github.com/MarkUsProject/Markus/issues/1203

Furthermore, found another bug: the _errors_list partials are throwing exceptions since the .each_line method doesn't exist for ActiveRecord::Errors. However, some of the controllers and tests expect error strings, so I'll look into that in a separate pull request.

![screen shot 2013-10-03 at 12 44 10 am](https://f.cloud.github.com/assets/817212/1259537/f03bc62a-2beb-11e3-8d95-bd6046d3550a.png)
