### PR TITLE
Replace controller symbol hash rockets (part 1)

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -6,11 +6,11 @@ class AdminsController < ApplicationController
   end
 
   def populate
-    admins_data = Admin.all(:order => 'user_name')
+    admins_data = Admin.all(order: 'user_name')
     # construct_table_rows defined in UsersHelper
     @admins = construct_table_rows(admins_data)
     respond_to do |format|
-      format.json { render :json => @admins }
+      format.json { render json: @admins }
     end
   end
 
@@ -31,8 +31,8 @@ class AdminsController < ApplicationController
       render :edit
     else
       flash[:success] = I18n.t('admins.update.success',
-        :user_name => @user.user_name)
-      redirect_to :action => 'index'
+        user_name: @user.user_name)
+      redirect_to action: 'index'
     end
   end
 
@@ -47,9 +47,9 @@ class AdminsController < ApplicationController
     # updates the existing record
     if @user.save
       flash[:success] = I18n.t('admins.create.success',
-        :user_name => @user.user_name)
+        user_name: @user.user_name)
 
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       flash[:error] = I18n.t('admins.create.error')
       render 'new'

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -84,17 +84,17 @@ class AnnotationCategoriesController < ApplicationController
     case params[:format]
     when 'csv'
       send_data convert_to_csv(@annotation_categories),
-                :filename => "#{@assignment.short_identifier}_annotations.csv",
-                :disposition => 'attachment'
+                filename: "#{@assignment.short_identifier}_annotations.csv",
+                disposition: 'attachment'
     when 'yml'
       send_data convert_to_yml(@annotation_categories),
-                :filename => "#{@assignment.short_identifier}_annotations.yml",
-                :disposition => 'attachment'
+                filename: "#{@assignment.short_identifier}_annotations.yml",
+                disposition: 'attachment'
     else
       flash[:error] = I18n.t('annotations.upload.flash_error',
-        :format => params[:format])
-      redirect_to :action => 'index',
-                  :id => params[:id]
+        format: params[:format])
+      redirect_to action: 'index',
+                  id: params[:id]
     end
   end
 
@@ -102,7 +102,7 @@ class AnnotationCategoriesController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     encoding = params[:encoding]
     unless request.post?
-      redirect_to :action => 'index', :id => @assignment.id
+      redirect_to action: 'index', id: @assignment.id
       return
     end
     annotation_category_list = params[:annotation_category_list_csv]
@@ -116,7 +116,7 @@ class AnnotationCategoriesController < ApplicationController
         result = AnnotationCategory.add_by_row(row, @assignment, current_user)
         if result[:annotation_upload_invalid_lines].size > 0
           flash[:error] = I18n.t('annotations.upload.error',
-            :annotation_category => row, :annotation_line => annotation_line)
+            annotation_category: row, annotation_line: annotation_line)
           break
         else
           annotation_category_number += 1
@@ -124,17 +124,17 @@ class AnnotationCategoriesController < ApplicationController
       end
       if annotation_category_number > 0
         flash[:success] = I18n.t('annotations.upload.success',
-          :annotation_category_number => annotation_category_number)
+          annotation_category_number: annotation_category_number)
       end
     end
-    redirect_to :action => 'index', :id => @assignment.id
+    redirect_to action: 'index', id: @assignment.id
   end
 
   def yml_upload
     @assignment = Assignment.find(params[:assignment_id])
     encoding = params[:encoding]
     unless request.post?
-      redirect_to :action => 'index', :assignment_id => @assignment.id
+      redirect_to action: 'index', assignment_id: @assignment.id
       return
     end
     file = params[:annotation_category_list_yml]
@@ -147,8 +147,8 @@ class AnnotationCategoriesController < ApplicationController
       # is thrown by Psych in Ruby 2.*.
       rescue ArgumentError, Psych::SyntaxError => e
         flash[:error] = I18n.t('annotations.upload.syntax_error',
-          :error => "#{e}")
-        redirect_to :action => 'index', :assignment_id => @assignment.id
+          error: "#{e}")
+        redirect_to action: 'index', assignment_id: @assignment.id
         return
       end
       annotations.each_key do |key|
@@ -156,7 +156,7 @@ class AnnotationCategoriesController < ApplicationController
       annotation_line += 1
       if result[:annotation_upload_invalid_lines].size > 0
         flash[:error] = I18n.t('annotations.upload.error',
-          :annotation_category => key, :annotation_line => annotation_line)
+          annotation_category: key, annotation_line: annotation_line)
         break
       else
         annotation_category_number += 1
@@ -164,9 +164,9 @@ class AnnotationCategoriesController < ApplicationController
      end
      if annotation_category_number > 0
         flash[:success] = I18n.t('annotations.upload.success',
-          :annotation_category_number => annotation_category_number)
+          annotation_category_number: annotation_category_number)
      end
     end
-    redirect_to :action => 'index', :assignment_id => @assignment.id
+    redirect_to action: 'index', assignment_id: @assignment.id
   end
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -12,20 +12,20 @@ class AnnotationsController < ApplicationController
     if params[:annotation_type] == 'image'
       @annotation = ImageAnnotation.new
       @annotation.update_attributes({
-        :x1 => Integer(params[:x1]), :x2 => Integer(params[:x2]),
-        :y1 => Integer(params[:y1]), :y2 => Integer(params[:y2]),
-        :submission_file_id => params[:submission_file_id],
-        :is_remark => is_remark,
-        :annotation_number => submission.annotations.count + 1
+        x1: Integer(params[:x1]), x2: Integer(params[:x2]),
+        y1: Integer(params[:y1]), y2: Integer(params[:y2]),
+        submission_file_id: params[:submission_file_id],
+        is_remark: is_remark,
+        annotation_number: submission.annotations.count + 1
       })
     else
       @annotation = TextAnnotation.new
       @annotation.update_attributes({
-        :line_start => params[:line_start],
-        :line_end => params[:line_end],
-        :submission_file_id => params[:submission_file_id],
-        :is_remark => is_remark,
-        :annotation_number => submission.annotations.count + 1
+        line_start: params[:line_start],
+        line_end: params[:line_end],
+        submission_file_id: params[:submission_file_id],
+        is_remark: is_remark,
+        annotation_number: submission.annotations.count + 1
       })
     end
     @annotation.annotation_text = @text
@@ -36,10 +36,10 @@ class AnnotationsController < ApplicationController
 
   def create
     @text = AnnotationText.create({
-      :content => params[:content],
-      :annotation_category_id => params[:category_id],
-      :creator_id => current_user.id,
-      :last_editor_id => current_user.id
+      content: params[:content],
+      annotation_category_id: params[:category_id],
+      creator_id: current_user.id,
+      last_editor_id: current_user.id
     })
     @submission_file_id = params[:submission_file_id]
     @submission_file = SubmissionFile.find(@submission_file_id)
@@ -48,21 +48,21 @@ class AnnotationsController < ApplicationController
     case params[:annotation_type]
       when 'text'
         @annotation = TextAnnotation.create({
-          :line_start => params[:line_start],
-          :line_end => params[:line_end],
-          :annotation_text_id => @text.id,
-          :submission_file_id => params[:submission_file_id],
-          :is_remark => is_remark,
-          :annotation_number => submission.annotations.count + 1
+          line_start: params[:line_start],
+          line_end: params[:line_end],
+          annotation_text_id: @text.id,
+          submission_file_id: params[:submission_file_id],
+          is_remark: is_remark,
+          annotation_number: submission.annotations.count + 1
         })
       when 'image'
         @annotation = ImageAnnotation.create({
-          :annotation_text_id => @text.id,
-          :submission_file_id => params[:submission_file_id],
-          :x1 => Integer(params[:x1]), :x2 => Integer(params[:x2]),
-          :y1 => Integer(params[:y1]), :y2 => Integer(params[:y2]),
-          :is_remark => is_remark,
-          :annotation_number => submission.annotations.count + 1
+          annotation_text_id: @text.id,
+          submission_file_id: params[:submission_file_id],
+          x1: Integer(params[:x1]), x2: Integer(params[:x2]),
+          y1: Integer(params[:y1]), y2: Integer(params[:y2]),
+          is_remark: is_remark,
+          annotation_number: submission.annotations.count + 1
         })
     end
     @submission = @submission_file.submission

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -18,9 +18,9 @@ module Api
       fields = fields_to_render(@@default_fields)
 
       respond_to do |format|
-        format.xml{render :xml => assignments.to_xml(:only => fields, :root =>
-          'assignments', :skip_types => 'true')}
-        format.json{render :json => assignments.to_json(:only => fields)}
+        format.xml{render xml: assignments.to_xml(only: fields, root:
+          'assignments', skip_types: 'true')}
+        format.json{render json: assignments.to_json(only: fields)}
       end
     end
 
@@ -31,15 +31,15 @@ module Api
       assignment = Assignment.find_by_id(params[:id])
       if assignment.nil?
         # No assignment with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No assignment exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No assignment exists with that id'}, status: 404
       else
         fields = fields_to_render(@@default_fields)
 
         respond_to do |format|
-          format.xml{render :xml => assignment.to_xml(:only => fields, :root =>
-            'assignment', :skip_types => 'true')}
-          format.json{render :json => assignment.to_json(:only => fields)}
+          format.xml{render xml: assignment.to_xml(only: fields, root:
+            'assignment', skip_types: 'true')}
+          format.json{render json: assignment.to_json(only: fields)}
         end
       end
     end
@@ -55,21 +55,21 @@ module Api
     def create
       if has_missing_params?([:short_identifier, :due_date, :description])
         # incomplete/invalid HTTP params
-        render 'shared/http_status', :locals => {:code => '422', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['422']}, :status => 422
+        render 'shared/http_status', locals: {code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
         return
       end
 
       # check if there is an existing assignment
       assignment = Assignment.find_by_short_identifier(params[:short_identifier])
       unless assignment.nil?
-        render 'shared/http_status', :locals => {:code => '409', :message =>
-          'Assignment already exists'}, :status => 409
+        render 'shared/http_status', locals: {code: '409', message:
+          'Assignment already exists'}, status: 409
         return
       end
 
       # No assignment found so create new one
-      attributes = { :short_identifier => params[:short_identifier] }
+      attributes = { short_identifier: params[:short_identifier] }
       attributes = process_attributes(params, attributes)
 
       new_assignment = Assignment.new(attributes)
@@ -79,8 +79,8 @@ module Api
       submission_rule = get_submission_rule(params)
 
       if submission_rule.nil?
-        render 'shared/http_status', :locals => {:code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500']}, :status => 500
+        render 'shared/http_status', locals: {code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500']}, status: 500
         return
       end
 
@@ -88,14 +88,14 @@ module Api
 
       unless new_assignment.save
         # Some error occurred
-        render 'shared/http_status', :locals => {:code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500']}, :status => 500
+        render 'shared/http_status', locals: {code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500']}, status: 500
         return
       end
 
       # Otherwise everything went alright.
-      render 'shared/http_status', :locals => {:code => '201', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['201']}, :status => 201
+      render 'shared/http_status', locals: {code: '201', message:
+        HttpStatusHelper::ERROR_CODE['message']['201']}, status: 201
     end
 
     # Updates an existing assignment
@@ -110,8 +110,8 @@ module Api
       # If no assignment is found, render an error.
       assignment = Assignment.find_by_id(params[:id])
       if assignment.nil?
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'Assignment was not found'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'Assignment was not found'}, status: 404
         return
       end
 
@@ -123,8 +123,8 @@ module Api
         other_assignment = Assignment.find_by_short_identifier(
           params[:short_identifier])
         if !other_assignment.nil? && other_assignment != assignment
-          render 'shared/http_status', :locals => {:code => '409', :message =>
-            'short_identifier already in use'}, :status => 409
+          render 'shared/http_status', locals: {code: '409', message:
+            'short_identifier already in use'}, status: 409
           return
         end
         attributes[:short_identifier] = params[:short_identifier]
@@ -137,8 +137,8 @@ module Api
       unless params[:submission_rule_type].nil?
         submission_rule = get_submission_rule(params)
         if submission_rule.nil?
-          render 'shared/http_status', :locals => {:code => '500', :message =>
-            HttpStatusHelper::ERROR_CODE['message']['500']}, :status => 500
+          render 'shared/http_status', locals: {code: '500', message:
+            HttpStatusHelper::ERROR_CODE['message']['500']}, status: 500
           return
         else
           # If it's a valid submission rule, replace the existing one
@@ -151,14 +151,14 @@ module Api
 
       unless assignment.save
         # Some error occurred
-        render 'shared/http_status', :locals => {:code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500']}, :status => 500
+        render 'shared/http_status', locals: {code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500']}, status: 500
         return
       end
 
       # Made it this far, render success
-      render 'shared/http_status', :locals => {:code => '200', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['200']}, :status => 200
+      render 'shared/http_status', locals: {code: '200', message:
+        HttpStatusHelper::ERROR_CODE['message']['200']}, status: 200
     end
 
     # Process the parameters passed for assignment creation and update
@@ -173,11 +173,11 @@ module Api
       # Some attributes have to be set with default values when creating a new
       # assignment. They're based on the view's defaults.
       if request.post?
-        required_fields = { :enable_test => 0,  :assign_graders_to_criteria => 0,
-                            :repository_folder => attributes[:short_identifier],
-                            :allow_web_submits => 1, :group_min => 1,
-                            :display_grader_names_to_students => 0,
-                            :marking_scheme_type => 'rubric',:is_hidden => 0 }
+        required_fields = { enable_test: 0,  assign_graders_to_criteria: 0,
+                            repository_folder: attributes[:short_identifier],
+                            allow_web_submits: 1, group_min: 1,
+                            display_grader_names_to_students: 0,
+                            marking_scheme_type: 'rubric',is_hidden: 0 }
         required_fields.each do |field_name, default_value|
           attributes[field_name] = default_value if params[field_name].nil?
         end
@@ -191,20 +191,20 @@ module Api
     def get_submission_rule(params)
       if params[:submission_rule_type] == 'GracePeriod'
         submission_rule = GracePeriodSubmissionRule.new
-        period = Period.new(:hours => params[:submission_rule_hours])
+        period = Period.new(hours: params[:submission_rule_hours])
         submission_rule.periods << period
 
       elsif params[:submission_rule_type] == 'PenaltyDecayPeriod'
         submission_rule = PenaltyDecayPeriodSubmissionRule.new
-        period = Period.new(:hours => params[:submission_rule_hours],
-                            :deduction => params[:submission_rule_deduction],
-                            :interval => params[:submission_rule_interval])
+        period = Period.new(hours: params[:submission_rule_hours],
+                            deduction: params[:submission_rule_deduction],
+                            interval: params[:submission_rule_interval])
         submission_rule.periods << period
 
       elsif params[:submission_rule_type] == 'PenaltyPeriod'
         submission_rule = PenaltyPeriodSubmissionRule.new
-        period = Period.new(:hours => params[:submission_rule_hours],
-                            :deduction => params[:submission_rule_deduction])
+        period = Period.new(hours: params[:submission_rule_hours],
+                            deduction: params[:submission_rule_deduction])
         submission_rule.periods << period
 
       else

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -15,23 +15,23 @@ module Api
       assignment = Assignment.find_by_id(params[:assignment_id])
       if assignment.nil?
         # No assignment with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No assignment exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No assignment exists with that id'}, status: 404
         return
       end
 
-      collection = Group.joins(:assignments).where(:assignments =>
-        {:id => params[:assignment_id]})
+      collection = Group.joins(:assignments).where(assignments:
+        {id: params[:assignment_id]})
       groups = get_collection(Group, collection)
       fields = fields_to_render(@@default_fields)
 
       students = include_students(fields)
 
       respond_to do |format|
-        format.xml{render :xml => groups.to_xml(:only => fields, :root =>
-          'groups', :skip_types => 'true', :include => students)}
-        format.json{render :json => groups.to_json(:only => fields,
-          :include => students)}
+        format.xml{render xml: groups.to_xml(only: fields, root:
+          'groups', skip_types: 'true', include: students)}
+        format.json{render json: groups.to_json(only: fields,
+          include: students)}
       end
     end
 
@@ -42,16 +42,16 @@ module Api
       # Error if no assignment exists with that id
       assignment = Assignment.find_by_id(params[:assignment_id])
       if assignment.nil?
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No assignment exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No assignment exists with that id'}, status: 404
         return
       end
 
       # Error if no group exists with that id
       group = Group.find_by_id(params[:id])
       if group.nil?
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No group exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No group exists with that id'}, status: 404
         return
       end
 
@@ -61,22 +61,22 @@ module Api
         students = include_students(fields)
 
         respond_to do |format|
-          format.xml{render :xml => group.to_xml(:only => fields, :root =>
-            'group', :skip_types => 'true', :include => students)}
-          format.json{render :json => group.to_json(:only => fields,
-            :include => students)}
+          format.xml{render xml: group.to_xml(only: fields, root:
+            'group', skip_types: 'true', include: students)}
+          format.json{render json: group.to_json(only: fields,
+            include: students)}
         end
       else
         # The group doesn't have a grouping associated with that assignment
-        render 'shared/http_status', :locals => {:code => '422', :message =>
-          'The group is not involved with that assignment'}, :status => 422
+        render 'shared/http_status', locals: {code: '422', message:
+          'The group is not involved with that assignment'}, status: 422
       end
     end
 
     # Include student_memberships and user info if required
     def include_students(fields)
       if fields.include?(:student_memberships)
-        {:student_memberships => {:include => :user}}
+        {student_memberships: {include: :user}}
       end
     end
 

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -11,28 +11,28 @@ module Api
 
     # Unless overridden by a subclass, all routes are 404's by default
     def index
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404']}, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404']}, status: 404
     end
 
     def show
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end
 
     def create
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end
 
     def update
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end
 
     def destroy
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end
 
     private
@@ -48,8 +48,8 @@ module Api
           @current_user = User.find_by_user_name(markus_auth_remote_user)
         else
           # REMOTE_USER_AUTH is true, but REMOTE_USER wasn't set, bail out
-          render 'shared/http_status', :locals => {:code => '403', :message =>
-            HttpStatusHelper::ERROR_CODE['message']['403']}, :status => 403
+          render 'shared/http_status', locals: {code: '403', message:
+            HttpStatusHelper::ERROR_CODE['message']['403']}, status: 403
           return
         end
       else
@@ -57,8 +57,8 @@ module Api
         auth_token = parse_auth_token(request.headers['HTTP_AUTHORIZATION'])
         # pretend resource not found if missing or authentication is invalid
         if auth_token.nil?
-          render 'shared/http_status', :locals => {:code => '403', :message =>
-            HttpStatusHelper::ERROR_CODE['message']['403']}, :status => 403
+          render 'shared/http_status', locals: {code: '403', message:
+            HttpStatusHelper::ERROR_CODE['message']['403']}, status: 403
           return
         end
         # Find user by api_key_md5
@@ -67,24 +67,24 @@ module Api
 
       if @current_user.nil?
         # Key/username does not exist, return 403 error
-        render 'shared/http_status', :locals => {:code => '403', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['403']}, :status => 403
+        render 'shared/http_status', locals: {code: '403', message:
+          HttpStatusHelper::ERROR_CODE['message']['403']}, status: 403
         return
       elsif markus_auth_remote_user.blank?
         # see if the MD5 matches only if REMOTE_USER wasn't used
         curr_user_md5 = Base64.decode64(@current_user.api_key)
         if Base64.decode64(auth_token) != curr_user_md5
           # MD5 mismatch, return 403 error
-          render 'shared/http_status', :locals => {:code => '403', :message =>
-            HttpStatusHelper::ERROR_CODE['message']['403']}, :status => 403
+          render 'shared/http_status', locals: {code: '403', message:
+            HttpStatusHelper::ERROR_CODE['message']['403']}, status: 403
           return
         end
       end
       # Student's aren't allowed yet
       if @current_user.student?
         # API is available for TAs and Admins only
-        render 'shared/http_status', :locals => {:code => '403', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['403']}, :status => 403
+        render 'shared/http_status', locals: {code: '403', message:
+          HttpStatusHelper::ERROR_CODE['message']['403']}, status: 403
       end
     end
 
@@ -99,7 +99,7 @@ module Api
       request_format = request.format.symbol
       if request_format != :xml && request_format != :json
         # 406 is the default status code when the format is not support
-        render :nothing => true, :status => 406
+        render nothing: true, status: 406
       end
     end
 

--- a/app/controllers/api/submission_downloads_controller.rb
+++ b/app/controllers/api/submission_downloads_controller.rb
@@ -15,16 +15,16 @@ module Api
       assignment = Assignment.find_by_id(params[:assignment_id])
       if assignment.nil?
         # No assignment with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No assignment exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No assignment exists with that id'}, status: 404
         return
       end
 
       group = Group.find_by_id(params[:group_id])
       if group.nil?
         # No group exists with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No group exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No group exists with that id'}, status: 404
         return
       end
 
@@ -32,8 +32,8 @@ module Api
         group[:group_name], assignment[:short_identifier])
       if submission.nil?
         # No assignment submission by that group
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'Submission was not found'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'Submission was not found'}, status: 404
         return
       end
 
@@ -53,8 +53,8 @@ module Api
       files.each do |file|
         if file.nil?
           # No such file in the submission
-          render 'shared/http_status', :locals => {:code => '422', :message =>
-            'File was not found'}, :status => 422
+          render 'shared/http_status', locals: {code: '422', message:
+            'File was not found'}, status: 422
           return
         end
 
@@ -67,14 +67,14 @@ module Api
           end
         rescue Exception
             # Could not retrieve file
-            render 'shared/http_status', :locals => {:code => '500', :message =>
-              HttpStatusHelper::ERROR_CODE['message']['500'] }, :status => 500
+            render 'shared/http_status', locals: {code: '500', message:
+              HttpStatusHelper::ERROR_CODE['message']['500'] }, status: 500
           return
         end
 
         if files.length == 1
           # If we only have 1 file being requested, send it
-          send_data file_contents, :disposition => 'inline', :filename => file.filename
+          send_data file_contents, disposition: 'inline', filename: file.filename
         else
           # Otherwise zip up the requested submission files
           Zip::File.open("tmp/#{zip_name}", Zip::File::CREATE) do |zipfile|
@@ -89,7 +89,7 @@ module Api
 
       # Send the zip
       if files.length > 1
-        send_file "tmp/#{zip_name}", :disposition => 'inline', :filename =>
+        send_file "tmp/#{zip_name}", disposition: 'inline', filename:
           zip_name
       end
     end

--- a/app/controllers/api/test_results_controller.rb
+++ b/app/controllers/api/test_results_controller.rb
@@ -20,9 +20,9 @@ module Api
       fields = fields_to_render(@@default_fields)
 
       respond_to do |format|
-        format.xml{render :xml => test_results.to_xml(:only => fields, :root =>
-          'test_results', :skip_types => 'true')}
-        format.json{render :json => test_results.to_json(:only => fields)}
+        format.xml{render xml: test_results.to_xml(only: fields, root:
+          'test_results', skip_types: 'true')}
+        format.json{render json: test_results.to_json(only: fields)}
       end
     end
 
@@ -37,14 +37,14 @@ module Api
 
       # Render error if the TestResult does not exist
       if test_result.nil?
-        render 'shared/http_status', :locals => { :code => '404', :message =>
-          'Test result was not found'}, :status => 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'Test result was not found'}, status: 404
         return
       end
 
       # Everything went fine; send file_content
-      send_data test_result.file_content, :disposition => 'inline',
-                                          :filename => test_result.filename
+      send_data test_result.file_content, disposition: 'inline',
+                                          filename: test_result.filename
     end
 
     # Creates a new test result for a group's latest assignment submission
@@ -56,8 +56,8 @@ module Api
     def create
       if has_missing_params?([:filename, :file_content])
         # incomplete/invalid HTTP params
-        render 'shared/http_status', :locals => {:code => '422', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['422']}, :status => 422
+        render 'shared/http_status', locals: {code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
         return
       end
 
@@ -68,22 +68,22 @@ module Api
       # Render error if there's an existing test result with that filename
       test_result = submission.test_results.find_by_filename(params[:filename])
       unless test_result.nil?
-        render 'shared/http_status', :locals => {:code => '409', :message =>
-          'A TestResult with that filename already exists'}, :status => 409
+        render 'shared/http_status', locals: {code: '409', message:
+          'A TestResult with that filename already exists'}, status: 409
         return
       end
 
       # Try creating the TestResult
-      if TestResult.create(:filename => params[:filename],
-         :file_content => params[:file_content],
-         :submission_id => submission.id)
+      if TestResult.create(filename: params[:filename],
+         file_content: params[:file_content],
+         submission_id: submission.id)
         # It worked, render success
-        render 'shared/http_status', :locals => {:code => '201', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['201']}, :status => 201
+        render 'shared/http_status', locals: {code: '201', message:
+          HttpStatusHelper::ERROR_CODE['message']['201']}, status: 201
       else
         # Some other error occurred
-        render 'shared/http_status', :locals => { :code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500'] }, :status => 500
+        render 'shared/http_status', locals: { code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500'] }, status: 500
       end
     end
 
@@ -98,19 +98,19 @@ module Api
 
       # Render error if the TestResult does not exist
       if test_result.nil?
-        render 'shared/http_status', :locals => { :code => '404', :message =>
-          'Test result was not found'}, :status => 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'Test result was not found'}, status: 404
         return
       end
 
       if test_result.destroy
         # Successfully deleted the TestResult; render success
-        render 'shared/http_status', :locals => { :code => '200', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['200']}, :status => 200
+        render 'shared/http_status', locals: { code: '200', message:
+          HttpStatusHelper::ERROR_CODE['message']['200']}, status: 200
       else
         # Some other error occurred
-        render 'shared/http_status', :locals => { :code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500'] }, :status => 500
+        render 'shared/http_status', locals: { code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500'] }, status: 500
       end
     end
 
@@ -128,16 +128,16 @@ module Api
 
       # Render error if the TestResult does not exist
       if test_result.nil?
-        render 'shared/http_status', :locals => { :code => '404', :message =>
-          'Test result was not found'}, :status => 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'Test result was not found'}, status: 404
         return
       end
 
       # Render error if the filename is used by another TestResult for that submission
       existing_file = submission.test_results.find_by_filename(params[:filename])
       if !existing_file.nil? && existing_file.id != params[:id]
-        render 'shared/http_status', :locals => {:code => '409', :message =>
-          'A TestResult with that filename already exists'}, :status => 409
+        render 'shared/http_status', locals: {code: '409', message:
+          'A TestResult with that filename already exists'}, status: 409
         return
       end
 
@@ -146,12 +146,12 @@ module Api
 
       if test_result.save && test_result.update_file_content(params[:file_content])
         # Everything went fine; report success
-        render 'shared/http_status', :locals => { :code => '200', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['200']}, :status => 200
+        render 'shared/http_status', locals: { code: '200', message:
+          HttpStatusHelper::ERROR_CODE['message']['200']}, status: 200
       else
         # Some other error occurred
-        render 'shared/http_status', :locals => { :code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500'] }, :status => 500
+        render 'shared/http_status', locals: { code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500'] }, status: 500
       end
     end
 
@@ -161,16 +161,16 @@ module Api
       assignment = Assignment.find_by_id(assignment_id)
       if assignment.nil?
         # No assignment with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No assignment exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No assignment exists with that id'}, status: 404
         return nil
       end
 
       group = Group.find_by_id(group_id)
       if group.nil?
         # No group exists with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No group exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No group exists with that id'}, status: 404
         return nil
       end
 
@@ -178,8 +178,8 @@ module Api
         group[:group_name], assignment[:short_identifier])
       if submission.nil?
         # No assignment submission by that group
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'Submission was not found'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'Submission was not found'}, status: 404
       end
 
       submission

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -15,9 +15,9 @@ module Api
       fields = fields_to_render(@@default_fields)
 
       respond_to do |format|
-        format.xml{render :xml => users.to_xml(:only => fields, :root => 'users',
-          :skip_types => 'true')}
-        format.json{render :json => users.to_json(:only => fields)}
+        format.xml{render xml: users.to_xml(only: fields, root: 'users',
+          skip_types: 'true')}
+        format.json{render json: users.to_json(only: fields)}
       end
     end
 
@@ -27,16 +27,16 @@ module Api
     def create
       if has_missing_params?([:user_name, :type, :first_name, :last_name])
         # incomplete/invalid HTTP params
-        render 'shared/http_status', :locals => {:code => '422', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['422']}, :status => 422
+        render 'shared/http_status', locals: {code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
         return
       end
 
       # Check if that user_name is taken
       user = User.find_by_user_name(params[:user_name])
       unless user.nil?
-        render 'shared/http_status', :locals => {:code => '409', :message =>
-          'User already exists'}, :status => 409
+        render 'shared/http_status', locals: {code: '409', message:
+          'User already exists'}, status: 409
         return
       end
 
@@ -54,26 +54,26 @@ module Api
         user_class = Admin
         user_type = User::ADMIN
       else # Unknown user type, Invalid HTTP params.
-        render 'shared/http_status', :locals => { :code => '422', :message =>
-          'Unknown user type' }, :status => 422
+        render 'shared/http_status', locals: { code: '422', message:
+          'Unknown user type' }, status: 422
         return
       end
 
-      attributes = { :user_name => params[:user_name] }
+      attributes = { user_name: params[:user_name] }
       attributes = process_attributes(params, attributes)
 
       new_user = user_class.new(attributes)
       new_user.type = user_type
       unless new_user.save
         # Some error occurred
-        render 'shared/http_status', :locals => {:code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500']}, :status => 500
+        render 'shared/http_status', locals: {code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500']}, status: 500
         return
       end
 
       # Otherwise everything went alright.
-      render 'shared/http_status', :locals => {:code => '201', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['201']}, :status => 201
+      render 'shared/http_status', locals: {code: '201', message:
+        HttpStatusHelper::ERROR_CODE['message']['201']}, status: 201
     end
 
     # Returns a user and its attributes
@@ -83,15 +83,15 @@ module Api
       user = User.find_by_id(params[:id])
       if user.nil?
         # No user with that id
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'No user exists with that id'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'No user exists with that id'}, status: 404
       else
         fields = fields_to_render(@@default_fields)
 
         respond_to do |format|
-          format.xml{render :xml => user.to_xml(:only => fields, :root => 'user',
-            :skip_types => 'true')}
-          format.json{render :json => user.to_json(:only => fields)}
+          format.xml{render xml: user.to_xml(only: fields, root: 'user',
+            skip_types: 'true')}
+          format.json{render json: user.to_json(only: fields)}
         end
       end
     end
@@ -99,8 +99,8 @@ module Api
     # Requires nothing, does nothing
     def destroy
       # Admins should not be deleting users, so pretend this URL doesn't exist
-      render 'shared/http_status', :locals => {:code => '404', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404
+      render 'shared/http_status', locals: {code: '404', message:
+        HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end
 
     # Requires: id
@@ -109,8 +109,8 @@ module Api
       # If no user is found, render an error.
       user = User.find_by_id(params[:id])
       if user.nil?
-        render 'shared/http_status', :locals => {:code => '404', :message =>
-          'User was not found'}, :status => 404
+        render 'shared/http_status', locals: {code: '404', message:
+          'User was not found'}, status: 404
         return
       end
 
@@ -121,8 +121,8 @@ module Api
         # Make sure the user_name isn't taken
         other_user = User.find_by_user_name(params[:user_name])
         if !other_user.nil? && other_user != user
-          render 'shared/http_status', :locals => {:code => '409', :message =>
-            'Username already in use'}, :status => 409
+          render 'shared/http_status', locals: {code: '409', message:
+            'Username already in use'}, status: 409
           return
         end
         attributes[:user_name] = params[:user_name]
@@ -133,14 +133,14 @@ module Api
       user.attributes = attributes
       unless user.save
         # Some error occurred
-        render 'shared/http_status', :locals => { :code => '500', :message =>
-          HttpStatusHelper::ERROR_CODE['message']['500'] }, :status => 500
+        render 'shared/http_status', locals: { code: '500', message:
+          HttpStatusHelper::ERROR_CODE['message']['500'] }, status: 500
         return
       end
 
       # Otherwise everything went alright.
-      render 'shared/http_status', :locals => {:code => '200', :message =>
-        HttpStatusHelper::ERROR_CODE['message']['200']}, :status => 200
+      render 'shared/http_status', locals: {code: '200', message:
+        HttpStatusHelper::ERROR_CODE['message']['200']}, status: 200
     end
 
     # Process the parameters passed for user creation and update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,11 +13,11 @@ class ApplicationController < ActionController::Base
   # activate i18n for renaming constants in views
   before_filter :set_locale, :set_markus_version, :set_remote_user, :get_file_encodings
   # check for active session on every page
-  before_filter :authenticate, :except => [:login, :page_not_found]
+  before_filter :authenticate, except: [:login, :page_not_found]
 
   # Define default URL options to include the locale
   def default_url_options(options={})
-    { :locale => I18n.locale }
+    { locale: I18n.locale }
   end
 
   protected
@@ -61,7 +61,7 @@ class ApplicationController < ActionController::Base
   # handle unknown locales
   rescue Exception => err
     logger.error err
-    flash.now[:notice] = I18n.t('locale_not_available', :locale => I18n.locale)
+    flash.now[:notice] = I18n.t('locale_not_available', locale: I18n.locale)
 
     I18n.load_path -= [locale_path]
     I18n.locale = I18n.default_locale

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,6 +1,6 @@
 class AssignmentsController < ApplicationController
   before_filter      :authorize_only_for_admin,
-                     :except => [:deletegroup,
+                     except: [:deletegroup,
                                  :delete_rejected,
                                  :disinvite_member,
                                  :invite_member,
@@ -13,7 +13,7 @@ class AssignmentsController < ApplicationController
                                  :render_test_result]
 
   before_filter      :authorize_for_student,
-                     :only => [:student_interface,
+                     only: [:student_interface,
                               :deletegroup,
                               :delete_rejected,
                               :disinvite_member,
@@ -23,7 +23,7 @@ class AssignmentsController < ApplicationController
                               :decline_invitation]
 
   before_filter      :authorize_for_user,
-                     :only => [:index, :render_test_result]
+                     only: [:index, :render_test_result]
 
   auto_complete_for  :assignment,
                      :name
@@ -50,18 +50,18 @@ class AssignmentsController < ApplicationController
     if current_user.student? &&
         (@test_result.submission.grouping.membership_status(current_user).nil? ||
         @test_result.submission.get_latest_result.released_to_students == false)
-      render :partial => 'shared/handle_error',
-       :locals => {:error => I18n.t('test_result.error.no_access', :test_result_id => @test_result.id)}
+      render partial: 'shared/handle_error',
+       locals: {error: I18n.t('test_result.error.no_access', test_result_id: @test_result.id)}
       return
     end
 
-    render :template => 'assignments/render_test_result', :layout => 'plain'
+    render template: 'assignments/render_test_result', layout: 'plain'
   end
 
   def student_interface
     @assignment = Assignment.find(params[:id])
     if @assignment.is_hidden
-      render :file => "public/404.html", :status => 404
+      render file: "public/404.html", status: 404
       return
     end
 
@@ -92,10 +92,10 @@ class AssignmentsController < ApplicationController
             Grouping.find_by_group_id_and_assignment_id( Group.find_by_group_name(@student.user_name), @assignment.id).destroy
           end
         rescue RuntimeError => @error
-          render 'shared/generic_error', :layout => 'error'
+          render 'shared/generic_error', layout: 'error'
           return
         end
-        redirect_to :action => 'student_interface', :id => @assignment.id
+        redirect_to action: 'student_interface', id: @assignment.id
       else
         render :student_interface
       end
@@ -140,12 +140,12 @@ class AssignmentsController < ApplicationController
   # assignment information
   def index
     #@assignments = Assignment.all(:order => :id)
-    @grade_entry_forms = GradeEntryForm.all(:order => :id)
+    @grade_entry_forms = GradeEntryForm.all(order: :id)
     @default_fields = DEFAULT_FIELDS
     if current_user.student?
-      @assignments = Assignment.find(:all, :conditions =>
-                                             { :is_hidden => false },
-                                            :order => :id)
+      @assignments = Assignment.find(:all, conditions:
+                                             { is_hidden: false },
+                                            order: :id)
       #get the section of current user
       @section = current_user.section
       # get results for assignments for the current user
@@ -177,10 +177,10 @@ class AssignmentsController < ApplicationController
 
       render :student_assignment_list
     elsif current_user.ta?
-      @assignments = Assignment.all(:order => :id)
+      @assignments = Assignment.all(order: :id)
       render :grader_index
     else
-      @assignments = Assignment.all(:order => :id)
+      @assignments = Assignment.all(order: :id)
       render :index
     end
   end
@@ -193,7 +193,7 @@ class AssignmentsController < ApplicationController
     @assignments = Assignment.all
     @sections = Section.all
 
-    @section_due_dates = SectionDueDate.where(:assignment_id => @assignment.id).order('due_date DESC').joins(:section).order('name ASC')
+    @section_due_dates = SectionDueDate.where(assignment_id: @assignment.id).order('due_date DESC').joins(:section).order('name ASC')
 
     unless @past_date.nil? || @past_date.empty?
       flash.now[:notice] = t('past_due_date_notice') + @past_date.join(', ')
@@ -202,7 +202,7 @@ class AssignmentsController < ApplicationController
     # build section_due_dates for each section that doesn't already have a due date
     Section.all.each do |s|
       unless SectionDueDate.find_by_assignment_id_and_section_id(@assignment.id, s.id)
-        @assignment.section_due_dates.build(:section => s)
+        @assignment.section_due_dates.build(section: s)
       end
     end
   end
@@ -229,16 +229,16 @@ class AssignmentsController < ApplicationController
       @assignment = process_assignment_form(@assignment, params)
       rescue Exception, RuntimeError => e
         @assignment.errors.add(:base, I18n.t('assignment.error',
-                                              :message => e.message))
-        render :edit, :id => @assignment.id
+                                              message: e.message))
+        render :edit, id: @assignment.id
       return
     end
 
     if @assignment.save
       flash[:success] = I18n.t('assignment.update_success')
-      redirect_to :action => 'edit', :id => params[:id]
+      redirect_to action: 'edit', id: params[:id]
     else
-      render :edit, :id => @assignment.id
+      render :edit, id: @assignment.id
     end
   end
 
@@ -252,7 +252,7 @@ class AssignmentsController < ApplicationController
     @assignment.build_assignment_stat
 
     # build section_due_dates for each section
-    Section.all.each { |s| @assignment.section_due_dates.build(:section => s)}
+    Section.all.each { |s| @assignment.section_due_dates.build(section: s)}
 
     # set default value if web submits are allowed
     @assignment.allow_web_submits =
@@ -284,7 +284,7 @@ class AssignmentsController < ApplicationController
       end
     end
 
-    redirect_to :action => 'edit', :id => @assignment.id
+    redirect_to action: 'edit', id: @assignment.id
   end
 
   def update_group_properties_on_persist
@@ -292,7 +292,7 @@ class AssignmentsController < ApplicationController
   end
 
   def download_csv_grades_report
-    assignments = Assignment.all(:order => 'id')
+    assignments = Assignment.all(order: 'id')
     students = Student.all
     csv_string = CSV.generate do |csv|
       students.each do |student|
@@ -322,8 +322,8 @@ class AssignmentsController < ApplicationController
     end
     course_name = "#{COURSE_NAME}"
     course_name_underscore = course_name.squish.downcase.tr(" ", "_")
-    send_data csv_string, :disposition => 'attachment',
-                          :filename => "#{course_name_underscore}_grades_report.csv"
+    send_data csv_string, disposition: 'attachment',
+                          filename: "#{course_name_underscore}_grades_report.csv"
   end
 
 
@@ -337,7 +337,7 @@ class AssignmentsController < ApplicationController
     m_logger = MarkusLogger.instance
     m_logger.log("Student '#{@user.user_name}' joined group '#{@grouping.group.group_name}'" +
                  '(accepted invitation).')
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def decline_invitation
@@ -348,7 +348,7 @@ class AssignmentsController < ApplicationController
     m_logger = MarkusLogger.instance
     m_logger.log("Student '#{@user.user_name}' declined invitation for group '" +
                  "#{@grouping.group.group_name}'.")
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def creategroup
@@ -372,7 +372,7 @@ class AssignmentsController < ApplicationController
       if params[:workalone]
         if @assignment.group_min != 1
           raise I18n.t('create_group.fail.can_not_work_alone',
-                        :group_min => @assignment.group_min)
+                        group_min: @assignment.group_min)
         end
         # fix for issue #627
         # currently create_group_for_working_alone_student only returns false
@@ -393,7 +393,7 @@ class AssignmentsController < ApplicationController
       m_logger.log("Failed to create group. User: '#{@student.user_name}', Error: '" +
                    "#{e.message}'.", MarkusLogger::ERROR)
     end
-    redirect_to :action => 'student_interface', :id => @assignment.id
+    redirect_to action: 'student_interface', id: @assignment.id
   end
 
   def deletegroup
@@ -411,7 +411,7 @@ class AssignmentsController < ApplicationController
       if @grouping.has_submission?
         raise I18n.t('groups.cant_delete_already_submitted')
       end
-      @grouping.student_memberships.all(:include => :user).each do |member|
+      @grouping.student_memberships.all(include: :user).each do |member|
         member.destroy
       end
       # update repository permissions
@@ -432,7 +432,7 @@ class AssignmentsController < ApplicationController
                      "#{current_user.user_name}', Error: '#{e.message}'.", MarkusLogger::ERROR)
       end
     end
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def invite_member
@@ -455,7 +455,7 @@ class AssignmentsController < ApplicationController
     if flash[:fail_notice].blank?
       flash[:success] = I18n.t('invite_student.success')
     end
-    redirect_to :action => 'student_interface', :id => @assignment.id
+    redirect_to action: 'student_interface', id: @assignment.id
   end
 
   # Called by clicking the cancel link in the student's interface
@@ -485,7 +485,7 @@ class AssignmentsController < ApplicationController
     end
     membership.delete
     membership.save
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def update_collected_submissions
@@ -496,7 +496,7 @@ class AssignmentsController < ApplicationController
   def refresh_graph
     assignment = Assignment.find(params[:id])
     assignment.assignment_stat.refresh_grade_distribution
-    redirect_to :controller => 'main'
+    redirect_to controller: 'main'
   end
 
   def download_assignment_list
@@ -528,21 +528,21 @@ class AssignmentsController < ApplicationController
         format = 'text/csv'
       else
         flash[:error] = t(:incorrect_format)
-        redirect_to :action => 'index'
+        redirect_to action: 'index'
         return
     end
 
     send_data(output,
-              :filename => "assignments_#{Time.
+              filename: "assignments_#{Time.
                   now.strftime('%Y%m%dT%H%M%S')}.#{params[:file_format]}",
-              :type => format, :disposition => 'inline')
+              type: format, disposition: 'inline')
   end
 
   def upload_assignment_list
     assignment_list = params[:assignment_list]
 
     if assignment_list.blank?
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
       return
     end
 
@@ -562,7 +562,7 @@ class AssignmentsController < ApplicationController
           end
         rescue ActiveRecord::ActiveRecordError, ArgumentError => e
           flash[:error] = e.message
-          redirect_to :action => 'index'
+          redirect_to action: 'index'
           return
         end
       when 'yml'
@@ -573,14 +573,14 @@ class AssignmentsController < ApplicationController
           end
         rescue ActiveRecord::ActiveRecordError, ArgumentError => e
           flash[:error] = e.message
-          redirect_to :action => 'index'
+          redirect_to action: 'index'
           return
         end
       else
         return
     end
 
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 
   private
@@ -628,7 +628,7 @@ class AssignmentsController < ApplicationController
 
     unless potential_rule && potential_rule.ancestors.include?(SubmissionRule)
       raise I18n.t('assignment.not_valid_submission_rule',
-        :type => params[:assignment][:submission_rule_attributes][:type])
+        type: params[:assignment][:submission_rule_attributes][:type])
     end
 
     # Was the SubmissionRule changed?  If so, switch the type of the SubmissionRule.

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -23,8 +23,8 @@ class AutomatedTestsController < ApplicationController
       Process.detach(child_pid) unless child_pid.nil?
     end
     render :test_replace,
-           :locals => {:test_result_files => @test_result_files,
-                       :result => @result}
+           locals: {test_result_files: @test_result_files,
+                       result: @result}
   end
 
 
@@ -40,16 +40,16 @@ class AutomatedTestsController < ApplicationController
           @assignment = process_test_form(@assignment, params)
         rescue Exception, RuntimeError => e
           @assignment.errors.add(:base, I18n.t('assignment.error',
-            :message => e.message))
-          return redirect_to :action => 'manage',
-            :assignment_id => params[:assignment_id]
+            message: e.message))
+          return redirect_to action: 'manage',
+            assignment_id: params[:assignment_id]
         end
 
         # Save assignment and associated test files
         if @assignment.save
           flash[:success] = I18n.t('assignment.update_success')
-          redirect_to :action => 'manage',
-            :assignment_id => params[:assignment_id]
+          redirect_to action: 'manage',
+            assignment_id: params[:assignment_id]
         else
           render :manage
         end

--- a/app/controllers/flexible_criteria_controller.rb
+++ b/app/controllers/flexible_criteria_controller.rb
@@ -10,7 +10,7 @@ class FlexibleCriteriaController < ApplicationController
     # TODO until Assignment gets its criteria method
     @criteria =
       FlexibleCriterion.find_all_by_assignment_id( @assignment.id,
-                                                   :order => :position)
+                                                   order: :position)
   end
 
   def edit
@@ -66,9 +66,9 @@ class FlexibleCriteriaController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     file_out = FlexibleCriterion.create_csv(@assignment)
     send_data(file_out,
-              :type => 'text/csv',
-              :filename => "#{@assignment.short_identifier}_flexible_criteria.csv",
-              :disposition => 'inline')
+              type: 'text/csv',
+              filename: "#{@assignment.short_identifier}_flexible_criteria.csv",
+              disposition: 'inline')
   end
 
   def upload
@@ -86,25 +86,25 @@ class FlexibleCriteriaController < ApplicationController
           end
           if nb_updates > 0
             flash[:notice] = I18n.t('flexible_criteria.upload.success',
-              :nb_updates => nb_updates)
+              nb_updates: nb_updates)
           end
         end
       end
     end
-    redirect_to :action => 'index', :assignment_id => @assignment.id
+    redirect_to action: 'index', assignment_id: @assignment.id
   end
 
   # This method handles the drag/drop criteria sorting
   def update_positions
     unless request.post?
-      render :nothing => true
+      render nothing: true
       return
     end
     @assignment = Assignment.find(params[:assignment_id])
     @criteria = @assignment.flexible_criteria
     params[:flexible_criteria_pane_list].each_with_index do |id, position|
       unless id == ''
-        FlexibleCriterion.update(id, :position => position + 1)
+        FlexibleCriterion.update(id, position: position + 1)
       end
     end
   end
@@ -116,7 +116,7 @@ class FlexibleCriteriaController < ApplicationController
     elsif  params[:direction] == 'down'
       offset = 1
     else
-      render :nothing => true
+      render nothing: true
       return
     end
 
@@ -126,7 +126,7 @@ class FlexibleCriteriaController < ApplicationController
     index = @criteria.index(criterion)
     other_criterion = @criteria[index + offset]
     if other_criterion.nil?
-      render :nothing => true
+      render nothing: true
       return
     end
     # Increase the index by one as the position value is 1 greater than the index

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -5,48 +5,48 @@ class GradeEntryFormsController < ApplicationController
   include GradeEntryFormsHelper
 
   before_filter :authorize_only_for_admin,
-                :except => [:student_interface,
+                except: [:student_interface,
                             :grades,
                             :g_table_paginate,
                             :csv_download,
                             :csv_upload,
                             :update_grade]
   before_filter :authorize_for_ta_and_admin,
-                :only => [:grades,
+                only: [:grades,
                           :g_table_paginate,
                           :csv_download,
                           :csv_upload,
                           :update_grade]
   before_filter :authorize_for_student,
-                :only => [:student_interface]
+                only: [:student_interface]
 
   # Filters will be added as the student UI is implemented (eg. Show Released,
   # Show All,...)
-  G_TABLE_PARAMS = {:model => GradeEntryStudent,
-                    :per_pages => [15, 30, 50, 100, 150, 500, 1000],
-                    :filters => {
+  G_TABLE_PARAMS = {model: GradeEntryStudent,
+                    per_pages: [15, 30, 50, 100, 150, 500, 1000],
+                    filters: {
                         'none' => {
-                            :display => 'Show All',
-                            :proc => lambda { |sort_by, order, user|
+                            display: 'Show All',
+                            proc: lambda { |sort_by, order, user|
                               if user.instance_of? Admin
-                                conditions = {:hidden => false}
+                                conditions = {hidden: false}
                               else
                                 #Display only students to which the TA has been assigned
-                                conditions = {:hidden => false, :id =>
-                                    Ta.find(user.id).grade_entry_students.all(:select => :user_id).collect(&:user_id)}
+                                conditions = {hidden: false, id:
+                                    Ta.find(user.id).grade_entry_students.all(select: :user_id).collect(&:user_id)}
                               end
 
                               if sort_by.present?
                                 if sort_by == 'section'
-                                  Student.includes(:section).all(:conditions => conditions,
-                                                              :order => 'sections.name ' + order)
+                                  Student.includes(:section).all(conditions: conditions,
+                                                              order: 'sections.name ' + order)
                                 else
-                                  Student.all(:conditions => conditions,
-                                              :order => sort_by + ' ' + order)
+                                  Student.all(conditions: conditions,
+                                              order: sort_by + ' ' + order)
                                 end
                               else
-                                Student.all(:conditions => conditions,
-                                            :order => 'user_name ' + order)
+                                Student.all(conditions: conditions,
+                                            order: 'user_name ' + order)
                               end
                             }}}
   }
@@ -66,7 +66,7 @@ class GradeEntryFormsController < ApplicationController
       if @grade_entry_form.update_attributes(new_params)
         # Success message
         flash[:success] = I18n.t('grade_entry_forms.create.success')
-        redirect_to :action => 'edit', :id => @grade_entry_form.id
+        redirect_to action: 'edit', id: @grade_entry_form.id
       else
         render 'new'
       end
@@ -89,9 +89,9 @@ class GradeEntryFormsController < ApplicationController
       if @grade_entry_form.update_attributes(new_params)
         # Success message
         flash[:success] = I18n.t('grade_entry_forms.edit.success')
-        redirect_to :action => 'edit', :id => @grade_entry_form.id
+        redirect_to action: 'edit', id: @grade_entry_form.id
       else
-        render 'edit', :id => @grade_entry_form.id
+        render 'edit', id: @grade_entry_form.id
       end
     end
   end
@@ -125,8 +125,8 @@ class GradeEntryFormsController < ApplicationController
                                       @filter,
                                       @sort_by,
                                       @desc)
-    @students = all_students.paginate(:per_page => @per_page,
-                                      :page => @current_page)
+    @students = all_students.paginate(per_page: @per_page,
+                                      page: @current_page)
     @students_total = all_students.size
     @alpha_pagination_options = @grade_entry_form.alpha_paginate(all_students,
                                                                  @per_page,
@@ -144,7 +144,7 @@ class GradeEntryFormsController < ApplicationController
     @grade_entry_form = GradeEntryForm.find(params[:id])
     @students, @students_total = handle_paginate_event(
         G_TABLE_PARAMS,
-        {:grade_entry_form => @grade_entry_form},
+        {grade_entry_form: @grade_entry_form},
         params)
 
     @current_page = params[:page]
@@ -256,22 +256,22 @@ class GradeEntryFormsController < ApplicationController
     # Display success message
     if numGradeEntryStudentsChanged > 0
       flash[:success] = I18n.t('grade_entry_forms.grades.successfully_changed',
-                               {:numGradeEntryStudentsChanged => numGradeEntryStudentsChanged})
+                               {numGradeEntryStudentsChanged: numGradeEntryStudentsChanged})
       m_logger = MarkusLogger.instance
       m_logger.log(log_message)
     end
     flash[:error] = errors
 
-    redirect_to :action => 'grades', :id => params[:id]
+    redirect_to action: 'grades', id: params[:id]
   end
 
   # Download the grades for this grade entry form as a CSV file
   def csv_download
     grade_entry_form = GradeEntryForm.find(params[:id])
     send_data grade_entry_form.get_csv_grades_report,
-              :disposition => 'attachment',
-              :type => 'application/vnd.ms-excel',
-              :filename => "#{grade_entry_form.short_identifier}_grades_report.csv"
+              disposition: 'attachment',
+              type: 'application/vnd.ms-excel',
+              filename: "#{grade_entry_form.short_identifier}_grades_report.csv"
   end
 
   # Upload the grades for this grade entry form using a CSV file
@@ -313,12 +313,12 @@ class GradeEntryFormsController < ApplicationController
           end
           if num_updates > 0
             flash[:notice] = I18n.t('grade_entry_forms.csv.upload_success',
-                                    :num_updates => num_updates)
+                                    num_updates: num_updates)
           end
         end
       end
     end
-  redirect_to :action => 'grades', :id => @grade_entry_form.id
+  redirect_to action: 'grades', id: @grade_entry_form.id
   end
 
 end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -16,28 +16,28 @@ class GradersController < ApplicationController
 
   def upload_dialog
     @assignment = Assignment.find(params[:assignment_id])
-    render :partial => 'graders/modal_dialogs/upload_dialog',
-           :handlers => [:rjs]
+    render partial: 'graders/modal_dialogs/upload_dialog',
+           handlers: [:rjs]
   end
 
   def download_dialog
     @assignment = Assignment.find(params[:assignment_id])
-    render :partial => 'graders/modal_dialogs/download_dialog',
-           :handlers => [:rjs]
+    render partial: 'graders/modal_dialogs/download_dialog',
+           handlers: [:rjs]
   end
 
   def groups_coverage_dialog
     @assignment = Assignment.find(params[:assignment_id])
     @grouping = Grouping.find(params[:grouping])
-    render :partial => 'graders/modal_dialogs/groups_coverage_dialog',
-           :handlers => [:rjs]
+    render partial: 'graders/modal_dialogs/groups_coverage_dialog',
+           handlers: [:rjs]
   end
 
   def grader_criteria_dialog
     @assignment = Assignment.find(params[:assignment_id])
     @grader = Ta.find(params[:grader])
-    render :partial => 'graders/modal_dialogs/grader_criteria_dialog',
-           :handlers => [:rjs]
+    render partial: 'graders/modal_dialogs/grader_criteria_dialog',
+           handlers: [:rjs]
   end
 
 
@@ -80,7 +80,7 @@ class GradersController < ApplicationController
   def csv_upload_grader_groups_mapping
     if !request.post? || params[:grader_mapping].nil?
       flash[:error] = I18n.t('csv.group_to_grader')
-      redirect_to :action => 'index', :assignment_id => params[:assignment_id]
+      redirect_to action: 'index', assignment_id: params[:assignment_id]
       return
     end
 
@@ -89,7 +89,7 @@ class GradersController < ApplicationController
     if invalid_lines.size > 0
       flash[:error] = I18n.t('csv_invalid_lines') + invalid_lines.join(', ')
     end
-    redirect_to :action => 'index', :assignment_id => params[:assignment_id]
+    redirect_to action: 'index', assignment_id: params[:assignment_id]
   end
 
   # Assign TAs to Criteria via a csv file
@@ -97,7 +97,7 @@ class GradersController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     if !request.post? || params[:grader_criteria_mapping].nil?
       flash[:error] = I18n.t('csv.criteria_to_grader')
-      redirect_to :action => 'index', :assignment_id => params[:assignment_id]
+      redirect_to action: 'index', assignment_id: params[:assignment_id]
       return
     end
 
@@ -109,7 +109,7 @@ class GradersController < ApplicationController
     if invalid_lines.size > 0
       flash[:error] = I18n.t('csv_invalid_lines') + invalid_lines.join(', ')
     end
-    redirect_to :action => 'index', :assignment_id => params[:assignment_id]
+    redirect_to action: 'index', assignment_id: params[:assignment_id]
   end
 
   def download_grader_groupings_mapping
@@ -127,7 +127,7 @@ class GradersController < ApplicationController
        end
      end
 
-    send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', disposition: 'inline')
   end
 
   def download_grader_criteria_mapping
@@ -145,13 +145,13 @@ class GradersController < ApplicationController
        end
      end
 
-    send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', disposition: 'inline')
   end
 
   def add_grader_to_grouping
     @assignment = Assignment.find(params[:assignment_id])
     @grouping = Grouping.find(params[:grouping_id],
-                                :include => [:students, :tas, :group])
+                                include: [:students, :tas, :group])
     grader = Ta.find(params[:grader_id])
     @grouping.add_tas(grader)
     @groupings_data = construct_table_rows([@grouping.reload],@assignment)
@@ -161,7 +161,7 @@ class GradersController < ApplicationController
       criterion.save
     end
     @criteria_data = construct_criterion_table_rows(criteria, @assignment)
-    render :add_grader_to_grouping, :formats => [:js] 
+    render :add_grader_to_grouping, formats: [:js]
   end
 
   #These actions act on all currently selected graders & groups
@@ -177,7 +177,7 @@ class GradersController < ApplicationController
          #if there is a global action than there should be a group selected
           if params[:global_actions]
               @global_action_warning = I18n.t('assignment.group.select_a_group')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
           end
         end
@@ -185,7 +185,7 @@ class GradersController < ApplicationController
           when 'assign'
             if params[:graders].nil? or params[:graders].size ==  0
               @global_action_warning = I18n.t('assignment.group.select_a_grader')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
             end
             assign_all_graders(grouping_ids, grader_ids)
@@ -196,7 +196,7 @@ class GradersController < ApplicationController
           when 'random_assign'
             if params[:graders].nil? or params[:graders].size ==  0
               @global_action_warning = I18n.t('assignment.group.select_a_grader')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
             end
             randomly_assign_graders(grouping_ids, grader_ids)
@@ -204,11 +204,11 @@ class GradersController < ApplicationController
         end
       when 'criteria_table'
         @assignment = Assignment.find(params[:assignment_id],
-          :include => [{:groupings => [:students,
-                {:tas => :criterion_ta_associations}, :group]}])
+          include: [{groupings: [:students,
+                {tas: :criterion_ta_associations}, :group]}])
         if params[:criteria].nil? or params[:criteria].size ==  0
       #don't do anything if no criteria
-          render :nothing => true
+          render nothing: true
           return
         end
         criteria = criteria_with_assoc(@assignment,
@@ -217,10 +217,10 @@ class GradersController < ApplicationController
           when 'assign'
           if params[:graders].nil? or params[:graders].size ==  0
             #don't do anything if no graders
-            render :nothing => true
+            render nothing: true
             return
           end
-            graders = Ta.where(:id => grader_ids)
+            graders = Ta.where(id: grader_ids)
             add_graders_to_criteria(criteria, graders)
             return
           when 'unassign'
@@ -229,7 +229,7 @@ class GradersController < ApplicationController
           when 'random_assign'
             if params[:graders].nil? or params[:graders].size ==  0
               #don't do anything if no graders
-              render :nothing => true
+              render nothing: true
               return
             end
             randomly_assign_graders_to_criteria(criteria, grader_ids)
@@ -265,7 +265,7 @@ class GradersController < ApplicationController
   end
 
   def randomly_assign_graders_to_criteria(criteria, grader_ids)
-    graders = Ta.where(:id => grader_ids)
+    graders = Ta.where(id: grader_ids)
     # Shuffle the criteria
     criteria = criteria.sort_by{rand}
     # Now, deal them out like cards...
@@ -286,7 +286,7 @@ class GradersController < ApplicationController
       grouping.save
     end
     construct_all_rows(groupings, graders, criteria)
-    render :modify_criteria, :formats => [:js] 
+    render :modify_criteria, formats: [:js]
   end
 
   def randomly_assign_graders(grouping_ids, grader_ids)
@@ -315,7 +315,7 @@ class GradersController < ApplicationController
       grouping.save
     end
     construct_all_rows(groupings, graders, criteria)
-    render :modify_criteria, :formats => [:js] 
+    render :modify_criteria, formats: [:js]
   end
 
   def remove_graders_from_criteria(criteria, params)
@@ -340,7 +340,7 @@ class GradersController < ApplicationController
       grouping.save
     end
     construct_all_rows(groupings , all_graders, criteria)
-    render :modify_criteria, :formats => [:js] 
+    render :modify_criteria, formats: [:js]
   end
 
   def unassign_graders(grader_membership_ids, grouping_ids)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -35,7 +35,7 @@ class GroupsController < ApplicationController
       return
     end
     @new_grouping = construct_table_row(new_grouping_data, @assignment)
-    render :add_group, :formats => [:js] 
+    render :add_group, formats: [:js] 
   end
 
   def remove_group
@@ -51,29 +51,29 @@ class GroupsController < ApplicationController
 		@students_data = construct_student_table_rows(students_to_remove, @assignment)
     if grouping.has_submission?
         @errors.push(grouping.group.group_name)
-        render :delete_groupings, :formats => [:js] 
+        render :delete_groupings, formats: [:js] 
     else
       grouping.delete_grouping
       @removed_groupings.push(grouping)
-      render :delete_groupings, :formats => [:js] 
+      render :delete_groupings, formats: [:js] 
     end
   end
 
   def upload_dialog
     @assignment = Assignment.find(params[:id])
-    render :partial => 'groups/modal_dialogs/upload_dialog', :handlers => [:rjs]
+    render partial: 'groups/modal_dialogs/upload_dialog', handlers: [:rjs]
   end
 
   def download_dialog
     @assignment = Assignment.find(params[:id])
-    render :partial => 'groups/modal_dialogs/download_dialog', :handlers => [:rjs]
+    render partial: 'groups/modal_dialogs/download_dialog', handlers: [:rjs]
   end
 
   def rename_group_dialog
     @assignment = Assignment.find(params[:assignment_id])
     # id is really the grouping_id, this is due to rails routing
     @grouping_id = params[:id]
-    render :partial => 'groups/modal_dialogs/rename_group_dialog', :handlers => [:rjs]
+    render partial: 'groups/modal_dialogs/rename_group_dialog', handlers: [:rjs]
   end
 
   def rename_group
@@ -84,7 +84,7 @@ class GroupsController < ApplicationController
 
     # Checking if a group with this name already exists
 
-    if (@groups = Group.first(:conditions => {:group_name =>
+    if (@groups = Group.first(conditions: {group_name:
     [params[:new_groupname]]}))
        existing = true
        groupexist_id = @groups.id
@@ -103,16 +103,16 @@ class GroupsController < ApplicationController
       params[:groupexist_id] = groupexist_id
       params[:assignment_id] = @assignment.id
 
-      if Grouping.all(:conditions => ["assignment_id =
-      :assignment_id and group_id = :groupexist_id", {:groupexist_id =>
-      groupexist_id, :assignment_id => @assignment.id}])
+      if Grouping.all(conditions: ["assignment_id =
+      :assignment_id and group_id = :groupexist_id", {groupexist_id:
+      groupexist_id, assignment_id: @assignment.id}])
          flash[:error] = I18n.t('groups.rename_group.already_in_use')
       else
         @grouping.update_attribute(:group_id, groupexist_id)
       end
     end
     @grouping_data = construct_table_row(@grouping, @assignment)
-    render :rename_group, :formats => [:js] 
+    render :rename_group, formats: [:js] 
   end
 
   def valid_grouping
@@ -120,7 +120,7 @@ class GroupsController < ApplicationController
     @grouping = Grouping.find(params[:grouping_id])
     @grouping.validate_grouping
     @grouping_data = construct_table_row(@grouping, @assignment)
-    render :valid_grouping, :formats => [:js] 
+    render :valid_grouping, formats: [:js] 
   end
 
   def invalid_grouping
@@ -128,31 +128,31 @@ class GroupsController < ApplicationController
     @grouping = Grouping.find(params[:grouping_id])
     @grouping.invalidate_grouping
     @grouping_data = construct_table_row(@grouping, @assignment)
-    render :invalid_grouping, :formats => [:js] 
+    render :invalid_grouping, formats: [:js] 
   end
 
   def populate
     @assignment = Assignment.find(params[:assignment_id],
-                                  :include => [{
-                                      :groupings => [
+                                  include: [{
+                                      groupings: [
                                           :students,
                                           :non_rejected_student_memberships,
                                           :group]}])
     @groupings = @assignment.groupings
     @table_rows = {}
     @table_rows = construct_table_rows(@groupings, @assignment)
-    render :populate, :formats => [:js] 
+    render :populate, formats: [:js] 
   end
 
   def populate_students
     @assignment = Assignment.find(params[:assignment_id],
-                                  :include => [:groupings])
+                                  include: [:groupings])
     @students = Student.all
     @table_rows = construct_student_table_rows(@students, @assignment)
   end
 
   def index
-    @all_assignments = Assignment.all(:order => :id)
+    @all_assignments = Assignment.all(order: :id)
     @assignment = Assignment.find(params[:assignment_id])
   end
 
@@ -183,19 +183,19 @@ class GroupsController < ApplicationController
               collision_error = @assignment.add_csv_group(row)
               unless collision_error.nil?
                 flash_message(:error, I18n.t('csv.line_nr_csv_file_prefix',
-                  { :line_number => line_nr + 1 }) + " #{collision_error}")
+                  { line_number: line_nr + 1 }) + " #{collision_error}")
               end
             rescue CSVInvalidLineError => e
               flash_message(:error, I18n.t('csv.line_nr_csv_file_prefix',
-                { :line_number => line_nr + 1 }) + " #{e.message}")
+                { line_number: line_nr + 1 }) + " #{e.message}")
             end
           end
           @assignment.reload # Need to reload to get newly created groupings
           number_groupings_added = @assignment.groupings.length
           if number_groupings_added > 0 && flash[:error].is_a?(Array)
             invalid_lines_count = flash[:error].length
-            flash[:notice] = I18n.t('csv.groups_added_msg', { :number_groups =>
-              number_groupings_added, :number_lines => invalid_lines_count })
+            flash[:notice] = I18n.t('csv.groups_added_msg', { number_groups:
+              number_groupings_added, number_lines: invalid_lines_count })
           end
         rescue Exception
           # We should only get here if something *really* bad/unexpected
@@ -208,7 +208,7 @@ class GroupsController < ApplicationController
       # This is not handled by the roll back.
       @assignment.update_repository_permissions_forall_groupings
     end
-    redirect_to :action => 'index', :id => params[:id]
+    redirect_to action: 'index', id: params[:id]
   end
 
   def download_grouplist
@@ -221,14 +221,14 @@ class GroupsController < ApplicationController
        groupings.each do |grouping|
          group_array = [grouping.group.group_name, grouping.group.repo_name]
          # csv format is group_name, repo_name, user1_name, user2_name, ... etc
-         grouping.student_memberships.all(:include => :user).each do |member|
+         grouping.student_memberships.all(include: :user).each do |member|
             group_array.push(member.user.user_name)
          end
          csv << group_array
        end
      end
 
-    send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', disposition: 'inline')
   end
 
   def use_another_assignment_groups
@@ -249,10 +249,10 @@ class GroupsController < ApplicationController
   #These actions act on all currently selected students & groups
   def global_actions
     @assignment = Assignment.find(params[:assignment_id],
-                                  :include => [{
-                                      :groupings => [{
-                                          :student_memberships => :user,
-                                          :ta_memberships => :user},
+                                  include: [{
+                                      groupings: [{
+                                          student_memberships: :user,
+                                          ta_memberships: :user},
                                         :group]}])
     @tas = Ta.all
     grouping_ids = params[:groupings]
@@ -262,11 +262,11 @@ class GroupsController < ApplicationController
 	 #if there is a global action than there should be a group selected
          if params[:global_actions]
                @global_action_warning = I18n.t('assignment.group.select_a_group')
-               render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+               render partial: 'shared/global_action_warning', handlers: [:rjs]
                return
          end
       #Just do nothing
-      render :nothing => true
+      render nothing: true
       return
     end
 
@@ -293,7 +293,7 @@ class GroupsController < ApplicationController
           return
         else
           @global_action_warning = I18n.t('assignment.group.select_a_student')
-          render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+          render partial: 'shared/global_action_warning', handlers: [:rjs]
           return
         end
       when 'unassign'
@@ -311,7 +311,7 @@ class GroupsController < ApplicationController
      grouping.invalidate_grouping
     end
     @groupings_data = construct_table_rows(groupings, @assignment)
-    render :modify_groupings, :formats => [:js] 
+    render :modify_groupings, formats: [:js] 
   end
 
   # Given a list of grouping, sets their group status to valid if possible
@@ -320,7 +320,7 @@ class GroupsController < ApplicationController
       grouping.validate_grouping
     end
     @groupings_data = construct_table_rows(groupings, @assignment)
-    render :modify_groupings, :formats => [:js] 
+    render :modify_groupings, formats: [:js] 
   end
 
   # Deletes the given list of groupings if possible. Removes each member first.
@@ -341,7 +341,7 @@ class GroupsController < ApplicationController
         end
       end
 			@students_data = construct_student_table_rows(students_to_remove, @assignment)
-      render :delete_groupings, :formats => [:js] 
+      render :delete_groupings, formats: [:js] 
   end
 
   # Adds the students given in student_ids to the grouping given in grouping_id
@@ -361,11 +361,11 @@ class GroupsController < ApplicationController
     if assignment.student_form_groups
       if students_in_group > assignment.group_max
         @warning_group_size = I18n.t('assignment.group.assign_over_limit',
-          :group => group_name)
+          group: group_name)
 
       end
     end
-    render :add_members, :formats => [:js] 
+    render :add_members, formats: [:js] 
   end
 
   # Adds the student given in student_id to the grouping given in grouping
@@ -379,11 +379,11 @@ class GroupsController < ApplicationController
 
     begin
       if student.hidden
-        raise I18n.t('add_student.fail.hidden', :user_name => student.user_name)
+        raise I18n.t('add_student.fail.hidden', user_name: student.user_name)
       end
       if student.has_accepted_grouping_for?(@assignment.id)
         raise I18n.t('add_student.fail.already_grouped',
-          :user_name => student.user_name)
+          user_name: student.user_name)
       end
       membership_count = grouping.student_memberships.length
       grouping.invite(student.user_name, set_membership_status, true)
@@ -392,10 +392,10 @@ class GroupsController < ApplicationController
       # report success only if # of memberships increased
       if membership_count < grouping.student_memberships.length
         @messages.push(I18n.t('add_student.success',
-            :user_name => student.user_name))
+            user_name: student.user_name))
       else # something clearly went wrong
         raise I18n.t('add_student.fail.general',
-          :user_name => student.user_name)
+          user_name: student.user_name)
       end
 
       # only the first student should be the "inviter"
@@ -406,7 +406,7 @@ class GroupsController < ApplicationController
       # have less grace days credits than already used by that group
       if student.remaining_grace_credits < grouping.grace_period_deduction_single
         @warning_grace_day = I18n.t('assignment.group.grace_day_over_limit',
-          :group => grouping.group.group_name)
+          group: grouping.group.group_name)
       end
     rescue Exception => e
       @error = true
@@ -439,7 +439,7 @@ class GroupsController < ApplicationController
     end
     @students_data = construct_student_table_rows(all_members, @assignment)
     @groupings_data = construct_table_rows(groupings, @assignment)
-    render :remove_members, :formats => [:js] 
+    render :remove_members, formats: [:js] 
   end
 
   #Removes the given student membership from the given grouping


### PR DESCRIPTION
A better place to review this PR is at zhangsu@3a63483 with no Hound
comments, since this PR doesn't address style issues.

This is a global search-and-replace that replaces the Ruby 1.8 symbol
key hash rocket syntax to Ruby 1.9 syntax in

```
    app/controllers/{a,b,c,e,f,g}*.rb
```

Since this is a big change list, the style issues in the changed lines
are not being dealt with so that errors are minimized and code review
is easier. There is one exception though:

If the lines before the change have a good alignment of hash keys that
span multiple lines and the lines after the change do not (because the
change might alters the number of spaces needed for the alignment), then
the alignment is fixed, such that no new style issues are introduced. If
the alignment was not correct to begin with, then it is not fixed.

As a result, please ignore linter comments for this change.

This is for #1498.

Tested:
- rake test:units
- rake test:functionals
- rails s
