### PR TITLE
Fix for issue 1378 Sorting of Marks Spreadsheet

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -38,7 +38,7 @@ class GradeEntryFormsController < ApplicationController
 
                               if sort_by.present?
                                 if sort_by == 'section'
-                                  Student.joins(:section).all(:conditions => conditions,
+                                  Student.includes(:section).all(:conditions => conditions,
                                                               :order => 'sections.name ' + order)
                                 else
                                   Student.all(:conditions => conditions,
@@ -116,7 +116,7 @@ class GradeEntryFormsController < ApplicationController
     else
       params[:sort_by] = 'last_name'
     end
-    @sort_by = cookies[c_sort_by]
+    @sort_by = params[:sort_by]
     @desc = params[:desc]
     @filters = get_filters(G_TABLE_PARAMS)
     @per_pages = G_TABLE_PARAMS[:per_pages]
@@ -124,7 +124,7 @@ class GradeEntryFormsController < ApplicationController
     all_students = get_filtered_items(G_TABLE_PARAMS,
                                       @filter,
                                       @sort_by,
-                                      params[:desc])
+                                      @desc)
     @students = all_students.paginate(:per_page => @per_page,
                                       :page => @current_page)
     @students_total = all_students.size

--- a/app/views/grade_entry_forms/_grades_table_column_names.html.erb
+++ b/app/views/grade_entry_forms/_grades_table_column_names.html.erb
@@ -14,13 +14,22 @@
       <% if @current_user.admin? || @current_user.ta?%>
           class="<%="ap_sorting_by" if (sort_by == 'user_name')%>
                     <%="ap_sorting_by_desc" if (sort_by == 'user_name' && !desc.blank?)%>">
-          <%= link_to I18n.t("user.user_name"),
-                  :desc => (sort_by == 'user_name' && desc.blank?),
-                  :sort_by => 'user_name',
-                  :per_page => per_page,
-                  :filter =>filter,
-                  :controller =>controller,
-                  :action => action%>
+          <% if desc.blank? %>
+            <%= link_to I18n.t("user.user_name"),
+              :desc => (sort_by == 'user_name' && desc.blank?),
+              :sort_by => 'user_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% else %>
+            <%= link_to I18n.t("user.user_name"),
+              :sort_by => 'user_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% end %>
       <% else %>
           ><%= t('user.user_name') %>
       <% end %>
@@ -29,13 +38,22 @@
       <% if @current_user.admin? || @current_user.ta?%>
           class="<%="ap_sorting_by" if (sort_by == 'last_name')%>
                     <%="ap_sorting_by_desc" if (sort_by == 'last_name' && !desc.blank?)%>">
-          <%= link_to I18n.t("user.last_name"),
-                    :desc => (sort_by == 'last_name' && desc.blank?),
-                    :sort_by => 'last_name',
-                    :per_page => per_page,
-                    :filter =>filter,
-                    :controller =>controller,
-                    :action => action%>
+          <% if desc.blank? %>
+            <%= link_to I18n.t("user.last_name"),
+              :desc => (sort_by == 'last_name' && desc.blank?),
+              :sort_by => 'last_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% else %>
+             <%= link_to I18n.t("user.last_name"),
+              :sort_by => 'last_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% end %>
        <% else %>
           ><%= t('user.last_name') %>
        <% end %>
@@ -44,13 +62,22 @@
       <% if @current_user.admin? || @current_user.ta?%>
           class="<%="ap_sorting_by" if (sort_by == 'first_name')%>
                     <%="ap_sorting_by_desc" if (sort_by == 'first_name' && !desc.blank?)%>">
-          <%= link_to I18n.t("user.first_name"),
-                  :desc => (sort_by == 'first_name' && desc.blank?),
-                  :sort_by => 'first_name',
-                  :per_page => per_page,
-                  :filter =>filter,
-                  :controller =>controller,
-                  :action => action%>
+          <% if desc.blank? %>
+            <%= link_to I18n.t("user.first_name"),
+              :desc => (sort_by == 'first_name' && desc.blank?),
+              :sort_by => 'first_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% else %>
+            <%= link_to I18n.t("user.first_name"),
+              :sort_by => 'first_name',
+              :per_page => per_page,
+              :filter =>filter,
+              :controller =>controller,
+              :action => action%>
+          <% end %>
       <% else %>
          ><%= t('user.first_name') %>
       <% end %>
@@ -58,13 +85,22 @@
   <% if @current_user.admin? || @current_user.ta?%>
   <th class="<%="ap_sorting_by" if (sort_by == 'section')%>
                       <%="ap_sorting_by_desc" if (sort_by == 'section' && !desc.blank?)%>">
-          <%= link_to I18n.t("user.section"),
-                  :desc => (sort_by == 'section' && desc.blank?),
-                  :sort_by => 'section',
-                  :per_page => per_page,
-                  :filter =>filter,
-                  :controller =>controller,
-                  :action => action%>
+    <% if desc.blank? %>
+        <%= link_to I18n.t("user.section"),
+                    :desc => (sort_by == 'section' && desc.blank?),
+                    :sort_by => 'section',
+                    :per_page => per_page,
+                    :filter =>filter,
+                    :controller =>controller,
+                    :action => action%>
+    <% else %>
+        <%= link_to I18n.t("user.section"),
+                    :sort_by => 'section',
+                    :per_page => per_page,
+                    :filter =>filter,
+                    :controller =>controller,
+                    :action => action%>
+    <% end %>
   </th>
   <% end %>
 


### PR DESCRIPTION
Fixed the sorting of First, last, and user names in the spreadsheet by adding an if else condition on "desc" field in the http get request. Also fixed an isolated issue with sorting by the sections. We changed from an inner join to left outer join since sections could be null. 
