### PR TITLE
Fix for issue #1365: Adding missing ruby's 2.0 gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'dynamic_form'
 # FIXME: The 'exception_notification' gem version 4
 # is not compatible with Rails 3.0.x
 gem 'exception_notification', '<4.0'
+gem 'minitest',"4.7.5", :platforms => :ruby_20
 
 gem 'json'
 gem 'coffee-script'
@@ -61,8 +62,9 @@ end
 # for production.
 group :development, :test do
   gem 'rdoc'
+  gem 'iconv', :platforms => :mri_20
   gem 'rcov', :platforms => :mri_18
-  gem 'simplecov', :platforms => :mri_19
+  gem 'simplecov', :platforms => [:mri_19,:mri_20]
   # FIXME: shoulda (>=4.0) introduces several deprecation warnings in tests
   # we have to fix before doing an upgrade
   gem 'shoulda', '<3.4'
@@ -75,7 +77,7 @@ group :development, :test do
   gem 'railroady'
   gem 'time-warp'
   gem 'ruby-debug', :platforms => :mri_18
-  gem 'debugger', :platforms => :mri_19
+  gem 'debugger', :platforms =>  [:mri_19,:mri_20]
   gem 'mocha', :require => false
 end
 


### PR DESCRIPTION
Added missing ruby's 2.0 gems:
- [x] Minitest
- [x] Iconv
- [x] Simplecov
- [x] Debugger
