### PR TITLE
Fix for issue-1414: Grade doesn't get updated when grading under TA

### DIFF
--- a/app/views/results/marker/_update_mark.rjs
+++ b/app/views/results/marker/_update_mark.rjs
@@ -13,7 +13,11 @@ end
 page.replace_html "mark_#{result_mark.id.to_s}_summary_mark", result_mark.mark
 page.replace_html "current_subtotal_div", result_mark.result.get_subtotal
 
-page['released'].disable
+# Check if the released button exists (only for admins, not TAs)
+page << "if (jQuery('released')) {"
+  page['released'].disable
+page << "}"
+
 page.call 'update_marking_state_selected', result_mark.result.marking_state.to_s, Result::MARKING_STATES[:partial]
 
 page.call "update_total_mark", result_mark.result.total_mark


### PR DESCRIPTION
Added a check for disabling the released checkbox. Since only admins have that checkbox, disabling it fails for TAs, causing the JavaScript to update the grade and marking state to fail too.
