### PR TITLE
Fix for issue-1340

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,5 +1,6 @@
 include CsvHelper
 require 'zip/zip'
+require 'cgi'
 
 class SubmissionsController < ApplicationController
   include SubmissionsHelper
@@ -662,8 +663,9 @@ class SubmissionsController < ApplicationController
         # If the file appears to be binary, send it as a download
         send_data file_contents, :disposition => 'attachment', :filename => params[:file_name]
       else
-        # Otherwise, blast it out to the screen
-        render :text => file_contents, :layout => 'sanitized_html'
+        # Otherwise, sanitize it for HTML and blast it out to the screen
+        sanitized_contents = CGI.escapeHTML(file_contents)
+        render :text => sanitized_contents, :layout => 'sanitized_html'
       end
     end
   end


### PR DESCRIPTION
Added line to require cgi (http://www.ruby-doc.org/stdlib-1.9.3/libdoc/cgi/rdoc/CGI.html) which has a CGI.escapeHTML method that changes strings with "<" and ">" to "&lt" and "&gt" respectively.

Only escaping the characters when about to render submitted code on screen, this should not affect binary files.
