### PR TITLE
Replace RJS symbol hash rockets with 1.9 syntax

### DIFF
--- a/app/views/annotations/add_existing_annotation.rjs
+++ b/app/views/annotations/add_existing_annotation.rjs
@@ -5,5 +5,5 @@ else
   page.call(:add_annotation_text, @text.id, simple_format(@text.content))
   page << @annotation.add_annotation_js_string
 end
-page.replace_html 'annotation_summary_list', :partial => 'results/marker/annotation_summary', :locals => {:annots => @annotations, :submission_file_id => @submission_file_id}
+page.replace_html 'annotation_summary_list', partial: 'results/marker/annotation_summary', locals: {annots: @annotations, submission_file_id: @submission_file_id}
 page.call :hide_all_annotation_content_editors

--- a/app/views/annotations/create.rjs
+++ b/app/views/annotations/create.rjs
@@ -1,7 +1,7 @@
-page.replace_html 'annotation_summary_list', :partial => 'results/marker/annotation_summary', :locals => {:annots => @annotations, :submission_file_id => @submission_file_id}
+page.replace_html 'annotation_summary_list', partial: 'results/marker/annotation_summary', locals: {annots: @annotations, submission_file_id: @submission_file_id}
 
 if(@text.annotation_category_id != nil)
-  page.replace_html "annotation_text_list_#{@text.annotation_category_id}", :partial => 'annotation_list', :locals => {:annotation_category => @text.annotation_category}
+  page.replace_html "annotation_text_list_#{@text.annotation_category_id}", partial: 'annotation_list', locals: {annotation_category: @text.annotation_category}
 end
 
 page.call(:add_annotation_text, @text.id, @text.content)

--- a/app/views/annotations/destroy.rjs
+++ b/app/views/annotations/destroy.rjs
@@ -1,5 +1,5 @@
 page << @annotation.remove_annotation_js_string
 
-page.replace_html 'annotation_summary_list', :partial => 'results/marker/annotation_summary', :locals => {:annots => @annotations, :submission_file_id => @submission_file_id}
+page.replace_html 'annotation_summary_list', partial: 'results/marker/annotation_summary', locals: {annots: @annotations, submission_file_id: @submission_file_id}
 
 page.call :hide_all_annotation_content_editors

--- a/app/views/annotations/update_annotation.rjs
+++ b/app/views/annotations/update_annotation.rjs
@@ -1,7 +1,7 @@
-page.replace_html 'annotation_summary_list', :partial => 'results/marker/annotation_summary', :locals => {:annots => @annotations, :submission_file_id => @submission_file_id}
+page.replace_html 'annotation_summary_list', partial: 'results/marker/annotation_summary', locals: {annots: @annotations, submission_file_id: @submission_file_id}
 
 if(@annotation_text.annotation_category_id != nil)
-  page.replace_html "annotation_text_list_#{@annotation_text.annotation_category_id}", :partial => 'annotation_list', :locals => {:annotation_category => @annotation_text.annotation_category}
+  page.replace_html "annotation_text_list_#{@annotation_text.annotation_category_id}", partial: 'annotation_list', locals: {annotation_category: @annotation_text.annotation_category}
 end
 
 page.call(:update_annotation_text, @id, CGI.escapeHTML(@content))

--- a/app/views/assignments/disinvite_member.rjs
+++ b/app/views/assignments/disinvite_member.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/automated_tests/test_replace.rjs
+++ b/app/views/automated_tests/test_replace.rjs
@@ -1,4 +1,4 @@
 page.replace_html 'test_results_controls',
-                  :partial => 'results/common/test_selector',
-                  :locals => {:test_result_files => @test_result_files,
-                              :result => @result}
+                  partial: 'results/common/test_selector',
+                  locals: {test_result_files: @test_result_files,
+                           result: @result}

--- a/app/views/flexible_criteria/add_criterion_error.rjs
+++ b/app/views/flexible_criteria/add_criterion_error.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'new_criterion_error', :partial => 'new_flexible_criterion_errors', :locals => {:errors => @errors}
+page.replace_html 'new_criterion_error', partial: 'new_flexible_criterion_errors', locals: {errors: @errors}
 page.show 'new_criterion_error'

--- a/app/views/flexible_criteria/create_and_edit.rjs
+++ b/app/views/flexible_criteria/create_and_edit.rjs
@@ -1,30 +1,30 @@
 if @criteria.count > 2
   page.insert_html :bottom,
                    'flexible_criteria_pane_list',
-                   :partial => 'flexible_criterion',
-                   :locals => {:criterion => @criterion, :location => :last}
+                   partial: 'flexible_criterion',
+                   locals: {criterion: @criterion, location: :last}
   page.replace "criterion_#{@criteria[-2].id}",
-               :partial => 'flexible_criterion',
-               :locals => {:criterion => @criteria[-2], :location => :middle}
+               partial: 'flexible_criterion',
+               locals: {criterion: @criteria[-2], location: :middle}
 elsif @criteria.count == 2
   page.insert_html :bottom,
                    'flexible_criteria_pane_list',
-                   :partial => 'flexible_criterion',
-                   :locals => {:criterion => @criterion, :location => :last }
+                   partial: 'flexible_criterion',
+                   locals: {criterion: @criterion, location: :last }
   page.replace "criterion_#{@criteria.first.id}",
-                :partial => 'flexible_criterion',
-                :locals => {:criterion => @criteria.first, :location => :first}
+                partial: 'flexible_criterion',
+                locals: {criterion: @criteria.first, location: :first}
 else
   page.insert_html :bottom,
                    'flexible_criteria_pane_list',
-                   :partial => 'flexible_criterion',
-                   :locals => {:criterion => @criterion, :location => :single}
+                   partial: 'flexible_criterion',
+                   locals: {criterion: @criterion, location: :single}
 end
 page.remove 'new_flexible_criterion'
 page.replace_html 'flexible_edition_pane_menu',
-                  :partial => 'criterion_editor',
-                  :locals => {:criterion => @criterion}
+                  partial: 'criterion_editor',
+                  locals: {criterion: @criterion}
 page.replace_html "criteria_total_mark", @criterion.assignment.total_mark
 page.sortable 'flexible_criteria_pane_list',
-              :constraint => :vertical,
-              :url => update_positions_assignment_flexible_criteria_path(:aid => @criterion.assignment.id)
+              constraint: :vertical,
+              url: update_positions_assignment_flexible_criteria_path(aid: @criterion.assignment.id)

--- a/app/views/flexible_criteria/delete.rjs
+++ b/app/views/flexible_criteria/delete.rjs
@@ -1,2 +1,2 @@
-page.replace_html "flexible_criteria_pane", :partial => "flexible_criteria/flexible_criteria_pane"
-page.replace_html "flexible_edition_pane_menu", :partial => "flexible_criteria_manager_help"
+page.replace_html "flexible_criteria_pane", partial: "flexible_criteria/flexible_criteria_pane"
+page.replace_html "flexible_edition_pane_menu", partial: "flexible_criteria_manager_help"

--- a/app/views/flexible_criteria/destroy.rjs
+++ b/app/views/flexible_criteria/destroy.rjs
@@ -1,2 +1,2 @@
-page.replace_html "flexible_criteria_pane", :partial => "flexible_criteria/flexible_criteria_pane"
-page.replace_html "flexible_edition_pane_menu", :partial => "flexible_criteria_manager_help"
+page.replace_html "flexible_criteria_pane", partial: "flexible_criteria/flexible_criteria_pane"
+page.replace_html "flexible_edition_pane_menu", partial: "flexible_criteria_manager_help"

--- a/app/views/flexible_criteria/edit.rjs
+++ b/app/views/flexible_criteria/edit.rjs
@@ -1,1 +1,1 @@
-page.replace_html 'flexible_edition_pane_menu', :partial => 'criterion_editor', :locals => {:criterion => @criterion}
+page.replace_html 'flexible_edition_pane_menu', partial: 'criterion_editor', locals: {criterion: @criterion}

--- a/app/views/flexible_criteria/errors.rjs
+++ b/app/views/flexible_criteria/errors.rjs
@@ -1,2 +1,2 @@
-page.replace_html "criterion_#{@criterion.id}_error", :partial => 'errors_list', :locals => {:criterion => @criterion}
+page.replace_html "criterion_#{@criterion.id}_error", partial: 'errors_list', locals: {criterion: @criterion}
 page.show "criterion_#{@criterion.id}_error"

--- a/app/views/flexible_criteria/move_criterion.rjs
+++ b/app/views/flexible_criteria/move_criterion.rjs
@@ -1,1 +1,1 @@
-page.replace_html "flexible_criteria_pane", :partial => "flexible_criteria/flexible_criteria_pane"
+page.replace_html "flexible_criteria_pane", partial: "flexible_criteria/flexible_criteria_pane"

--- a/app/views/flexible_criteria/new.rjs
+++ b/app/views/flexible_criteria/new.rjs
@@ -1,2 +1,2 @@
-page.insert_html :top, 'flexible_criteria_pane_list', :partial => 'new_flexible_criterion', :locals => {:assignment => @assignment}
+page.insert_html :top, 'flexible_criteria_pane_list', partial: 'new_flexible_criterion', locals: {assignment: @assignment}
 page['new_flexible_criterion_prompt'].focus

--- a/app/views/flexible_criteria/update.rjs
+++ b/app/views/flexible_criteria/update.rjs
@@ -1,4 +1,4 @@
 page.replace_html "criterion_title_#{@criterion.id}", @criterion.flexible_criterion_name
 page.replace_html "criterion_max_#{@criterion.id}", @criterion.max
 page.replace_html "criteria_total_mark", @criterion.assignment.total_mark
-page.replace_html "flexible_edition_pane_menu", :partial => 'criterion_editor', :locals => {:criterion => @criterion}
+page.replace_html "flexible_edition_pane_menu", partial: 'criterion_editor', locals: {criterion: @criterion}

--- a/app/views/flexible_criteria/update_positions.rjs
+++ b/app/views/flexible_criteria/update_positions.rjs
@@ -1,1 +1,1 @@
-page.replace_html "flexible_criteria_pane", :partial => "flexible_criteria/flexible_criteria_pane"
+page.replace_html "flexible_criteria_pane", partial: "flexible_criteria/flexible_criteria_pane"

--- a/app/views/grade_entry_forms/g_table_paginate.rjs
+++ b/app/views/grade_entry_forms/g_table_paginate.rjs
@@ -1,44 +1,44 @@
-page.replace 'grades', :partial => 'grades_table'
+page.replace 'grades', partial: 'grades_table'
 
-page.replace_html 'ap_page_links_1', :partial => 'ajax_paginate/initial_paginate_links_alpha',
-                                                 :locals => {:per_page => @per_page, :current_page => @current_page.to_i,
-                                                             :page_items => @students.size, :total_items => @students_total,
-                                                             :assignment => @grade_entry_form, :filter => @filter,
-                                                             :sort_by => @sort_by, :desc => @desc, :action => 'g_table_paginate',
-                                                             :table_name => 'grades', :alpha_category => @alpha_category,
-                                                             :alpha_pagination_options => @alpha_pagination_options}
+page.replace_html 'ap_page_links_1', partial: 'ajax_paginate/initial_paginate_links_alpha',
+                                              locals: {per_page: @per_page, current_page: @current_page.to_i,
+                                                       page_items: @students.size, total_items: @students_total,
+                                                       assignment: @grade_entry_form, filter: @filter,
+                                                       sort_by: @sort_by, desc: @desc, action: 'g_table_paginate',
+                                                       table_name: 'grades', alpha_category: @alpha_category,
+                                                       alpha_pagination_options: @alpha_pagination_options}
 
-page.replace_html 'ap_page_links_2', :partial => 'ajax_paginate/initial_paginate_links_alpha',
-                                                 :locals => {:per_page => @per_page, :current_page => @current_page.to_i,
-                                                             :page_items => @students.size, :total_items => @students_total,
-                                                             :assignment => @grade_entry_form, :filter => @filter,
-                                                             :sort_by => @sort_by, :desc => @desc, :action => 'g_table_paginate',
-                                                             :table_name => 'grades', :alpha_category => @alpha_category,
-                                                             :alpha_pagination_options => @alpha_pagination_options}
+page.replace_html 'ap_page_links_2', partial: 'ajax_paginate/initial_paginate_links_alpha',
+                                              locals: {per_page: @per_page, current_page: @current_page.to_i,
+                                                       page_items: @students.size, total_items: @students_total,
+                                                       assignment: @grade_entry_form, filter: @filter,
+                                                       sort_by: @sort_by, desc: @desc, action: 'g_table_paginate',
+                                                       table_name: 'grades', alpha_category: @alpha_category,
+                                                       alpha_pagination_options: @alpha_pagination_options}
 
-page.replace_html 'ap_filters_1', :partial => 'grades_table_filters',
-                                              :locals => {:filter => @filter, :sort_by => @sort_by, :desc => @desc,
-                                              :grade_entry_form => @grade_entry_form, :filters => @filters,
-                                              :per_page => @per_page, :per_pages => @per_pages,
-                                              :alpha_pagination_options => @alpha_pagination_options,
-                                              :alpha_category => @alpha_category}
+page.replace_html 'ap_filters_1', partial: 'grades_table_filters',
+                                           locals: {filter: @filter, sort_by: @sort_by, desc: @desc,
+                                           grade_entry_form: @grade_entry_form, filters: @filters,
+                                           per_page: @per_page, per_pages: @per_pages,
+                                           alpha_pagination_options: @alpha_pagination_options,
+                                           alpha_category: @alpha_category}
 
-page.replace_html 'ap_filters_2', :partial => 'grades_table_filters',
-                                              :locals => {:filter => @filter, :sort_by => @sort_by, :desc => @desc,
-                                              :grade_entry_form => @grade_entry_form, :filters => @filters,
-                                              :per_page => @per_page, :per_pages => @per_pages,
-                                              :alpha_pagination_options => @alpha_pagination_options,
-                                              :alpha_category => @alpha_category}
+page.replace_html 'ap_filters_2', partial: 'grades_table_filters',
+                                           locals: {filter: @filter, sort_by: @sort_by, desc: @desc,
+                                           grade_entry_form: @grade_entry_form, filters: @filters,
+                                           per_page: @per_page, per_pages: @per_pages,
+                                           alpha_pagination_options: @alpha_pagination_options,
+                                           alpha_category: @alpha_category}
 
-page.replace_html 'grades_table_head', :partial => 'grades_table_column_names',
-                                                    :locals => {:filter => @filter, :per_page => @per_page,
-                                                    :sort_by => @sort_by, :desc => @desc, :controller => 'grade_entry_forms',
-                                                    :action => 'grades'}
+page.replace_html 'grades_table_head', partial: 'grades_table_column_names',
+                                                locals: {filter: @filter, per_page: @per_page,
+                                                sort_by: @sort_by, desc: @desc, controller: 'grade_entry_forms',
+                                                action: 'grades'}
 
-page.replace_html 'grades_table_footer', :partial => 'grades_table_column_names',
-                                                      :locals => {:filter => @filter, :per_page => @per_page,
-                                                      :sort_by => @sort_by, :desc => @desc, :controller => 'grade_entry_forms',
-                                                      :action => 'grades'}
+page.replace_html 'grades_table_footer', partial: 'grades_table_column_names',
+                                                  locals: {filter: @filter, per_page: @per_page,
+                                                  sort_by: @sort_by, desc: @desc, controller: 'grade_entry_forms',
+                                                  action: 'grades'}
 
-page.replace_html 'ap_selects', :partial => 'ajax_paginate/selects', :locals => {:page_items => @students.size, :total_items => @students_total}
+page.replace_html 'ap_selects', partial: 'ajax_paginate/selects', locals: {page_items: @students.size, total_items: @students_total}
 

--- a/app/views/grade_entry_forms/update_grade.rjs
+++ b/app/views/grade_entry_forms/update_grade.rjs
@@ -1,7 +1,7 @@
 if @grade_saved
   # The grade was successfully updated so highlight the table cell to indicate this
-  page["grade_#{@student_id}_#{@grade_entry_item_id}"].visual_effect :highlight, :startcolor => "#99CCFF",
-                                                                     :endcolor => "#FFFFFF", :restorecolor => "#FFFFFF"
+  page["grade_#{@student_id}_#{@grade_entry_item_id}"].visual_effect :highlight, startcolor: "#99CCFF",
+                                                                     endcolor: "#FFFFFF", restorecolor: "#FFFFFF"
 
 
   # This code calls the javascript function 'update_cell(cell, value)' in
@@ -21,7 +21,7 @@ if @grade_saved
 
 else
   # Change the background colour of the cell to red to indicate that an error has occurred
-  page["grade_#{@student_id}_#{@grade_entry_item_id}"].visual_effect :highlight, :startcolor => "#FFCCCC",
-                                                                     :endcolor => "#FF9999", :restorecolor => "#FF9999"
+  page["grade_#{@student_id}_#{@grade_entry_item_id}"].visual_effect :highlight, startcolor: "#FFCCCC",
+                                                                     endcolor: "#FF9999", restorecolor: "#FF9999"
 end
 

--- a/app/views/graders/add_grader_to_grouping.rjs
+++ b/app/views/graders/add_grader_to_grouping.rjs
@@ -1,5 +1,5 @@
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 page.call 'modify_graders', @graders_data.to_json
 page.call 'modify_groupings', @groupings_data.to_json
 page.call 'modify_criteria', @criteria_data.to_json
-page.replace_html 'groups_coverage_dialog', :partial => 'graders/modal_dialogs/groups_coverage'
+page.replace_html 'groups_coverage_dialog', partial: 'graders/modal_dialogs/groups_coverage'

--- a/app/views/graders/filter.rjs
+++ b/app/views/graders/filter.rjs
@@ -1,3 +1,3 @@
-page.replace_html 'groupings_table', :partial => 'graders/manage/groupings_table', :locals => {:groupings => @groupings, :assignment => @assignment}
+page.replace_html 'groupings_table', partial: 'graders/manage/groupings_table', locals: {groupings: @groupings, assignment: @assignment}
 
 

--- a/app/views/graders/modify_groupings.rjs
+++ b/app/views/graders/modify_groupings.rjs
@@ -1,4 +1,4 @@
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 page.call 'modify_graders', @graders_data.to_json
 page.call 'modify_groupings', @groupings_data.to_json
 if @assignment.assign_graders_to_criteria

--- a/app/views/groups/add_members.rjs
+++ b/app/views/groups/add_members.rjs
@@ -21,7 +21,7 @@ else
 end
 
 
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 
 page.call 'modify_students', @students_data.to_json
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/csv_upload.rjs
+++ b/app/views/groups/csv_upload.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'manage', :id => @assignment.id
+page.redirect_to action: 'manage', id: @assignment.id

--- a/app/views/groups/decline_invitation.rjs
+++ b/app/views/groups/decline_invitation.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/groups/delete_group.rjs
+++ b/app/views/groups/delete_group.rjs
@@ -1,2 +1,2 @@
-page.redirect_to :controller => 'assignments', :action =>
-'student_interface', :id => @assignment.id
+page.redirect_to controller: 'assignments', action:
+'student_interface', id: @assignment.id

--- a/app/views/groups/delete_groupings.rjs
+++ b/app/views/groups/delete_groupings.rjs
@@ -2,11 +2,11 @@ page.hide 'errors'
 
 if !@errors.empty?
   page.replace_html 'errors_title', I18n.t('groups.could_not_delete')
-  page.replace_html 'errors_contents', :partial => 'delete_errors', :locals => {:group_names => @errors}
+  page.replace_html 'errors_contents', partial: 'delete_errors', locals: {group_names: @errors}
   page.show 'errors'
 end
 
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 
 ids = []
 @removed_groupings.each do |grouping|

--- a/app/views/groups/delete_rejected.rjs
+++ b/app/views/groups/delete_rejected.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/groups/disinvite_member.rjs
+++ b/app/views/groups/disinvite_member.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/groups/filter.rjs
+++ b/app/views/groups/filter.rjs
@@ -1,3 +1,3 @@
-page.replace_html 'groupings_table', :partial => 'groups/manage/groupings_table', :locals => {:groupings => @groupings, :assignment => @assignment}
+page.replace_html 'groupings_table', partial: 'groups/manage/groupings_table', locals: {groupings: @groupings, assignment: @assignment}
 
 

--- a/app/views/groups/invite_member.rjs
+++ b/app/views/groups/invite_member.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/groups/join.rjs
+++ b/app/views/groups/join.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'student_interface', :id => @assignment.id
+page.redirect_to action: 'student_interface', id: @assignment.id

--- a/app/views/groups/modify_groupings.rjs
+++ b/app/views/groups/modify_groupings.rjs
@@ -1,3 +1,3 @@
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/note_message.rjs
+++ b/app/views/groups/note_message.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'manage', :id => @assignment.id
+page.redirect_to action: 'manage', id: @assignment.id

--- a/app/views/groups/remove_members.rjs
+++ b/app/views/groups/remove_members.rjs
@@ -1,4 +1,4 @@
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 
 page.call 'modify_students', @students_data.to_json
 page.call "modify_groupings", @groupings_data.to_json

--- a/app/views/groups/use_another_assignment_groups.rjs
+++ b/app/views/groups/use_another_assignment_groups.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'manage', :id => @target_assignment.id
+page.redirect_to action: 'manage', id: @target_assignment.id

--- a/app/views/marks_graders/filter.rjs
+++ b/app/views/marks_graders/filter.rjs
@@ -1,2 +1,2 @@
-page.replace_html('groupings_table', :partial => 'marks_graders/manage/groupings_table',
-    :locals => { :students => @students, :grade_entry_form => @grade_entry_form })
+page.replace_html('groupings_table', partial: 'marks_graders/manage/groupings_table',
+    locals: { students: @students, grade_entry_form: @grade_entry_form })

--- a/app/views/marks_graders/modify_groupings.rjs
+++ b/app/views/marks_graders/modify_groupings.rjs
@@ -1,3 +1,3 @@
-page << render(:partial => 'shared/global_action_warning')
+page << render(partial: 'shared/global_action_warning')
 page.call 'modify_graders', @graders_data.to_json
 page.call 'modify_groupings', @students_data.to_json

--- a/app/views/results/delete_grace_period_deduction.rjs
+++ b/app/views/results/delete_grace_period_deduction.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'submission_rule_viewer', :partial => @grouping.assignment.submission_rule.grader_tab_partial, :locals => {:grouping => @grouping}
+page.replace_html 'submission_rule_viewer', partial: @grouping.assignment.submission_rule.grader_tab_partial, locals: {grouping: @grouping}
 

--- a/app/views/results/note_message.rjs
+++ b/app/views/results/note_message.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'edit', :id => @result.id
+page.redirect_to action: 'edit', id: @result.id

--- a/app/views/results/set_released_to_students.rjs
+++ b/app/views/results/set_released_to_students.rjs
@@ -1,5 +1,5 @@
 if @old_result
-  page.redirect_to :action => 'edit', :id => @old_result.id
+  page.redirect_to action: 'edit', id: @old_result.id
 else
-  page.redirect_to :action => 'edit', :id => @result.id
+  page.redirect_to action: 'edit', id: @result.id
 end

--- a/app/views/rubrics/create_and_edit.rjs
+++ b/app/views/rubrics/create_and_edit.rjs
@@ -1,31 +1,31 @@
 if @criteria.count > 2
   page.insert_html :bottom,
                    'rubric_criteria_pane_list',
-                   :partial => 'rubric_criterion',
-                   :locals => {:criterion => @criterion,
-                               :location => :last }
+                   partial: 'rubric_criterion',
+                   locals: {criterion: @criterion,
+                               location: :last }
   page.replace "criterion_#{@criteria[-2].id}",
-                :partial => 'rubric_criterion',
-                :locals => {:criterion => @criteria[-2],
-                            :location => :middle }
+                partial: 'rubric_criterion',
+                locals: {criterion: @criteria[-2],
+                            location: :middle }
 elsif @criteria.count == 2
   page.insert_html :bottom,
                    'rubric_criteria_pane_list',
-                   :partial => 'rubric_criterion',
-                   :locals => {:criterion => @criterion,
-                               :location => :last }
+                   partial: 'rubric_criterion',
+                   locals: {criterion: @criterion,
+                               location: :last }
   page.replace "criterion_#{@criteria.first.id}",
-               :partial => 'rubric_criterion',
-               :locals => {:criterion => @criteria.first,
-                           :location => :first }
+               partial: 'rubric_criterion',
+               locals: {criterion: @criteria.first,
+                           location: :first }
 else
   page.insert_html :bottom,
                    'rubric_criteria_pane_list',
-                   :partial => 'rubric_criterion',
-                   :locals => {:criterion => @criterion,
-                               :location => :single }
+                   partial: 'rubric_criterion',
+                   locals: {criterion: @criterion,
+                               location: :single }
 end
 page.remove 'new_rubric_criterion'
-page.replace_html 'rubric_levels_pane_menu', :partial => 'criterion_editor', :locals => {:criterion => @criterion}
+page.replace_html 'rubric_levels_pane_menu', partial: 'criterion_editor', locals: {criterion: @criterion}
 page.replace_html "rubric_total_weight", @criterion.assignment.total_criteria_weight
-page.sortable 'rubric_criteria_pane_list', :constraint => :vertical, :url => { :action => :update_positions, :aid => @criterion.assignment.id }
+page.sortable 'rubric_criteria_pane_list', constraint: :vertical, url: { action: :update_positions, aid: @criterion.assignment.id }

--- a/app/views/rubrics/errors.rjs
+++ b/app/views/rubrics/errors.rjs
@@ -1,2 +1,2 @@
-page.replace_html "criterion_#{@criterion.id}_error", :partial => 'errors_list', :locals => {:criterion => @criterion}
+page.replace_html "criterion_#{@criterion.id}_error", partial: 'errors_list', locals: {criterion: @criterion}
 page.show "criterion_#{@criterion.id}_error"

--- a/app/views/rubrics/show_help.rjs
+++ b/app/views/rubrics/show_help.rjs
@@ -1,1 +1,1 @@
-page.replace_html 'rubric_levels_pane_menu', :partial => 'rubric_manager_help'
+page.replace_html 'rubric_levels_pane_menu', partial: 'rubric_manager_help'

--- a/app/views/rubrics/update.rjs
+++ b/app/views/rubrics/update.rjs
@@ -1,4 +1,4 @@
 page.replace_html  "criterion_title_#{@criterion.id}", @criterion.rubric_criterion_name
 page.replace_html "criterion_weight_#{@criterion.id}", @criterion.weight
 page.replace_html "rubric_total_weight", @criterion.assignment.total_criteria_weight
-page.replace_html "rubric_levels_pane_menu", :partial => 'criterion_editor', :locals => {:criterion => @criterion}
+page.replace_html "rubric_levels_pane_menu", partial: 'criterion_editor', locals: {criterion: @criterion}

--- a/app/views/rubrics/update_positions.rjs
+++ b/app/views/rubrics/update_positions.rjs
@@ -1,1 +1,1 @@
-page.replace_html "rubric_criteria_pane", :partial => "rubrics/rubric_criteria_pane"
+page.replace_html "rubric_criteria_pane", partial: "rubrics/rubric_criteria_pane"

--- a/app/views/students/bulk_action.rjs
+++ b/app/views/students/bulk_action.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :controller => 'students', :action => 'index'
+page.redirect_to controller: 'students', action: 'index'

--- a/app/views/students/delete_grace_period_deduction.rjs
+++ b/app/views/students/delete_grace_period_deduction.rjs
@@ -1,1 +1,1 @@
-page.replace_html 'grace_period_deductions', :partial => 'grace_period_deductions', :locals => {:grace_period_deductions => @grace_period_deductions}
+page.replace_html 'grace_period_deductions', partial: 'grace_period_deductions', locals: {grace_period_deductions: @grace_period_deductions}

--- a/app/views/students/filter.rjs
+++ b/app/views/students/filter.rjs
@@ -1,3 +1,3 @@
 page.replace_html 'students_table',
-                  :partial => 'students/students_table',
-                  :locals => {:students => @students}
+                  partial: 'students/students_table',
+                  locals: {students: @students}

--- a/app/views/students/note_message.rjs
+++ b/app/views/students/note_message.rjs
@@ -1,1 +1,1 @@
-page.redirect_to :action => 'index', :id => @student.id
+page.redirect_to action: 'index', id: @student.id

--- a/app/views/submissions/s_table_paginate.rjs
+++ b/app/views/submissions/s_table_paginate.rjs
@@ -1,15 +1,15 @@
-page.replace 'submissions', :partial => 'submissions_table_body', :locals => {:groupings => @groupings, :assignment => @assignment}
+page.replace 'submissions', partial: 'submissions_table_body', locals: {groupings: @groupings, assignment: @assignment}
 
-page.replace_html 'ap_page_links_1', :partial => 'ajax_paginate/initial_paginate_links', :locals => {:per_page => @per_page, :current_page => @current_page.to_i, :page_items => @groupings.size, :total_items => @groupings_total, :assignment => @assignment, :filter => @filter, :sort_by => @sort_by, :table_name => 'submissions'}
+page.replace_html 'ap_page_links_1', partial: 'ajax_paginate/initial_paginate_links', locals: {per_page: @per_page, current_page: @current_page.to_i, page_items: @groupings.size, total_items: @groupings_total, assignment: @assignment, filter: @filter, sort_by: @sort_by, table_name: 'submissions'}
 
-page.replace_html 'ap_page_links_2', :partial => 'ajax_paginate/initial_paginate_links', :locals => {:per_page => @per_page, :current_page => @current_page.to_i, :page_items => @groupings.size, :total_items => @groupings_total, :assignment => @assignment, :filter => @filter, :sort_by => @sort_by, :table_name => 'submissions'}
+page.replace_html 'ap_page_links_2', partial: 'ajax_paginate/initial_paginate_links', locals: {per_page: @per_page, current_page: @current_page.to_i, page_items: @groupings.size, total_items: @groupings_total, assignment: @assignment, filter: @filter, sort_by: @sort_by, table_name: 'submissions'}
 
-page.replace_html 'ap_filters_1', :partial => 'submissions_table_filters', :locals => {:filter => @filter, :sort_by => @sort_by, :assignment => @assignment, :filters => @filters, :per_page => @per_page, :per_pages => @per_pages}
+page.replace_html 'ap_filters_1', partial: 'submissions_table_filters', locals: {filter: @filter, sort_by: @sort_by, assignment: @assignment, filters: @filters, per_page: @per_page, per_pages: @per_pages}
 
-page.replace_html 'ap_filters_2', :partial => 'submissions_table_filters', :locals => {:filter => @filter, :sort_by => @sort_by, :assignment => @assignment, :filters => @filters, :per_page => @per_page, :per_pages => @per_pages}
+page.replace_html 'ap_filters_2', partial: 'submissions_table_filters', locals: {filter: @filter, sort_by: @sort_by, assignment: @assignment, filters: @filters, per_page: @per_page, per_pages: @per_pages}
 
-page.replace_html 'submissions_table_head', :partial => 'submissions_table_sorting_links', :locals => {:assignment => @assignment, :filter => @filter, :page => @current_page.to_i, :per_page => @per_page, :sort_by => @sort_by, :desc => @desc}
+page.replace_html 'submissions_table_head', partial: 'submissions_table_sorting_links', locals: {assignment: @assignment, filter: @filter, page: @current_page.to_i, per_page: @per_page, sort_by: @sort_by, desc: @desc}
 
-page.replace_html 'submissions_table_foot', :partial => 'submissions_table_sorting_links', :locals => {:assignment => @assignment, :filter => @filter, :page => @current_page.to_i, :per_page => @per_page, :sort_by => @sort_by, :desc => @desc}
+page.replace_html 'submissions_table_foot', partial: 'submissions_table_sorting_links', locals: {assignment: @assignment, filter: @filter, page: @current_page.to_i, per_page: @per_page, sort_by: @sort_by, desc: @desc}
 
-page.replace_html 'ap_selects', :partial => 'ajax_paginate/selects', :locals => {:page_items => @groupings.size, :total_items => @groupings_total}
+page.replace_html 'ap_selects', partial: 'ajax_paginate/selects', locals: {page_items: @groupings.size, total_items: @groupings_total}

--- a/app/views/submissions/update_converted_pdfs.rjs
+++ b/app/views/submissions/update_converted_pdfs.rjs
@@ -2,21 +2,21 @@ submission_collector = SubmissionCollector.instance
 if submission_collector.safely_stop_child_exited
   if MarkusConfigurator.markus_config_pdf_support
     page['progress_text'].update(I18n.t('converting_pdfs',
-        :converted => @converted_count, :total => @pdf_count))
+        converted: @converted_count, total: @pdf_count))
     if @converted_count == @pdf_count
     submission_collector.safely_stop_child_exited = false
     submission_collector.save
       page.redirect_to edit_assignment_submission_result_path(
-      :assignment_id => @grouping.assignment_id,
-      :submission_id => @grouping.current_submission_used.id,
-      :id => @grouping.current_submission_used.get_latest_result.id)
+      assignment_id: @grouping.assignment_id,
+      submission_id: @grouping.current_submission_used.id,
+      id: @grouping.current_submission_used.get_latest_result.id)
     end
   else
     submission_collector.safely_stop_child_exited = false
     submission_collector.save
     page.redirect_to edit_assignment_submission_result_path(
-      :assignment_id => @grouping.assignment_id,
-      :submission_id => @grouping.current_submission_used.id,
-      :id => @grouping.current_submission_used.get_latest_result.id)
+      assignment_id: @grouping.assignment_id,
+      submission_id: @grouping.current_submission_used.id,
+      id: @grouping.current_submission_used.get_latest_result.id)
   end
 end


### PR DESCRIPTION
This is a global search-and-replace that replaces the Ruby 1.8 symbol
key hash rocket syntax to Ruby 1.9 syntax in RJS files.

Since this is a big change list, the style issues in the changed lines
are not being dealt with so that errors are minimized and code review
is easier. There is one exception though:

If the lines before the change have a good alignment of hash keys that
span multiple lines and the lines after the change do not (because the
change might alters the number of spaces needed for the alignment), then
the alignment is fixed, such that no new style issues are introduced. If
the alignment was not correct to begin with, then it is not fixed.

As a result, please ignore linter comments for this change.

This is for #1498.

Tested:
- rake test:units
- rake test:functionals
- rails s
