### PR TITLE
Fix for invalid group span message

### DIFF
--- a/app/views/submissions/submissions_table_row/_table_row.html.erb
+++ b/app/views/submissions/submissions_table_row/_table_row.html.erb
@@ -35,7 +35,9 @@
                    grouping.current_submission_used.get_latest_result) %>
   <% end %>
     (<%= grouping.accepted_students.collect{ |student| student.user_name}.join(',') %>)
-  <%='<span class="invalid">' + t(:invalid_grouping) + '</span>' if !grouping.is_valid? %>
+    <% if !grouping.is_valid? %>
+      <span class="invalid"><%= t(:invalid_grouping) %></span>
+    <% end %>
   </td>
   <% if !@details.nil? %>
     <% assignment.rubric_criteria.each do |criterion| %>


### PR DESCRIPTION
Properly shows the span instead of actually showing the span code as text.
