### PR TITLE
Put inactive students in a separate tab

### DIFF
--- a/app/assets/javascripts/manage_groups.js
+++ b/app/assets/javascripts/manage_groups.js
@@ -18,6 +18,7 @@ function filter(filter_name) {
         break;
       case 'assigned':
       case 'unassigned':
+      case 'inactive':
         students_table.filter_only_by(filter_name).render();
         break;
       case 'students_none':

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -706,11 +706,11 @@ input#extra_mark_description {
 
 .colLeftGroups {
   min-width: 365px;
-  width: 35%;
+  width: 40%;
 }
 
 .colRightGroups {
-  width: 55%;
+  width: 51%;
 }
 
 .colLeftGraders {

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -70,6 +70,7 @@ module GroupsHelper
     table_row[:first_name] = student.first_name
     table_row[:last_name] = student.last_name
     table_row[:filter_student_assigned] = students_in_assignment.include?(student)
+    table_row[:active] = !student.hidden
 
     table_row
 end

--- a/app/views/groups/_boot.js.erb
+++ b/app/views/groups/_boot.js.erb
@@ -96,10 +96,13 @@ document.observe("dom:loaded", function() {
     default_filters: ['unassigned'],
     filters: {
       assigned: function(row) {
-        return row.filter_student_assigned;
+        return row.filter_student_assigned && row.active;
       },
       unassigned: function(row) {
-        return !row.filter_student_assigned;
+        return !row.filter_student_assigned && row.active;
+      },
+      inactive: function(row) {
+        return !row.active;
       },
       search: function(row) {
         return (row.user_name.toLowerCase().indexOf($('search_students').value.toLowerCase()) != -1
@@ -127,7 +130,8 @@ document.observe("dom:loaded", function() {
     total_count_id: 'all_students_count',
     filter_count_ids: {
       assigned: 'assigned_students_count',
-      unassigned: 'unassigned_students_count'
+      unassigned: 'unassigned_students_count',
+      inactive: 'inactive_students_count'
     }
   });
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -194,11 +194,17 @@
               <%= raw(I18n.t("groups.assigned_students")) %>
             </a>
           </li>
+          <li class="tab">
+            <a href="#inactive" id="filter_link_students_inactive">
+              <%= raw(I18n.t("groups.inactive_students")) %>
+            </a>
+          </li>
         </ul>
 
         <div id="students_none"></div>
         <div id="unassigned"></div>
         <div id="assigned"></div>
+        <div id="inactive"></div>
 
         <div class="tabbedArea">
           <div class="search_box">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -480,6 +480,7 @@ en:
       all_students:     "All students(<span id=\"all_students_count\"></span>)"
       unassigned_students: "Unassigned(<span id=\"unassigned_students_count\"></span>)"
       assigned_students: "Assigned(<span id=\"assigned_students_count\"></span>)"
+      inactive_students: "Inactive(<span id=\"inactive_students_count\"></span>)"
       another_assignment_group: "Use another assignment's groups"
       graders: "Graders (%{graders})"
       all_grouping_counts: "All Groups(<span id=\"all_groupings_count\"></span>)"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -482,6 +482,7 @@ fr:
       all_students: "Tous les étudiants(<span id=\"all_students_count\"></span>)"
       unassigned_students: "Non assigné(s)(<span id=\"unassigned_students_count\"></span>)"
       assigned_students: "Assigné(s)(<span id=\"assigned_students_count\"></span>)"
+      inactive_students: "Inactif(<span id=\"inactive_students_count\"></span>)"
       another_assignment_group: "Utiliser les groupes d'un autre projet"
       graders: "Correcteurs (%{graders})"
       all_grouping_counts: "Tous (<span id=\"all_groupings_count\"></span>)"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -480,6 +480,7 @@ pt:
       all_students: "Todos os alunos(<span id=\"all_students_count\"></span>)"
       unassigned_students: "Não-atribuídos(<span id=\"unassigned_students_count\"></span>)"
       assigned_students: "Atribuídos(<span id=\"assigned_students_count\"></span>)"
+      inactive_students: "Inativo(<span id=\"inactive_students_count\"></span>)"
       another_assignment_group: "Use grupos de outro projeto"
       graders: "Avaliadores (%{graders})"
       all_grouping_counts: "Todos os grupos(<span id=\"all_groupings_count\"></span>)"


### PR DESCRIPTION
This partially solves #1467, which adds a new tab under the group view
just for inactive students, resulting 3 disjoint sets:
- { assigned students }
- { unassigned students }
- { inactive students }

And the union of them is the set of all students.

Tested:
- rake test:units
- rake test:functionals
- rails s
- en, fr, pt
- Ruby 1.9.3-p545, 2.1.2
