### PR TITLE
Fixed issue 1342 - groups not being rendered under assignment tab

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -141,6 +141,7 @@ class GroupsController < ApplicationController
     @groupings.each do |grouping|
       @table_rows[grouping.id] = construct_table_row(grouping, @assignment)
     end
+    render :populate, :formats => [:js]
   end
 
   def populate_students


### PR DESCRIPTION
Added a render statement in the populate function in the groups controller. This fixes the issue where the data coming in is not being properly rendered by the web browser. This is also related  to issue #1360 where @cj343 and @beepted helped to solve. 
