### PR TITLE
Fix for issue 1485. Updated controller to include values 500 and 1000

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -23,7 +23,7 @@ class GradeEntryFormsController < ApplicationController
   # Filters will be added as the student UI is implemented (eg. Show Released,
   # Show All,...)
   G_TABLE_PARAMS = {:model => GradeEntryStudent,
-                    :per_pages => [15, 30, 50, 100, 150],
+                    :per_pages => [15, 30, 50, 100, 150, 500, 1000],
                     :filters => {
                         'none' => {
                             :display => 'Show All',


### PR DESCRIPTION
Problem Description: Issue #1485. The Marks Spreadsheet has a Show ## per page drop down but it does not go high enough. It can only go up to 150 records per page. The request was to make it similar to the assignments page and include 500 and 1000 as options

Solution: Updated the grade_entry_forms_controller.rb file to include the values 500 and 1000.

Testing: Tried every option from 15 per page all the way to 1000 per page just to make sure that everything still works as expected and they do.
