### PR TITLE
Warn user if bundler version is to low

### DIFF
--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -5,7 +5,7 @@ rescue LoadError
   raise "Could not load the bundler gem. Install it with `gem install bundler`."
 end
 
-if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("0.9.24")
+if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("1.3.5")
   raise RuntimeError, "Your bundler version is too old." +
    "Run `gem install bundler` to upgrade."
 end


### PR DESCRIPTION
As we are enabling the support for ruby 2.0 platform (mri_20 in
Gemfile), we need to have Bundler >= 1.3.5
