### PR TITLE
Fix for issue #1363

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -9,5 +9,5 @@ require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 # on Ruby 1.9
 if RUBY_VERSION > "1.9"
   require 'yaml'
-  YAML::ENGINE.yamler= 'syck'
+  YAML::ENGINE.yamler = 'syck' if (defined?(Syck) || defined?(YAML::Syck)) && defined?(YAML::ENGINE)
 end


### PR DESCRIPTION
Fixed a warning message (issue #1363 ) when using ruby >= 2.0.0: syck is used if it is defined, otherwise psych (the new default one) will be used
