### PR TITLE
config.action_view.debug_rjs is removed in Rails3.1

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,10 +11,11 @@ Markus::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true
-  # The following line can be commented out when jQuery is fully implemented in MarkUs
-  #  config.action_view.debug_rjs                         = true
-  #  config.action_controller.perform_caching             = false
-  #  config.action_controller.allow_forgery_protection    = true
+
+  # FIXME: The following lines can be commented
+  # out when jQuery is fully implemented
+  # config.action_controller.perform_caching             = false
+  # config.action_controller.allow_forgery_protection    = true
 
   # Load any local configuration that is kept out of source control
   if File.exists?(File.join(File.dirname(__FILE__), 'local_environment_override.rb'))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,9 @@ Markus::Application.configure do
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local = true
   # set to false to turn off traces
-  config.action_view.debug_rjs                         = true
+
+  # FIXME: The following lines can be commented
+  # out when jQuery is fully implemented
   config.action_controller.perform_caching             = true
   config.cache_classes                                 = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,7 @@ Markus::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true
-  config.action_controller.perform_caching             = false
+  config.action_controller.perform_caching = false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
We will need to install prototype-rails to continue to use RJS templates
