### PR TITLE
Fix i18n warning about enforcing locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,6 @@ module Markus
   config.assets.version = '1.0'
 
   # Validate passed locales
-  config.i18n.enforce_available_locales = true
+  I18n.enforce_available_locales = true
   end
 end


### PR DESCRIPTION
This gets rid of the warning

```
[deprecated] I18n.enforce_available_locales will default to true in the
future. If you really want to skip validation of your locale you can set
I18n.enforce_available_locales = false to avoid this message.
```

See
http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
