### PR TITLE
Replace debugger with byebug in Ruby 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,8 @@ group :development, :test do
   gem 'faker'
   gem 'railroady'
   gem 'time-warp'
-  gem 'debugger'
+  gem 'debugger', :platforms => :mri_19
+  gem 'byebug', :platforms => [:mri_20, :mri_21]
   gem 'mocha', :require => false
   gem 'quiet_assets'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
     builder (3.0.4)
+    byebug (3.0.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -173,6 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   auto_complete
+  byebug
   calendar_date_select!
   coffee-rails (~> 3.2.1)
   coffee-script

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,8 +31,6 @@ Markus::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
-  require 'debugger'
-
   # Raise exception on mass assignment protection for Active Record models
   config.active_record.mass_assignment_sanitizer = :strict
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,8 +28,6 @@ Markus::Application.configure do
   # Show Deprecated Warnings (to :log or to :stderr)
   config.active_support.deprecation = :stderr
 
-  require 'debugger'
-
   # Raise exception on mass assignment protection for Active Record models
   config.active_record.mass_assignment_sanitizer = :strict
 


### PR DESCRIPTION
The `debugger` gem hacks into the Ruby core and doesn't support Ruby 2
very well. `byebug` is a modern debugger that makes use of new APIs in
Ruby 2 for debugging. Also, `debugger` gem is broken in Ruby 2.1.2
(cldwalker/debugger#125).

Since `byebug` only supports Ruby 2, `debugger` still needs to be used
by Ruby 1.9.

There is no need to explicitly require the library as Bundler does that
automatically, unless specified as `:require => false`.

With this change, instead of calling `debugger` in the code to start the
debugger repl, call `byebug`. More docs at
https://github.com/deivid-rodriguez/byebug

Tested:
- Ruby 1.9.3, 2.1.1, 2.1.2
- manually using byebug to debug
