### PR TITLE
Fix for issue-1001: added code to update group coverage when graders are randomly assigned to criteria

### DIFF
--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -267,6 +267,11 @@ class GradersController < ApplicationController
       groupings.concat(grader.get_groupings_by_assignment(@assignment))
     end
     groupings = groupings.uniq
+    groupings.each do |grouping|
+      covered_criteria = grouping.all_assigned_criteria(grouping.tas)
+      grouping.criteria_coverage_count = covered_criteria.length
+      grouping.save
+    end
     construct_all_rows(groupings, graders, criteria)
     render :modify_criteria
   end


### PR DESCRIPTION
#1001

In graders_controller.rb, there is no update action in the randomly_assign_graders_to_criteria method to update group coverage (such action exists in add_graders_to_criteria method). Therefore the group coverage remains unchanged when randomly assigning graders. The required update code is added to randomly_assign_graders_to_criteria method.
