### PR TITLE
Fix issue #1295: Check to see if every group being collected had only one TA assigned to them.

### DIFF
--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -6,57 +6,65 @@
      <%= I18n.t("browse_submissions.grading_can_begin") %>
   <% else %>
      <%= I18n.t("browse_submissions.grading_can_begin_after",
-                :time => I18n.l(@assignment.submission_rule.calculate_collection_time,
-                               :format => :long_date)) %>
+                time: I18n.l(@assignment.submission_rule.calculate_collection_time,
+                format: :long_date)) %>
   <% end %>
 </div>
 
 <div id="title_bar">
   <h1>
     <%= I18n.t("browse_submissions.workspace",
-               :short_identifier => sanitize(@assignment.short_identifier)) %>
+               short_identifier: sanitize(@assignment.short_identifier)) %>
   </h1>
   <div class="heading_buttons">
     <% if @current_user.admin? %>
       <%= link_to I18n.t("collect_submissions.collect_all"),
-                  collect_all_submissions_assignment_submissions_path(
-                      @assignment.id),
-                  :confirm => I18n.t("collect_submissions.results_loss_warning") %>
+                         collect_all_submissions_assignment_submissions_path(
+                           @assignment.id),
+                         confirm: I18n.t("collect_submissions.results_loss_warning") %>
       <span class="menu_bar"></span>
       <%= link_to I18n.t("browse_submissions.csv_report"),
-                  download_simple_csv_report_assignment_submissions_path(@assignment) %>
+                         download_simple_csv_report_assignment_submissions_path(
+                           @assignment) %>
       <span class="menu_bar"></span>
       <%= link_to I18n.t("browse_submissions.detailled_csv_report"),
-                  download_detailed_csv_report_assignment_submissions_path(
-                      @assignment) %>
+                         download_detailed_csv_report_assignment_submissions_path(
+                           @assignment) %>
       <span class="menu_bar"></span>
       <%= link_to I18n.t("browse_submissions.subversion_repo_list"),
-                  download_svn_repo_list_assignment_submissions_path(
-                      @assignment) %>
+                         download_svn_repo_list_assignment_submissions_path(
+                           @assignment) %>
       <span class="menu_bar"></span>
       <%= link_to I18n.t("browse_submissions.subversion_export_file"),
-                  download_svn_export_commands_assignment_submissions_path(
-                      @assignment) %>
+                         download_svn_export_commands_assignment_submissions_path(
+                           @assignment) %>
     <% end %>
 
-    <% if @current_user.ta? and @assignment.past_collection_date? %>
+    <% # Allow submission collection only if all the submissions are assigned to exactly one TA. %>
+    <% if @current_user.ta? and @assignment.past_collection_date? and 
+          @groupings.all?{|grouping| grouping.get_ta_names.size == 1} %>
+
       <%= link_to I18n.t("collect_submissions.collect_ta"),
-                  collect_ta_submissions_assignment_submissions_path(
-                      @assignment),
-                  :confirm => I18n.t("collect_submissions.results_loss_warning") %>
+                         collect_ta_submissions_assignment_submissions_path(
+                           @assignment),
+                         confirm: I18n.t("collect_submissions.results_loss_warning") %>
+    <% elsif @current_user.ta? and @assignment.past_collection_date? %>
+      <a id="disable" title="<%= I18n.t("collect_submissions.disable_collect") %>">
+        <%= I18n.t("collect_submissions.collect_ta") %>
+      </a>
     <% end %>
 
     <span class="menu_bar"></span>
 
     <% if all_assignments_marked? %>
       <%= link_to t('browse_submissions.download_groupings_files'),
-                  download_groupings_files_assignment_submissions_path(
-                          :groupings => @groupings) %>
+                    download_groupings_files_assignment_submissions_path(
+                      groupings: @groupings) %>
     <% else %>
       <%= link_to t('browse_submissions.download_groupings_files'),
-                  download_groupings_files_assignment_submissions_path(
-                          :groupings => @groupings),
-                          :confirm => I18n.t("collect_submissions.marking_incomplete_warning") %>
+                    download_groupings_files_assignment_submissions_path(
+                      groupings: @groupings),
+                    confirm: I18n.t("collect_submissions.marking_incomplete_warning") %>
     <% end %>
   </div>
 </div>
@@ -67,6 +75,7 @@
       <%= flash[:error] %>
     </div>
   <% end %>
+
   <% if flash[:success] %>
     <div class="success">
       <%= flash[:success] %>
@@ -91,12 +100,12 @@
       <% if @current_user.admin? %>
         <div class="floatLeft">
           <%= submit_tag I18n.t("browse_submissions.release_marks"),
-                                :name => "release_results" %>
+                                name: "release_results" %>
           <%= submit_tag I18n.t("browse_submissions.unrelease_marks"),
-                                :name => "unrelease_results" %>
+                                name: "unrelease_results" %>
           <% if !@assignment.results_average.nil? %>
             <%= I18n.t("browse_submissions.class_average",
-                       :results_average => @assignment.results_average) %>
+                       results_average: @assignment.results_average) %>
           <% end %>
         </div>
       <% end %>
@@ -116,94 +125,88 @@
       				<% end %>
       			<% end %>
       		</select>
-      		<%= submit_tag t(:apply), :id => 'apply_collect_section',
-      			                        :name => 'collect_section',
-                                    :class => 'thin-button' %>
+      		<%= submit_tag t(:apply), id: 'apply_collect_section',
+      			                        name: 'collect_section',
+                                    class: 'thin-button' %>
       	</div>
       <% end %>
 
       <div class="ap_filters" id="ap_filters_1">
-        <%= render  :partial => 'submissions_table_filters',
-                    :locals => {
-                      :filter => @filter,
-                      :page => @current_page,
-                      :desc => @desc,
-                      :sort_by => @sort_by,
-                      :assignment => @assignment,
-                      :filters => @filters,
-                      :per_page => @per_page,
-                      :per_pages => @per_pages } %>
+        <%= render  partial: 'submissions_table_filters',
+                    locals: { filter: @filter,
+                              page: @current_page,
+                              desc: @desc,
+                              sort_by: @sort_by,
+                              assignment: @assignment,
+                              filters: @filters,
+                              per_page: @per_page,
+                              per_pages: @per_pages } %>
       </div>
       <div class="clear"></div>
       <div class="ap_page_links" id="ap_page_links_1">
-        <%= render  :partial => 'ajax_paginate/initial_paginate_links',
-                    :locals => {
-                      :per_page => @per_page,
-                      :current_page => @current_page,
-                      :page_items => @groupings.size,
-                      :total_items => @groupings_total,
-                      :assignment => @assignment,
-                      :filter => @filter,
-                      :sort_by => @sort_by,
-                      :desc => @desc } %>
+        <%= render  partial: 'ajax_paginate/initial_paginate_links',
+                    locals: { per_page: @per_page,
+                              current_page: @current_page,
+                              page_items: @groupings.size,
+                              total_items: @groupings_total,
+                              assignment: @assignment,
+                              filter: @filter,
+                              sort_by: @sort_by,
+                              desc: @desc } %>
       </div>
       <div id="ap_selector">
-        <%= render :partial => 'ajax_paginate/selector' %>
+        <%= render partial: 'ajax_paginate/selector' %>
       </div>
       <div class="clear"></div>
     </div>
 
     <div id="ap_selects">
-      <%= render :partial => 'ajax_paginate/selects',
-        :locals => {:page_items => @groupings.size,
-                    :total_items => @groupings_total} %>
+      <%= render partial: 'ajax_paginate/selects',
+        locals: { page_items: @groupings.size,
+                    total_items: @groupings_total } %>
     </div>
 
     <table>
       <thead id="submissions_table_head">
-        <%= render  :partial => 'submissions_table_sorting_links',
-                    :locals => {
-                      :assignment => @assignment,
-                      :filter => 'none',
-                      :page => @current_page,
-                      :per_page => @per_page,
-                      :sort_by => @sort_by,
-                      :desc => @desc } %>
+        <%= render  partial: 'submissions_table_sorting_links',
+                    locals: { assignment: @assignment,
+                              filter: 'none',
+                              page: @current_page,
+                              per_page: @per_page,
+                              sort_by: @sort_by,
+                              desc: @desc } %>
       </thead>
 
-      <%= render  :partial => 'submissions_table_body',
-                  :locals => {
-                    :groupings => @groupings,
-                    :assignment => @assignment } %>
+      <%= render  partial: 'submissions_table_body',
+                  locals: { groupings: @groupings,
+                            assignment: @assignment } %>
 
       <tfoot id="submissions_table_foot">
-        <%= render  :partial => 'submissions_table_sorting_links',
-                    :locals => {
-                      :assignment => @assignment,
-                      :filter => 'none',
-                      :page => @current_page,
-                      :per_page => @per_page,
-                      :sort_by => @sort_by,
-                      :desc => @desc } %>
+        <%= render  partial: 'submissions_table_sorting_links',
+                    locals: { assignment: @assignment,
+                              filter: 'none',
+                              page: @current_page,
+                              per_page: @per_page,
+                              sort_by: @sort_by,
+                              desc: @desc } %>
       </tfoot>
     </table>
 
 
     <div class="ap_nav_box">
       <div class="ap_page_links" id="ap_page_links_2">
-        <%= render  :partial => 'ajax_paginate/initial_paginate_links',
-                    :locals => {
-                      :per_page => @per_page,
-                      :current_page => @current_page,
-                      :page_items => @groupings.size,
-                      :total_items => @groupings_total,
-                      :assignment => @assignment,
-                      :filter => @filter,
-                      :sort_by => @sort_by,
-                      :desc => @desc } %>
+        <%= render  partial: 'ajax_paginate/initial_paginate_links',
+                    locals: { per_page: @per_page,
+                              current_page: @current_page,
+                              page_items: @groupings.size,
+                              total_items: @groupings_total,
+                              assignment: @assignment,
+                              filter: @filter,
+                              sort_by: @sort_by,
+                              desc: @desc } %>
       </div>
       <div id="ap_selector">
-        <%= render :partial => 'ajax_paginate/selector' %>
+        <%= render partial: 'ajax_paginate/selector' %>
       </div>
 
       <div class="clear"></div>
@@ -211,23 +214,22 @@
       <div class="floatLeft">
         <% if @current_user.admin? %>
           <%= submit_tag I18n.t("browse_submissions.release_marks"),
-                                :name => "release_results" %>
+                                name: "release_results" %>
           <%= submit_tag I18n.t("browse_submissions.unrelease_marks"),
-                                :name => "unrelease_results" %>
+                                name: "unrelease_results" %>
         <% end %>
       </div>
 
       <div class="ap_filters" id="ap_filters_2">
-        <%= render  :partial => 'submissions_table_filters',
-                    :locals => {
-                      :filter => @filter,
-                      :page => @current_page,
-                      :desc => @desc,
-                      :sort_by => @sort_by,
-                      :assignment => @assignment,
-                      :filters => @filters,
-                      :per_page => @per_page,
-                      :per_pages => @per_pages } %>
+        <%= render  partial: 'submissions_table_filters',
+                    locals: { filter: @filter,
+                              page: @current_page,
+                              desc: @desc,
+                              sort_by: @sort_by,
+                              assignment: @assignment,
+                              filters: @filters,
+                              per_page: @per_page,
+                              per_pages: @per_pages } %>
       </div>
       <div class="clear"></div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
     collect_submissions:
       collect_all: "Collect All Submissions"
       collect_ta: "Collect all your assigned submissions"
-      disable_collect: "Collection disabled, more than one TA marking displayed submissions"
+      disable_collect: "Collection disabled, more than one TA marking displayed submissions."
       could_not_collect: "Could not collect submissions for assignment %{assignment_identifier} - the collection date has not been reached"
       collection_job_started: "Submission collection for assignment %{assignment_identifier} has begun. The complete process may take some time, but you can access submissions as they become available."
       priority_given: "The submission has been given collection priority. It will be ready soon."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -112,6 +112,7 @@ fr:
     collect_submissions:
       collect_all: "Récupérer tous les envois"
       collect_ta: "Récupérer tous les envois qui me sont assignés"
+      disable_collect: "Récupération des envois n'est pas disponible, il y a déjà un correcteur assigné aux envois."
       could_not_collect: "Les envois du projet %{assignment_identifier} ne peuvent pas être récupérés : la date de récupération n'est pas encore passée."
       collection_job_started: "La récupération des envois pour le projet %{assignment_identifier} a débuté. Cela peut prendre du temps, mais vous avez accès aux envois dès qu'ils sont disponibles."
       priority_given: "Une priorité importante a été donné à cet envoi. Il va bientot être prêt."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -109,6 +109,7 @@ pt:
     collect_submissions:
       collect_all: "Coletar todas as submissões"
       collect_ta: "Coletar todas as submissões atribuidos à você"
+      disable_collect: "Coleta de submissões desabilitada, já existe um monitor avaliando as submissões exibidas."
       could_not_collect: "Não foi possível coletar todas as submissões para o projeto %{assignment_identifier} - a data da coleta não foi atingida"
       collection_job_started: "Coleta das submissões para o projeto %{assignment_identifier} começou. O processo pode demorar, você poderá acessar as submissões assim que elas tornarem-se disponíveis."
       priority_given: "A submissão foi dada prioridade de coleta. Ela estará pronta em breve."


### PR DESCRIPTION
There is now an additional expression to be checked before displaying the collect button for a TA. It checks that every submission has just one TA, if that is false the button does not appear. 

I did some manual testing. I assigned two TAs to a set of submissions, and one TA to the rest of the submissions. The collect button does not appear for the two TAs that are assigned the same submissions, but does appear for the TA assigned to their own set of submissions.  
