### PR TITLE
Fix warnings generated by assert_select

### DIFF
--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -115,10 +115,10 @@
   </div>
 
   <div id="create_annotation_dialog" style="display:none;">
-    <input type="hidden" id="x1" value=""></input>
-    <input type="hidden" id="x2" value=""></input>
-    <input type="hidden" id="y1" value=""></input>
-    <input type="hidden" id="y2" value=""></input>
+    <input type="hidden" id="x1" value="">
+    <input type="hidden" id="x2" value="">
+    <input type="hidden" id="y1" value="">
+    <input type="hidden" id="y2" value="">
     <p>
       <h2><%= I18n.t("marker.annotation.new_annotation") %></h2>
     </p>

--- a/app/views/results/marker/_marker_summary.html.erb
+++ b/app/views/results/marker/_marker_summary.html.erb
@@ -74,8 +74,12 @@
     <div class="clear"></div>
 
     <div class="summary_block">
-      <b class="total_extra_points_label"><%= I18n.t("marker.marks.total_extra_marks").html_safe %></b>
-        <span id="total_extra_points"><%= old_result.get_total_extra_points %></span><br/></b>
+      <b class="total_extra_points_label">
+        <%= I18n.t("marker.marks.total_extra_marks").html_safe %>
+        <span id="total_extra_points">
+          <%= old_result.get_total_extra_points %>
+        </span><br/>
+      </b>
     </div>
 
     <div class="clear"></div>

--- a/app/views/results/student/_extra_marks_table.html.erb
+++ b/app/views/results/student/_extra_marks_table.html.erb
@@ -4,10 +4,11 @@
     <th><%= I18n.t("marker.marks.mark") %></th>
   </thead>
   <tbody id="extra_marks_list" >
-    <tr>
-     <% extra_marks_points.each do |extra_mark| -%>
-       <%= render :partial => "results/student/extra_mark", :locals => {:extra_mark => extra_mark, :result_id => result_id} %>
-     <% end -%>
-   </tbody>
+    <% extra_marks_points.each do |extra_mark| -%>
+      <%= render :partial => "results/student/extra_mark",
+                 :locals => {:extra_mark => extra_mark,
+                             :result_id => result_id} %>
+    <% end -%>
+  </tbody>
 </table>
 


### PR DESCRIPTION
Some tags are not closed properly, so the HTML parser complains when
doing assert_select in functional tests.

Tested:
- rake test:functionals
