### PR TITLE
Fixed positioning of the 'Delete annotation category' button

### DIFF
--- a/app/views/annotation_categories/_annotation_category_edit.html.erb
+++ b/app/views/annotation_categories/_annotation_category_edit.html.erb
@@ -1,18 +1,17 @@
 <div id="current_annotation_category" class="annotation_category_edit">
  <%= render 'shared/flash_message' %>
- <div class="float_right">
-   <%= button_to t("annotations.delete.delete_message"),
-                delete_annotation_category_assignment_annotation_category_path(
-                      :id => annotation_category.id),
-                :method => 'delete',
-	        :confirm => t('annotations.delete.annotation_category'),
-	        :html => {:class => 'delete'},
-		:remote => true
-   %>
- </div>
  <div id="annotation_category_controls">
-   <h2><%=(annotation_category.annotation_category_name)%></h2>
-
+  <div class="float_right">
+  <%= button_to t("annotations.delete.delete_message"),
+        delete_annotation_category_assignment_annotation_category_path(
+          :id => annotation_category.id),
+          :method => 'delete',
+          :confirm => t('annotations.delete.annotation_category'),
+          :html => { :class => 'delete' },
+          :remote => true %>
+  </div>
+  <h2><%= annotation_category.annotation_category_name %></h2>
+ <div class="clear"></div>
 <fieldset>
    <%= form_for :annotation_category,
 		            :as => :annotation_category,


### PR DESCRIPTION
Repositioned the button so it fit better with the layout at higher resolutions.

Before:
![screen shot 2013-10-05 at 10 21 01 pm](https://f.cloud.github.com/assets/817212/1276071/8719d164-2e2f-11e3-8d6e-e52f41e167ce.png)

After:
![screen shot 2013-10-05 at 10 26 09 pm](https://f.cloud.github.com/assets/817212/1276072/8726745a-2e2f-11e3-8408-dbcbc4ee190a.png)
