### PR TITLE
Fixed issue#764: Use correct HTTP status code for expired sessions

### DIFF
--- a/lib/session_handler.rb
+++ b/lib/session_handler.rb
@@ -61,7 +61,8 @@ module SessionHandler
         session[:redirect_uri] = request.referer
         render :nothing => true, :status => :forbidden  # 403 http code
       else
-        render :controller => 'main', :action => 'login', :status => :unauthorized # 401 http code
+        # redirect_to :controller => 'main', :action => 'login'
+	render :controller => 'main', :template => 'main/login', :action => 'login', :status => :unauthorized #401 http code
       end
     end
   end


### PR DESCRIPTION
Changing HTTP status code for expired sessions from 200:OK to 401:unauthorized.
