### PR TITLE
Fix for issue #1312

### DIFF
--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -6,9 +6,9 @@
       <%= simple_format(annot.annotation_text.content) %>
     </div>
 
-    <%= button_to I18n.t("edit"),
-         "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",
-         {:class => "float_left edit_remove_annotation_button"} %>
+    <%= button_to_function I18n.t("edit"),
+         "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",{:class => "float_left edit_remove_annotation_button"} %>
+
     <%= button_to I18n.t("remove"),
          annotations_path(:id => annot.id, :submission_file_id => @submission_file_id),
          :method => :delete, :class => "edit_remove_annotation_button",


### PR DESCRIPTION
Fix for issue #1312, button "edit" was giving 404 because an ancient commit (d51f985882afbb1109f68b8e0fce3daf7642e814) changed the function "link_to_function" to "button_to". However, to make it work correctly it should be button_to_function.
