### PR TITLE
Adding Javascript runtime to MarkUs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
   gem 'uglifier',     '>= 1.0.3'
+  gem 'execjs'
+  gem 'therubyracer'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     kgio (2.8.1)
+    libv8 (3.16.14.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     machinist (1.0.6)
@@ -108,6 +109,7 @@ GEM
     rcov (1.0.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     rghost (0.9.3)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
@@ -138,6 +140,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.8)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.3.7)
     time-warp (1.0.13)
@@ -164,6 +169,7 @@ DEPENDENCIES
   debugger
   dynamic_form
   exception_notification (< 4.0)
+  execjs
   faker
   fastercsv
   i18n
@@ -186,6 +192,7 @@ DEPENDENCIES
   shoulda-matchers (~> 1.5)
   simplecov
   sqlite3
+  therubyracer
   tilt (~> 1.3.7)
   time-warp
   uglifier (>= 1.0.3)


### PR DESCRIPTION
This patch solves issues with Javascript runtime.
