### PR TITLE
Replace controller symbol hash rockets (part 2)

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -5,13 +5,13 @@ class MainController < ApplicationController
 
   include ApplicationHelper, MainHelper, CookieDetection
 
-  protect_from_forgery :except => [:login, :page_not_found]
+  protect_from_forgery except: [:login, :page_not_found]
 
   # check for authorization
   before_filter      :authorize_for_user,
-                     :except => [:login,
+                     except: [:login,
                                  :page_not_found]
-  before_filter :authorize_only_for_admin, :only => [:login_as]
+  before_filter :authorize_only_for_admin, only: [:login_as]
 
   layout 'main'
 
@@ -27,7 +27,7 @@ class MainController < ApplicationController
     # external auth has been done, skip markus authorization
     if MarkusConfigurator.markus_config_remote_user_auth
       if @markus_auth_remote_user.nil?
-        render 'shared/http_status', :formats => [:html], :locals => { :code => '403', :message => HttpStatusHelper::ERROR_CODE['message']['403'] }, :status => 403, :layout => false
+        render 'shared/http_status', formats: [:html], locals: { code: '403', message: HttpStatusHelper::ERROR_CODE['message']['403'] }, status: 403, layout: false
         return
       else
         login_success = login_without_authentication(@markus_auth_remote_user)
@@ -37,7 +37,7 @@ class MainController < ApplicationController
           refresh_timeout
           current_user.set_api_key # set api key in DB for user if not yet set
           # redirect to last visited page or to main page
-          redirect_to( uri || { :action => 'index' } )
+          redirect_to( uri || { action: 'index' } )
           return
         else
           @login_error = flash[:error][0]
@@ -51,7 +51,7 @@ class MainController < ApplicationController
     if cookies_enabled
       unless params[:cookieTest].nil?
         # remove the :cookieTest => "currentlyTesting" parameter after testing for cookies by redirecting
-        redirect_to :controller => 'main', :action => 'login'
+        redirect_to controller: 'main', action: 'login'
       end
     else
       flash_message(:error, I18n.t(:cookies_off))
@@ -73,7 +73,7 @@ class MainController < ApplicationController
     @current_user = current_user
     # redirect to main page if user is already logged in.
     if logged_in? && !request.post?
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
       return
     end
     return unless request.post?
@@ -86,7 +86,7 @@ class MainController < ApplicationController
     validation_result = validate_user(params[:user_login], params[:user_login], params[:user_password])
     unless validation_result[:error].nil?
       flash_message(:error, validation_result[:error])
-      redirect_to :action => 'login'
+      redirect_to action: 'login'
       return
     end
     # validation worked
@@ -98,7 +98,7 @@ class MainController < ApplicationController
     # Has this student been hidden?
     if found_user.student? && found_user.hidden
       flash_message(:error, I18n.t('account_disabled'))
-      redirect_to(:action => 'login') && return
+      redirect_to(action: 'login') && return
     end
 
     self.current_user = found_user
@@ -109,7 +109,7 @@ class MainController < ApplicationController
       refresh_timeout
       current_user.set_api_key # set api key in DB for user if not yet set
       # redirect to last visited page or to main page
-      redirect_to( uri || { :action => 'index' } )
+      redirect_to( uri || { action: 'index' } )
     else
       flash_message(:error, I18n.t(:login_failed))
     end
@@ -138,7 +138,7 @@ class MainController < ApplicationController
     cookies.delete :auth_token
     reset_session
     if logout_redirect == 'DEFAULT'
-      redirect_to :action => 'login'
+      redirect_to action: 'login'
     else
       redirect_to logout_redirect
     end
@@ -147,16 +147,16 @@ class MainController < ApplicationController
   def index
     @current_user = current_user
     if @current_user.student? or @current_user.ta?
-      redirect_to :controller => 'assignments', :action => 'index'
+      redirect_to controller: 'assignments', action: 'index'
       return
     end
     @assignments = Assignment.unscoped.includes([
       :assignment_stat, :ta_memberships,
-      :groupings => :current_submission_used,
-      :submission_rule => :assignment
-    ]).all(:order => 'due_date DESC')
+      groupings: :current_submission_used,
+      submission_rule: :assignment
+    ]).all(order: 'due_date DESC')
 
-    render :index, :layout => 'content'
+    render :index, layout: 'content'
   end
 
   def about
@@ -165,22 +165,22 @@ class MainController < ApplicationController
   end
 
   def reset_api_key
-    render 'shared/http_status', :formats => [:html], :locals => { :code => '404', :message => HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404, :layout => false and return unless request.post?
+    render 'shared/http_status', formats: [:html], locals: { code: '404', message: HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404, layout: false and return unless request.post?
     # Students shouldn't be able to change their API key
     unless @current_user.student?
       @current_user.reset_api_key
       @current_user.save
     else
-      render 'shared/http_status', :formats => [:html], :locals => { :code => '404', :message => HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404, :layout => false and return
+      render 'shared/http_status', formats: [:html], locals: { code: '404', message: HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404, layout: false and return
     end
-    render 'api_key_replace', :locals => {:user => @current_user },
-      :formats => [:js], :handlers => [:erb]
+    render 'api_key_replace', locals: {user: @current_user },
+      formats: [:js], handlers: [:erb]
   end
 
   # Render 404 error (page not found) if no other route matches.
   # See config/routes.rb
   def page_not_found
-    render 'shared/http_status', :formats => [:html], :locals => { :code => '404', :message => HttpStatusHelper::ERROR_CODE['message']['404'] }, :status => 404, :layout => false
+    render 'shared/http_status', formats: [:html], locals: { code: '404', message: HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404, layout: false
   end
 
   # Authenticates the admin (i.e. validates her password). Given the user, that
@@ -208,9 +208,9 @@ class MainController < ApplicationController
     end
     unless validation_result[:error].nil?
       # There were validation errors
-      render :partial => 'role_switch_handler',
-        :formats => [:js], :handlers => [:erb],
-        :locals => { :error => validation_result[:error] }
+      render partial: 'role_switch_handler',
+        formats: [:js], handlers: [:erb],
+        locals: { error: validation_result[:error] }
       return
     end
 
@@ -222,9 +222,9 @@ class MainController < ApplicationController
     # Check if an admin is trying to login as another admin. Should not be allowed
     if found_user.admin?
       # error
-      render :partial => 'role_switch_handler',
-        :formats => [:js], :handlers => [:erb],
-        :locals => { :error => I18n.t(:cannot_login_as_another_admin) }
+      render partial: 'role_switch_handler',
+        formats: [:js], handlers: [:erb],
+        locals: { error: I18n.t(:cannot_login_as_another_admin) }
       return
     end
 
@@ -245,13 +245,13 @@ class MainController < ApplicationController
       current_user.set_api_key # set api key in DB for user if not yet set
       # All good, redirect to the main page of the viewer, discard
       # role switch modal
-      render :partial => 'role_switch_handler',
-        :formats => [:js], :handlers => [:erb],
-        :locals => { :error => nil }
+      render partial: 'role_switch_handler',
+        formats: [:js], handlers: [:erb],
+        locals: { error: nil }
     else
-      render :partial => 'role_switch_handler',
-        :formats => [:js], :handlers => [:erb],
-        :locals => { :error => I18n.t(:login_failed) }
+      render partial: 'role_switch_handler',
+        formats: [:js], handlers: [:erb],
+        locals: { error: I18n.t(:login_failed) }
     end
   end
 
@@ -280,7 +280,7 @@ class MainController < ApplicationController
     clear_session
     cookies.delete :auth_token
     reset_session
-    redirect_to :action => 'login'
+    redirect_to action: 'login'
   end
 
 private

--- a/app/controllers/marks_graders_controller.rb
+++ b/app/controllers/marks_graders_controller.rb
@@ -24,7 +24,7 @@ class MarksGradersController < ApplicationController
   def csv_upload_grader_groups_mapping
     if !request.post? || params[:grader_mapping].nil?
       flash[:error] = I18n.t('csv.student_to_grader')
-      redirect_to :action => 'index', :grade_entry_form_id => params[:grade_entry_form_id]
+      redirect_to action: 'index', grade_entry_form_id: params[:grade_entry_form_id]
       return
     end
 
@@ -35,7 +35,7 @@ class MarksGradersController < ApplicationController
       flash[:error] = I18n.t('graders.lines_not_processed') + invalid_lines.join(', ')
     end
 
-    redirect_to :action => 'index', :grade_entry_form_id => params[:grade_entry_form_id]
+    redirect_to action: 'index', grade_entry_form_id: params[:grade_entry_form_id]
   end
 
   #Download grader/student mappings in CSV format.
@@ -56,7 +56,7 @@ class MarksGradersController < ApplicationController
       end
     end
 
-    send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', disposition: 'inline')
   end
 
   # These actions act on all currently selected graders & students
@@ -72,17 +72,17 @@ class MarksGradersController < ApplicationController
          # If there is a global action than there should be a student selected
           if params[:global_actions]
               @global_action_warning = I18n.t('assignment.group.select_a_student')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
           end
         end
-        students = Student.where(:id => student_ids)
+        students = Student.where(id: student_ids)
 
         case params[:global_actions]
           when "assign"
             if params[:graders].nil? or params[:graders].size ==  0
               @global_action_warning = I18n.t('assignment.group.select_a_grader')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
             end
             add_graders(students, grader_ids)
@@ -93,7 +93,7 @@ class MarksGradersController < ApplicationController
           when "random_assign"
             if params[:graders].nil? or params[:graders].size ==  0
               @global_action_warning = I18n.t('assignment.group.select_a_grader')
-              render :partial => 'shared/global_action_warning', :handlers => [:rjs]
+              render partial: 'shared/global_action_warning', handlers: [:rjs]
               return
             end
             randomly_assign_graders(students, grader_ids)
@@ -106,7 +106,7 @@ class MarksGradersController < ApplicationController
   # These methods are called through global actions
 
   def randomly_assign_graders(students, grader_ids)
-    graders = Ta.where(:id => grader_ids)
+    graders = Ta.where(id: grader_ids)
     # Shuffle the students
     students = students.sort_by{rand}
     # Now, deal them out like cards...
@@ -122,7 +122,7 @@ class MarksGradersController < ApplicationController
   end
 
   def add_graders(students, grader_ids)
-    graders = Ta.where(:id => grader_ids)
+    graders = Ta.where(id: grader_ids)
     # Only want valid graders
     graders = graders.collect { |grader| grader if grader.valid? }
     students.each do |student|

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
   before_filter :authorize_for_ta_and_admin
-  before_filter :ensure_can_modify, :only => [:edit, :update]
+  before_filter :ensure_can_modify, only: [:edit, :update]
 
   # TODO this method needs explaining ! What is return_id ?
   def notes_dialog
@@ -12,10 +12,10 @@ class NotesController < ApplicationController
     @highlight_field = params[:highlight_field]
     @number_of_notes_field = params[:number_of_notes_field]
 
-    @notes = Note.all(:conditions => {:noteable_id => @noteable.id,
-                                      :noteable_type => @noteable.class.name})
-    render :partial => 'notes/modal_dialogs/notes_dialog_script',
-      :formats => [:js], :handlers => [:erb]
+    @notes = Note.all(conditions: {noteable_id: @noteable.id,
+                                      noteable_type: @noteable.class.name})
+    render partial: 'notes/modal_dialogs/notes_dialog_script',
+      formats: [:js], handlers: [:erb]
   end
 
   def add_note
@@ -27,30 +27,30 @@ class NotesController < ApplicationController
     @note.noteable_type = params[:noteable_type]
     unless @note.save
       render 'notes/modal_dialogs/notes_dialog_error',
-        :formats => [:js], :handlers => [:erb]
+        formats: [:js], handlers: [:erb]
     else
       @note.reload
       @number_of_notes_field = params[:number_of_notes_field]
       @highlight_field = params[:highlight_field]
       @number_of_notes = @note.noteable.notes.size
       render 'notes/modal_dialogs/notes_dialog_success',
-        :formats => [:js], :handlers => [:erb]
+        formats: [:js], handlers: [:erb]
     end
   end
 
   def index
-    @notes = Note.all(:order => "created_at DESC", :include => [:user, :noteable])
+    @notes = Note.all(order: "created_at DESC", include: [:user, :noteable])
     @current_user = current_user
     # Notes are attached to noteables, if there are no noteables, we can't make notes.
     @noteables_available = Note.noteables_exist?
-		render 'index', :formats => [:html]
+		render 'index', formats: [:html]
   end
 
   # gets the objects for groupings on first load.
   def new
     new_retrieve
     @note = Note.new
-		render 'new', :formats => [:html], :handlers => [:erb]
+		render 'new', formats: [:html], handlers: [:erb]
   end
 
   def create
@@ -60,24 +60,24 @@ class NotesController < ApplicationController
 
     if @note.save
       flash[:success] = I18n.t('notes.create.success')
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       new_retrieve
-      render 'new', :formats => [:html], :handlers => [:erb]
+      render 'new', formats: [:html], handlers: [:erb]
     end
   end
 
   # Used to update the values in the groupings dropdown in the new note form
   def new_update_groupings
     retrieve_groupings(Assignment.find(params[:assignment_id]))
-    render 'new_update_groupings', :formats => [:js], :handlers => [:erb]
+    render 'new_update_groupings', formats: [:js], handlers: [:erb]
   end
 
   # used for RJS call
   def noteable_object_selector
     case params[:noteable_type]
       when 'Student'
-        @students = Student.all(:order => 'user_name')
+        @students = Student.all(order: 'user_name')
       when 'Assignment'
         @assignments = Assignment.all
       when 'Grouping'
@@ -88,19 +88,19 @@ class NotesController < ApplicationController
         flash[:error] = I18n.t('notes.new.invalid_selector')
         new_retrieve
     end
-		render 'noteable_object_selector', :formats => [:js], :handlers => [:erb]
+		render 'noteable_object_selector', formats: [:js], handlers: [:erb]
   end
 
   def edit
-		render 'edit', :formats => [:html], :handlers => [:erb]
+		render 'edit', formats: [:html], handlers: [:erb]
   end
 
   def update
     if @note.update_attributes(params[:note])
       flash[:success] = I18n.t('notes.update.success')
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
-      render 'edit', :formats => [:html], :handlers => [:erb]
+      render 'edit', formats: [:html], handlers: [:erb]
     end
   end
 
@@ -112,7 +112,7 @@ class NotesController < ApplicationController
     else
       flash[:error] = I18n.t('notes.delete.error_permissions')
     end
-	  render 'destroy', :formats => [:js], :handlers => [:erb]
+	  render 'destroy', formats: [:js], handlers: [:erb]
   end
 
   private
@@ -122,7 +122,7 @@ class NotesController < ApplicationController
         return
       end
       @groupings = Grouping.find_all_by_assignment_id(assignment.id,
-        :include => [:group, {:student_memberships => :user}])
+        include: [:group, {student_memberships: :user}])
     end
 
     def new_retrieve
@@ -135,9 +135,9 @@ class NotesController < ApplicationController
       @note = Note.find(params[:id])
 
       unless @note.user_can_modify?(current_user)
-        render 'shared/http_status', :formats => [:html], :status => 404,
-          :layout => false, :locals => {
-            :code => '404', :message => HttpStatusHelper::ERROR_CODE['message']['404']
+        render 'shared/http_status', formats: [:html], status: 404,
+          layout: false, locals: {
+            code: '404', message: HttpStatusHelper::ERROR_CODE['message']['404']
           }
       end
     end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,6 +1,6 @@
 class ResultsController < ApplicationController
   before_filter :authorize_only_for_admin,
-                :except => [:codeviewer,
+                except: [:codeviewer,
                             :edit,
                             :update_mark,
                             :view_marks,
@@ -9,13 +9,13 @@ class ResultsController < ApplicationController
                         :collapse_criteria, :remove_extra_mark, :expand_unmarked_criteria, :update_marking_state,
                         :download, :download_zip, :note_message,
                         :update_overall_remark_comment, :update_remark_request, :cancel_remark_request]
-  before_filter      :authorize_for_ta_and_admin, :only => [:edit, :update_mark, :create, :add_extra_mark,
+  before_filter      :authorize_for_ta_and_admin, only: [:edit, :update_mark, :create, :add_extra_mark,
                         :next_grouping, :update_overall_comment, :expand_criteria,
                         :collapse_criteria, :remove_extra_mark, :expand_unmarked_criteria,
                         :update_marking_state, :note_message, :update_overall_remark_comment]
-  before_filter      :authorize_for_user, :only => [:codeviewer, :download, :download_zip]
-  before_filter      :authorize_for_student, :only => [:view_marks, :update_remark_request, :cancel_remark_request]
-  after_filter       :update_remark_request_count, :only =>
+  before_filter      :authorize_for_user, only: [:codeviewer, :download, :download_zip]
+  before_filter      :authorize_for_student, only: [:view_marks, :update_remark_request, :cancel_remark_request]
+  after_filter       :update_remark_request_count, only:
    [:update_remark_request, :cancel_remark_request, :set_released_to_students]
 
   def note_message
@@ -35,8 +35,8 @@ class ResultsController < ApplicationController
 
     @old_result = nil
     if @submission.remark_submitted?
-      @old_result = Result.all(:conditions => ['submission_id = ?', @submission.id],
-                               :order => ['id ASC'])[0]
+      @old_result = Result.all(conditions: ['submission_id = ?', @submission.id],
+                               order: ['id ASC'])[0]
     end
 
     @annotation_categories = @assignment.annotation_categories
@@ -54,12 +54,12 @@ class ResultsController < ApplicationController
     @mark_criteria = @assignment.get_criteria
     @assignment.get_criteria.each do |criterion|
       mark = criterion.marks.find_or_create_by_result_id(@result.id)
-      mark.save(:validate => false)
+      mark.save(validate: false)
       @marks_map[criterion.id] = mark
 
       if @old_result
         oldmark = criterion.marks.find_or_create_by_result_id(@old_result.id)
-        oldmark.save(:validate => false)
+        oldmark.save(validate: false)
         @old_marks_map[criterion.id] = oldmark
       end
     end
@@ -70,13 +70,13 @@ class ResultsController < ApplicationController
     if current_user.ta?
        groupings = @assignment.ta_memberships.find_all_by_user_id(
                       current_user.id,
-                      :include => [:grouping => :group],
-                      :order => 'id ASC').collect do |m|
+                      include: [grouping: :group],
+                      order: 'id ASC').collect do |m|
          m.grouping
        end
     elsif current_user.admin?
-      groupings = @assignment.groupings.all(:include => :group,
-                                            :order => 'id ASC')
+      groupings = @assignment.groupings.all(include: :group,
+                                            order: 'id ASC')
     end
 
     # If a grouping's submission's marking_status is complete, we're not going
@@ -117,13 +117,13 @@ class ResultsController < ApplicationController
   def next_grouping
     grouping = Grouping.find(params[:id])
     if grouping.has_submission? && grouping.is_collected?
-        redirect_to :action => 'edit',
-                    :id => grouping.current_submission_used.get_latest_result.id
+        redirect_to action: 'edit',
+                    id: grouping.current_submission_used.get_latest_result.id
     else
-      redirect_to :controller => 'submissions',
-                  :action => 'collect_and_begin_grading',
-                  :id => grouping.assignment.id,
-                  :grouping_id => grouping.id
+      redirect_to controller: 'submissions',
+                  action: 'collect_and_begin_grading',
+                  id: grouping.assignment.id,
+                  grouping_id: grouping.id
     end
   end
 
@@ -158,21 +158,21 @@ class ResultsController < ApplicationController
         @result.submission.assignment.assignment_stat.refresh_grade_distribution
         @result.submission.assignment.set_results_statistics
       end
-      render :template => 'results/update_marking_state'
+      render template: 'results/update_marking_state'
     else # Failed to pass validations
       # Show error message
-      render :template => 'results/marker/show_result_error'
+      render template: 'results/marker/show_result_error'
     end
   end
 
   def download
     #Ensure student doesn't download a file not submitted by his own grouping
-    unless authorized_to_download?(:file_id => params[:select_file_id])
-      render 'shared/http_status', :formats => [:html],
-             :locals => { :code => '404',
-                          :message => HttpStatusHelper::ERROR_CODE[
-                              'message']['404'] }, :status => 404,
-             :layout => false
+    unless authorized_to_download?(file_id: params[:select_file_id])
+      render 'shared/http_status', formats: [:html],
+             locals: { code: '404',
+                          message: HttpStatusHelper::ERROR_CODE[
+                              'message']['404'] }, status: 404,
+             layout: false
       return
     end
     file = SubmissionFile.find(params[:select_file_id])
@@ -184,37 +184,37 @@ class ResultsController < ApplicationController
       end
     rescue Exception => e
       flash[:file_download_error] = e.message
-      redirect_to :action => 'edit',
-                  :assignment_id => params[:assignment_id],
-                  :submission_id => file.submission,
-                  :id => file.submission.get_latest_result.id
+      redirect_to action: 'edit',
+                  assignment_id: params[:assignment_id],
+                  submission_id: file.submission,
+                  id: file.submission.get_latest_result.id
       return
     end
     filename = file.filename
     #Display the file in the page if it is an image/pdf, and download button
     #was not explicitly pressed
     if file.is_supported_image? && !params[:show_in_browser].nil?
-      send_data file_contents, :type => 'image', :disposition => 'inline',
-        :filename => filename
+      send_data file_contents, type: 'image', disposition: 'inline',
+        filename: filename
     elsif file.is_pdf? && !params[:show_in_browser].nil?
       send_file File.join(MarkusConfigurator.markus_config_pdf_storage,
         file.submission.grouping.group.repository_name, file.path,
         filename.split('.')[0] + '_' + sprintf('%04d' % params[:file_index].to_s()) + '.jpg'),
-        :type => 'image', :disposition => 'inline', :filename => filename
+        type: 'image', disposition: 'inline', filename: filename
     else
-      send_data file_contents, :filename => filename
+      send_data file_contents, filename: filename
     end
   end
 
   def download_zip
 
     #Ensure student doesn't download files not submitted by his own grouping
-    unless authorized_to_download?(:submission_id => params[:submission_id])
-      render 'shared/http_status', :formats => [:html],
-             :locals => { :code => '404',
-                          :message => HttpStatusHelper::ERROR_CODE[
-                              'message']['404'] }, :status => 404,
-             :layout => false
+    unless authorized_to_download?(submission_id: params[:submission_id])
+      render 'shared/http_status', formats: [:html],
+             locals: { code: '404',
+                          message: HttpStatusHelper::ERROR_CODE[
+                              'message']['404'] }, status: 404,
+             layout: false
       return
     end
     assignment = Assignment.find(params[:assignment_id])
@@ -226,7 +226,7 @@ class ResultsController < ApplicationController
     zip_name = "#{repo_folder}-#{grouping.group.repo_name}"
 
     if submission.blank?
-      render :text => t('student.submission.no_files_available')
+      render text: t('student.submission.no_files_available')
       return
     end
 
@@ -249,8 +249,8 @@ class ResultsController < ApplicationController
             file_content = file.retrieve_file
           end
         rescue Exception => e
-          render :text => t('student.submission.missing_file',
-                            :file_name => file.filename, :message => e.message)
+          render text: t('student.submission.missing_file',
+                            file_name: file.filename, message: e.message)
           return
         end
         # Create the folder in the Zip file if it doesn't exist
@@ -262,8 +262,8 @@ class ResultsController < ApplicationController
       end
     end
     # Send the Zip file
-    send_file zip_path, :disposition => 'inline',
-              :filename => zip_name + '.zip'
+    send_file zip_path, disposition: 'inline',
+              filename: zip_name + '.zip'
   end
 
   def codeviewer
@@ -277,9 +277,9 @@ class ResultsController < ApplicationController
     if current_user.student?
       # The Student does not have access to this file. Display an error.
       if @file.submission.grouping.membership_status(current_user).nil?
-        render :partial => 'shared/handle_error',
-               :locals => {:error => I18n.t('submission_file.error.no_access',
-                 :submission_file_id => @submission_file_id)}
+        render partial: 'shared/handle_error',
+               locals: {error: I18n.t('submission_file.error.no_access',
+                 submission_file_id: @submission_file_id)}
         return
       end
     end
@@ -290,8 +290,8 @@ class ResultsController < ApplicationController
     begin
       @file_contents = @file.retrieve_file
     rescue Exception => e
-      render :partial => 'shared/handle_error',
-             :locals => {:error => e.message}
+      render partial: 'shared/handle_error',
+             locals: {error: e.message}
       return
     end
     @code_type = @file.get_file_type
@@ -311,7 +311,7 @@ class ResultsController < ApplicationController
       @nb_pdf_files_to_download = i
     end
 
-    render :template => 'results/common/codeviewer'
+    render template: 'results/common/codeviewer'
   end
 
   def update_mark
@@ -331,19 +331,19 @@ class ResultsController < ApplicationController
                          "#{current_user.user_name}', Submission ID: '#{submission.id}'," +
                          " Assignment: '#{assignment.short_identifier}', Group: '#{group.group_name}'.",
                      MarkusLogger::ERROR)
-        render :partial => 'shared/handle_error',
-               :locals => {:error => I18n.t('mark.error.save') + result_mark.errors.full_messages.join}
+        render partial: 'shared/handle_error',
+               locals: {error: I18n.t('mark.error.save') + result_mark.errors.full_messages.join}
       else
         m_logger.log("User '#{current_user.user_name}' updated mark for submission (id: " +
                          "#{submission.id}) of assignment '#{assignment.short_identifier}' for group" +
                          " '#{group.group_name}'.", MarkusLogger::INFO)
-        render :partial => 'results/marker/update_mark',
-               :locals => { :result_mark => result_mark, :mark_value => result_mark.mark}
+        render partial: 'results/marker/update_mark',
+               locals: { result_mark: result_mark, mark_value: result_mark.mark}
       end
     else
-      render :partial => 'results/marker/mark_verify_result',
-             :locals => {:mark_id => result_mark.id,
-                         :mark_error => result_mark.errors.full_messages.join}
+      render partial: 'results/marker/mark_verify_result',
+             locals: {mark_id: result_mark.id,
+                         mark_error: result_mark.errors.full_messages.join}
     end
   end
 
@@ -352,9 +352,9 @@ class ResultsController < ApplicationController
     @grouping = current_user.accepted_grouping_for(@assignment.id)
 
     if @grouping.nil?
-      redirect_to :controller => 'assignments',
-                  :action => 'student_interface',
-                  :id => params[:id]
+      redirect_to controller: 'assignments',
+                  action: 'student_interface',
+                  id: params[:id]
       return
     end
     unless @grouping.has_submission?
@@ -399,12 +399,12 @@ class ResultsController < ApplicationController
     @mark_criteria = @assignment.get_criteria
     @assignment.get_criteria.each do |criterion|
       mark = criterion.marks.find_or_create_by_result_id(@result.id)
-      mark.save(:validate => false)
+      mark.save(validate: false)
       @marks_map[criterion.id] = mark
 
       if @old_result
         oldmark = criterion.marks.find_or_create_by_result_id(@old_result.id)
-        oldmark.save(:validate => false)
+        oldmark.save(validate: false)
         @old_marks_map[criterion.id] = oldmark
       end
     end
@@ -422,13 +422,13 @@ class ResultsController < ApplicationController
       if @extra_mark.update_attributes(params[:extra_mark])
         # need to re-calculate total mark
         @result.update_total_mark
-        render :template => 'results/marker/insert_extra_mark'
+        render template: 'results/marker/insert_extra_mark'
       else
-        render :template => 'results/marker/add_extra_mark_error'
+        render template: 'results/marker/add_extra_mark_error'
       end
       return
     end
-    render :template => 'results/marker/add_extra_mark'
+    render template: 'results/marker/add_extra_mark'
   end
 
   #Deletes an extra mark from the database and removes it from the html
@@ -439,21 +439,21 @@ class ResultsController < ApplicationController
     #need to recalculate total mark
     @result = @extra_mark.result
     @result.update_total_mark
-    render :template => 'results/marker/remove_extra_mark'
+    render template: 'results/marker/remove_extra_mark'
   end
 
   def update_overall_comment
     @result = Result.find(params[:id])
     @result.overall_comment = params[:result][:overall_comment]
     @result.save
-		render 'update_overall_comment', :formats => [:js]
+		render 'update_overall_comment', formats: [:js]
   end
 
   def update_overall_remark_comment
     @result = Result.find(params[:id])
     @result.overall_comment = params[:result][:overall_comment]
     @result.save
-		render 'update_overall_remark_comment', :formats => [:js]
+		render 'update_overall_remark_comment', formats: [:js]
   end
 
   def update_remark_request
@@ -475,7 +475,7 @@ class ResultsController < ApplicationController
         @old_result.save
       end
     end
-		render 'update_remark_request', :formats => [:js]
+		render 'update_remark_request', formats: [:js]
   end
 
   def cancel_remark_request
@@ -493,22 +493,22 @@ class ResultsController < ApplicationController
     @result.released_to_students = true
     @result.save
 
-    redirect_to :controller => 'results',
-                :action => 'view_marks',
-                :id => params[:id]
+    redirect_to controller: 'results',
+                action: 'view_marks',
+                id: params[:id]
   end
 
   def expand_criteria
     @assignment = Assignment.find(params[:assignment_id])
     @mark_criteria = @assignment.get_criteria
-    render :partial => 'results/marker/expand_criteria',
-           :locals => {:mark_criteria => @mark_criteria}
+    render partial: 'results/marker/expand_criteria',
+           locals: {mark_criteria: @mark_criteria}
   end
 
   def collapse_criteria
     @assignment = Assignment.find(params[:assignment_id])
     @mark_criteria = @assignment.get_criteria
-    render :partial => 'results/marker/collapse_criteria', :locals => {:mark_criteria => @mark_criteria}
+    render partial: 'results/marker/collapse_criteria', locals: {mark_criteria: @mark_criteria}
   end
 
   def expand_unmarked_criteria
@@ -516,8 +516,8 @@ class ResultsController < ApplicationController
     @result = Result.find(params[:id])
     # nil_marks are the marks that have a "nil" value for Mark.mark - so they're
     # unmarked.
-    @nil_marks = @result.marks.all(:conditions => {:mark => nil})
-    render :partial => 'results/marker/expand_unmarked_criteria', :locals => {:nil_marks => @nil_marks}
+    @nil_marks = @result.marks.all(conditions: {mark: nil})
+    render partial: 'results/marker/expand_unmarked_criteria', locals: {nil_marks: @nil_marks}
   end
 
   def delete_grace_period_deduction

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -4,12 +4,12 @@ class RubricsController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:assignment_id])
-    @criteria = @assignment.rubric_criteria(:order => 'position')
+    @criteria = @assignment.rubric_criteria(order: 'position')
   end
 
   def edit
     @criterion = RubricCriterion.find(params[:id])
-    render 'edit', :formats => [:js]
+    render 'edit', formats: [:js]
   end
 
   def update
@@ -24,7 +24,7 @@ class RubricsController < ApplicationController
   def new
     @assignment = Assignment.find(params[:assignment_id])
     @criterion = RubricCriterion.new
-    render 'new', :formats => [:js]
+    render 'new', formats: [:js]
   end
 
   def create
@@ -42,7 +42,7 @@ class RubricsController < ApplicationController
     @criterion.position = new_position
     unless @criterion.update_attributes(params[:rubric_criterion])
       @errors = @criterion.errors
-      render 'add_criterion_error', :formats => [:js]
+      render 'add_criterion_error', formats: [:js]
       return
     end
     @criteria.reload
@@ -56,19 +56,19 @@ class RubricsController < ApplicationController
     #delete all marks associated with this criterion
     @criterion.destroy
     flash.now[:success] = I18n.t('criterion_deleted_success')
-    render 'destroy', :formats => [:js]
+    render 'destroy', formats: [:js]
   end
 
   def download_csv
     @assignment = Assignment.find(params[:assignment_id])
     file_out = RubricCriterion.create_csv(@assignment)
-    send_data(file_out, :type => 'text/csv', :filename => "#{@assignment.short_identifier}_rubric_criteria.csv", :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', filename: "#{@assignment.short_identifier}_rubric_criteria.csv", disposition: 'inline')
   end
 
   def download_yml
      assignment = Assignment.find(params[:assignment_id])
      file_out = assignment.export_rubric_criteria_yml
-     send_data(file_out, :type => 'text/plain', :filename => "#{assignment.short_identifier}_rubric_criteria.yml", :disposition => 'inline')
+     send_data(file_out, type: 'text/plain', filename: "#{assignment.short_identifier}_rubric_criteria.yml", disposition: 'inline')
   end
 
   def csv_upload
@@ -85,12 +85,12 @@ class RubricsController < ApplicationController
           end
           if nb_updates > 0
             flash[:notice] = I18n.t('rubric_criteria.upload.success',
-              :nb_updates => nb_updates)
+              nb_updates: nb_updates)
           end
         end
       end
     end
-    redirect_to :action => 'index', :id => @assignment.id
+    redirect_to action: 'index', id: @assignment.id
   end
 
   def yml_upload
@@ -98,7 +98,7 @@ class RubricsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     encoding = params[:encoding]
     unless request.post?
-      redirect_to :action => 'index', :id => assignment.id
+      redirect_to action: 'index', id: assignment.id
       return
     end
     file = params[:yml_upload][:rubric]
@@ -109,14 +109,14 @@ class RubricsController < ApplicationController
       # is thrown by Psych in Ruby 2.*.
       rescue ArgumentError, Psych::SyntaxError => e
         flash[:error] = I18n.t('rubric_criteria.upload.error') + '  ' +
-           I18n.t('rubric_criteria.upload.syntax_error', :error => "#{e}")
-        redirect_to :action => 'index', :id => assignment.id
+           I18n.t('rubric_criteria.upload.syntax_error', error: "#{e}")
+        redirect_to action: 'index', id: assignment.id
         return
       end
       unless rubrics
         flash[:error] = I18n.t('rubric_criteria.upload.error') +
           '  ' + I18n.t('rubric_criteria.upload.empty_error')
-        redirect_to :action => 'index', :id => assignment.id
+        redirect_to action: 'index', id: assignment.id
         return
       end
       successes = 0
@@ -129,7 +129,7 @@ class RubricsController < ApplicationController
           #collect the names of the criterion that contains an error in it.
           criteria_with_errors[i] = key.at(0)
           i = i + 1
-          flash[:error] = I18n.t('rubric_criteria.upload.syntax_error', :error => "#{e}")
+          flash[:error] = I18n.t('rubric_criteria.upload.syntax_error', error: "#{e}")
         end
       end
 
@@ -150,24 +150,24 @@ class RubricsController < ApplicationController
       end
 
       if successes > 0
-        flash[:notice] = I18n.t('rubric_criteria.upload.success', :nb_updates => successes)
+        flash[:notice] = I18n.t('rubric_criteria.upload.success', nb_updates: successes)
       end
     end
-    redirect_to :action => 'index', :assignment_id => assignment.id
+    redirect_to action: 'index', assignment_id: assignment.id
   end
 
 
   #This method handles the drag/drop RubricCriteria sorting
   def update_positions
     unless request.post?
-      render :nothing => true
+      render nothing: true
       return
     end
     @assignment = Assignment.find(params[:assignment_id])
     @criteria = @assignment.rubric_criteria
     params[:rubric_criteria_pane_list].each_with_index do |id, position|
       if id != ''
-        RubricCriterion.update(id, :position => position + 1)
+        RubricCriterion.update(id, position: position + 1)
       end
     end
   end
@@ -179,7 +179,7 @@ class RubricsController < ApplicationController
     elsif  params[:direction] == 'down'
       offset = 1
     else
-      render :nothing => true
+      render nothing: true
       return
     end
     @assignment = Assignment.find(params[:assignment_id])
@@ -188,7 +188,7 @@ class RubricsController < ApplicationController
     index = @criteria.index(criterion)
     other_criterion = @criteria[index + offset]
     if other_criterion.nil?
-      render :nothing => true
+      render nothing: true
       return
     end
     position = criterion.position
@@ -198,7 +198,7 @@ class RubricsController < ApplicationController
       flash[:error] = I18n.t('rubrics.move_criterion.error')
     end
     @criteria.reload
-    render 'move_criterion', :formats => [:js]
+    render 'move_criterion', formats: [:js]
   end
 
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -21,12 +21,12 @@ class SectionsController < ApplicationController
     @section = Section.new(params[:section])
     if @section.save
       @sections = Section.all
-      flash[:success] = I18n.t('section.create.success', :name => @section.name)
+      flash[:success] = I18n.t('section.create.success', name: @section.name)
       if params[:section_modal]
         render 'close_modal_add_section'
         return
       end
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       flash[:error] = I18n.t('section.create.error')
       if params[:section_modal]
@@ -46,8 +46,8 @@ class SectionsController < ApplicationController
   def update
     @section = Section.find(params[:id])
     if @section.update_attributes(params[:section])
-      flash[:success] = I18n.t('section.update.success', :name => @section.name)
-      redirect_to :action => 'index'
+      flash[:success] = I18n.t('section.update.success', name: @section.name)
+      redirect_to action: 'index'
     else
       flash[:error] = I18n.t('section.update.error')
       render :edit
@@ -68,6 +68,6 @@ class SectionsController < ApplicationController
     else
       flash[:error] = I18n.t('section.delete.error_permissions')
     end
-    redirect_to :action => :index
+    redirect_to action: :index
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -12,8 +12,8 @@ class StudentsController < ApplicationController
   end
 
   def index
-    @students = Student.all(:order => 'user_name')
-    @sections = Section.all(:order => 'name')
+    @students = Student.all(order: 'user_name')
+    @sections = Section.all(order: 'name')
   end
 
   def populate
@@ -21,20 +21,20 @@ class StudentsController < ApplicationController
     # 1. AJAX call made by jQuery to populate the student table
     # 2. Find students from the database
     # 3. Pass in the student data into the helper function (construct_table_rows defined in UsersHelper)
-    @students_data = Student.all(:order => 'user_name',
-                                 :include => [:section,
+    @students_data = Student.all(order: 'user_name',
+                                 include: [:section,
                                               :grace_period_deductions])
 
     # Function below contained within helpers/users_helper.rb
     @students = construct_table_rows(@students_data)
     respond_to do |format|
-      format.json { render :json => @students }
+      format.json { render json: @students }
     end
   end
 
   def edit
     @user = Student.find_by_id(params[:id])
-    @sections = Section.all(:order => 'name')
+    @sections = Section.all(order: 'name')
   end
 
   def update
@@ -43,11 +43,11 @@ class StudentsController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if @user.update_attributes(attrs)
       flash[:success] = I18n.t('students.update.success',
-                               :user_name => @user.user_name)
-      redirect_to :action => 'index'
+                               user_name: @user.user_name)
+      redirect_to action: 'index'
     else
       flash[:error] = I18n.t('students.update.error')
-      @sections = Section.all(:order => 'name')
+      @sections = Section.all(order: 'name')
       render :edit
     end
   end
@@ -72,7 +72,7 @@ class StudentsController < ApplicationController
           Student.update_section(student_ids, params[:section])
           @students = construct_table_rows(Student.find(student_ids))
       end
-      render :bulk_modify, :formats => [:js]
+      render :bulk_modify, formats: [:js]
     rescue RuntimeError => e
       @error = e.message
       render :display_error
@@ -81,7 +81,7 @@ class StudentsController < ApplicationController
 
   def new
     @user = Student.new(params[:user])
-    @sections = Section.all(:order => 'name')
+    @sections = Section.all(order: 'name')
   end
 
   def create
@@ -91,10 +91,10 @@ class StudentsController < ApplicationController
     @user = Student.new(params[:user])
     if @user.save
       flash[:success] = I18n.t('students.create.success',
-                               :user_name => @user.user_name)
-      redirect_to :action => 'index' # Redirect
+                               user_name: @user.user_name)
+      redirect_to action: 'index' # Redirect
     else
-      @sections = Section.all(:order => 'name')
+      @sections = Section.all(order: 'name')
       flash[:error] = I18n.t('students.create.error')
       render :new
     end
@@ -110,7 +110,7 @@ class StudentsController < ApplicationController
   #downloads users with the given role as a csv list
   def download_student_list
     #find all the users
-    students = Student.all(:order => 'user_name')
+    students = Student.all(order: 'user_name')
     case params[:format]
     when 'csv'
       output = User.generate_csv_list(students)
@@ -123,7 +123,7 @@ class StudentsController < ApplicationController
       output = students.to_xml
       format = 'text/xml'
     end
-    send_data(output, :type => format, :disposition => 'inline')
+    send_data(output, type: format, disposition: 'inline')
   end
 
   def upload_student_list
@@ -140,7 +140,7 @@ class StudentsController < ApplicationController
       end
 
     end
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 
   def delete_grace_period_deduction

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -8,7 +8,7 @@ class SubmissionsController < ApplicationController
   helper_method :all_assignments_marked?
 
   before_filter :authorize_only_for_admin,
-                :except => [:server_time,
+                except: [:server_time,
                             :populate_file_manager,
                             :browse,
                             :index,
@@ -26,7 +26,7 @@ class SubmissionsController < ApplicationController
                             :update_converted_pdfs,
                             :update_submissions]
   before_filter :authorize_for_ta_and_admin,
-                :only => [:browse,
+                only: [:browse,
                           :index,
                           :s_table_paginate,
                           :collect_and_begin_grading,
@@ -38,29 +38,29 @@ class SubmissionsController < ApplicationController
                           :update_converted_pdfs,
                           :update_submissions]
   before_filter :authorize_for_student,
-                :only => [:file_manager,
+                only: [:file_manager,
                           :populate_file_manager,
                           :update_files]
-  before_filter :authorize_for_user, :only => [:download, :downloads]
+  before_filter :authorize_for_user, only: [:download, :downloads]
 
   # TABLE FOR TAs
   TA_TABLE_PARAMS = {
-    :model => Grouping,
-    :per_pages => [15, 30, 50, 100, 150, 500, 1000],
-    :filters => {
+    model: Grouping,
+    per_pages: [15, 30, 50, 100, 150, 500, 1000],
+    filters: {
       'none' => {
-        :display => I18n.t('browse_submissions.show_all'),
-        :proc => lambda { |params, to_include|
+        display: I18n.t('browse_submissions.show_all'),
+        proc: lambda { |params, to_include|
           params[:assignment].ta_memberships.find_all_by_user_id(
-              params[:user_id], :include => [:grouping => to_include]).
+              params[:user_id], include: [grouping: to_include]).
               collect { |m| m.grouping }
         }
       },
       'unmarked' => {
-        :display => I18n.t('browse_submissions.show_unmarked'),
-        :proc => lambda { |params, to_include|
+        display: I18n.t('browse_submissions.show_unmarked'),
+        proc: lambda { |params, to_include|
            (params[:assignment].ta_memberships.find_all_by_user_id(
-               params[:user_id], :include => [:grouping => to_include]).
+               params[:user_id], include: [grouping: to_include]).
                collect{|m| m.grouping}
            ).select { |g| !g.has_submission? || (g.has_submission? &&
                    g.current_submission_used.get_latest_result.marking_state ==
@@ -68,10 +68,10 @@ class SubmissionsController < ApplicationController
       },
 
       'partial' => {
-        :display => I18n.t('browse_submissions.show_partial'),
-        :proc => lambda { |params, to_include|
+        display: I18n.t('browse_submissions.show_partial'),
+        proc: lambda { |params, to_include|
            (params[:assignment].ta_memberships.find_all_by_user_id(
-                    params[:user_id], :include => [:grouping => to_include]).
+                    params[:user_id], include: [grouping: to_include]).
                collect{|m| m.grouping}
            ).select{ |g| g.has_submission? &&
                g.current_submission_used.get_latest_result.marking_state ==
@@ -79,10 +79,10 @@ class SubmissionsController < ApplicationController
       },
 
       'complete' => {
-        :display => I18n.t('browse_submissions.show_complete'),
-        :proc => lambda{ |params, to_include|
+        display: I18n.t('browse_submissions.show_complete'),
+        proc: lambda{ |params, to_include|
           (params[:assignment].ta_memberships.find_all_by_user_id(
-              params[:user_id], :include => [:grouping => to_include]).
+              params[:user_id], include: [grouping: to_include]).
               collect{|m| m.grouping}
           ).select{|g| g.has_submission? &&
               g.current_submission_used.get_latest_result.marking_state ==
@@ -90,24 +90,24 @@ class SubmissionsController < ApplicationController
       },
 
       'released' => {
-        :display => I18n.t('browse_submissions.show_released'),
-        :proc => lambda{ |params, to_include|
+        display: I18n.t('browse_submissions.show_released'),
+        proc: lambda{ |params, to_include|
           (params[:assignment].ta_memberships.find_all_by_user_id(
-              params[:user_id], :include => [:grouping => to_include]).
+              params[:user_id], include: [grouping: to_include]).
               collect{|m| m.grouping}
           ).select{|g| g.has_submission? &&
               g.current_submission_used.get_latest_result.released_to_students}}
       },
 
       'assigned' => {
-        :display => I18n.t('browse_submissions.show_assigned_to_me'),
-        :proc => lambda { |params, to_include|
+        display: I18n.t('browse_submissions.show_assigned_to_me'),
+        proc: lambda { |params, to_include|
           params[:assignment].ta_memberships.find_all_by_user_id(
-              params[:user_id], :include => [:grouping => to_include]).
+              params[:user_id], include: [grouping: to_include]).
               collect{|m| m.grouping} }}
     },
 
-    :sorts => {
+    sorts: {
       'group_name' => lambda { |a,b| a.group.group_name.downcase <=>
         b.group.group_name.downcase},
       'repo_name' => lambda { |a,b| a.group.repo_name.downcase <=>
@@ -143,48 +143,48 @@ class SubmissionsController < ApplicationController
 
   # TABLE FOR Admin
   ADMIN_TABLE_PARAMS = {
-    :model => Grouping,
-    :per_pages => [15, 30, 50, 100, 150, 500, 1000],
-    :filters => {
+    model: Grouping,
+    per_pages: [15, 30, 50, 100, 150, 500, 1000],
+    filters: {
       'none' => {
-        :display => I18n.t('browse_submissions.show_all'),
-        :proc => lambda { |params, to_include|
-          params[:assignment].groupings.all(:include => to_include)}},
+        display: I18n.t('browse_submissions.show_all'),
+        proc: lambda { |params, to_include|
+          params[:assignment].groupings.all(include: to_include)}},
       'unmarked' => {
-        :display => I18n.t('browse_submissions.show_unmarked'),
-        :proc => lambda { |params, to_include|
-          params[:assignment].groupings.all(:include => [to_include]).
+        display: I18n.t('browse_submissions.show_unmarked'),
+        proc: lambda { |params, to_include|
+          params[:assignment].groupings.all(include: [to_include]).
               select{|g| !g.has_submission? || (g.has_submission? &&
               g.current_submission_used.get_latest_result.marking_state ==
                   Result::MARKING_STATES[:unmarked]) } }},
       'partial' => {
-        :display => I18n.t('browse_submissions.show_partial'),
-        :proc => lambda { |params, to_include|
-          params[:assignment].groupings.all(:include => [to_include]).
+        display: I18n.t('browse_submissions.show_partial'),
+        proc: lambda { |params, to_include|
+          params[:assignment].groupings.all(include: [to_include]).
               select{|g| g.has_submission? &&
               g.current_submission_used.get_latest_result.marking_state ==
                   Result::MARKING_STATES[:partial] } }},
       'complete' => {
-        :display => I18n.t('browse_submissions.show_complete'),
-        :proc => lambda { |params, to_include|
-          params[:assignment].groupings.all(:include => [to_include]).
+        display: I18n.t('browse_submissions.show_complete'),
+        proc: lambda { |params, to_include|
+          params[:assignment].groupings.all(include: [to_include]).
               select{|g| g.has_submission? &&
               g.current_submission_used.get_latest_result.marking_state ==
                   Result::MARKING_STATES[:complete] } }},
       'released' => {
-        :display => I18n.t('browse_submissions.show_released'),
-        :proc => lambda { |params, to_include|
-          params[:assignment].groupings.all(:include => [to_include]).
+        display: I18n.t('browse_submissions.show_released'),
+        proc: lambda { |params, to_include|
+          params[:assignment].groupings.all(include: [to_include]).
               select{|g| g.has_submission? &&
               g.current_submission_used.get_latest_result.released_to_students}}},
       'assigned' => {
-        :display => I18n.t('browse_submissions.show_assigned_to_me'),
-        :proc => lambda { |params, to_include|
+        display: I18n.t('browse_submissions.show_assigned_to_me'),
+        proc: lambda { |params, to_include|
           params[:assignment].ta_memberships.find_all_by_user_id(
-              params[:user_id], :include => [:grouping => to_include]).
+              params[:user_id], include: [grouping: to_include]).
               collect{|m| m.grouping} }}
     },
-    :sorts => {
+    sorts: {
       'group_name' => lambda { |a,b|
         a.group.group_name.downcase <=> b.group.group_name.downcase},
       'repo_name' => lambda { |a,b|
@@ -273,8 +273,8 @@ class SubmissionsController < ApplicationController
         revision = nil
       end
       if revision
-        @revisions_history << {:num => revision.revision_number,
-                               :date => revision.timestamp}
+        @revisions_history << {num: revision.revision_number,
+                               date: revision.timestamp}
       end
     end
     repo.close
@@ -293,7 +293,7 @@ class SubmissionsController < ApplicationController
         @files = @revision.files_at_path(File.join(@assignment.repository_folder, @path))
       rescue Exception => @find_revision_error
         respond_to do |format|
-          format.js { render :action => 'submissions/repo_browser/find_revision_error' }
+          format.js { render action: 'submissions/repo_browser/find_revision_error' }
         end
         return
       end
@@ -316,9 +316,9 @@ class SubmissionsController < ApplicationController
     @grouping = current_user.accepted_grouping_for(@assignment.id)
 
     if @grouping.nil?
-      redirect_to :controller => 'assignments',
-                  :action => 'student_interface',
-                  :id => params[:id]
+      redirect_to controller: 'assignments',
+                  action: 'student_interface',
+                  id: params[:id]
       return
     end
 
@@ -369,7 +369,7 @@ class SubmissionsController < ApplicationController
     @revision_number = params[:current_revision_number].to_i
     SubmissionCollector.instance.manually_collect_submission(@grouping,
       @revision_number)
-    redirect_to :action => 'update_converted_pdfs', :id => @grouping.id
+    redirect_to action: 'update_converted_pdfs', id: @grouping.id
   end
 
   def collect_and_begin_grading
@@ -383,43 +383,43 @@ class SubmissionsController < ApplicationController
       flash[:success] = I18n.t('collect_submissions.priority_given')
     else
       flash[:error] = I18n.t('browse_submissions.could_not_collect',
-                             :group_name => grouping.group.group_name)
+                             group_name: grouping.group.group_name)
     end
-    redirect_to :action   => 'browse',
-                :id       => assignment.id
+    redirect_to action:   'browse',
+                id:       assignment.id
   end
 
   def collect_all_submissions
-    assignment = Assignment.find(params[:assignment_id], :include => [:groupings])
+    assignment = Assignment.find(params[:assignment_id], include: [:groupings])
     if assignment.submission_rule.can_collect_now?
       submission_collector = SubmissionCollector.instance
       submission_collector.push_groupings_to_queue(assignment.groupings)
       flash[:success] = I18n.t('collect_submissions.collection_job_started',
-                               :assignment_identifier => assignment.short_identifier)
+                               assignment_identifier: assignment.short_identifier)
     else
       flash[:error] = I18n.t('collect_submissions.could_not_collect',
-                             :assignment_identifier => assignment.short_identifier)
+                             assignment_identifier: assignment.short_identifier)
     end
-    redirect_to :action => 'browse',
-                :id => assignment.id
+    redirect_to action: 'browse',
+                id: assignment.id
   end
 
   def collect_ta_submissions
     assignment = Assignment.find(params[:assignment_id])
     if assignment.submission_rule.can_collect_now?
-      groupings = assignment.groupings.all(:include => :tas,
-                                           :conditions => ['users.id = ?',
+      groupings = assignment.groupings.all(include: :tas,
+                                           conditions: ['users.id = ?',
                                                            current_user.id])
       submission_collector = SubmissionCollector.instance
       submission_collector.push_groupings_to_queue(groupings)
       flash[:success] = I18n.t('collect_submissions.collection_job_started',
-                               :assignment_identifier => assignment.short_identifier)
+                               assignment_identifier: assignment.short_identifier)
     else
       flash[:error] = I18n.t('collect_submissions.could_not_collect',
-                             :assignment_identifier => assignment.short_identifier)
+                             assignment_identifier: assignment.short_identifier)
     end
-    redirect_to :action => 'browse',
-                :id => assignment.id
+    redirect_to action: 'browse',
+                id: assignment.id
   end
 
   def update_converted_pdfs
@@ -470,24 +470,24 @@ class SubmissionsController < ApplicationController
     if current_user.ta?
         @groupings, @groupings_total = handle_paginate_event(
       TA_TABLE_PARAMS,
-        { :assignment => @assignment,
-          :user_id => current_user.id},
+        { assignment: @assignment,
+          user_id: current_user.id},
       params)
     else
       @groupings, @groupings_total = handle_paginate_event(
         ADMIN_TABLE_PARAMS,
-          { :assignment => @assignment,
-            :user_id => current_user.id},
+          { assignment: @assignment,
+            user_id: current_user.id},
         params)
     end
 
     #Eager load all data only for those groupings that will be displayed
     sorted_groupings = @groupings
-    @groupings = Grouping.all(:conditions => {:id => sorted_groupings},
-                              :include =>
+    @groupings = Grouping.all(conditions: {id: sorted_groupings},
+                              include:
                                   [:assignment, :group, :grace_period_deductions,
-                                   {:current_submission_used => :results},
-                                   {:accepted_student_memberships => :user}])
+                                   {current_submission_used: :results},
+                                   {accepted_student_memberships: :user}])
 
     #re-sort @groupings by the previous order, because eager loading query
     #messed up the grouping order
@@ -527,8 +527,8 @@ class SubmissionsController < ApplicationController
   end
 
   def index
-    @assignments = Assignment.all(:order => :id)
-    render :index, :layout => 'sidebar'
+    @assignments = Assignment.all(order: :id)
+    render :index, layout: 'sidebar'
   end
 
   # update_files action handles transactional submission of files.
@@ -555,7 +555,7 @@ class SubmissionsController < ApplicationController
     unless @grouping.is_valid?
       # can't use redirect_to here. See comment of this action for more details.
       set_filebrowser_vars(@grouping.group, @assignment)
-      render :file_manager, :id => assignment_id
+      render :file_manager, id: assignment_id
       return
     end
     @grouping.group.access_repo do |repo|
@@ -617,7 +617,7 @@ class SubmissionsController < ApplicationController
           flash[:transaction_warning] = I18n.t('student.submission.no_action_detected')
           # can't use redirect_to here. See comment of this action for more details.
           set_filebrowser_vars(@grouping.group, @assignment)
-          render :file_manager, :id => assignment_id
+          render :file_manager, id: assignment_id
           return
         end
         if repo.commit(txn)
@@ -637,7 +637,7 @@ class SubmissionsController < ApplicationController
         end
         # can't use redirect_to here. See comment of this action for more details.
         set_filebrowser_vars(@grouping.group, @assignment)
-        render :file_manager, :id => assignment_id
+        render :file_manager, id: assignment_id
 
       rescue Exception => e
         m_logger = MarkusLogger.instance
@@ -645,7 +645,7 @@ class SubmissionsController < ApplicationController
         # can't use redirect_to here. See comment of this action for more details.
         @file_manager_errors[:commit_error] = e.message
         set_filebrowser_vars(@grouping.group, @assignment)
-        render :file_manager, :id => assignment_id
+        render :file_manager, id: assignment_id
       end
     end
   end
@@ -669,17 +669,17 @@ class SubmissionsController < ApplicationController
        file = @revision.files_at_path(File.join(@assignment.repository_folder, path))[params[:file_name]]
        file_contents = repo.download_as_string(file)
       rescue Exception => e
-        render :text => I18n.t('student.submission.missing_file', :file_name => params[:file_name], :message => e.message)
+        render text: I18n.t('student.submission.missing_file', file_name: params[:file_name], message: e.message)
         return
       end
 
       if SubmissionFile.is_binary?(file_contents)
         # If the file appears to be binary, send it as a download
-        send_data file_contents, :disposition => 'attachment', :filename => params[:file_name]
+        send_data file_contents, disposition: 'attachment', filename: params[:file_name]
       else
         # Otherwise, sanitize it for HTML and blast it out to the screen
         sanitized_contents = CGI.escapeHTML(file_contents)
-        render :text => sanitized_contents, :layout => 'sanitized_html'
+        render text: sanitized_contents, layout: 'sanitized_html'
       end
     end
   end
@@ -689,11 +689,11 @@ class SubmissionsController < ApplicationController
   # returns true if all assignments are marked completely
   ##
   def all_assignments_marked?
-    marked = Assignment.joins(:groupings => [{:current_submission_used =>
+    marked = Assignment.joins(groupings: [{current_submission_used:
       :results}]).where('assignments.id' => params[:assignment_id],
       'results.marking_state' => Result::MARKING_STATES[:complete])
-    total_assignments = Assignment.joins(:groupings =>
-      [{:current_submission_used => :results}]).where('assignments.id' =>
+    total_assignments = Assignment.joins(groupings:
+      [{current_submission_used: :results}]).where('assignments.id' =>
       params[:assignment_id])
     return marked.size == total_assignments.size
   end
@@ -719,7 +719,7 @@ class SubmissionsController < ApplicationController
 
     ## if there is no grouping, render a message
     if grouping_ids.blank?
-      render :text => t('student.submission.no_groupings_available')
+      render text: t('student.submission.no_groupings_available')
       return
     end
 
@@ -760,7 +760,7 @@ class SubmissionsController < ApplicationController
     end
 
     ## Send the Zip file
-    send_file zip_path, :disposition => 'inline', :filename => zip_name
+    send_file zip_path, disposition: 'inline', filename: zip_name
   end
 
   ##
@@ -784,7 +784,7 @@ class SubmissionsController < ApplicationController
           "#{@grouping.group.group_name}_r#{@revision.revision_number}.zip"
 
       if revision_number && revision_number.to_i == 0
-        render :text => t('student.submission.no_revision_available')
+        render text: t('student.submission.no_revision_available')
         return
       end
       # Open Zip file and fill it with all the files in the repo_folder
@@ -792,7 +792,7 @@ class SubmissionsController < ApplicationController
 
         files = @revision.files_at_path(full_path)
         if files.count == 0
-          render :text => t('student.submission.no_files_available')
+          render text: t('student.submission.no_files_available')
           return
         end
 
@@ -800,8 +800,8 @@ class SubmissionsController < ApplicationController
           begin
             file_contents = repo.download_as_string(file.last)
           rescue Exception => e
-            render :text => t('student.submission.missing_file',
-                              :file_name => file.first, :message => e.message)
+            render text: t('student.submission.missing_file',
+                              file_name: file.first, message: e.message)
             return
           end
 
@@ -815,8 +815,8 @@ class SubmissionsController < ApplicationController
       end
 
       # Send the Zip file
-      send_file zip_path, :disposition => 'inline',
-                :filename => zip_name + '.zip'
+      send_file zip_path, disposition: 'inline',
+                filename: zip_name + '.zip'
     end
   end
 
@@ -834,9 +834,9 @@ class SubmissionsController < ApplicationController
 
       # Get all Groupings for this filter
       if current_user.ta?
-        groupings = TA_TABLE_PARAMS[:filters][params[:filter]][:proc].call({:assignment => assignment, :user_id => current_user.id}, {})
+        groupings = TA_TABLE_PARAMS[:filters][params[:filter]][:proc].call({assignment: assignment, user_id: current_user.id}, {})
       else
-        groupings = ADMIN_TABLE_PARAMS[:filters][params[:filter]][:proc].call({:assignment => assignment, :user_id => current_user.id}, {})
+        groupings = ADMIN_TABLE_PARAMS[:filters][params[:filter]][:proc].call({assignment: assignment, user_id: current_user.id}, {})
       end
 
     else
@@ -863,7 +863,7 @@ class SubmissionsController < ApplicationController
       else
         collected = collect_submissions_for_section(params[:section_to_collect], assignment, errors)
         if collected > 0
-          flash[:success] = I18n.t('collect_submissions.successfully_collected', :collected => collected)
+          flash[:success] = I18n.t('collect_submissions.successfully_collected', collected: collected)
         end
       end
     end
@@ -874,17 +874,17 @@ class SubmissionsController < ApplicationController
     end
 
     if changed && changed > 0
-      flash[:success] = I18n.t('results.successfully_changed', {:changed => changed})
+      flash[:success] = I18n.t('results.successfully_changed', {changed: changed})
       m_logger = MarkusLogger.instance
       m_logger.log(log_message)
     end
     flash[:errors] = errors
 
-    redirect_to :action => 'browse',
-                :id => params[:id],
-                :per_page => params[:per_page],
-                :filter   => params[:filter],
-                :sort_by  => params[:sort_by]
+    redirect_to action: 'browse',
+                id: params[:id],
+                per_page: params[:per_page],
+                filter:   params[:filter],
+                sort_by:  params[:sort_by]
   end
 
   def unrelease
@@ -900,26 +900,26 @@ class SubmissionsController < ApplicationController
       m_logger.log("Marks unreleased for assignment '#{assignment.short_identifier}', ID: '" +
                    "#{assignment.id}' (for #{params[:groupings].length} groups).")
     end
-    redirect_to :action => 'browse',
-                :id => params[:id]
+    redirect_to action: 'browse',
+                id: params[:id]
   end
 
   # See Assignment.get_simple_csv_report for details
   def download_simple_csv_report
     assignment = Assignment.find(params[:assignment_id])
     send_data assignment.get_simple_csv_report,
-              :disposition => 'attachment',
-              :type => 'application/vnd.ms-excel',
-              :filename => "#{assignment.short_identifier}_simple_report.csv"
+              disposition: 'attachment',
+              type: 'application/vnd.ms-excel',
+              filename: "#{assignment.short_identifier}_simple_report.csv"
   end
 
   # See Assignment.get_detailed_csv_report for details
   def download_detailed_csv_report
     assignment = Assignment.find(params[:assignment_id])
     send_data assignment.get_detailed_csv_report,
-              :disposition => 'attachment',
-              :type => 'application/vnd.ms-excel',
-              :filename => "#{assignment.short_identifier}_detailed_report.csv"
+              disposition: 'attachment',
+              type: 'application/vnd.ms-excel',
+              filename: "#{assignment.short_identifier}_detailed_report.csv"
   end
 
   # See Assignment.get_svn_export_commands for details
@@ -927,23 +927,23 @@ class SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     svn_commands = assignment.get_svn_export_commands
     send_data svn_commands.join("\n"),
-              :disposition => 'attachment',
-              :type => 'application/vnd.ms-excel',
-              :filename => "#{assignment.short_identifier}_svn_exports.csv"
+              disposition: 'attachment',
+              type: 'application/vnd.ms-excel',
+              filename: "#{assignment.short_identifier}_svn_exports.csv"
   end
 
   # See Assignment.get_svn_repo_list for details
   def download_svn_repo_list
     assignment = Assignment.find(params[:assignment_id])
     send_data assignment.get_svn_repo_list,
-              :disposition => 'attachment',
-              :type => 'text/plain',
-              :filename => "#{assignment.short_identifier}_svn_repo_list"
+              disposition: 'attachment',
+              type: 'text/plain',
+              filename: "#{assignment.short_identifier}_svn_repo_list"
   end
 
   # This action is called periodically from file_manager.
   def server_time
-    render :partial => 'server_time'
+    render partial: 'server_time'
   end
 
   private

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -3,15 +3,15 @@ class TasController < ApplicationController
   before_filter  :authorize_only_for_admin
 
   def index
-    @tas = Ta.all(:order => 'user_name')
+    @tas = Ta.all(order: 'user_name')
   end
 
   def populate
-    @tas_data = Ta.all(:order => 'user_name')
+    @tas_data = Ta.all(order: 'user_name')
     # construct_table_rows defined in UsersHelper
     @tas = construct_table_rows(@tas_data)
     respond_to do |format|
-      format.json { render :json => @tas }
+      format.json { render json: @tas }
     end
   end
 
@@ -29,9 +29,9 @@ class TasController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if @user.update_attributes(attrs)
       flash[:success] = I18n.t('tas.update.success',
-                               :user_name => @user.user_name)
+                               user_name: @user.user_name)
 
-      redirect_to :action => :index
+      redirect_to action: :index
     else
       flash[:error] = I18n.t('tas.update.error')
       render :edit
@@ -48,8 +48,8 @@ class TasController < ApplicationController
     # updates the existing record
     if @user.save
       flash[:success] = I18n.t('tas.create.success',
-                               :user_name => @user.user_name)
-      redirect_to :action => 'index' # Redirect
+                               user_name: @user.user_name)
+      redirect_to action: 'index' # Redirect
     else
       flash[:error] = I18n.t('tas.create.error')
       render :new
@@ -59,7 +59,7 @@ class TasController < ApplicationController
   #downloads users with the given role as a csv list
   def download_ta_list
     #find all the users
-    tas = Ta.all(:order => 'user_name')
+    tas = Ta.all(order: 'user_name')
     case params[:format]
     when 'csv'
       output = User.generate_csv_list(tas)
@@ -72,7 +72,7 @@ class TasController < ApplicationController
       output = tas.to_xml
       format = 'text/xml'
     end
-    send_data(output, :type => format, :disposition => 'inline')
+    send_data(output, type: format, disposition: 'inline')
   end
 
   def upload_ta_list
@@ -80,7 +80,7 @@ class TasController < ApplicationController
       result = User.upload_user_list(Ta, params[:userlist], params[:encoding])
       if !result
         flash[:notice] = I18n.t('csv.invalid_csv')
-        redirect_to :action => 'index'
+        redirect_to action: 'index'
         return
       end
       if result[:invalid_lines].length > 0
@@ -88,6 +88,6 @@ class TasController < ApplicationController
       end
       flash[:notice] = result[:upload_notice]
     end
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 end


### PR DESCRIPTION
A better place to review this PR is at zhangsu@3c347ed with no Hound
comments, since this PR doesn't address style issues.

This is a global search-and-replace that replaces the Ruby 1.8 symbol
key hash rocket syntax to Ruby 1.9 syntax in

```
    app/controllers/{m,n,r,s,t}*.rb
```

Since this is a big change list, the style issues in the changed lines
are not being dealt with so that errors are minimized and code review
is easier. There is one exception though:

If the lines before the change have a good alignment of hash keys that
span multiple lines and the lines after the change do not (because the
change might alters the number of spaces needed for the alignment), then
the alignment is fixed, such that no new style issues are introduced. If
the alignment was not correct to begin with, then it is not fixed.

As a result, please ignore linter comments for this change.

This is for #1498.

Tested:
- rake test:units
- rake test:functionals
- rails s
