### PR TITLE
Fix for issue-1375: Fixed Download Grades Spreadsheet Error

### DIFF
--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -200,7 +200,7 @@ class GradeEntryForm < ActiveRecord::Base
               final_result.push(grade.grade || BLANK_MARK)
             end
           end
-          total_percent = self.calculate_total_percent(student.id)
+          total_percent = self.calculate_total_percent(grade_entry_student)
           final_result.push(total_percent)
         end
         csv << final_result


### PR DESCRIPTION
Updated  invalid student.id reference to grade_entry_student, since error results from total grade function is being called on it.
