### PR TITLE
Fix position of 'Note:' in the Notes edit page

### DIFF
--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -18,7 +18,10 @@
       <b><%=I18n.t('notes.creation_time')%>:</b> <%= @note.format_date %>
     </p>
 
-    <%= raw(f.label :notes_message, I18n.t('notes.note')+":") %>
+    <p>
+      <b><%= I18n.t('notes.note') %>:</b>
+    </p>
+
     <%= raw(f.text_area :notes_message, :rows => 8, :cols => 50,
                         :onchange => "set_onbeforeunload(true);") %>
 


### PR DESCRIPTION
Another small fix.

Before:
![screen shot 2013-10-05 at 11 11 05 pm](https://f.cloud.github.com/assets/817212/1276098/253a9ae4-2e36-11e3-9790-c40aaef68485.png)

After:
![screen shot 2013-10-05 at 11 18 00 pm](https://f.cloud.github.com/assets/817212/1276099/25404354-2e36-11e3-9bc5-1b86ec0dda74.png)

An alternative would be to continue to use a label, but we'd need to reset the style for the element. I'm hoping to avoid adding one-time-use classes to the css.
