### PR TITLE
Fix catching of YAML parsing error in Ruby 2.*

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -143,7 +143,9 @@ class AnnotationCategoriesController < ApplicationController
     unless file.blank?
       begin
         annotations = YAML::load(file.utf8_encode(encoding))
-      rescue ArgumentError => e
+      # ArgumentError is thrown by Syck in Ruby 1.* whereas Psych::SyntaxError
+      # is thrown by Psych in Ruby 2.*.
+      rescue ArgumentError, Psych::SyntaxError => e
         flash[:error] = I18n.t('annotations.upload.syntax_error',
           :error => "#{e}")
         redirect_to :action => 'index', :assignment_id => @assignment.id

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -105,7 +105,9 @@ class RubricsController < ApplicationController
     unless file.blank?
       begin
         rubrics = YAML::load(file.utf8_encode(encoding))
-      rescue ArgumentError => e
+      # ArgumentError is thrown by Syck in Ruby 1.* whereas Psych::SyntaxError
+      # is thrown by Psych in Ruby 2.*.
+      rescue ArgumentError, Psych::SyntaxError => e
         flash[:error] = I18n.t('rubric_criteria.upload.error') + '  ' +
            I18n.t('rubric_criteria.upload.syntax_error', :error => "#{e}")
         redirect_to :action => 'index', :id => assignment.id


### PR DESCRIPTION
Ruby 2.\* uses Psych under the hood for parsing YAML, deprecating Syck.
Now Psych throws a Psych::SyntaxError for parsing error whereas Syck
throws ArgumentError.

This also fixes test failures for #1383.

Tested:
- Ruby 1.9.3-p545
- Ruby 2.1.1-p76
- rake test:units
- rake test:functionals
- rails s
