### PR TITLE
Replace all uses of Iconv with String#encode (GH-1079)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ end
 group :development, :test do
   gem 'rdoc'
   gem 'thin'
-  gem 'iconv', :platforms => :mri_20
   gem 'rcov', :platforms => :mri_18
   gem 'simplecov', :platforms => [:mri_19,:mri_20]
   # FIXME: shoulda (>=4.0) introduces several deprecation warnings in tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ GEM
     fastercsv (1.5.5)
     hike (1.2.3)
     i18n (0.6.9)
-    iconv (1.0.4)
     journey (1.0.4)
     jquery-rails (3.1.0)
       railties (>= 3.0, < 5.0)
@@ -193,7 +192,6 @@ DEPENDENCIES
   faker
   fastercsv
   i18n
-  iconv
   jquery-rails
   json
   libv8

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 
 class AnnotationCategoriesController < ApplicationController
   include AnnotationCategoriesHelper
@@ -109,10 +109,8 @@ class AnnotationCategoriesController < ApplicationController
     annotation_category_list = params[:annotation_category_list_csv]
     annotation_category_number = 0
     annotation_line = 0
-    unless annotation_category_list.nil?
-      if encoding != nil
-        annotation_category_list = StringIO.new(Iconv.iconv('UTF-8', encoding, annotation_category_list.read).join)
-      end
+    if annotation_category_list
+      annotation_category_list = annotation_category_list.utf8_encode encoding
       CsvHelper::Csv.parse(annotation_category_list) do |row|
         next if CsvHelper::Csv.generate_line(row).strip.empty?
         annotation_line += 1
@@ -143,12 +141,9 @@ class AnnotationCategoriesController < ApplicationController
     file = params[:annotation_category_list_yml]
     annotation_category_number = 0
     annotation_line = 0
-    if !file.nil? && !file.blank?
+    unless file.blank?
       begin
-        if encoding != nil
-          file = StringIO.new(Iconv.iconv('UTF-8', encoding, file.read).join)
-        end
-        annotations = YAML::load(file)
+        annotations = YAML::load(file.utf8_encode encoding)
       rescue ArgumentError => e
         flash[:error] = I18n.t('annotations.upload.syntax_error',
           :error => "#{e}")

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -548,12 +548,7 @@ class AssignmentsController < ApplicationController
     end
 
     encoding = params[:encoding]
-    assignment_list = if encoding != nil
-                        StringIO.new(Iconv.iconv('UTF-8', encoding,
-                                                 assignment_list.read).join)
-                      else
-                        assignment_list.read
-                      end
+    assignment_list = assignment_list.utf8_encode encoding
 
     case params[:file_format]
       when 'csv'

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 require 'auto_complete'
 require 'csv_invalid_line_error'
 
@@ -171,16 +171,14 @@ class GroupsController < ApplicationController
       # Transaction allows us to potentially roll back if something
       # really bad happens.
       ActiveRecord::Base.transaction do
-        if encoding != nil
-          file = StringIO.new(Iconv.iconv('UTF-8', encoding, file.read).join)
-        end
+        file = file.utf8_encode encoding
         # Old groupings get wiped out
         if !@assignment.groupings.nil? && @assignment.groupings.length > 0
           @assignment.groupings.destroy_all
         end
         begin
           # Loop over each row, which lists the members to be added to the group.
-          CsvHelper::Csv.parse(file.read).each_with_index do |row, line_nr|
+          CsvHelper::Csv.parse(file).each_with_index do |row, line_nr|
             begin
               # Potentially raises CSVInvalidLineError
               collision_error = @assignment.add_csv_group(row)

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -102,12 +102,9 @@ class RubricsController < ApplicationController
       return
     end
     file = params[:yml_upload][:rubric]
-    if !file.nil? && !file.blank?
+    unless file.blank?
       begin
-        if encoding != nil
-          file = StringIO.new(Iconv.iconv('UTF-8', encoding, file.read).join)
-        end
-        rubrics = YAML::load(file)
+        rubrics = YAML::load(file.utf8_encode encoding)
       rescue ArgumentError => e
         flash[:error] = I18n.t('rubric_criteria.upload.error') + '  ' +
            I18n.t('rubric_criteria.upload.syntax_error', :error => "#{e}")

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 # Represents a flexible criterion used to mark an assignment that
 # has the marking_scheme_type attribute set to 'flexible'.
 class FlexibleCriterion < ActiveRecord::Base
@@ -196,9 +196,7 @@ class FlexibleCriterion < ActiveRecord::Base
   # Returns an array containing the criterion names that didn't exist
   def self.assign_tas_by_csv(csv_file_contents, assignment_id, encoding)
     failures = []
-    if encoding != nil
-      csv_file_contents = StringIO.new(Iconv.iconv('UTF-8', encoding, csv_file_contents.read).join)
-    end
+    csv_file_contents = csv_file_contents.utf8_encode encoding
     CsvHelper::Csv.parse(csv_file_contents) do |row|
       criterion_name = row.shift # Knocks the first item from array
       criterion = FlexibleCriterion.find_by_assignment_id_and_flexible_criterion_name(assignment_id, criterion_name)

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 
 # GradeEntryForm can represent a test, lab, exam, etc.
 # A grade entry form has many columns which represent the questions and their total
@@ -217,10 +217,7 @@ class GradeEntryForm < ActiveRecord::Base
     num_lines_read = 0
     names = []
     totals = []
-    grades_file = StringIO.new(grades_file.read)
-    if encoding != nil
-      grades_file = StringIO.new(Iconv.iconv('UTF-8', encoding, grades_file.read).join)
-    end
+    grades_file = StringIO.new(grades_file.read.utf8_encode encoding)
 
     # Parse the question names
     CsvHelper::Csv.parse(grades_file.readline) do |row|

--- a/app/models/grade_entry_student.rb
+++ b/app/models/grade_entry_student.rb
@@ -1,3 +1,5 @@
+require 'encoding'
+
 # GradeEntryStudent represents a row (i.e. a student's grades for each question)
 # in a grade entry form.
 class GradeEntryStudent < ActiveRecord::Base
@@ -61,12 +63,10 @@ class GradeEntryStudent < ActiveRecord::Base
 
   # Returns an array containing the student names that didn't exist
   def self.assign_tas_by_csv(csv_file_contents, grade_entry_form_id, encoding)
-    grade_entry_form = GradeEntryForm.find(grade_entry_form_id)
+    grade_entry_form  = GradeEntryForm.find(grade_entry_form_id)
+    csv_file_contents = csv_file_contents.utf8_encode encoding
 
     failures = []
-    if encoding != nil
-      csv_file_contents = StringIO.new(Iconv.iconv('UTF-8', encoding, csv_file_contents).join)
-    end
     CsvHelper::Csv.parse(csv_file_contents) do |row|
       student_name = row.shift # Knocks the first item from array
       student = Student.find_by_user_name(student_name)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -1,3 +1,5 @@
+require 'encoding'
+
 # we need repository permission constants
 require File.join(File.dirname(__FILE__),'..', '..', 'lib', 'repo', 'repository')
 
@@ -497,9 +499,7 @@ class Grouping < ActiveRecord::Base
   # Returns an array containing the group names that didn't exist
   def self.assign_tas_by_csv(csv_file_contents, assignment_id, encoding)
     failures = []
-    if encoding != nil
-      csv_file_contents = StringIO.new(Iconv.iconv('UTF-8', encoding, csv_file_contents).join)
-    end
+    csv_file_contents = csv_file_contents.utf8_encode encoding
     CsvHelper::Csv.parse(csv_file_contents) do |row|
       group_name = row.shift # Knocks the first item from array
       group = Group.find_by_group_name(group_name)

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 
 class RubricCriterion < ActiveRecord::Base
   before_save :round_weight
@@ -225,10 +225,8 @@ class RubricCriterion < ActiveRecord::Base
   # The number of successfully created criteria.
   def self.parse_csv(file, assignment, invalid_lines, encoding)
     nb_updates = 0
-    if encoding != nil
-      file = StringIO.new(Iconv.iconv('UTF-8', encoding, file.read).join)
-    end
-    CsvHelper::Csv.parse(file.read) do |row|
+    file_contents = file.utf8_encode encoding
+    CsvHelper::Csv.parse(file_contents) do |row|
       next if CsvHelper::Csv.generate_line(row).strip.empty?
       begin
         RubricCriterion.create_or_update_from_csv_row(row, assignment)
@@ -306,9 +304,7 @@ class RubricCriterion < ActiveRecord::Base
   # Returns an array containing the criterion names that didn't exist
   def self.assign_tas_by_csv(csv_file_contents, assignment_id, encoding)
     failures = []
-    if encoding != nil
-      csv_file_contents = StringIO.new(Iconv.iconv('UTF-8', encoding, csv_file_contents.read).join)
-    end
+    csv_file_contents = csv_file_contents.utf8_encode encoding
     CsvHelper::Csv.parse(csv_file_contents) do |row|
       criterion_name = row.shift # Knocks the first item from array
       criterion = RubricCriterion.find_by_assignment_id_and_rubric_criterion_name(assignment_id, criterion_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 include CsvHelper
-require 'iconv'
+require 'encoding'
 require 'digest' # required for {set,reset}_api_token
 require 'base64' # required for {set,reset}_api_token
 # required for repository actions
@@ -145,11 +145,7 @@ class User < ActiveRecord::Base
     result[:invalid_lines] = []  # store lines that were not processed
     # read each line of the file and update classlist
     begin
-      if encoding != nil
-        user_list = StringIO.new(Iconv.iconv('UTF-8',
-                                            encoding,
-                                            user_list.read).join)
-      end
+      user_list = user_list.utf8_encode encoding
       User.transaction do
         processed_users = []
         CsvHelper::Csv.parse(user_list,

--- a/app/views/results/common/codeviewer.rjs
+++ b/app/views/results/common/codeviewer.rjs
@@ -24,9 +24,9 @@
          end
        else
          begin
-           @file_contents = Iconv.iconv('utf-8', 'utf-8', @file_contents)
-         rescue Iconv::Failure
-           @file_contents = Iconv.iconv('utf-8', 'ISO-8859-1', @file_contents)
+           @file_contents = @file_contents.utf8_encode Encoding::UTF_8
+         rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+           @file_contents = @file_contents.utf8_encode Encoding::ISO_8859_1
          end
          page.replace_html 'codeviewer',
                            :partial => 'results/common/text_codeviewer',

--- a/lib/encoding.rb
+++ b/lib/encoding.rb
@@ -1,0 +1,34 @@
+##
+# MarkUs extensions to the String class.
+class String
+  def utf8_encode src_encoding
+    if src_encoding
+      self.encode Encoding::UTF_8, src_encoding
+    else
+      self
+    end
+  end
+end
+
+##
+# We need to wrap a number of other duck types which
+# can end up in places where strings or files are wanted
+
+class File
+  def utf8_encode src_encoding
+    read.utf8_encode src_encoding
+  end
+end
+
+class StringIO
+  def utf8_encode src_encoding
+    string.utf8_encode src_encoding
+  end
+end
+
+class ActionDispatch::Http::UploadedFile
+  def utf8_encode src_encoding
+    read.utf8_encode src_encoding
+  end
+end
+

--- a/test/functional/grade_entry_forms_controller_test.rb
+++ b/test/functional/grade_entry_forms_controller_test.rb
@@ -980,7 +980,7 @@ class GradeEntryFormsControllerTest < AuthenticatedControllerTest
       end
 
       should 'have invalid values in database after an upload of an ISO-8859-1 encoded file parsed as UTF-8' do
-        assert_raise Iconv::IllegalSequence do
+        assert_raise ArgumentError, "invalid byte sequence in UTF-8" do
           post_as @admin,
                   :csv_upload,
                   :id => @grade_entry_form_with_grade_entry_items.id,


### PR DESCRIPTION
String#encode is part of the Ruby standard library as of Ruby 1.9 and has replaced the Iconv library. This change breaks support for Ruby 1.8.

There were some inconsistencies in the code paths related to transcoding depending on if an `encoding` was specified or not. It was confusing to figure out what the types of objects were. My strategy here was to implement an interface for transcoding that takes as input all the different types currently in use (that I ran into) and always returns a `String`.

Testing done:
- `rake test`
- ran a local server and uploaded a CSV file for annotations in both Unicode and ISO 8859-1 encodings.
