### PR TITLE
Fix for issue-1211: added html_safe to unescape html <span> tag

### DIFF
--- a/app/views/automated_tests/_test_file.html.erb
+++ b/app/views/automated_tests/_test_file.html.erb
@@ -1,7 +1,7 @@
 <div class="test_file">
 <%= form.fields_for :test_files, test_file do |f| %>
 
-  <%= f.label :filename, t(:filename) %>
+  <%= f.label :filename, t(:filename).html_safe %>
 
   <% if f.object.id %>
     <%= text_field_tag 'test_file_' + f.object_id.to_s, f.object.filename, :readonly => "true" %>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
#1211

Rails automatically escapes the tag inside f.label. Added html_safe to unescape the tag so it displays properly.
