### PR TITLE
Replace helpers, lib, config, Gemfile hash rockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem 'i18n'
 gem 'will_paginate'
 gem 'dynamic_form'
 gem 'exception_notification'
-gem 'minitest',"4.7.5", :platforms => :ruby_20
-gem 'calendar_date_select', :git => 'git://github.com/paneq/calendar_date_select.git'
+gem 'minitest',"4.7.5", platforms: :ruby_20
+gem 'calendar_date_select', git: 'git://github.com/paneq/calendar_date_select.git'
 gem 'auto_complete'
 gem 'json'
 gem 'coffee-script'
@@ -71,9 +71,9 @@ group :development, :test do
   gem 'faker'
   gem 'railroady'
   gem 'time-warp'
-  gem 'debugger', :platforms => :mri_19
-  gem 'byebug', :platforms => [:mri_20, :mri_21]
-  gem 'mocha', :require => false
+  gem 'debugger', platforms: :mri_19
+  gem 'byebug', platforms: [:mri_20, :mri_21]
+  gem 'mocha', require: false
   gem 'quiet_assets'
 end
 

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -2,7 +2,7 @@ module AssignmentsHelper
 
   def add_assignment_file_link(name, form)
     link_to_function name do |page|
-      assignment_file = render(:partial => 'assignment_file', :locals => {:form => form, :assignment_file => AssignmentFile.new})
+      assignment_file = render(partial: 'assignment_file', locals: {form: form, assignment_file: AssignmentFile.new})
       page << %{
         var new_assignment_file_id = "new_" + new Date().getTime();
         $('assignment_files').insert({bottom: "#{ escape_javascript assignment_file }".replace(/(attributes_\\d+|\[\\d+\])/g, new_assignment_file_id) });
@@ -12,8 +12,8 @@ module AssignmentsHelper
   end
 
   def add_grace_period_link(name, form, element_id)
-    link_to_function name , nil, :id => element_id, :style => 'display:none' do |page|
-      period = render(:partial => 'grace_period', :locals => {:pf => form, :grace_period => Period.new})
+    link_to_function name , nil, id: element_id, style: 'display:none' do |page|
+      period = render(partial: 'grace_period', locals: {pf: form, grace_period: Period.new})
       page << %{
         if ($F('grace_period_submission_rule') != null) {
           var new_period_id = new Date().getTime();
@@ -27,8 +27,8 @@ module AssignmentsHelper
   end
 
   def add_penalty_decay_period_link(name, form, element_id)
-    link_to_function name , nil, :id => element_id, :style => 'display:none' do |page|
-      period = render(:partial => 'penalty_decay_period', :locals => {:pf => form, :penalty_decay_period => Period.new})
+    link_to_function name , nil, id: element_id, style: 'display:none' do |page|
+      period = render(partial: 'penalty_decay_period', locals: {pf: form, penalty_decay_period: Period.new})
       page << %{
       if ($F('penalty_decay_period_submission_rule') != null) {
         var new_period_id =  new Date().getTime();
@@ -42,8 +42,8 @@ module AssignmentsHelper
   end
 
   def add_penalty_period_link(name, form, element_id)
-    link_to_function name , nil, :id => element_id, :style => 'display:none' do |page|
-      period = render(:partial => 'penalty_period', :locals => {:pf => form, :penalty_period => Period.new})
+    link_to_function name , nil, id: element_id, style: 'display:none' do |page|
+      period = render(partial: 'penalty_period', locals: {pf: form, penalty_period: Period.new})
       page << %{
       if ($F('penalty_period_submission_rule') != null) {
         var new_period_id =  new Date().getTime();

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -3,10 +3,10 @@ module AutomatedTestsHelper
 
   def add_test_file_link(name, form)
     link_to_function name do |page|
-      test_file = render(:partial => 'test_file',
-                         :locals => {:form => form,
-                                     :test_file => TestFile.new,
-                                     :file_type => 'test'})
+      test_file = render(partial: 'test_file',
+                         locals: {form: form,
+                                     test_file: TestFile.new,
+                                     file_type: 'test'})
       page << %{
         if ($F('is_testing_framework_enabled') != null) {
           var new_test_file_id = new Date().getTime();
@@ -21,10 +21,10 @@ module AutomatedTestsHelper
 
   def add_lib_file_link(name, form)
     link_to_function name do |page|
-      test_file = render(:partial => 'test_file',
-                         :locals => {:form => form,
-                                     :test_file => TestFile.new,
-                                     :file_type => 'lib'})
+      test_file = render(partial: 'test_file',
+                         locals: {form: form,
+                                     test_file: TestFile.new,
+                                     file_type: 'lib'})
       page << %{
         if ($F('is_testing_framework_enabled') != null) {
           var new_test_file_id = new Date().getTime();
@@ -39,10 +39,10 @@ module AutomatedTestsHelper
 
   def add_parser_file_link(name, form)
     link_to_function name do |page|
-      test_file = render(:partial => 'test_file',
-                         :locals => {:form => form,
-                                     :test_file => TestFile.new,
-                                     :file_type => 'parse'})
+      test_file = render(partial: 'test_file',
+                         locals: {form: form,
+                                     test_file: TestFile.new,
+                                     file_type: 'parse'})
       page << %{
         if ($F('is_testing_framework_enabled') != null) {
           var new_test_file_id = new Date().getTime();
@@ -62,13 +62,13 @@ module AutomatedTestsHelper
       @ant_build_file.assignment = assignment
       @ant_build_file.filetype = 'build.xml'
       @ant_build_file.filename = 'tempbuild.xml'        # temporary placeholder for now
-      @ant_build_file.save(:validate => false)
+      @ant_build_file.save(validate: false)
 
       @ant_build_prop = TestFile.new
       @ant_build_prop.assignment = assignment
       @ant_build_prop.filetype = 'build.properties'
       @ant_build_prop.filename = 'tempbuild.properties' # temporary placeholder for now
-      @ant_build_prop.save(:validate => false)
+      @ant_build_prop.save(validate: false)
 
       # Setup Testing Framework repository
       test_dir = File.join(
@@ -222,7 +222,7 @@ module AutomatedTestsHelper
   def copy_ant_files(assignment, repo_dest_dir)
     # Check if the repository where you want to copy Ant files to exists
     unless File.exists?(repo_dest_dir)
-      raise I18n.t('automated_tests.dir_not_exist', {:dir => repo_dest_dir})
+      raise I18n.t('automated_tests.dir_not_exist', {dir: repo_dest_dir})
     end
 
     # Create the src repository to put student's files
@@ -233,7 +233,7 @@ module AutomatedTestsHelper
     # Move student's source files to the src repository
     pwd = FileUtils.pwd
     FileUtils.cd(repo_assignment_dir)
-    FileUtils.mv(Dir.glob('*'), File.join(repo_assignment_dir, 'src'), :force => true )
+    FileUtils.mv(Dir.glob('*'), File.join(repo_assignment_dir, 'src'), force: true )
 
     # You always have to come back to your former working directory if you want to avoid errors
     FileUtils.cd(pwd)
@@ -273,7 +273,7 @@ module AutomatedTestsHelper
         FileUtils.cp_r(File.join(assignment_dir, 'parse'), repo_assignment_dir)
       end
     else
-      raise I18n.t('automated_tests.dir_not_exist', {:dir => assignment_dir})
+      raise I18n.t('automated_tests.dir_not_exist', {dir: assignment_dir})
     end
   end
 
@@ -281,7 +281,7 @@ module AutomatedTestsHelper
   def run_ant_file(result, assignment, repo_dest_dir)
     # Check if the repository where you want to copy Ant files to exists
     unless File.exists?(repo_dest_dir)
-      raise I18n.t('automated_tests.dir_not_exist', {:dir => repo_dest_dir})
+      raise I18n.t('automated_tests.dir_not_exist', {dir: repo_dest_dir})
     end
 
     # Go to the directory where the Ant program must be run
@@ -297,7 +297,7 @@ module AutomatedTestsHelper
     FileUtils.cd(pwd)
 
     # File to store build details
-    filename = I18n.l(Time.zone.now, :format => :ant_date) + '.log'
+    filename = I18n.l(Time.zone.now, format: :ant_date) + '.log'
     # Status of Ant build
     status = ''
 
@@ -342,11 +342,11 @@ module AutomatedTestsHelper
 
     # Create TestResult object
     # (Build failures and errors will be logged and stored as well for diagnostic purposes)
-    TestResult.create(:filename => filename,
-      :file_content => data,
-      :submission_id => result.submission.id,
-      :status => status,
-      :user_id => @current_user.id)
+    TestResult.create(filename: filename,
+      file_content: data,
+      submission_id: result.submission.id,
+      status: status,
+      user_id: @current_user.id)
   end
 
   # Send output to parser(s) if any

--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -8,10 +8,10 @@ module GradeEntryFormsHelper
   # is creating a new grade entry form).
   def add_grade_entry_item_link(name, form)
     link_to_function name do |page|
-      grade_entry_item = render(:partial => 'grade_entry_item',
-                                :locals => {:form => form,
-                                            :new_position => 0,
-                                            :grade_entry_item => GradeEntryItem.new})
+      grade_entry_item = render(partial: 'grade_entry_item',
+                                locals: {form: form,
+                                            new_position: 0,
+                                            grade_entry_item: GradeEntryItem.new})
       page << %{
       var new_grade_entry_item_id = "new_" + new Date().getTime();
       $('grade_entry_items').insert({bottom: "#{ escape_javascript grade_entry_item }".replace(/attributes_\\d+|\\d+\(?=\\]\)/g, new_grade_entry_item_id) });
@@ -30,7 +30,7 @@ module GradeEntryFormsHelper
         grade_entry_student.released_to_student = release
         unless grade_entry_student.save
           raise I18n.t('grade_entry_forms.grades.update_error',
-                       :user_name => grade_entry_student.user.user_name)
+                       user_name: grade_entry_student.user.user_name)
         end
         numGradeEntryStudentsChanged += 1
       rescue Exception => e

--- a/app/helpers/grade_entry_forms_pagination_helper.rb
+++ b/app/helpers/grade_entry_forms_pagination_helper.rb
@@ -48,7 +48,7 @@ module GradeEntryFormsPaginationHelper
       params[:page] = AP_DEFAULT_PAGE
     end
 
-    return items.paginate(:per_page => params[:per_page], :page => params[:page]).clone, items.size
+    return items.paginate(per_page: params[:per_page], page: params[:page]).clone, items.size
 
   end
 

--- a/app/helpers/graders_helper.rb
+++ b/app/helpers/graders_helper.rb
@@ -42,11 +42,11 @@ module GradersHelper
 
       table_row[:id] = grouping.id
       table_row[:filter_table_row_contents] =
-        render_to_string :partial => 'graders/table_row/filter_table_row',
-        :formats => [:html], :handlers => [:erb],
-        :locals => { :grouping => grouping,
-                     :assignment => assignment,
-                     :total_criteria_count => total_criteria_count }
+        render_to_string partial: 'graders/table_row/filter_table_row',
+        formats: [:html], handlers: [:erb],
+        locals: { grouping: grouping,
+                     assignment: assignment,
+                     total_criteria_count: total_criteria_count }
 
       #These are used for sorting
       table_row[:name] = grouping.group.group_name
@@ -71,8 +71,8 @@ module GradersHelper
 
     table_row[:id] = grader.id
     table_row[:filter_table_row_contents] =
-      render_to_string :partial => 'graders/table_row/filter_table_grader_row',
-      :locals => {:grader => grader}
+      render_to_string partial: 'graders/table_row/filter_table_grader_row',
+      locals: {grader: grader}
 
     #These used only for searching
     table_row[:first_name] = grader.first_name
@@ -95,9 +95,9 @@ module GradersHelper
 
     table_row[:id] = criterion.id
     table_row[:filter_table_row_contents] =
-      render_to_string :partial => 'graders/table_row/filter_table_criterion_row',
-      :formats => [:html], :handlers => [:erb],
-      :locals => {:criterion => criterion, :assignment => assignment}
+      render_to_string partial: 'graders/table_row/filter_table_criterion_row',
+      formats: [:html], handlers: [:erb],
+      locals: {criterion: criterion, assignment: assignment}
 
     table_row[:criterion_name] = criterion.get_name
     table_row[:members] = criterion.get_ta_names.to_s

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -17,7 +17,7 @@ module GroupsHelper
   # Called whenever it is necessary to update the students table with multiple
   # changes.
   def construct_student_table_rows(students, assignment)
-    student_memberships = StudentMembership.all(:conditions => {:grouping_id => assignment.groupings, :user_id => students})
+    student_memberships = StudentMembership.all(conditions: {grouping_id: assignment.groupings, user_id: students})
     students_in_assignment = student_memberships.collect do |membership|
       membership.user
     end
@@ -36,12 +36,12 @@ module GroupsHelper
 
       table_row[:id] = grouping.id
       table_row[:filter_table_row_contents] =
-          render_to_string :partial => 'groups/table_row/filter_table_row',
-                           :formats => [:html],
-                           :handlers => [:erb],
-                           :locals => {
-                               :grouping => grouping,
-                               :assignment => assignment }
+          render_to_string partial: 'groups/table_row/filter_table_row',
+                           formats: [:html],
+                           handlers: [:erb],
+                           locals: {
+                               grouping: grouping,
+                               assignment: assignment }
 
       table_row[:name] = grouping.group.group_name
 
@@ -64,7 +64,7 @@ module GroupsHelper
     table_row = {}
 
     table_row[:id] = student.id
-    table_row[:filter_table_row_contents] = render_to_string :partial => 'groups/table_row/filter_table_student_row', :locals => {:student => student}
+    table_row[:filter_table_row_contents] = render_to_string partial: 'groups/table_row/filter_table_student_row', locals: {student: student}
 
     table_row[:user_name] = student.user_name
     table_row[:first_name] = student.first_name

--- a/app/helpers/marks_graders_helper.rb
+++ b/app/helpers/marks_graders_helper.rb
@@ -33,9 +33,9 @@ module MarksGradersHelper
 
       table_row[:id] = student.id
       table_row[:filter_table_row_contents] =
-        render_to_string :partial => 'marks_graders/table_row/filter_table_row',
-        :formats => [:html], :handlers => [:erb],
-        :locals => { :student => student, :grade_entry_form => grade_entry_form }
+        render_to_string partial: 'marks_graders/table_row/filter_table_row',
+        formats: [:html], handlers: [:erb],
+        locals: { student: student, grade_entry_form: grade_entry_form }
 
       #These are used for sorting
       table_row[:user_name] = student.user_name
@@ -58,8 +58,8 @@ module MarksGradersHelper
 
     table_row[:id] = grader.id
     table_row[:filter_table_row_contents] =
-      render_to_string :partial => 'marks_graders/table_row/filter_table_grader_row',
-      :locals => { :grader => grader }
+      render_to_string partial: 'marks_graders/table_row/filter_table_grader_row',
+      locals: { grader: grader }
 
     #These used only for searching
     table_row[:first_name] = grader.first_name

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -48,7 +48,7 @@ module PaginationHelper
       params[:page] = AP_DEFAULT_PAGE
     end
 
-    return items.paginate(:per_page => params[:per_page], :page => params[:page]).clone, items.size
+    return items.paginate(per_page: params[:per_page], page: params[:page]).clone, items.size
 
   end
 
@@ -69,8 +69,8 @@ module PaginationHelper
       when 'repo_name' then to_include = [:group]
       when 'section' then to_include = [:group]
       when 'revision_timestamp' then to_include = [:current_submission_used]
-      when 'marking_state' then to_include = [{:current_submission_used => :results}]
-      when 'total_mark' then to_include = [{:current_submission_used => :results}]
+      when 'marking_state' then to_include = [{current_submission_used: :results}]
+      when 'total_mark' then to_include = [{current_submission_used: :results}]
       when 'grace_credits_used' then to_include = [:grace_period_deductions]
     end
     items = hash[:filters][filter][:proc].call(object_hash, to_include)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -12,17 +12,17 @@ module SubmissionsHelper
     changed = 0
     groupings.each do |grouping|
       begin
-        raise I18n.t('marking_state.no_submission', :group_name => grouping.group.group_name) if !grouping.has_submission?
+        raise I18n.t('marking_state.no_submission', group_name: grouping.group.group_name) if !grouping.has_submission?
         submission = grouping.current_submission_used
-        raise I18n.t('marking_state.no_result', :group_name => grouping.group.group_name) if !submission.has_result?
-        raise I18n.t('marking_state.not_complete', :group_name => grouping.group.group_name) if
+        raise I18n.t('marking_state.no_result', group_name: grouping.group.group_name) if !submission.has_result?
+        raise I18n.t('marking_state.not_complete', group_name: grouping.group.group_name) if
           submission.get_latest_result.marking_state != Result::MARKING_STATES[:complete] && release
-        raise I18n.t('marking_state.not_complete_unrelease', :group_name => grouping.group.group_name) if
+        raise I18n.t('marking_state.not_complete_unrelease', group_name: grouping.group.group_name) if
           submission.get_latest_result.marking_state != Result::MARKING_STATES[:complete]
         @result = submission.get_latest_result
         @result.released_to_students = release
         unless @result.save
-          raise I18n.t('marking_state.result_not_saved', :group_name => grouping.group.group_name)
+          raise I18n.t('marking_state.result_not_saved', group_name: grouping.group.group_name)
         end
         changed += 1
       rescue Exception => e
@@ -47,8 +47,8 @@ module SubmissionsHelper
       # Check collection date
       if Time.zone.now < SectionDueDate.due_date_for(section, assignment)
         raise I18n.t('collect_submissions.could_not_collect_section',
-          :assignment_identifier => assignment.short_identifier,
-          :section_name => section.name)
+          assignment_identifier: assignment.short_identifier,
+          section_name: section.name)
       end
 
       # Collect and count submissions for all groupings of this section
@@ -63,7 +63,7 @@ module SubmissionsHelper
 
       if collected == 0
         raise I18n.t('collect_submissions.no_submission_for_section',
-          :section_name => section.name)
+          section_name: section.name)
       end
 
     rescue Exception => e
@@ -78,7 +78,7 @@ module SubmissionsHelper
   def construct_file_manager_dir_table_row(directory_name, directory)
     table_row = {}
     table_row[:id] = directory.object_id
-    table_row[:filter_table_row_contents] = render_to_string :partial => 'submissions/table_row/directory_table_row', :locals => {:directory_name => directory_name, :directory => directory}
+    table_row[:filter_table_row_contents] = render_to_string partial: 'submissions/table_row/directory_table_row', locals: {directory_name: directory_name, directory: directory}
     table_row[:filename] = directory_name
     table_row[:last_modified_date_unconverted] = directory.last_modified_date.strftime('%b %d, %Y %H:%M')
     table_row[:revision_by] = directory.user_id
@@ -89,7 +89,7 @@ module SubmissionsHelper
   def construct_file_manager_table_row(file_name, file)
     table_row = {}
     table_row[:id] = file.object_id
-    table_row[:filter_table_row_contents] = render_to_string :partial => 'submissions/table_row/filter_table_row', :locals => {:file_name => file_name, :file => file}
+    table_row[:filter_table_row_contents] = render_to_string partial: 'submissions/table_row/filter_table_row', locals: {file_name: file_name, file: file}
 
     table_row[:filename] = file_name
 
@@ -114,7 +114,7 @@ module SubmissionsHelper
   def construct_repo_browser_table_row(file_name, file)
     table_row = {}
     table_row[:id] = file.object_id
-    table_row[:filter_table_row_contents] = render_to_string :partial => 'submissions/repo_browser/filter_table_row', :locals => {:file_name => file_name, :file => file}
+    table_row[:filter_table_row_contents] = render_to_string partial: 'submissions/repo_browser/filter_table_row', locals: {file_name: file_name, file: file}
     table_row[:filename] = file_name
     table_row[:last_modified_date] = file.last_modified_date.strftime('%d %B, %l:%M%p')
     table_row[:last_modified_date_unconverted] = file.last_modified_date.strftime('%b %d, %Y %H:%M')
@@ -125,7 +125,7 @@ module SubmissionsHelper
   def construct_repo_browser_directory_table_row(directory_name, directory)
     table_row = {}
     table_row[:id] = directory.object_id
-    table_row[:filter_table_row_contents] = render_to_string :partial => 'submissions/repo_browser/directory_row', :locals => {:directory_name => directory_name, :directory => directory}
+    table_row[:filter_table_row_contents] = render_to_string partial: 'submissions/repo_browser/directory_row', locals: {directory_name: directory_name, directory: directory}
     table_row[:filename] = directory_name
     table_row[:last_modified_date] = directory.last_modified_date.strftime('%d %B, %l:%M%p')
     table_row[:last_modified_date_unconverted] = directory.last_modified_date.strftime('%b %d, %Y %H:%M')

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -28,11 +28,11 @@ module UsersHelper
     end
     result[:hidden] = user.hidden
     result[:filter_table_row_contents] =
-       render_to_string :partial => 'users/table_row/filter_table_row',
-                        :formats => [:html], :handlers => [:erb],
-                        :locals => {:user => user,
-                                    :controller => self.controller_name,
-                                    :render_note_link => @render_note_link}
+       render_to_string partial: 'users/table_row/filter_table_row',
+                        formats: [:html], handlers: [:erb],
+                        locals: {user: user,
+                                    controller: self.controller_name,
+                                    render_note_link: @render_note_link}
     result
   end
 

--- a/config/initializers/06_session_store.rb
+++ b/config/initializers/06_session_store.rb
@@ -9,14 +9,14 @@
 # the :secret string to something else than you find below.
 
 Rails.application.config.session_store :cookie_store,
-  :key => MarkusConfigurator.markus_config_session_cookie_name,
-  :secret      => MarkusConfigurator.markus_config_session_cookie_secret,
-  :path => '/',
-  :expire_after => MarkusConfigurator.markus_config_session_cookie_expire_after,
-  :http_only => MarkusConfigurator.markus_config_session_cookie_http_only,
+  key: MarkusConfigurator.markus_config_session_cookie_name,
+  secret:      MarkusConfigurator.markus_config_session_cookie_secret,
+  path: '/',
+  expire_after: MarkusConfigurator.markus_config_session_cookie_expire_after,
+  http_only: MarkusConfigurator.markus_config_session_cookie_http_only,
   # if you use secure in Base.session, you will have to do an https connection,
   # but https is not implemented yet in MarkUs
-  :secure => MarkusConfigurator.markus_config_session_cookie_secure
+  secure: MarkusConfigurator.markus_config_session_cookie_secure
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Markus::Application.config.session_store :cookie_store, :key => '_markus_session'
+Markus::Application.config.session_store :cookie_store, key: '_markus_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/lib/benchmarking/submission_files/admins_controller.rb
+++ b/lib/benchmarking/submission_files/admins_controller.rb
@@ -6,7 +6,7 @@ class AdminsController < ApplicationController
   end
 
   def populate
-    admins_data = Admin.all(:order => "user_name")
+    admins_data = Admin.all(order: "user_name")
     # construct_table_rows defined in UsersHelper
     @admins = construct_table_rows(admins_data)
   end
@@ -22,7 +22,7 @@ class AdminsController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if @user.update_attributes(attrs)
       flash[:edit_notice] = @user.user_name + ' has been updated.'
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       render :edit
     end
@@ -40,6 +40,6 @@ class AdminsController < ApplicationController
     # updates the existing record
     return unless @user.save
 
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 end

--- a/lib/benchmarking/submission_files/annotation_categories_controller.rb
+++ b/lib/benchmarking/submission_files/annotation_categories_controller.rb
@@ -73,19 +73,19 @@ class AnnotationCategoriesController < ApplicationController
     @annotation_categories = @assignment.annotation_categories
     case params[:format]
     when 'csv'
-      send_data convert_to_csv(@annotation_categories), :type => 'csv', :disposition => 'attachment'
+      send_data convert_to_csv(@annotation_categories), type: 'csv', disposition: 'attachment'
     when 'yml'
-      send_data convert_to_yml(@annotation_categories), :type => 'yml', :disposition => 'attachment'
+      send_data convert_to_yml(@annotation_categories), type: 'yml', disposition: 'attachment'
     else
       flash[:error] = "Could not recognize #{params[:format]} format to download with"
-      redirect_to :action => 'index', :id => params[:id]
+      redirect_to action: 'index', id: params[:id]
     end
   end
 
   def csv_upload
     @assignment = Assignment.find(params[:id])
     unless request.post?
-      redirect_to :action => 'index', :id => @assignment.id
+      redirect_to action: 'index', id: @assignment.id
     end
     annotation_category_list = params[:annotation_category_list]
     annotation_category_number = 0
@@ -97,7 +97,7 @@ class AnnotationCategoriesController < ApplicationController
         flash[:annotation_upload_invalid_lines] << row.join(',')
       end
     end
-    flash[:annotation_upload_success] = I18n.t('annotations.upload.success', :annotation_category_number => annotation_category_number)
-    redirect_to :action => 'index', :id => @assignment.id
+    flash[:annotation_upload_success] = I18n.t('annotations.upload.success', annotation_category_number: annotation_category_number)
+    redirect_to action: 'index', id: @assignment.id
   end
 end

--- a/lib/benchmarking/submission_files/annotations_controller.rb
+++ b/lib/benchmarking/submission_files/annotations_controller.rb
@@ -11,9 +11,9 @@ class AnnotationsController < ApplicationController
     @submission_file = SubmissionFile.find(@submission_file_id)
     @annotation = Annotation.new
     @annotation.update_attributes({
-      :line_start => params[:line_start],
-      :line_end => params[:line_end],
-      :submission_file_id => params[:submission_file_id]
+      line_start: params[:line_start],
+      line_end: params[:line_end],
+      submission_file_id: params[:submission_file_id]
     })
     @annotation.annotation_text = @text
     @annotation.save
@@ -23,16 +23,16 @@ class AnnotationsController < ApplicationController
 
   def create
     @text = AnnotationText.create({
-      :content => params[:content],
-      :annotation_category_id => params[:category_id]
+      content: params[:content],
+      annotation_category_id: params[:category_id]
     })
     @submission_file_id = params[:submission_file_id]
     @submission_file = SubmissionFile.find(@submission_file_id)
     @annotation = Annotation.create({
-      :line_start => params[:line_start],
-      :line_end => params[:line_end],
-      :annotation_text_id => @text.id,
-      :submission_file_id => params[:submission_file_id]
+      line_start: params[:line_start],
+      line_end: params[:line_end],
+      annotation_text_id: @text.id,
+      submission_file_id: params[:submission_file_id]
     })
     @submission = @submission_file.submission
     @annotations = @submission.annotations
@@ -73,7 +73,7 @@ class AnnotationsController < ApplicationController
     result.marking_state = params[:value]
     result.save
     render :update do |page|
-       page.redirect_to :controller => 'results', :action => 'edit', :id =>
+       page.redirect_to controller: 'results', action: 'edit', id:
        result.id
     end
   end

--- a/lib/benchmarking/submission_files/application_controller.rb
+++ b/lib/benchmarking/submission_files/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   # activate i18n for renaming constants in views
   before_filter :set_locale
   # check for active session on every page
-  before_filter :authenticate, :except => [:login]
+  before_filter :authenticate, except: [:login]
 
   # See ActionController::Base for details
   # Filter the contents of submitted sensitive data parameters

--- a/lib/benchmarking/submission_files/assignments_controller.rb
+++ b/lib/benchmarking/submission_files/assignments_controller.rb
@@ -1,10 +1,10 @@
 require 'fastercsv'
 class AssignmentsController < ApplicationController
-  before_filter      :authorize_only_for_admin, :except => [:deletegroup, :delete_rejected, :disinvite_member, :invite_member,
+  before_filter      :authorize_only_for_admin, except: [:deletegroup, :delete_rejected, :disinvite_member, :invite_member,
   :creategroup, :join_group, :decline_invitation, :index, :student_interface]
-  before_filter      :authorize_for_student, :only => [:student_interface, :deletegroup, :delete_rejected, :disinvite_member,
+  before_filter      :authorize_for_student, only: [:student_interface, :deletegroup, :delete_rejected, :disinvite_member,
   :invite_member, :creategroup, :join_group, :decline_invitation]
-  before_filter      :authorize_for_user, :only => [:index]
+  before_filter      :authorize_for_user, only: [:index]
 
   auto_complete_for :assignment, :name
   # Publicly accessible actions ---------------------------------------
@@ -19,9 +19,9 @@ class AssignmentsController < ApplicationController
     if @grouping.nil?
       if @assignment.group_max == 1
         @student.create_group_for_working_alone_student(@assignment.id)
-        redirect_to :action => 'student_interface', :id => @assignment.id
+        redirect_to action: 'student_interface', id: @assignment.id
       else
-        render :student_interface, :layout => 'no_menu_header'
+        render :student_interface, layout: 'no_menu_header'
         return
       end
     else
@@ -52,7 +52,7 @@ class AssignmentsController < ApplicationController
   # Displays "Manage Assignments" page for creating and editing
   # assignment information
   def index
-    @assignments = Assignment.all(:order => :id)
+    @assignments = Assignment.all(order: :id)
     if current_user.student?
       # get results for assignments for the current user
       @a_id_results = Hash.new()
@@ -123,7 +123,7 @@ class AssignmentsController < ApplicationController
 
     if @assignment.save
       flash[:notice] = 'Successfully Updated Assignment'
-      redirect_to :action => 'edit', :id => params[:id]
+      redirect_to action: 'edit', id: params[:id]
     else
       render :edit
     end
@@ -166,7 +166,7 @@ class AssignmentsController < ApplicationController
       if params[:assignment_files]
         params[:assignment_files].each do |assignment_file_name|
           unless assignment_file_name.empty?
-            assignment_file = AssignmentFile.new(:filename => assignment_file_name, :assignment => @assignment)
+            assignment_file = AssignmentFile.new(filename: assignment_file_name, assignment: @assignment)
             assignment_file.save
           end
         end
@@ -176,7 +176,7 @@ class AssignmentsController < ApplicationController
       end
       @assignment.save
     end
-    redirect_to :action => 'edit', :id => @assignment.id
+    redirect_to action: 'edit', id: @assignment.id
   end
 
   def update_group_properties_on_persist
@@ -206,7 +206,7 @@ class AssignmentsController < ApplicationController
         csv << row
       end
     end
-    send_data csv_string, :disposition => 'attachment', :filename => "#{COURSE_NAME}_grades_report.csv"
+    send_data csv_string, disposition: 'attachment', filename: "#{COURSE_NAME}_grades_report.csv"
   end
 
 
@@ -217,7 +217,7 @@ class AssignmentsController < ApplicationController
     @grouping = Grouping.find(params[:grouping_id])
     @user = Student.find(session[:uid])
     @user.join(@grouping.id)
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def decline_invitation
@@ -225,7 +225,7 @@ class AssignmentsController < ApplicationController
     @grouping = Grouping.find(params[:grouping_id])
     @user = Student.find(session[:uid])
     @grouping.decline_invitation(@user)
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def creategroup
@@ -250,7 +250,7 @@ class AssignmentsController < ApplicationController
     rescue RuntimeError => e
       flash[:fail_notice] = e.message
     end
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def deletegroup
@@ -269,7 +269,7 @@ class AssignmentsController < ApplicationController
       if @grouping.is_valid?
         raise 'Your group is valid, and can only be deleted by instructors.'
       end
-      @grouping.student_memberships.all(:include => :user).each do |member|
+      @grouping.student_memberships.all(include: :user).each do |member|
         member.destroy
       end
       # update repository permissions
@@ -280,7 +280,7 @@ class AssignmentsController < ApplicationController
     rescue RuntimeError => e
       flash[:fail_notice] = e.message
     end
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
   def invite_member
@@ -303,31 +303,31 @@ class AssignmentsController < ApplicationController
       @invited = Student.find_by_user_name(user_name)
       begin
         if @grouping.student_membership_number >= @assignment.group_max
-          raise I18n.t('invite_student.fail.group_max_reached', :user_name => user_name)
+          raise I18n.t('invite_student.fail.group_max_reached', user_name: user_name)
         end
         if @invited.nil?
-          raise I18n.t('invite_student.fail.dne', :user_name => user_name)
+          raise I18n.t('invite_student.fail.dne', user_name: user_name)
         end
         if @invited == @student
           raise I18n.t('invite_student.fail.inviting_self')
         end
         if @invited.hidden
-          raise I18n.t('invite_student.fail.hidden', :user_name => user_name)
+          raise I18n.t('invite_student.fail.hidden', user_name: user_name)
         end
         if @grouping.pending?(@invited)
-          raise I18n.t('invite_student.fail.already_pending', :user_name => user_name)
+          raise I18n.t('invite_student.fail.already_pending', user_name: user_name)
         end
         if @invited.has_accepted_grouping_for?(@assignment.id)
-          raise I18n.t('invite_student.fail.already_grouped', :user_name => user_name)
+          raise I18n.t('invite_student.fail.already_grouped', user_name: user_name)
         end
 
         @invited.invite(@grouping.id)
-        flash[:success].push(I18n.t('invite_student.success', :user_name => @invited.user_name))
+        flash[:success].push(I18n.t('invite_student.success', user_name: @invited.user_name))
       rescue Exception => e
         flash[:fail_notice].push(e.message)
       end
     end
-    redirect_to :action => 'student_interface', :id => @assignment.id
+    redirect_to action: 'student_interface', id: @assignment.id
   end
 
   # Called by clicking the cancel link in the student's interface
@@ -349,7 +349,7 @@ class AssignmentsController < ApplicationController
     membership = StudentMembership.find(params[:membership])
     membership.delete
     membership.save
-    redirect_to :action => 'student_interface', :id => params[:id]
+    redirect_to action: 'student_interface', id: params[:id]
   end
 
 end

--- a/lib/benchmarking/submission_files/groups_controller.rb
+++ b/lib/benchmarking/submission_files/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
     return unless (request.post? && params[:student_user_name])
     # add member to the group with status depending if group is empty or not
     grouping = Grouping.find(params[:grouping_id])
-    @assignment = Assignment.find(params[:id], :include => [{:groupings => [{:student_memberships => :user, :ta_memberships => :user}, :group]}])
+    @assignment = Assignment.find(params[:id], include: [{groupings: [{student_memberships: :user, ta_memberships: :user}, :group]}])
     student = Student.find_by_user_name(params[:student_user_name])
     if student.nil?
       @error = "Could not find student with user name #{params[:student_user_name]}"
@@ -53,7 +53,7 @@ class GroupsController < ApplicationController
     end
 
     render :update do |page|
-      page.visual_effect(:fade, "mbr_#{params[:mbr_id]}", :duration => 0.5)
+      page.visual_effect(:fade, "mbr_#{params[:mbr_id]}", duration: 0.5)
       page.delay(0.5) { page.remove "mbr_#{params[:mbr_id]}" }
       # add members back to student list
       page.insert_html :bottom, 'student_list',
@@ -63,8 +63,8 @@ class GroupsController < ApplicationController
  #       inviter = grouping.student_memberships.find_by_membership_status(StudentMembership::STATUSES[:inviter])
         # replace the status of the new inviter to 'inviter'
          page.replace_html "mbr_#{inviter.id}",
-           :partial => 'groups/manage/member', :locals => {:grouping =>
-          grouping, :member => inviter}
+           partial: 'groups/manage/member', locals: {grouping:
+          grouping, member: inviter}
       end
     end
   end
@@ -106,8 +106,8 @@ class GroupsController < ApplicationController
 
     # Checking if a group with this name already exists
 
-    if (@groups = Group.first(:conditions =>
-                                  {:group_name => [params[:new_groupname]]}))
+    if (@groups = Group.first(conditions:
+                                  {group_name: [params[:new_groupname]]}))
          existing = true
          groupexist_id = @groups.id
     end
@@ -121,9 +121,9 @@ class GroupsController < ApplicationController
       params[:groupexist_id] = groupexist_id
       params[:assignment_id] = @assignment.id
 
-        if Grouping.all(:conditions => ["assignment_id =
-        :assignment_id and group_id = :groupexist_id", {:groupexist_id =>
-        groupexist_id, :assignment_id => @assignment.id}])
+        if Grouping.all(conditions: ["assignment_id =
+        :assignment_id and group_id = :groupexist_id", {groupexist_id:
+        groupexist_id, assignment_id: @assignment.id}])
            flash[:fail_notice] = 'This name is already used for this
            assignement'
         else
@@ -140,7 +140,7 @@ class GroupsController < ApplicationController
   end
 
   def populate
-    @assignment = Assignment.find(params[:id], :include => [{:groupings => [{:student_memberships => :user, :ta_memberships => :user}, :group]}])
+    @assignment = Assignment.find(params[:id], include: [{groupings: [{student_memberships: :user, ta_memberships: :user}, :group]}])
     @groupings = @assignment.groupings
     @table_rows = {}
     @groupings.each do |grouping|
@@ -151,8 +151,8 @@ class GroupsController < ApplicationController
   end
 
   def manage
-    @all_assignments = Assignment.all(:order => :id)
-    @assignment = Assignment.find(params[:id], :include => [{:groupings => [{:student_memberships => :user, :ta_memberships => :user}, :group]}])
+    @all_assignments = Assignment.all(order: :id)
+    @assignment = Assignment.find(params[:id], include: [{groupings: [{student_memberships: :user, ta_memberships: :user}, :group]}])
     @groupings = @assignment.groupings
     # Returns a hash where s.id is the key, and student record is the value
     @ungrouped_students = @assignment.ungrouped_students
@@ -163,7 +163,7 @@ class GroupsController < ApplicationController
   def csv_upload_grader_mapping
     if !request.post? || params[:grader_mapping].nil?
       flash[:error] = 'You must supply a CSV file for group to grader mapping'
-      redirect_to :action => 'manage', :id => params[:id]
+      redirect_to action: 'manage', id: params[:id]
       return
     end
 
@@ -171,7 +171,7 @@ class GroupsController < ApplicationController
     if invalid_lines.size > 0
       flash[:invalid_lines] = invalid_lines
     end
-    redirect_to :action => 'manage', :id => params[:id]
+    redirect_to action: 'manage', id: params[:id]
   end
 
   # Allows the user to upload a csv file listing groups.
@@ -216,7 +216,7 @@ class GroupsController < ApplicationController
         end
       end
     end
-    redirect_to :action => 'manage', :id => params[:id]
+    redirect_to action: 'manage', id: params[:id]
   end
 
   def download_grouplist
@@ -229,14 +229,14 @@ class GroupsController < ApplicationController
        groupings.each do |grouping|
          group_array = [grouping.group.group_name, grouping.group.repo_name]
          # csv format is group_name, repo_name, user1_name, user2_name, ... etc
-         grouping.memberships.all(:include => :user).each do |member|
+         grouping.memberships.all(include: :user).each do |member|
             group_array.push(member.user.user_name);
          end
          csv << group_array
        end
      end
 
-    send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+    send_data(file_out, type: 'text/csv', disposition: 'inline')
   end
 
   def use_another_assignment_groups
@@ -290,7 +290,7 @@ class GroupsController < ApplicationController
   # TODO:  This method is massive, and does way too much.  Whatever happened
   # to single-responsibility?
   def global_actions
-    @assignment = Assignment.find(params[:id], :include => [{:groupings => [{:student_memberships => :user, :ta_memberships => :user}, :group]}])
+    @assignment = Assignment.find(params[:id], include: [{groupings: [{student_memberships: :user, ta_memberships: :user}, :group]}])
     @tas = Ta.all
 
     if params[:submit_type] == 'random_assign'

--- a/lib/benchmarking/submission_files/main_controller.rb
+++ b/lib/benchmarking/submission_files/main_controller.rb
@@ -5,7 +5,7 @@ class MainController < ApplicationController
 
   include MainHelper
   # check for authorization
-  before_filter      :authorize_for_user,      :except => [:login]
+  before_filter      :authorize_for_user,      except: [:login]
 
   #########################################################################
   # Authentication
@@ -20,10 +20,10 @@ class MainController < ApplicationController
     # redirect to main page if user is already logged in.
     if logged_in? && !request.post?
       if @current_user.student?
-        redirect_to :controller => 'assignments', :action => 'index'
+        redirect_to controller: 'assignments', action: 'index'
         return
       else
-        redirect_to :action => 'index'
+        redirect_to action: 'index'
         return
       end
     end
@@ -34,7 +34,7 @@ class MainController < ApplicationController
     blank_login = params[:user_login].blank?
     blank_pwd = params[:user_password].blank?
     flash[:login_notice] = get_blank_message(blank_login, blank_pwd)
-    redirect_to(:action => 'login') && return if blank_login || blank_pwd
+    redirect_to(action: 'login') && return if blank_login || blank_pwd
 
     # authenticate user
     if User.authenticated?(params[:user_login], params[:user_password])
@@ -55,7 +55,7 @@ class MainController < ApplicationController
     # Has this student been hidden?
     if found_user.student? && found_user.hidden
       flash[:login_notice] = 'This account has been disabled'
-      redirect_to(:action => 'login') && return
+      redirect_to(action: 'login') && return
     end
 
     self.current_user = found_user
@@ -65,7 +65,7 @@ class MainController < ApplicationController
       session[:redirect_uri] = nil
       refresh_timeout
       # redirect to last visited page or to main page
-      redirect_to( uri || { :action => 'index' } )
+      redirect_to( uri || { action: 'index' } )
     else
       flash[:login_notice] = 'Login failed.'
     end
@@ -76,16 +76,16 @@ class MainController < ApplicationController
     clear_session
     cookies.delete :auth_token
     reset_session
-    redirect_to :action => 'login'
+    redirect_to action: 'login'
   end
 
   def index
     @current_user = current_user
     if @current_user.student? or  @current_user.ta?
-      redirect_to :controller => 'assignments', :action => 'index'
+      redirect_to controller: 'assignments', action: 'index'
       return
     end
-    render :index, :layout => 'content'
+    render :index, layout: 'content'
   end
 
 end

--- a/lib/benchmarking/submission_files/results_controller.rb
+++ b/lib/benchmarking/submission_files/results_controller.rb
@@ -1,10 +1,10 @@
 class ResultsController < ApplicationController
-  before_filter      :authorize_only_for_admin, :except => [:codeviewer,
+  before_filter      :authorize_only_for_admin, except: [:codeviewer,
   :edit, :update_mark, :view_marks, :create, :add_extra_mark, :next_grouping, :update_overall_comment, :expand_criteria, :collapse_criteria, :remove_extra_mark]
-  before_filter      :authorize_for_ta_and_admin, :only => [:edit,
+  before_filter      :authorize_for_ta_and_admin, only: [:edit,
   :update_mark, :create, :add_extra_mark, :download, :next_grouping, :update_overall_comment, :expand_criteria, :collapse_criteria, :remove_extra_mark]
-  before_filter      :authorize_for_user, :only => [:codeviewer]
-  before_filter      :authorize_for_student, :only => [:view_marks]
+  before_filter      :authorize_for_user, only: [:codeviewer]
+  before_filter      :authorize_for_student, only: [:view_marks]
 
   def create
     # Create new Result for this Submission
@@ -24,7 +24,7 @@ class ResultsController < ApplicationController
     new_result.submission = @submission
     new_result.marking_state = Result::MARKING_STATES[:partial]
     new_result.save
-    redirect_to :action => 'edit', :id => new_result.id
+    redirect_to action: 'edit', id: new_result.id
   end
 
   def index
@@ -50,7 +50,7 @@ class ResultsController < ApplicationController
     @marks_map = []
     @rubric_criteria.each do |criterion|
       mark = Mark.find_or_create_by_result_id_and_rubric_criterion_id(@result.id, criterion.id)
-      mark.save(:validate => false)
+      mark.save(validate: false)
       @marks_map[criterion.id] = mark
     end
 
@@ -79,9 +79,9 @@ class ResultsController < ApplicationController
   def next_grouping
     grouping = Grouping.find(params[:id])
     if grouping.has_submission?
-      redirect_to :action => 'edit', :id => grouping.get_submission_used.get_latest_result.id
+      redirect_to action: 'edit', id: grouping.get_submission_used.get_latest_result.id
     else
-      redirect_to :controller => 'submissions', :action => 'collect_and_begin_grading', :id => grouping.assignment.id, :grouping_id => grouping.id
+      redirect_to controller: 'submissions', action: 'collect_and_begin_grading', id: grouping.assignment.id, grouping_id: grouping.id
     end
   end
 
@@ -91,10 +91,10 @@ class ResultsController < ApplicationController
       file_contents = retrieve_file(file)
     rescue Exception => e
       flash[:file_download_error] = e.message
-      redirect_to :action => 'edit', :id => file.submission.get_latest_result.id
+      redirect_to action: 'edit', id: file.submission.get_latest_result.id
       return
     end
-    send_data file_contents, :disposition => 'inline', :filename => file.filename
+    send_data file_contents, disposition: 'inline', filename: file.filename
   end
 
   def codeviewer
@@ -158,7 +158,7 @@ class ResultsController < ApplicationController
     @grouping = current_user.accepted_grouping_for(@assignment.id)
 
     if @grouping.nil?
-      redirect_to :controller => 'assignments', :action => 'student_interface', :id => params[:id]
+      redirect_to controller: 'assignments', action: 'student_interface', id: params[:id]
       return
     end
 
@@ -198,7 +198,7 @@ class ResultsController < ApplicationController
     @marks_map = []
     @rubric_criteria.each do |criterion|
       mark = Mark.find_or_create_by_result_id_and_rubric_criterion_id(@result.id, criterion.id)
-      mark.save(:validate => false)
+      mark.save(validate: false)
       @marks_map[criterion.id] = mark
     end
   end
@@ -259,7 +259,7 @@ class ResultsController < ApplicationController
       end
     else
       output = {'status' => 'error'}
-      render :json => output.to_json
+      render json: output.to_json
     end
   end
 
@@ -272,13 +272,13 @@ class ResultsController < ApplicationController
   def expand_criteria
     @assignment = Assignment.find(params[:aid])
     @rubric_criteria = @assignment.rubric_criteria
-    render :partial => 'results/marker/expand_criteria', :locals => {:rubric_criteria => @rubric_criteria}
+    render partial: 'results/marker/expand_criteria', locals: {rubric_criteria: @rubric_criteria}
   end
 
   def collapse_criteria
     @assignment = Assignment.find(params[:aid])
     @rubric_criteria = @assignment.rubric_criteria
-    render :partial => 'results/marker/collapse_criteria', :locals => {:rubric_criteria => @rubric_criteria}
+    render partial: 'results/marker/collapse_criteria', locals: {rubric_criteria: @rubric_criteria}
   end
 
   def expand_unmarked_criteria
@@ -287,8 +287,8 @@ class ResultsController < ApplicationController
     @result = Result.find(params[:rid])
     # nil_marks are the marks that have a "nil" value for Mark.mark - so they're
     # unmarked.
-    @nil_marks = @result.marks.all(:conditions => {:mark => nil})
-    render :partial => 'results/marker/expand_unmarked_criteria', :locals => {:nil_marks => @nil_marks}
+    @nil_marks = @result.marks.all(conditions: {mark: nil})
+    render partial: 'results/marker/expand_unmarked_criteria', locals: {nil_marks: @nil_marks}
   end
 
   private

--- a/lib/benchmarking/submission_files/rubrics_controller.rb
+++ b/lib/benchmarking/submission_files/rubrics_controller.rb
@@ -9,7 +9,7 @@ class RubricsController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:id])
-    @criteria = @assignment.rubric_criteria(:order => 'position')
+    @criteria = @assignment.rubric_criteria(order: 'position')
   end
 
   def edit
@@ -46,7 +46,7 @@ class RubricsController < ApplicationController
     return unless request.delete?
     @criterion = RubricCriterion.find(params[:id])
      #delete all marks associated with this criterion
-    Mark.delete_all(['rubric_criterion_id = :c', {:c => @criterion.id}])
+    Mark.delete_all(['rubric_criterion_id = :c', {c: @criterion.id}])
     @criterion.destroy
     flash.now[:success] = I18n.t('criterion_deleted_success')
   end
@@ -60,7 +60,7 @@ class RubricsController < ApplicationController
      when 'yml'
        file_out = create_yml_rubric(@assignment)
      end
-     send_data(file_out, :type => 'text/csv', :disposition => 'inline')
+     send_data(file_out, type: 'text/csv', disposition: 'inline')
    end
 
    #given an assignment, return the names of the levels in the assignment's
@@ -148,7 +148,7 @@ class RubricsController < ApplicationController
 
 
 
-    redirect_to :action => 'index', :id => @assignment.id
+    redirect_to action: 'index', id: @assignment.id
    end
 
    def parse_csv_rubric(file, assignment)
@@ -227,10 +227,10 @@ class RubricsController < ApplicationController
   def update_positions
     params[:rubric_criteria_pane_list].each_with_index do |id, position|
       if id != ''
-        RubricCriterion.update(id, :position => position+1)
+        RubricCriterion.update(id, position: position+1)
       end
     end
-    render :nothing => true
+    render nothing: true
   end
 
 end

--- a/lib/benchmarking/submission_files/students_controller.rb
+++ b/lib/benchmarking/submission_files/students_controller.rb
@@ -3,11 +3,11 @@ class StudentsController < ApplicationController
   before_filter    :authorize_only_for_admin
 
   def index
-    @students = Student.all(:order => "user_name")
+    @students = Student.all(order: "user_name")
   end
 
   def populate
-    @students_data = Student.all(:order => "user_name")
+    @students_data = Student.all(order: "user_name")
     # construct_table_rows defined in UsersHelper
     @students = construct_table_rows(@students_data)
   end
@@ -23,7 +23,7 @@ class StudentsController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if @user.update_attributes(attrs)
       flash[:edit_notice] = @user.user_name + ' has been updated.'
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       render :edit
     end
@@ -58,11 +58,11 @@ class StudentsController < ApplicationController
   def filter
   case params[:filter]
     when 'hidden'
-       @students = Student.all(:conditions => {:hidden => true}, :order => :user_name)
+       @students = Student.all(conditions: {hidden: true}, order: :user_name)
     when 'visible'
-       @students = Student.all(:conditions => {:hidden => false}, :order => :user_name)
+       @students = Student.all(conditions: {hidden: false}, order: :user_name)
     else
-      @students = Student.all(:order => :user_name)
+      @students = Student.all(order: :user_name)
     end
 
   end
@@ -77,14 +77,14 @@ class StudentsController < ApplicationController
     # active records--creates a new record if the model is new, otherwise
     # updates the existing record
     return unless @user.save
-    redirect_to :action => 'index' # Redirect
+    redirect_to action: 'index' # Redirect
   end
 
 
   #downloads users with the given role as a csv list
   def download_student_list
     #find all the users
-    students = Student.all(:order => "user_name")
+    students = Student.all(order: "user_name")
     case params[:format]
     when 'csv'
       output = User.generate_csv_list(students)
@@ -97,7 +97,7 @@ class StudentsController < ApplicationController
       output = students.to_xml
       format = 'text/xml'
     end
-    send_data(output, :type => format, :disposition => 'inline')
+    send_data(output, type: format, disposition: 'inline')
   end
 
   def upload_student_list
@@ -113,7 +113,7 @@ class StudentsController < ApplicationController
       end
 
     end
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 
 end

--- a/lib/benchmarking/submission_files/tas_controller.rb
+++ b/lib/benchmarking/submission_files/tas_controller.rb
@@ -3,11 +3,11 @@ class TasController < ApplicationController
   before_filter  :authorize_only_for_admin
 
   def index
-    @tas = Ta.all(:order => "user_name")
+    @tas = Ta.all(order: "user_name")
   end
 
   def populate
-    @tas_data = Ta.all(:order => "user_name")
+    @tas_data = Ta.all(order: "user_name")
     # construct_table_rows defined in UsersHelper
     @tas = construct_table_rows(@tas_data)
   end
@@ -23,7 +23,7 @@ class TasController < ApplicationController
     # update_attributes supplied by ActiveRecords
     if @user.update_attributes(attrs)
       flash[:edit_notice] = @user.user_name + ' has been updated.'
-      redirect_to :action => 'index'
+      redirect_to action: 'index'
     else
       render :edit
     end
@@ -39,14 +39,14 @@ class TasController < ApplicationController
     # active records--creates a new record if the model is new, otherwise
     # updates the existing record
     return unless @user.save
-    redirect_to :action => 'index' # Redirect
+    redirect_to action: 'index' # Redirect
   end
 
 
   #downloads users with the given role as a csv list
   def download_ta_list
     #find all the users
-    tas = Ta.all(:order => "user_name")
+    tas = Ta.all(order: "user_name")
     case params[:format]
     when 'csv'
       output = User.generate_csv_list(tas)
@@ -59,7 +59,7 @@ class TasController < ApplicationController
       output = tas.to_xml
       format = 'text/xml'
     end
-    send_data(output, :type => format, :disposition => 'inline')
+    send_data(output, type: format, disposition: 'inline')
   end
 
 
@@ -71,6 +71,6 @@ class TasController < ApplicationController
       end
       flash[:upload_notice] = result[:upload_notice]
     end
-    redirect_to :action => 'index'
+    redirect_to action: 'index'
   end
 end

--- a/lib/cookie_detection.rb
+++ b/lib/cookie_detection.rb
@@ -11,7 +11,7 @@ module CookieDetection
         cookies[:cookieTest] = Time.now
         # we need to redirect in order to test, otherwise cookies[] will not be blank even if no actual cookie exists because cookies[] was set locally
         # send a parameter, "currentlyTesting" to same controller, and attempt to write cookie again
-        redirect_to :controller => "main", :action => "login", :cookieTest => "currentlyTesting"
+        redirect_to controller: "main", action: "login", cookieTest: "currentlyTesting"
       else
         # if the parameter cookieTest is set, then we have already tried to write a cookie and it is still empty. Cookies are off.
         return false

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -309,12 +309,12 @@ module Repository
         raise FileExistsConflict # raise conflict if path exists
       end
       dir = RevisionDirectory.new(rev.revision_number, {
-        :name => File.basename(full_path),
-        :path => File.dirname(full_path),
-        :last_modified_revision => rev.revision_number,
-        :last_modified_date => Time.now,
-        :changed => true,
-        :user_id => rev.user_id
+        name: File.basename(full_path),
+        path: File.dirname(full_path),
+        last_modified_revision: rev.revision_number,
+        last_modified_date: Time.now,
+        changed: true,
+        user_id: rev.user_id
       })
       rev.__add_directory(dir)
       return rev
@@ -327,12 +327,12 @@ module Repository
       end
       # file does not exist, so add it
       file = RevisionFile.new(rev.revision_number, {
-        :name => File.basename(full_path),
-        :path => File.dirname(full_path),
-        :last_modified_revision => rev.revision_number,
-        :changed => true,
-        :user_id => rev.user_id,
-        :last_modified_date => Time.now
+        name: File.basename(full_path),
+        path: File.dirname(full_path),
+        last_modified_revision: rev.revision_number,
+        changed: true,
+        user_id: rev.user_id,
+        last_modified_date: Time.now
       })
       rev.__add_file(file, content)
       return rev
@@ -382,22 +382,22 @@ module Repository
       original.files.each do |object|
         if object.instance_of?(RevisionFile)
           new_object = RevisionFile.new(object.from_revision, {
-            :name => object.name,
-            :path => object.path,
-            :last_modified_revision => object.last_modified_revision,
-            :changed => false, # for copies, set this to false
-            :user_id => object.user_id,
-            :last_modified_date => object.last_modified_date
+            name: object.name,
+            path: object.path,
+            last_modified_revision: object.last_modified_revision,
+            changed: false, # for copies, set this to false
+            user_id: object.user_id,
+            last_modified_date: object.last_modified_date
           })
           new_revision.files_content[new_object.to_s] = original.files_content[object.to_s]
         else
           new_object = RevisionDirectory.new(object.from_revision, {
-            :name => object.name,
-            :path => object.path,
-            :last_modified_revision => object.last_modified_revision,
-            :last_modified_date => object.last_modified_date,
-            :changed => false, # for copies, set this to false
-            :user_id => object.user_id
+            name: object.name,
+            path: object.path,
+            last_modified_revision: object.last_modified_revision,
+            last_modified_date: object.last_modified_date,
+            changed: false, # for copies, set this to false
+            user_id: object.user_id
           })
         end
         new_revision.files.push(new_object)

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -290,19 +290,19 @@ module Repository
     end
 
     def add_path(path)
-      @jobs.push(:action => :add_path, :path => path)
+      @jobs.push(action: :add_path, path: path)
     end
 
     def add(path, file_data=nil, mime_type=nil)
-      @jobs.push(:action => :add, :path => path, :file_data => file_data, :mime_type => mime_type)
+      @jobs.push(action: :add, path: path, file_data: file_data, mime_type: mime_type)
     end
 
     def remove(path, expected_revision_number)
-      @jobs.push(:action => :remove, :path => path, :expected_revision_number => expected_revision_number)
+      @jobs.push(action: :remove, path: path, expected_revision_number: expected_revision_number)
     end
 
     def replace(path, file_data, mime_type, expected_revision_number)
-      @jobs.push(:action => :replace, :path => path, :file_data => file_data, :mime_type => mime_type, :expected_revision_number => expected_revision_number)
+      @jobs.push(action: :replace, path: path, file_data: file_data, mime_type: mime_type, expected_revision_number: expected_revision_number)
     end
 
     def add_conflict(conflict)

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -8,13 +8,13 @@ module Repository
   # subversion specific module constants
   if !defined? SVN_CONSTANTS # avoid constants already defined warnings
     SVN_CONSTANTS = {
-      :author => Svn::Core::PROP_REVISION_AUTHOR,
-      :date => Svn::Core::PROP_REVISION_DATE,
-      :mime_type => Svn::Core::PROP_MIME_TYPE
+      author: Svn::Core::PROP_REVISION_AUTHOR,
+      date: Svn::Core::PROP_REVISION_DATE,
+      mime_type: Svn::Core::PROP_MIME_TYPE
     }
   end
   if !defined? SVN_FS_TYPES
-    SVN_FS_TYPES = {:fsfs => Svn::Fs::TYPE_FSFS, :bdb => Svn::Fs::TYPE_BDB}
+    SVN_FS_TYPES = {fsfs: Svn::Fs::TYPE_FSFS, bdb: Svn::Fs::TYPE_BDB}
   end
 
   class InvalidSubversionRepository < Repository::ConnectionError; end
@@ -949,12 +949,12 @@ module Repository
           last_modified_revision = @repo.__get_history(File.join(path, file_name)).last
           last_modified_date = @repo.__get_node_last_modified_date(File.join(path, file_name), @revision_number)
           new_directory = Repository::RevisionDirectory.new(@revision_number, {
-            :name => file_name,
-            :path => path,
-            :last_modified_revision => last_modified_revision,
-            :last_modified_date => last_modified_date,
-            :changed => (last_modified_revision == @revision_number),
-            :user_id => @repo.__get_property(:author, last_modified_revision)
+            name: file_name,
+            path: path,
+            last_modified_revision: last_modified_revision,
+            last_modified_date: last_modified_date,
+            changed: (last_modified_revision == @revision_number),
+            user_id: @repo.__get_property(:author, last_modified_revision)
           })
           result[file_name] = new_directory
         end
@@ -982,13 +982,13 @@ module Repository
 
           if(!only_changed || (last_modified_revision == @revision_number))
             new_file = Repository::RevisionFile.new(@revision_number, {
-              :name => file_name,
-              :path => path,
-              :last_modified_revision => last_modified_revision,
-              :changed => (last_modified_revision == @revision_number),
-              :user_id => @repo.__get_property(:author, last_modified_revision),
-              :mime_type => @repo.__get_file_property(:mime_type, File.join(path, file_name), last_modified_revision),
-              :last_modified_date => last_modified_date
+              name: file_name,
+              path: path,
+              last_modified_revision: last_modified_revision,
+              changed: (last_modified_revision == @revision_number),
+              user_id: @repo.__get_property(:author, last_modified_revision),
+              mime_type: @repo.__get_file_property(:mime_type, File.join(path, file_name), last_modified_revision),
+              last_modified_date: last_modified_date
             })
             result[file_name] = new_file
           end

--- a/lib/repo/test/memory_repository_test.rb
+++ b/lib/repo/test/memory_repository_test.rb
@@ -517,32 +517,32 @@ class MemoryRevisionTest < Test::Unit::TestCase
       @mem_rev = MemoryRevision.new(0) # create new revision
       # add some files to revision
       dir1 = RevisionDirectory.new( @mem_rev.revision_number, {
-          :name => "dir_1",
-          :path => "/",
-          :last_modified_revision => @mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "dir_1",
+          path: "/",
+          last_modified_revision: @mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       file1 = RevisionFile.new( @mem_rev.revision_number, {
-          :name => "MyClass.java",
-          :path => "/dir_1", # put MyClass.java into directory "dir_1"
-          :last_modified_revision => @mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "MyClass.java",
+          path: "/dir_1", # put MyClass.java into directory "dir_1"
+          last_modified_revision: @mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       file2 = RevisionFile.new( @mem_rev.revision_number, {
-          :name => "MyInterface.java",
-          :path => "/dir_1",
-          :last_modified_revision => @mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "MyInterface.java",
+          path: "/dir_1",
+          last_modified_revision: @mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       file3 = RevisionFile.new( @mem_rev.revision_number, {
-          :name => "test.xml",
-          :path => "/",
-          :last_modified_revision => @mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "test.xml",
+          path: "/",
+          last_modified_revision: @mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       @mem_rev.__add_file(file3, File.read(RESOURCE_DIR+"/"+file3.name))
       @mem_rev.__add_file(file1, File.read(RESOURCE_DIR+"/"+file1.name))
@@ -581,32 +581,32 @@ class MemoryRevisionTest < Test::Unit::TestCase
       mem_rev = MemoryRevision.new(0) # create new revision
       # add some files to revision
       dir1 = RevisionDirectory.new( mem_rev.revision_number, {
-          :name => "dir_1",
-          :path => "/",
-          :last_modified_revision => mem_rev.revision_number,
-          :changed => false,
-          :user_id => TEST_USER
+          name: "dir_1",
+          path: "/",
+          last_modified_revision: mem_rev.revision_number,
+          changed: false,
+          user_id: TEST_USER
       })
       file1 = RevisionFile.new( mem_rev.revision_number, {
-          :name => "MyClass.java",
-          :path => "/dir_1", # put MyClass.java into directory "dir_1"
-          :last_modified_revision => mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "MyClass.java",
+          path: "/dir_1", # put MyClass.java into directory "dir_1"
+          last_modified_revision: mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       file2 = RevisionFile.new( mem_rev.revision_number, {
-          :name => "MyInterface.java",
-          :path => "/dir_1",
-          :last_modified_revision => mem_rev.revision_number,
-          :changed => false,
-          :user_id => TEST_USER
+          name: "MyInterface.java",
+          path: "/dir_1",
+          last_modified_revision: mem_rev.revision_number,
+          changed: false,
+          user_id: TEST_USER
       })
       file3 = RevisionFile.new( mem_rev.revision_number, {
-          :name => "test.xml",
-          :path => "/",
-          :last_modified_revision => mem_rev.revision_number,
-          :changed => true,
-          :user_id => TEST_USER
+          name: "test.xml",
+          path: "/",
+          last_modified_revision: mem_rev.revision_number,
+          changed: true,
+          user_id: TEST_USER
       })
       mem_rev.__add_file(file3, File.read(RESOURCE_DIR+"/"+file3.name))
       mem_rev.__add_file(file2, File.read(RESOURCE_DIR+"/"+file2.name))
@@ -625,11 +625,11 @@ class MemoryRevisionTest < Test::Unit::TestCase
       # more testing
       mem_rev = MemoryRevision.new(0) # create new revision
       file1 = RevisionFile.new( mem_rev.revision_number, {
-          :name => "MyClass.java",
-          :path => "/",
-          :last_modified_revision => mem_rev.revision_number,
-          :changed => false,
-          :user_id => TEST_USER
+          name: "MyClass.java",
+          path: "/",
+          last_modified_revision: mem_rev.revision_number,
+          changed: false,
+          user_id: TEST_USER
       })
       mem_rev.__add_file(file1, File.read(RESOURCE_DIR+"/"+file1.name))
       files = mem_rev.changed_files_at_path("/")

--- a/lib/repo/test/subversion_repository_test.rb
+++ b/lib/repo/test/subversion_repository_test.rb
@@ -385,7 +385,7 @@ class SubversionRepositoryTest < Test::Unit::TestCase
       FileUtils.remove_dir(SVN_TEST_REPOS_DIR + "/Testrepo1", true)
       FileUtils.remove_dir(SVN_TEST_REPOS_DIR + "/Repository2", true)
       FileUtils.remove_dir(TEST_REPO, true)
-      FileUtils.rm(SVN_AUTHZ_FILE, :force => true)
+      FileUtils.rm(SVN_AUTHZ_FILE, force: true)
       # have a clean authz file
       FileUtils.cp(SVN_AUTHZ_FILE + '.orig', SVN_AUTHZ_FILE)
       # create repository first
@@ -422,7 +422,7 @@ class SubversionRepositoryTest < Test::Unit::TestCase
       SubversionRepository.delete(SVN_TEST_REPOS_DIR + "/Testrepo1")
       SubversionRepository.delete(SVN_TEST_REPOS_DIR + "/Repository2")
       SubversionRepository.delete(TEST_REPO)
-      FileUtils.rm(SVN_AUTHZ_FILE, :force => true)
+      FileUtils.rm(SVN_AUTHZ_FILE, force: true)
     end
 
     should "be able to get permissions for a user" do

--- a/lib/session_handler.rb
+++ b/lib/session_handler.rb
@@ -59,9 +59,9 @@ module SessionHandler
         # Redirect users back to referer, or else
         # they might be redirected to an rjs page.
         session[:redirect_uri] = request.referer
-        render :nothing => true, :status => :forbidden  # 403 http code
+        render nothing: true, status: :forbidden  # 403 http code
       else
-        redirect_to :controller => 'main', :action => 'login'
+        redirect_to controller: 'main', action: 'login'
       end
     end
   end
@@ -70,31 +70,31 @@ module SessionHandler
   # specific role.
   def authorize_only_for_admin
     unless authorized?(Admin)
-      render 'shared/http_status', :formats => [:html], :locals => { :code => "404", :message => HttpStatusHelper::ERROR_CODE["message"]["404"] }, :status => 404, :layout => false
+      render 'shared/http_status', formats: [:html], locals: { code: "404", message: HttpStatusHelper::ERROR_CODE["message"]["404"] }, status: 404, layout: false
     end
   end
 
   def authorize_for_ta_and_admin
     unless authorized?(Admin) || authorized?(Ta)
-      render 'shared/http_status', :formats => [:html], :locals => { :code => "404", :message => HttpStatusHelper::ERROR_CODE["message"]["404"] }, :status => 404, :layout => false
+      render 'shared/http_status', formats: [:html], locals: { code: "404", message: HttpStatusHelper::ERROR_CODE["message"]["404"] }, status: 404, layout: false
     end
   end
 
   def authorize_for_student
     unless authorized?(Student)
-      render 'shared/http_status', :formats => [:html], :locals => { :code => "404", :message => HttpStatusHelper::ERROR_CODE["message"]["404"] }, :status => 404, :layout => false
+      render 'shared/http_status', formats: [:html], locals: { code: "404", message: HttpStatusHelper::ERROR_CODE["message"]["404"] }, status: 404, layout: false
     end
   end
 
   def authorize_for_student_and_ta
     unless authorized?(Ta) || authorized?(Student)
-      render 'shared/http_status', :formats => [:html], :locals => { :code => "404", :message => HttpStatusHelper::ERROR_CODE["message"]["404"] }, :status => 404, :layout => false
+      render 'shared/http_status', formats: [:html], locals: { code: "404", message: HttpStatusHelper::ERROR_CODE["message"]["404"] }, status: 404, layout: false
     end
   end
 
   def authorize_for_user
     unless authorized?(User)
-      render 'shared/http_status', :formats => [:html], :locals => { :code => "404", :message => HttpStatusHelper::ERROR_CODE["message"]["404"] }, :status => 404, :layout => false
+      render 'shared/http_status', formats: [:html], locals: { code: "404", message: HttpStatusHelper::ERROR_CODE["message"]["404"] }, status: 404, layout: false
     end
   end
 

--- a/lib/tools/api_helper.rb
+++ b/lib/tools/api_helper.rb
@@ -61,7 +61,7 @@ end
 
 def load_params
   # By default, non verbose output
-  params = {:verbose => false}
+  params = {verbose: false}
 
   OPTS.each do |opt, arg|
     case opt

--- a/lib/tools/api_wrapper/api_wrapper.rb
+++ b/lib/tools/api_wrapper/api_wrapper.rb
@@ -14,7 +14,7 @@ class MarkusRESTfulAPI
   # Makes a GET request to the provided URL while supplying the authorization
   # header, and raising an exception on failure
   def MarkusRESTfulAPI.get(url)
-    response = HTTParty.get(@@api_url + url, :headers =>
+    response = HTTParty.get(@@api_url + url, headers:
       { 'Authorization' => "MarkUsAuth #{@@auth_key}", 'Accept' => 'application/json' })
     raise "#{response['code']}: #{response['description']}" unless response.success?
 
@@ -24,8 +24,8 @@ class MarkusRESTfulAPI
   # Makes a POST request to the provided URL, along with the supplied POST data.
   # Also uses the authorization header, and raises an exception on failure
   def MarkusRESTfulAPI.post(url, query)
-    options = { :headers => { 'Authorization' => "MarkUsAuth #{@@auth_key}",
-                'Accept' => 'application/json' }, :body => query }
+    options = { headers: { 'Authorization' => "MarkUsAuth #{@@auth_key}",
+                'Accept' => 'application/json' }, body: query }
     response = HTTParty.post(@@api_url + url, options)
     raise "#{response['code']}: #{response['description']}" unless response.success?
 
@@ -35,8 +35,8 @@ class MarkusRESTfulAPI
   # Makes a PUT request to the provided URL, along with the supplied data.
   # Also uses the authorization header, and raises an exception on failure
   def MarkusRESTfulAPI.put(url, query)
-    options = { :headers => { 'Authorization' => "MarkUsAuth #{@@auth_key}",
-                'Accept' => 'application/json' }, :body => query }
+    options = { headers: { 'Authorization' => "MarkUsAuth #{@@auth_key}",
+                'Accept' => 'application/json' }, body: query }
     response = HTTParty.put(@@api_url + url, options)
     raise "#{response['code']}: #{response['description']}" unless response.success?
 
@@ -46,7 +46,7 @@ class MarkusRESTfulAPI
   # Makes a DELETE request to the provided URL while supplying the authorization
   # header, and raising an exception on failure
   def MarkusRESTfulAPI.delete(url)
-    response = HTTParty.delete(@@api_url + url, :headers =>
+    response = HTTParty.delete(@@api_url + url, headers:
       { 'Authorization' => "MarkUsAuth #{@@auth_key}", 'Accept' => 'application/json' })
     puts response
     raise "#{response['code']}: #{response['description']}" unless response.success?


### PR DESCRIPTION
A better place to review this PR is at zhangsu@870b6e5 with no Hound
comments, since this PR doesn't address style issues.

This is a global search-and-replace that replaces the Ruby 1.8 symbol
key hash rocket syntax to Ruby 1.9 syntax in

```
    {lib,config,app/helpers,Gemfile}
```

Since this is a big change list, the style issues in the changed lines
are not being dealt with so that errors are minimized and code review
is easier. There is one exception though:

If the lines before the change have a good alignment of hash keys that
span multiple lines and the lines after the change do not (because the
change might alters the number of spaces needed for the alignment), then
the alignment is fixed, such that no new style issues are introduced. If
the alignment was not correct to begin with, then it is not fixed.

As a result, please ignore linter comments for this change.

This is for #1498.

Tested:
- rake test:units
- rake test:functionals
- rails s
