### PR TITLE
Replace remaining hash rockets in view

### DIFF
--- a/app/views/graders/manage/_ta.html.erb
+++ b/app/views/graders/manage/_ta.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <span id="<%= "asc_#{association.id}" %>">
-  <%= check_box_tag "#{association.criterion.id}_#{association.ta.user_name}", true, false, :class => 'inline_checkbox', :onclick => "$('criterion_select_' + #{association.criterion.id}).checked = true;"%>
-  <%=  label_tag "#{association.criterion.id}_#{association.ta.user_name}", association.ta.user_name, :class => 'inline_label' %>
+  <%= check_box_tag "#{association.criterion.id}_#{association.ta.user_name}", true, false, class: 'inline_checkbox', onclick: "$('criterion_select_' + #{association.criterion.id}).checked = true;"%>
+  <%=  label_tag "#{association.criterion.id}_#{association.ta.user_name}", association.ta.user_name, class: 'inline_label' %>
 </span>
 

--- a/app/views/graders/modal_dialogs/_download.html.erb
+++ b/app/views/graders/modal_dialogs/_download.html.erb
@@ -1,10 +1,10 @@
 <div id="download">
   <h2><%= I18n.t("groups.download.download_grader_maps") %></h2>
   <%= link_to t("groups.download.download_grader_groups_csv"),
-    {:controller=>"graders", :action=>"download_grader_groupings_mapping", :id=> @assignment.id}, :onclick => "modalDownload.close();" %>
+    {controller:"graders", action:"download_grader_groupings_mapping", id: @assignment.id}, onclick: "modalDownload.close();" %>
   <br> <br>
   <%= link_to t("groups.download.download_grader_criteria_csv"),
-    {:controller=>"graders", :action=>"download_grader_criteria_mapping", :id=> @assignment.id}, :onclick => "modalDownload.close();" %>
+    {controller:"graders", action:"download_grader_criteria_mapping", id: @assignment.id}, onclick: "modalDownload.close();" %>
   <br>
   <br>
   <button onclick="modalDownload.close(); return false;"><%= I18n.t('cancel') %>

--- a/app/views/graders/modal_dialogs/_download_dialog.rjs
+++ b/app/views/graders/modal_dialogs/_download_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'download_dialog', :partial => 'graders/modal_dialogs/download'
+page.replace_html 'download_dialog', partial: 'graders/modal_dialogs/download'
 page.call('modalDownload.open')

--- a/app/views/graders/modal_dialogs/_grader_criteria_dialog.rjs
+++ b/app/views/graders/modal_dialogs/_grader_criteria_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'grader_criteria_dialog', :partial => 'graders/modal_dialogs/grader_criteria'
+page.replace_html 'grader_criteria_dialog', partial: 'graders/modal_dialogs/grader_criteria'
 page.call('modal_criteria.open')

--- a/app/views/graders/modal_dialogs/_groups_coverage.html.erb
+++ b/app/views/graders/modal_dialogs/_groups_coverage.html.erb
@@ -4,8 +4,8 @@
 <% all =  @assignment.get_criteria %>
 <% all.each do |criterion| %>
   <% if assigned.include?(criterion) %>
-    <%=  image_tag("icons/tick.png", :alt => I18n.t('graders.covered'),
-      :title => I18n.t('graders.covered')) %>
+    <%=  image_tag("icons/tick.png", alt: I18n.t('graders.covered'),
+      title: I18n.t('graders.covered')) %>
     <b> <%= criterion.get_name %> </b>
     <br>
     <%= I18n.t('graders.assigned_graders') %>:
@@ -13,8 +13,8 @@
       <%= ta.user_name %>
     <% end %>
   <% else %>
-    <%=  image_tag("icons/cross.png", :alt => I18n.t('graders.not_covered'),
-      :title => I18n.t('graders.not_covered')) %>
+    <%=  image_tag("icons/cross.png", alt: I18n.t('graders.not_covered'),
+      title: I18n.t('graders.not_covered')) %>
     <b> <%= criterion.get_name %> </b>
     <% if criterion.tas.count > 0 %>
       <br>
@@ -22,8 +22,8 @@
       <% criterion.tas.each do |ta|%>
         <%= link_to ta.user_name,
                     add_grader_to_grouping_assignment_graders_path(
-                    :id => @assignment.id, :grouping_id => @grouping.id, :grader_id => ta.id),
-                    :remote => true %>
+                    id: @assignment.id, grouping_id: @grouping.id, grader_id: ta.id),
+                    remote: true %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/graders/modal_dialogs/_groups_coverage_dialog.rjs
+++ b/app/views/graders/modal_dialogs/_groups_coverage_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'groups_coverage_dialog', :partial => 'graders/modal_dialogs/groups_coverage'
+page.replace_html 'groups_coverage_dialog', partial: 'graders/modal_dialogs/groups_coverage'
 page.call('modal_coverage.open')

--- a/app/views/graders/modal_dialogs/_upload.html.erb
+++ b/app/views/graders/modal_dialogs/_upload.html.erb
@@ -1,9 +1,9 @@
 <h2><%= I18n.t("groups.upload.upload_grader_map") %></h2>
 <%= I18n.t("groups.upload.description_grader_map") %>
-<%= form_tag({:controller=>"graders",
-  :action => 'csv_upload_grader_groups_mapping',:id => @assignment.id},
-  {:multipart => true}) do -%>
-  <p><%= file_field_tag :grader_mapping, :size => 2 %> <br>
+<%= form_tag({controller:"graders",
+  action: 'csv_upload_grader_groups_mapping',id: @assignment.id},
+  {multipart: true}) do -%>
+  <p><%= file_field_tag :grader_mapping, size: 2 %> <br>
     <%= submit_tag t(:upload), :'data-disable-with' => t(:uploading_please_wait) %>
     <button onclick="modalUpload.close(); return false;"><%= I18n.t('cancel') %>
     </button>
@@ -13,10 +13,10 @@
 <% if @assignment.assign_graders_to_criteria %>
   <h2><%= I18n.t("groups.upload.upload_grader_criteria_map") %></h2>
   <%= I18n.t("groups.upload.description_grader_criteria_map") %>
-  <%= form_tag({:controller=>"graders",
-    :action => 'csv_upload_grader_criteria_mapping',:id => @assignment.id},
-    {:multipart => true}) do -%>
-    <p><%= file_field_tag :grader_criteria_mapping, :size => 2 %> <br>
+  <%= form_tag({controller:"graders",
+    action: 'csv_upload_grader_criteria_mapping',id: @assignment.id},
+    {multipart: true}) do -%>
+    <p><%= file_field_tag :grader_criteria_mapping, size: 2 %> <br>
       <%= submit_tag t(:upload), :'data-disable-with' => t(:uploading_please_wait) %>
       <button onclick="modalUpload.close(); return false;"><%= I18n.t('cancel') %>
       </button>

--- a/app/views/graders/modal_dialogs/_upload_dialog.rjs
+++ b/app/views/graders/modal_dialogs/_upload_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'upload_dialog', :partial => 'graders/modal_dialogs/upload'
+page.replace_html 'upload_dialog', partial: 'graders/modal_dialogs/upload'
 page.call('modalUpload.open')

--- a/app/views/graders/table_row/_filter_table_criterion_row.html.erb
+++ b/app/views/graders/table_row/_filter_table_criterion_row.html.erb
@@ -8,8 +8,8 @@
 
 <td>
 <% criterion.criterion_ta_associations.each do |association| %>
-   <%= render :partial => "graders/manage/ta",
-      :locals => {:association => association, :criterion => criterion} %>
+   <%= render partial: "graders/manage/ta",
+      locals: {association: association, criterion: criterion} %>
 <% end -%>
 </td>
 
@@ -17,11 +17,11 @@
   <span class="table_menu">
     <% assigned_length = criterion.assigned_groups_count %>
     <% if assigned_length == assignment.groupings.size %>
-      <%= image_tag("icons/tick.png", :alt => I18n.t('graders.covered'),
-        :title => I18n.t('graders.covered')) %>
+      <%= image_tag("icons/tick.png", alt: I18n.t('graders.covered'),
+        title: I18n.t('graders.covered')) %>
     <% else %>
-      <%= image_tag("icons/cross.png", :alt => I18n.t('graders.not_covered'),
-        :title => I18n.t('graders.not_covered')) %>
+      <%= image_tag("icons/cross.png", alt: I18n.t('graders.not_covered'),
+        title: I18n.t('graders.not_covered')) %>
     <% end %>
   </span>
   (<%= assigned_length %>/<%=  assignment.groupings.size %>)

--- a/app/views/graders/table_row/_filter_table_grader_row.erb
+++ b/app/views/graders/table_row/_filter_table_grader_row.erb
@@ -4,11 +4,11 @@
 <td>
   <% if @assignment.assign_graders_to_criteria %>
     <%= grader.get_criterion_associations_count_by_assignment(@assignment) %>
-    <%= link_to image_tag("icons/comment.png", :alt => I18n.t('criteria'),
-            :title => I18n.t('criteria')),
+    <%= link_to image_tag("icons/comment.png", alt: I18n.t('criteria'),
+            title: I18n.t('criteria')),
           grader_criteria_dialog_assignment_graders_path(
-          :id => @assignment.id, :grader => grader.id),
-          :remote => true %>
+          id: @assignment.id, grader: grader.id),
+          remote: true %>
   <% else %>
     <%= I18n.t('all') %>
   <% end %>

--- a/app/views/graders/table_row/_filter_table_row.html.erb
+++ b/app/views/graders/table_row/_filter_table_row.html.erb
@@ -10,9 +10,9 @@
 </td>
 
 <td>
-<%= render :partial => 'graders/manage/member',
-  :formats => [:html], :handlers => [:erb],
-  :locals => {:grouping => grouping } %>
+<%= render partial: 'graders/manage/member',
+  formats: [:html], handlers: [:erb],
+  locals: {grouping: grouping } %>
 </td>
 
 <td>
@@ -20,15 +20,15 @@
     <span class="table_menu">
       <% assigned_count = grouping.criteria_coverage_count %>
       <% if assigned_count == total_criteria_count %>
-        <%= link_to image_tag("icons/tick.png", :alt => I18n.t('graders.covered'),
-          :title => I18n.t('graders.covered')),
-          groups_coverage_dialog_assignment_graders_path(:id => @assignment.id, :grouping => grouping.id),
-          :remote => true %>
+        <%= link_to image_tag("icons/tick.png", alt: I18n.t('graders.covered'),
+          title: I18n.t('graders.covered')),
+          groups_coverage_dialog_assignment_graders_path(id: @assignment.id, grouping: grouping.id),
+          remote: true %>
       <% else %>
-        <%= link_to image_tag("icons/cross.png", :alt => I18n.t('graders.not_covered'),
-          :title => I18n.t('graders.not_covered')),
-          groups_coverage_dialog_assignment_graders_path(:id => @assignment.id, :grouping => grouping.id),
-          :remote => true %>
+        <%= link_to image_tag("icons/cross.png", alt: I18n.t('graders.not_covered'),
+          title: I18n.t('graders.not_covered')),
+          groups_coverage_dialog_assignment_graders_path(id: @assignment.id, grouping: grouping.id),
+          remote: true %>
       <% end %>
     </span>
       (<%= assigned_count %>/<%=  total_criteria_count %>)

--- a/app/views/groups/manage/_member.html.erb
+++ b/app/views/groups/manage/_member.html.erb
@@ -3,8 +3,8 @@
 %>
 
 <span id="<%= "mbr_#{member.id}" %>" class="<%= 'status_' + member.membership_status %>">
-  <%= check_box_tag "#{grouping.id}_#{member.user.user_name}", true, false, :class => 'inline_checkbox', :onclick => "$('grouping_select_' + #{grouping.id}).checked = true;"%>
-  <%=  label_tag "#{grouping.id}_#{member.user.user_name}", member.user.user_name, :class => 'inline_label' %>
+  <%= check_box_tag "#{grouping.id}_#{member.user.user_name}", true, false, class: 'inline_checkbox', onclick: "$('grouping_select_' + #{grouping.id}).checked = true;"%>
+  <%=  label_tag "#{grouping.id}_#{member.user.user_name}", member.user.user_name, class: 'inline_label' %>
   <% if member.membership_status == StudentMembership::STATUSES[:rejected] %>
     (<%= t(:rejected_invitation) %>)
   <% end %>

--- a/app/views/groups/modal_dialogs/_download.html.erb
+++ b/app/views/groups/modal_dialogs/_download.html.erb
@@ -1,7 +1,7 @@
 <div id="download">
   <h2><%= I18n.t("groups.download.download_groups_file") %></h2>
   <%= link_to t("groups.download.download_csv"),
-    {:controller=>"groups", :action=>"download_grouplist", :id=> @assignment.id}, :onclick => "modalDownload.close();" %>
+    {controller:"groups", action:"download_grouplist", id: @assignment.id}, onclick: "modalDownload.close();" %>
   <br>
   <br>
   <button onclick="modalDownload.close(); return false;"><%= I18n.t('cancel') %>

--- a/app/views/groups/modal_dialogs/_download_dialog.rjs
+++ b/app/views/groups/modal_dialogs/_download_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'download_dialog', :partial => 'groups/modal_dialogs/download'
+page.replace_html 'download_dialog', partial: 'groups/modal_dialogs/download'
 page.call('modalDownload.open')

--- a/app/views/groups/modal_dialogs/_rename_group.html.erb
+++ b/app/views/groups/modal_dialogs/_rename_group.html.erb
@@ -1,7 +1,7 @@
 <h2><%= I18n.t('groups.rename_group.title') %></h2>
 <%= form_tag(
      rename_group_assignment_group_path(@assignment.id, @grouping_id),
-     :remote => true ) do -%>
+     remote: true ) do -%>
   <fieldset>
   <%= label_tag "new_groupname", I18n.t('groups.rename_group.group_name') %>
   <input type="text" maxlength="30" id="new_groupname" name="new_groupname">

--- a/app/views/groups/modal_dialogs/_rename_group_dialog.rjs
+++ b/app/views/groups/modal_dialogs/_rename_group_dialog.rjs
@@ -1,4 +1,4 @@
-page.replace_html 'rename_group_dialog', :partial => 'groups/modal_dialogs/rename_group'
+page.replace_html 'rename_group_dialog', partial: 'groups/modal_dialogs/rename_group'
 
 page.call('modal_rename.open')
 page.call("$('new_groupname').focus")

--- a/app/views/groups/modal_dialogs/_upload.html.erb
+++ b/app/views/groups/modal_dialogs/_upload.html.erb
@@ -9,12 +9,12 @@
       </div>
     <% end %>
   </p>
-  <%= form_for :group, :html => {:multipart => true},
-                     :url => { :controller=>"groups",
-                               :action => 'csv_upload',
-                               :id => @assignment.id } do |f| -%>
+  <%= form_for :group, html: {multipart: true},
+               url: { controller:"groups",
+                      action: 'csv_upload',
+                      id: @assignment.id } do |f| -%>
   <p>
-    <%= f.file_field :grouplist, :size => 2 %> <br>
+    <%= f.file_field :grouplist, size: 2 %> <br>
     <%= submit_tag t(:upload), :'data-disable-with' => t(:uploading_please_wait) %>
     <button onclick="modalUpload.close(); return false;"><%= I18n.t('cancel') %></button>
   </p>

--- a/app/views/groups/modal_dialogs/_upload_dialog.rjs
+++ b/app/views/groups/modal_dialogs/_upload_dialog.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'upload_dialog', :partial => 'groups/modal_dialogs/upload'
+page.replace_html 'upload_dialog', partial: 'groups/modal_dialogs/upload'
 page.call('modalUpload.open')

--- a/app/views/groups/table_row/_filter_table_row.html.erb
+++ b/app/views/groups/table_row/_filter_table_row.html.erb
@@ -3,47 +3,47 @@
     <span class="table_menu">
       <% if grouping.is_valid?%>
         <%= link_to image_tag("icons/tick.png",
-			      :alt => I18n.t('groups.is_valid'),
-			      :title => I18n.t('groups.is_valid')),
-          invalid_grouping_assignment_groups_path(:grouping_id => grouping.id),
-                  :confirm =>  I18n.t('groups.invalidate_confirm'),
-		          :remote => true
+			      alt: I18n.t('groups.is_valid'),
+			      title: I18n.t('groups.is_valid')),
+          invalid_grouping_assignment_groups_path(grouping_id: grouping.id),
+                  confirm:  I18n.t('groups.invalidate_confirm'),
+		          remote: true
         %>
       <% else %>
         <%= link_to image_tag("icons/cross.png",
-			      :alt => I18n.t('groups.is_not_valid'),
-			      :title => I18n.t('groups.is_not_valid')),
-		          valid_grouping_assignment_groups_path(:grouping_id => grouping.id),
-	              :confirm =>  I18n.t('groups.validate_confirm'),
-		          :remote => true %>
+			      alt: I18n.t('groups.is_not_valid'),
+			      title: I18n.t('groups.is_not_valid')),
+		          valid_grouping_assignment_groups_path(grouping_id: grouping.id),
+	              confirm:  I18n.t('groups.validate_confirm'),
+		          remote: true %>
       <% end %>
       <%= link_to image_tag("icons/pencil.png",
-			    :alt => I18n.t('groups.rename_group.link'),
-			    :title => I18n.t('groups.rename_group.link')),
+			    alt: I18n.t('groups.rename_group.link'),
+			    title: I18n.t('groups.rename_group.link')),
 		        rename_group_dialog_assignment_group_path(assignment, grouping),
-		        :remote => true %>
+		        remote: true %>
       <%= link_to image_tag("icons/note.png",
-			    :alt => I18n.t('notes.title'),
-			    :title => I18n.t('notes.title')),
-		      notes_dialog_note_path(:id => assignment.id,
-			    :noteable_id => grouping.id,
-			    :noteable_type => 'Grouping',
-			    :action_to => 'note_message',
-			    :controller_to => 'groups' ),
-		        :remote => true %>
+			    alt: I18n.t('notes.title'),
+			    title: I18n.t('notes.title')),
+		      notes_dialog_note_path(id: assignment.id,
+			    noteable_id: grouping.id,
+			    noteable_type: 'Grouping',
+			    action_to: 'note_message',
+			    controller_to: 'groups' ),
+		        remote: true %>
       <%= link_to image_tag("icons/bin_closed.png",
-			    :alt => I18n.t('groups.delete')),
-		        remove_group_assignment_groups_path(:grouping_id => grouping.id),
-                :method => 'delete',
-	            :confirm =>  I18n.t('groups.delete_confirm'),
-		        :remote => true %>
+			    alt: I18n.t('groups.delete')),
+		        remove_group_assignment_groups_path(grouping_id: grouping.id),
+                method: 'delete',
+	            confirm:  I18n.t('groups.delete_confirm'),
+		        remote: true %>
     </span>
 </td>
 
 <td>
 <% grouping.student_memberships.each do |member| %>
-   <%= render :partial => 'groups/manage/member',
-              :formats => [:html], :handlers => [:erb],
-              :locals => {:member => member, :grouping => grouping } %>
+   <%= render partial: 'groups/manage/member',
+              formats: [:html], handlers: [:erb],
+              locals: {member: member, grouping: grouping } %>
 <% end -%>
 </td>

--- a/app/views/marks_graders/manage/_member.html.erb
+++ b/app/views/marks_graders/manage/_member.html.erb
@@ -2,9 +2,9 @@
 	<% ta_user = User.find(ta.id) %>
 	<span id="<%= "mbr_#{ta.id}" %>">
 	  <%= check_box_tag "#{student.id}_#{ta_user.user_name}", true, false,
-        :class => 'inline_checkbox', :onclick =>
+        class: 'inline_checkbox', onclick:
         "$('student_select_' + #{student.id}).checked = true;"%>
 	  <%= label_tag "#{student.id}_#{ta_user.user_name}", ta_user.user_name,
-        :class => 'inline_label' %>
+        class: 'inline_label' %>
 	</span>
 <% end %>

--- a/app/views/marks_graders/table_row/_filter_table_row.html.erb
+++ b/app/views/marks_graders/table_row/_filter_table_row.html.erb
@@ -12,8 +12,8 @@
 <td>
   <% if !grade_entry_form.grade_entry_students.nil? and
     !grade_entry_form.grade_entry_students.find_by_user_id(student.id).nil? %>
-    <%= render :partial => "marks_graders/manage/member",
-      :formats => [:html], :handlers => [:erb],
-      :locals => { :student => student, :grade_entry_form => grade_entry_form } %>
+    <%= render partial: "marks_graders/manage/member",
+      formats: [:html], handlers: [:erb],
+      locals: { student: student, grade_entry_form: grade_entry_form } %>
   <% end %>
 </td>

--- a/app/views/notes/modal_dialogs/_notes_dialog.html.erb
+++ b/app/views/notes/modal_dialogs/_notes_dialog.html.erb
@@ -23,16 +23,16 @@
 
         <div class="float_right">
             <%= form_tag(
-			        add_note_notes_path(:id => @return_id,
-			        :noteable_id => @noteable,
-			        :noteable_type => @cls,
-			        :user => @current_user,
-			        :action_to => @action,
-			        :controller_to => @cont,
-			        :highlight_field => @highlight_field,
-			        :number_of_notes_field => @number_of_notes_field ),
-			        :remote => true ) do %>
-            <%= text_area_tag(:new_notes, nil, :rows => 15, :cols=>32) %>
+			        add_note_notes_path(id: @return_id,
+			        noteable_id: @noteable,
+			        noteable_type: @cls,
+			        user: @current_user,
+			        action_to: @action,
+			        controller_to: @cont,
+			        highlight_field: @highlight_field,
+			        number_of_notes_field: @number_of_notes_field ),
+			        remote: true ) do %>
+            <%= text_area_tag(:new_notes, nil, rows: 15, cols:32) %>
             <p class="p_margin">
 
                 <div id="notes_error" class="error" style="display:none;">
@@ -42,7 +42,7 @@
                 </div>
 
                 <div class="float_right">
-	                <%= submit_tag I18n.t('notes.save'), :'data-disable-with' => I18n.t('working'), :id => "notes_submit" %>
+	                <%= submit_tag I18n.t('notes.save'), :'data-disable-with' => I18n.t('working'), id: "notes_submit" %>
 	                <button onclick="modalNotesGroup.close(); return false;">
 	                    <%= I18n.t(:cancel) %>
 	                </button>

--- a/app/views/notes/modal_dialogs/_notes_dialog_script.js.erb
+++ b/app/views/notes/modal_dialogs/_notes_dialog_script.js.erb
@@ -1,5 +1,5 @@
 jQuery('#notes_dialog').html('<%= escape_javascript(
-       render :partial => 'notes/modal_dialogs/notes_dialog').html_safe %>');
+       render partial: 'notes/modal_dialogs/notes_dialog').html_safe %>');
 
 modalNotesGroup.open();
 jQuery('#new_notes').select();

--- a/app/views/notes/modal_dialogs/notes_dialog_error.js.erb
+++ b/app/views/notes/modal_dialogs/notes_dialog_error.js.erb
@@ -1,4 +1,4 @@
 jQuery('#notes_error_list').html('<%= escape_javascript(
-     render :partial => 'notes/modal_dialogs/notes_dialog_error_list',
-            :locals => {:errors => @note.errors}).html_safe %>');
+     render partial: 'notes/modal_dialogs/notes_dialog_error_list',
+            locals: {errors: @note.errors}).html_safe %>');
 jQuery('#notes_error').show();

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -262,7 +262,7 @@ function load_submitted_file(submission_file_id, focus_line) {
   positions = null;
   annotation_manager = null;
   new Ajax.Request('<%=
-                  codeviewer_assignment_submission_result_path(:id => @assignment.id, :uid => @uid) %>',
+                  codeviewer_assignment_submission_result_path(id: @assignment.id, uid: @uid) %>',
                   { asynchronous:true,
                     evalScripts:true,
                     parameters:'submission_file_id=' + submission_file_id

--- a/app/views/results/common/_file_selector.html.erb
+++ b/app/views/results/common/_file_selector.html.erb
@@ -9,8 +9,8 @@
 <%= form_tag(download_assignment_submission_result_path(
                      @assignment.id, @grouping.current_submission_used.id,
                      @grouping.current_submission_used.get_latest_result.id),
-             :class => 'download_zip') do %>
-  <%= label_tag "select_file_id", I18n.t("common.submission_file"), :class => "inline_label" %>
+             class: 'download_zip') do %>
+  <%= label_tag "select_file_id", I18n.t("common.submission_file"), class: "inline_label" %>
   <input type="button" onclick="bump_select($('select_file_id'), -1,back_button,next_button); return false;" value="←" id="back_button" disabled>
   <select id="select_file_id" name="select_file_id" onchange="bump_select($('select_file_id'), 0,back_button,next_button); if ($(this).getValue() != '') { load_submitted_file($(this).getValue()); }">
     <% if files.empty? %>
@@ -28,15 +28,15 @@
   </span>
   <script type="text/javascript">bump_select($('select_file_id'), 0,back_button,next_button);</script>
   <%= submit_tag I18n.t(:download) if can_download && !files.empty? %>
-  <%= label_tag("include_annotations", I18n.t("marker.include_annotations"), :class => "inline_label") if can_download && !files.empty? %>
-  <%= check_box_tag("include_annotations", true, false, :id => "include_annotations", :class => "inline_checkbox") if can_download && !files.empty? %>
+  <%= label_tag("include_annotations", I18n.t("marker.include_annotations"), class: "inline_label") if can_download && !files.empty? %>
+  <%= check_box_tag("include_annotations", true, false, id: "include_annotations", class: "inline_checkbox") if can_download && !files.empty? %>
 <% end %>
 
 <%= form_tag(download_zip_assignment_submission_result_path(
-               :assignment_id => @assignment.id,
-               :submission_id => @submission.id,
-               :id => params[:id]),
-             :class => 'download_zip', :method => :get) do %>
-  <%= hidden_field_tag :include_annotations, true, :id => 'download_zip' %>
-  <%= submit_tag t('browse_submissions.download_all_files'), :onclick => 'with_annotations();' unless files.empty? %>
+               assignment_id: @assignment.id,
+               submission_id: @submission.id,
+               id: params[:id]),
+             class: 'download_zip', method: :get) do %>
+  <%= hidden_field_tag :include_annotations, true, id: 'download_zip' %>
+  <%= submit_tag t('browse_submissions.download_all_files'), onclick: 'with_annotations();' unless files.empty? %>
 <% end %>

--- a/app/views/results/common/_image_codeviewer.html.erb
+++ b/app/views/results/common/_image_codeviewer.html.erb
@@ -5,7 +5,7 @@
     <% @annots.each do |annot| %>
       <div id="annotation_holder_<%=annot.annotation_text.id%>" class="annotation_holder"></div>
     <%end%>
-    <img id="image_preview" src="<%=download_assignment_submission_results_path(:select_file_id => submission_file_id, :show_in_browser => true ) -%>" alt="<%=I18n.t("common.cant_display_image")%>"/>
+    <img id="image_preview" src="<%=download_assignment_submission_results_path(select_file_id: submission_file_id, show_in_browser: true ) -%>" alt="<%=I18n.t("common.cant_display_image")%>"/>
 
   <%# Keep track of all annotations associated with file.
   %>

--- a/app/views/results/common/_pdf_codeviewer.html.erb
+++ b/app/views/results/common/_pdf_codeviewer.html.erb
@@ -8,18 +8,18 @@
        <%# First image displayed with a different alt message, in case of boolean PDF_SUPPORT set to false %>
        <li>
          <%= image_tag( download_assignment_submission_results_path(
-            :select_file_id => submission_file_id,
-            :show_in_browser => true,
-            :file_index => 1),
-          :alt => I18n.t("common.cant_display_image"), :width => "950") %>
+            select_file_id: submission_file_id,
+            show_in_browser: true,
+            file_index: 1),
+          alt: I18n.t("common.cant_display_image"), width: "950") %>
        </li>
        <% (2..nb_files).each do|i| %>
          <li>
 	   <%= image_tag(download_assignment_submission_results_path(
-              :select_file_id => submission_file_id,
-              :show_in_browser => true,
-              :file_index => i),
-            :alt => I18n.t("common.image_downloading"), :width => "950") %>
+              select_file_id: submission_file_id,
+              show_in_browser: true,
+              file_index: i),
+            alt: I18n.t("common.image_downloading"), width: "950") %>
          </li>
        <% end %>
    </div>

--- a/app/views/results/common/_rubric_criterion.html.erb
+++ b/app/views/results/common/_rubric_criterion.html.erb
@@ -1,6 +1,6 @@
 <div id="<%="mark_criterion_title_#{mark_criterion.id}_name"%>"
 class="mark_criterion_title_div_level" class="float_left">
-  <strong><%=link_to_function mark_criterion.rubric_criterion_name, "return false", :class => "rubric_criterion_link" %></strong>
+  <strong><%=link_to_function mark_criterion.rubric_criterion_name, "return false", class: "rubric_criterion_link" %></strong>
 </div>
 <div class="clear"></div>
 

--- a/app/views/results/common/_submission_selector.html.erb
+++ b/app/views/results/common/_submission_selector.html.erb
@@ -5,25 +5,25 @@
 
 <span class="left">
   <% if !previous_grouping.nil?%>
-    <%= link_to I18n.t("marker.previous_submission"), :action => 'next_grouping', :id => previous_grouping.id %>
+    <%= link_to I18n.t("marker.previous_submission"), action: 'next_grouping', id: previous_grouping.id %>
   <% else %>
      <span class="disable"><%= I18n.t("marker.previous_submission") %></span>
   <% end %>
 </span>
   <span class="middle">
     <%= link_to raw(I18n.t("marker.notes",
-		:notes => @grouping.notes.size)),
-       notes_dialog_note_path(:id => @grouping.assignment_id,
-					:noteable_id => @grouping.id,
-					:noteable_type => 'Grouping',
-					:action_to => 'note_message',
-					:controller_to => 'results',
-					:highlight_field => 'notes_dialog_link',
-					:number_of_notes_field => 'number_of_notes'),
-     :id => 'notes_dialog_link',
-     :remote => true %>
+		notes: @grouping.notes.size)),
+       notes_dialog_note_path(id: @grouping.assignment_id,
+					noteable_id: @grouping.id,
+					noteable_type: 'Grouping',
+					action_to: 'note_message',
+					controller_to: 'results',
+					highlight_field: 'notes_dialog_link',
+					number_of_notes_field: 'number_of_notes'),
+     id: 'notes_dialog_link',
+     remote: true %>
   |
-    (<%=label_tag "marking_state", I18n.t("marker.marking_status"), :class => "inline_label" %>
+    (<%=label_tag "marking_state", I18n.t("marker.marking_status"), class: "inline_label" %>
      <% old_result_id = nil %>
      <% if @old_result %>
         <% old_result_id = @old_result.id %>
@@ -31,21 +31,21 @@
      <% else %>
         <% possible_states = [[I18n.t("unmarked"), Result::MARKING_STATES[:unmarked]], [I18n.t("partial"), Result::MARKING_STATES[:partial]], [I18n.t("complete"), Result::MARKING_STATES[:complete]]] %>
      <% end %>
-     <%=  select_tag "marking_state", options_for_select(possible_states,[result.marking_state]), :disabled => @result.released_to_students, 'data-action' => url_for(:action => 'update_marking_state', :id => @result.id) %>
+     <%=  select_tag "marking_state", options_for_select(possible_states,[result.marking_state]), disabled: @result.released_to_students, 'data-action' => url_for(action: 'update_marking_state', id: @result.id) %>
 
     <em><%= I18n.t("marker.marks.total_mark") %></em>
     <span id="current_mark_div"><%= result.total_mark %></span> /
     <span id="total_mark_div"><%= assignment.total_mark %></span>)
    <% if @current_user.admin? %>
-     | <%= label_tag "released", I18n.t("marker.marks.released"), :class => "inline_label" %>
-        <%= check_box_tag "released", true, result.released_to_students, :disabled => result.marking_state != Result::MARKING_STATES[:complete], :class => 'inline_checkbox', 'data-action' => url_for(:action => 'set_released_to_students', :id => @result.id) %>
+     | <%= label_tag "released", I18n.t("marker.marks.released"), class: "inline_label" %>
+        <%= check_box_tag "released", true, result.released_to_students, disabled: result.marking_state != Result::MARKING_STATES[:complete], class: 'inline_checkbox', 'data-action' => url_for(action: 'set_released_to_students', id: @result.id) %>
     <% end %>
   </span>
 
   <span class="right">
 
 <% if !next_grouping.nil? %>
-   <%= link_to I18n.t("marker.next_submission"), :action => 'next_grouping', :id => @next_grouping.id%>
+   <%= link_to I18n.t("marker.next_submission"), action: 'next_grouping', id: @next_grouping.id%>
 <% else %>
    <span class="disable"><%= I18n.t("marker.next_submission") %></span>
 <% end %>

--- a/app/views/results/common/_test_selector.html.erb
+++ b/app/views/results/common/_test_selector.html.erb
@@ -1,9 +1,9 @@
 <% # Make sure to include the public/javascripts/Grader/file_selector.js
    # file when using this partial
 %>
-  <%=label_tag "select_test_result_id", I18n.t("common.test_results"), :class => "inline_label" %>
-<%= link_to image_tag("icons/cog_go.png", :alt => I18n.t("common.test_code"), :title => I18n.t("common.test_code"), :id => "test_icon"),
-     assignment_automated_tests_path(:assignment_id => @assignment.id, :result => @result), :id => "test_select_link", :remote => true %>
+  <%=label_tag "select_test_result_id", I18n.t("common.test_results"), class: "inline_label" %>
+<%= link_to image_tag("icons/cog_go.png", alt: I18n.t("common.test_code"), title: I18n.t("common.test_code"), id: "test_icon"),
+     assignment_automated_tests_path(assignment_id: @assignment.id, result: @result), id: "test_select_link", remote: true %>
 
     <script type='text/javascript'>
     $("test_select_link").observe('ajax:after', function(evt, status, data, xhr) {
@@ -19,7 +19,7 @@
     <% if test_result_files.find_all_by_user_id(@current_user.id).empty? %>
       <option value=""><%= I18n.t("test_result.no_files_available")%></option>
     <% else %>
-      <% test_result_files.find_all_by_user_id(@current_user.id, :order => "created_at DESC").each do |file| %>
+      <% test_result_files.find_all_by_user_id(@current_user.id, order: "created_at DESC").each do |file| %>
         <option value="<%= file.id %>">
           <%= file.filename %>
         </option>
@@ -37,11 +37,11 @@
   <span id="tests_complete" style="display:none;">
     <% if test_result_files.find_last_by_user_id(@current_user.id) %>
       <% if test_result_files.find_last_by_user_id(@current_user.id).status == 'success' %>
-        <%= I18n.t("test_result.build_successful", {:logfile => test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
+        <%= I18n.t("test_result.build_successful", {logfile: test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
       <% elsif test_result_files.find_last_by_user_id(@current_user.id).status == 'failed' %>
-        <%= I18n.t("test_result.build_failed", {:logfile => test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
+        <%= I18n.t("test_result.build_failed", {logfile: test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
       <% else %>
-        <%= I18n.t("test_result.build_error", {:logfile => test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
+        <%= I18n.t("test_result.build_error", {logfile: test_result_files.find_last_by_user_id(@current_user.id).filename}) %>
       <% end %>
     <% end %>
   </span>

--- a/app/views/results/common/codeviewer.rjs
+++ b/app/views/results/common/codeviewer.rjs
@@ -9,17 +9,17 @@
           @file_encode = @file_contents.encode(Encoding::UTF_8,
                                                Encoding::UTF_8)
           page.replace_html 'codeviewer',
-            :partial => 'results/common/text_codeviewer',
-            :locals => { :uid => params[:uid],
-            :file_contents => @file_encode,
-            :annots => @annots, :code_type => @code_type}
+            partial: 'results/common/text_codeviewer',
+            locals: { uid: params[:uid],
+            file_contents: @file_encode,
+            annots: @annots, code_type: @code_type}
         rescue Exception => e
           page.alert e.message
           page.replace_html 'codeviewer',
-            :partial => 'results/common/text_codeviewer',
-            :locals => { :uid => params[:uid],
-            :file_contents => @file_contents,
-            :annots => @annots, :code_type => @code_type}
+            partial: 'results/common/text_codeviewer',
+            locals: { uid: params[:uid],
+            file_contents: @file_contents,
+            annots: @annots, code_type: @code_type}
         end
       else
         begin
@@ -28,46 +28,46 @@
           @file_contents = @file_contents.utf8_encode(Encoding::ISO_8859_1)
         end
         page.replace_html 'codeviewer',
-                          :partial => 'results/common/text_codeviewer',
-                          :locals => { :uid => params[:uid],
-                                       :file_contents => @file_contents,
-                                       :annots => @annots, :code_type => @code_type}
+                          partial: 'results/common/text_codeviewer',
+                          locals: { uid: params[:uid],
+                                    file_contents: @file_contents,
+                                    annots: @annots, code_type: @code_type}
       end
     # Supported image files
     elsif @file.is_supported_image?
       page.replace_html 'codeviewer',
-        :partial => 'results/common/image_codeviewer',
-        :locals => { :uid => params[:uid], :file_contents => @file_contents,
-        :annots => @annots, :code_type => @code_type,
-        :submission_file_id => @submission_file_id}
+        partial: 'results/common/image_codeviewer',
+        locals: { uid: params[:uid], file_contents: @file_contents,
+        annots: @annots, code_type: @code_type,
+        submission_file_id: @submission_file_id}
     # Pdf files
     elsif @file.is_pdf?
       page.replace_html 'codeviewer',
-        :partial => 'results/common/pdf_codeviewer',
-        :locals => { :uid => params[:uid], :file_contents => @file_contents,
-        :annots => @annots, :code_type => @code_type,
-        :nb_files => @nb_pdf_files_to_download,
-        :submission_file_id => @submission_file_id}
+        partial: 'results/common/pdf_codeviewer',
+        locals: { uid: params[:uid], file_contents: @file_contents,
+        annots: @annots, code_type: @code_type,
+        nb_files: @nb_pdf_files_to_download,
+        submission_file_id: @submission_file_id}
     else
       page.replace_html 'codeviewer',
-        :partial => 'results/common/text_codeviewer',
-        :locals => { :uid => params[:uid],
-        :file_contents => I18n.t("submission_file.error.binary_file_message"),
-        :annots => @annots, :code_type => @code_type}
+        partial: 'results/common/text_codeviewer',
+        locals: { uid: params[:uid],
+        file_contents: I18n.t("submission_file.error.binary_file_message"),
+        annots: @annots, code_type: @code_type}
     end
 
     # Also update the annotation_summary_list
     if @current_user.ta? || @current_user.admin?
       page.replace_html 'annotation_summary_list',
-        :partial => 'results/marker/annotation_summary',
-        :locals => {:annots => @all_annots,
-        :submission_file_id => @submission_file_id}
+        partial: 'results/marker/annotation_summary',
+        locals: {annots: @all_annots,
+        submission_file_id: @submission_file_id}
       page.call "hide_all_annotation_content_editors"
     else
       page.replace_html 'annotation_summary_list',
-        :partial => 'results/student/annotation_summary',
-        :locals => {:annots => @all_annots,
-        :submission_file_id => @submission_file_id}
+        partial: 'results/student/annotation_summary',
+        locals: {annots: @all_annots,
+        submission_file_id: @submission_file_id}
     end
 
 

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -1,33 +1,33 @@
 <% annots.each do |annot| %>
   <li class="<%= cycle('annotations1', 'annotations2') %>">
 
-    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
+    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render partial: annot.annotation_list_link_partial, locals: {annot: annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
     <div class="annotationContent" id="annotation_text_content_display_<%=(annot.annotation_text.id)%>">
       <%= simple_format(annot.annotation_text.content) %>
     </div>
 
     <%= button_to_function I18n.t("edit"),
-         "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",{:class => "float_left edit_remove_annotation_button"} %>
+         "$('annotation_text_content_edit_#{annot.annotation_text.id}').show();$('annotation_text_content_display_#{annot.annotation_text.id}').hide();",{class: "float_left edit_remove_annotation_button"} %>
 
     <%= button_to I18n.t("remove"),
-         annotations_path(:id => annot.id, :submission_file_id => @submission_file_id),
-         :method => :delete, :class => "edit_remove_annotation_button",
-         :confirm => I18n.t("marker.annotation.sure_to_remove"), :remote => true %>
+         annotations_path(id: annot.id, submission_file_id: @submission_file_id),
+         method: :delete, class: "edit_remove_annotation_button",
+         confirm: I18n.t("marker.annotation.sure_to_remove"), remote: true %>
 
     <div id="annotation_text_content_edit_<%= annot.annotation_text.id %>" class="annotation_text_content_editor">
 
       <%= form_for annot.annotation_text,
-		   :as => :annotation_text,
-		   :url => {:action => "update_annotation",
-			    :controller => "annotations"},
-		   :remote => true do |f| %>
+                   as: :annotation_text,
+                   url: {action: "update_annotation",
+                         controller: "annotations"},
+                   remote: true do |f| %>
 
         <%= f.hidden_field :id%>
         <input type="hidden" name="annotation_text[submission_file_id]" value="<%=(@submission_file_id)%>" />
-        <p class="manageAnnotations"><%= f.text_area :content, :cols => 60, :rows => 5 %></p>
+        <p class="manageAnnotations"><%= f.text_area :content, cols: 60, rows: 5 %></p>
 
         <p class="manageAnnotations">
-        <%= submit_tag I18n.t("marker.annotation.submit_edit") , :confirm => I18n.t("marker.annotation.change_across_submissions") %>
+        <%= submit_tag I18n.t("marker.annotation.submit_edit") , confirm: I18n.t("marker.annotation.change_across_submissions") %>
           <input type="reset" value="<%= I18n.t("cancel") %>" onclick="$('annotation_text_content_edit_<%=(annot.annotation_text.id)%>').hide();$('annotation_text_content_display_<%=(annot.annotation_text.id)%>').show();"></input>
         </p>
 

--- a/app/views/results/marker/_extra_mark.html.erb
+++ b/app/views/results/marker/_extra_mark.html.erb
@@ -11,8 +11,8 @@
   </td>
   <td>
     <%= button_to I18n.t("remove"),
-         remove_extra_mark_assignment_submission_result_path(:id => extra_mark.id),
-         :class => "table-button", :confirm => I18n.t("marker.marks.confirm_remove_mark"),
-         :remote => true %>
+         remove_extra_mark_assignment_submission_result_path(id: extra_mark.id),
+         class: "table-button", confirm: I18n.t("marker.marks.confirm_remove_mark"),
+         remote: true %>
   </td>
 </tr>

--- a/app/views/results/marker/_extra_marks_table.html.erb
+++ b/app/views/results/marker/_extra_marks_table.html.erb
@@ -6,7 +6,7 @@
   </thead>
   <tbody id="extra_marks_list" >
      <% extra_marks_points.each do |extra_mark| -%>
-       <%= render :partial => "results/marker/extra_mark", :locals => {:extra_mark => extra_mark, :result_id=>result_id} %>
+       <%= render partial: "results/marker/extra_mark", locals: {extra_mark: extra_mark, result_id:result_id} %>
      <% end -%>
    </tbody>
    <tbody>
@@ -15,7 +15,7 @@
           $('add_extra_mark_prompt').down('input').select();
           $('add_extra_mark_prompt').down('input').focus();
         } else {
-        #{remote_function :url => {:action => "add_extra_mark", :id => result_id}, :method => 'get'}
+        #{remote_function url: {action: "add_extra_mark", id: result_id}, method: 'get'}
         }|%>
         </td>
      </tr>

--- a/app/views/results/marker/_extra_percentage.html.erb
+++ b/app/views/results/marker/_extra_percentage.html.erb
@@ -11,8 +11,8 @@
   </td>
   <td>
     <%= button_to I18n.t("remove"),
-         remove_extra_mark_assignment_submission_result_path(:id => extra_percentage.id),
-         :class => "table-button", :confirm => I18n.t("marker.marks.confirm_remove_percentage"),
-         :remote => true %>
+         remove_extra_mark_assignment_submission_result_path(id: extra_percentage.id),
+         class: "table-button", confirm: I18n.t("marker.marks.confirm_remove_percentage"),
+         remote: true %>
   </td>
 </tr>

--- a/app/views/results/marker/_extra_percentage_table.html.erb
+++ b/app/views/results/marker/_extra_percentage_table.html.erb
@@ -6,7 +6,7 @@
   </thead>
   <tbody id="extra_percentage_list" >
      <% extra_marks_percentage.each do |extra_percentage| -%>
-       <%= render :partial => "results/marker/extra_percentage", :locals => {:extra_percentage => extra_percentage, :result_id=>result_id} %>
+       <%= render partial: "results/marker/extra_percentage", locals: {extra_percentage: extra_percentage, result_id:result_id} %>
      <% end -%>
    </tbody>
 </table>

--- a/app/views/results/marker/_marker_flexible_criterion_li.html.erb
+++ b/app/views/results/marker/_marker_flexible_criterion_li.html.erb
@@ -16,10 +16,10 @@
     </div>
     <div id="mark_flexible_<%=mark.id%>" class="float_right">
       <%= text_field_tag('mark_' + mark.id.to_s, mark.mark,
-          :size => 4,
-          :class => 'mark_grade_input',
-          'data-action' => url_for(:action => :update_mark,
-                            :mark_id => mark.id)) %>
+          size: 4,
+          class: 'mark_grade_input',
+          'data-action' => url_for(action: :update_mark,
+                            mark_id: mark.id)) %>
   	 /&nbsp; <span id="mark_flexible_max_<%=mark.id%>"><%= mark_criterion.max.to_s%> </span>
     </div>
     <div class="clear"></div>

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -10,8 +10,8 @@
     <div id="code_holder" class="tabbedArea">
       <div id="annotation_menu">
         <button id="new_annotation_button" onclick="make_new_annotation(); return false;"><%= I18n.t("marker.new_annot")%></button>
-        <%= render :partial => "annotations/annotation_categories",
-                   :locals => {:annotation_categories => annotation_categories}%>
+        <%= render partial: "annotations/annotation_categories",
+                   locals: {annotation_categories: annotation_categories}%>
          <div class="clear"></div>
       </div> <!-- End of annotation_menu -->
 
@@ -26,8 +26,8 @@
 
       <h3><%= I18n.t("marker.overall_comments") %></h3>
 
-        <%= render :partial => 'results/marker/overall_comment',
-                   :locals => {:result => old_result ? old_result : result } %>
+        <%= render partial: 'results/marker/overall_comment',
+                   locals: {result: old_result ? old_result : result } %>
 
       <h3><%= I18n.t("marker.current_annotations") %></h3>
       <p><%= I18n.t("marker.across_all_submission_files") %></p>
@@ -40,10 +40,10 @@
 
     <div id="remark_request_tab" class="tabbedArea">
       <% if @submission.has_remark? %>
-        <%= render :partial => 'results/marker/remark_request',
-                   :locals => {:result => result,
-                               :submission => submission,
-                               :assignment => assignment} %>
+        <%= render partial: 'results/marker/remark_request',
+                   locals: {result: result,
+                            submission: submission,
+                            assignment: assignment} %>
       <% end %>
     </div> <!-- Remark Request -->
   </div> <!-- Code Pane -->
@@ -63,31 +63,31 @@
         <% #FIXME:  Use :form-class for styling of button_to once available in current version of rails.
         %>
         <%= button_to(I18n.t("marker.marks.expand_all"),
-                       expand_criteria_assignment_submission_results_path(:assignment_id => @assignment.id),
-                      :method => :get,
-                      :class => "button_to_criteria_expansion",
-                      :remote => true) %>
+                       expand_criteria_assignment_submission_results_path(assignment_id: @assignment.id),
+                      method: :get,
+                      class: "button_to_criteria_expansion",
+                      remote: true) %>
         <%= button_to(I18n.t("marker.marks.collapse_all"),
-                      collapse_criteria_assignment_submission_results_path(:assignment_id => @assignment.id),
-                      :method => :get,
-                      :class => "button_to_criteria_expansion",
-                      :remote => true) %>
+                      collapse_criteria_assignment_submission_results_path(assignment_id: @assignment.id),
+                      method: :get,
+                      class: "button_to_criteria_expansion",
+                      remote: true) %>
         <%= button_to(I18n.t("marker.marks.expand_unmarked"),
-                      expand_unmarked_criteria_assignment_submission_results_path(:assignment_id => @assignment.id, :id => @result.id),
-                      :method => :get,
-                      :class => "button_to_criteria_expansion",
-                      :remote => true) %>
+                      expand_unmarked_criteria_assignment_submission_results_path(assignment_id: @assignment.id, id: @result.id),
+                      method: :get,
+                      class: "button_to_criteria_expansion",
+                      remote: true) %>
       </div>
       <div class="clear"></div> <!-- Criterion Tools -->
       <div id="mark_criteria">
           <ul id="mark_criteria_pane_list">
             <%# also need to render the mark per criteria (if exist) %>
             <% @mark_criteria.each do |mark_criterion| -%>
-            <%= render :partial => "results/marker/marker_#{@assignment.marking_scheme_type}_criterion_li",
-                       :locals => {:mark_criterion => mark_criterion,
-                                   :result => result,
-                                   :mark => marks_map[mark_criterion.id],
-                                   :old_mark => @old_marks_map[mark_criterion.id]} %>
+            <%= render partial: "results/marker/marker_#{@assignment.marking_scheme_type}_criterion_li",
+                       locals: {mark_criterion: mark_criterion,
+                                result: result,
+                                mark: marks_map[mark_criterion.id],
+                                old_mark: @old_marks_map[mark_criterion.id]} %>
             <% end -%>
           </ul> <!-- Criterion Pane List -->
        </div> <!-- Criterion Pane -->
@@ -95,19 +95,19 @@
     </div>  <!-- Criterion Viewer -->
 
   <div id="summary_viewer" class="marks_summary_pane tabbedArea">
-    <%= render :partial => "results/marker/marker_summary",
-               :locals => {:mark_criteria => mark_criteria,
-                           :marks_map => marks_map,
-                           :old_marks_map => @old_marks_map,
-                           :assignment => assignment,
-                           :old_result => @old_result,
-                           :result => result,
-                           :extra_marks_points => extra_marks_points,
-                           :extra_marks_percentage => extra_marks_percentage}%>
+    <%= render partial: "results/marker/marker_summary",
+               locals: {mark_criteria: mark_criteria,
+                        marks_map: marks_map,
+                        old_marks_map: @old_marks_map,
+                        assignment: assignment,
+                        old_result: @old_result,
+                        result: result,
+                        extra_marks_points: extra_marks_points,
+                        extra_marks_percentage: extra_marks_percentage}%>
   </div>
 
   <div id="submission_rule_viewer" class="tabbedArea">
-    <%= render :partial => assignment.submission_rule.grader_tab_partial, :locals => {:grouping => result.submission.grouping} %>
+    <%= render partial: assignment.submission_rule.grader_tab_partial, locals: {grouping: result.submission.grouping} %>
   </div>
 
   <!-- Annotation pane-->

--- a/app/views/results/marker/_marker_rubric_criterion_li.html.erb
+++ b/app/views/results/marker/_marker_rubric_criterion_li.html.erb
@@ -7,13 +7,13 @@
     <div id="<%="mark_criterion_title_#{mark_criterion.id}_expand"%>"
       class="float_left mark_criterion_expand expanded" >- &nbsp;
     </div>
-    <div id="mark_<%=mark.id%>_nil" class="mark_reset" onclick="new Ajax.Request('<%= update_mark_assignment_submission_results_path(:mark_id => mark.id, :mark => nil) %>',{asynchronous:true, evalScripts:true, parameters: 'authenticity_token=' + AUTH_TOKEN})">
-      <%=image_tag "icons/pencil_delete.png", :title => "reset mark"%>
+    <div id="mark_<%=mark.id%>_nil" class="mark_reset" onclick="new Ajax.Request('<%= update_mark_assignment_submission_results_path(mark_id: mark.id, mark: nil) %>',{asynchronous:true, evalScripts:true, parameters: 'authenticity_token=' + AUTH_TOKEN})">
+      <%=image_tag "icons/pencil_delete.png", title: "reset mark"%>
     </div>
-    <%= render :partial => 'results/common/rubric_criterion',
-               :locals => {:mark_criterion => mark_criterion,
-                         :mark => mark,
-                         :old_mark => old_mark} %>
+    <%= render partial: 'results/common/rubric_criterion',
+               locals: {mark_criterion: mark_criterion,
+                        mark: mark,
+                        old_mark: old_mark} %>
 
     <div id="<%="mark_criterion_inputs_#{mark_criterion.id}"%>" class="mark_criterion_level_container">
 
@@ -35,7 +35,7 @@
             if level_desc && !level_desc.empty? -%>
               <tr>
                  <td id="mark_<%=mark.id%>_<%=num_levels%>" class="<%=td_class%>"
-  			     onclick="new Ajax.Request('<%= update_mark_assignment_submission_results_path(:mark_id => mark.id, :mark => num_levels) %>',{asynchronous:true, evalScripts:true, parameters: 'authenticity_token=' + AUTH_TOKEN})">
+  			     onclick="new Ajax.Request('<%= update_mark_assignment_submission_results_path(mark_id: mark.id, mark: num_levels) %>',{asynchronous:true, evalScripts:true, parameters: 'authenticity_token=' + AUTH_TOKEN})">
                    <strong><%=num_levels%>: <%= level_name %></strong>
                    &nbsp;<%=level_desc%>
                  </td>

--- a/app/views/results/marker/_marker_summary.html.erb
+++ b/app/views/results/marker/_marker_summary.html.erb
@@ -6,8 +6,8 @@
 
 <div id="summary_criteria_pane">
 
-  <%= render :partial => "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
-             :locals => {:mark_criteria => mark_criteria, :marks_map => marks_map} %>
+  <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
+             locals: {mark_criteria: mark_criteria, marks_map: marks_map} %>
 
     <!-- Summary Criteria Pane -->
 
@@ -21,8 +21,8 @@
 
     <div id="extra_marks_pane" class="extra_marks_pane">
       <div class="bonus_deduction"><strong><%= I18n.t("marker.marks.bonus_deductions") %></strong></div>
-      <%= render :partial => 'results/marker/extra_marks_table',
-      :locals => {:extra_marks_points => extra_marks_points, :result_id => result.id} %>
+      <%= render partial: 'results/marker/extra_marks_table',
+      locals: {extra_marks_points: extra_marks_points, result_id: result.id} %>
     </div>
 
     <div class="clear"></div>
@@ -37,8 +37,8 @@
     <div class="clear"></div>
 
     <div id="extra_percentage_pane" class="extra_percentage_pane">
-        <%= render :partial => 'results/marker/extra_percentage_table',
-        :locals => {:extra_marks_percentage => extra_marks_percentage, :result_id => result.id} %>
+        <%= render partial: 'results/marker/extra_percentage_table',
+        locals: {extra_marks_percentage: extra_marks_percentage, result_id: result.id} %>
     </div>
 
     <div class="clear"></div>
@@ -54,8 +54,8 @@
 <% if old_result %>
   <div id="old_summary_criteria_pane">
 
-    <%= render :partial => "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
-    :locals => {:mark_criteria => mark_criteria, :marks_map => old_marks_map} %>
+    <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
+    locals: {mark_criteria: mark_criteria, marks_map: old_marks_map} %>
 
     <div class="summary_block">
       <span><strong><%= I18n.t("marker.marks.old_subtotal") %></strong></span>
@@ -67,8 +67,8 @@
 
     <div id="extra_marks_pane" class="extra_marks_pane">
       <div class="bonus_deduction"><strong><%= I18n.t("marker.marks.bonus_deductions") %></strong></div>
-      <%= render :partial => 'results/student/extra_marks_table',
-      :locals => {:extra_marks_points => old_result.extra_marks.points, :result_id => old_result.id} %>
+      <%= render partial: 'results/student/extra_marks_table',
+      locals: {extra_marks_points: old_result.extra_marks.points, result_id: old_result.id} %>
     </div>
 
     <div class="clear"></div>
@@ -85,8 +85,8 @@
     <div class="clear"></div>
 
     <div id="extra_percentage_pane" class="extra_percentage_pane">
-        <%= render :partial => 'results/student/extra_percentage_table',
-        :locals => {:extra_marks_percentage => old_result.extra_marks.percentage, :result_id => old_result.id} %>
+        <%= render partial: 'results/student/extra_percentage_table',
+        locals: {extra_marks_percentage: old_result.extra_marks.percentage, result_id: old_result.id} %>
     </div>
 
     <div class="clear"></div>

--- a/app/views/results/marker/_new_extra_mark.html.erb
+++ b/app/views/results/marker/_new_extra_mark.html.erb
@@ -1,13 +1,12 @@
 <tr id="add_extra_mark_prompt">
 <td colspan="3">
 <%= form_for :extra_mark,
-	     :url => {:action => 'add_extra_mark',
-		      :id => result.id},
-	      :remote => true do |f| %>
+             url: {action: 'add_extra_mark', id: result.id},
+             remote: true do |f| %>
   <%= f.label :description, I18n.t("marker.marks.comment") %>
   <%= f.text_field :description %><br>
   <%= f.label :extra_mark, I18n.t("marker.marks.mark") %>
-  <%= f.text_field :extra_mark, :size => 3 %> <br>
+  <%= f.text_field :extra_mark, size: 3 %> <br>
   <div class="error" style="display:none;" id="new_extra_mark_error">
   </div>
   <%= f.submit I18n.t("save") , :'data-disable-with' => I18n.t('working')%>

--- a/app/views/results/marker/_overall_comment.html.erb
+++ b/app/views/results/marker/_overall_comment.html.erb
@@ -1,18 +1,18 @@
 <div id="overall_comment">
       <div id="overall_comment_edit">
         <%= form_for result,
-          :remote => true,
-          :url => { :action => 'update_overall_comment', :id => result.id } do |f| %>
+          remote: true,
+          url: { action: 'update_overall_comment', id: result.id } do |f| %>
           <%= f.text_area :overall_comment,
-            :cols => 50,
-            :rows => 5,
-            :id => 'overall_comment_text_area',
-            :onkeydown => "$('overall_comment_submit').enable();" %>
+            cols: 50,
+            rows: 5,
+            id: 'overall_comment_text_area',
+            onkeydown: "$('overall_comment_submit').enable();" %>
        <div>
          <%= f.submit t(:save_changes),
            :'data-disable-with' => I18n.t('working'),
-           :disabled => true,
-           :id => "overall_comment_submit" %>
+           disabled: true,
+           id: "overall_comment_submit" %>
        </div>
       <% end %>
   </div>

--- a/app/views/results/marker/_overall_remark_comment.html.erb
+++ b/app/views/results/marker/_overall_remark_comment.html.erb
@@ -1,21 +1,21 @@
 <div id="overall_remark_comment_edit">
     <%= form_for result,
-          :url => { :controller => 'results',
-            :action => 'update_overall_remark_comment',
-            :id => result.id,
-            :submission_id => result.submission_id },
-          :html => { :method => :post },
-          :remote => true do |f| %>
+          url: { controller: 'results',
+            action: 'update_overall_remark_comment',
+            id: result.id,
+            submission_id: result.submission_id },
+          html: { method: :post },
+          remote: true do |f| %>
     <%= f.text_area :overall_comment,
-		    :cols => 50,
-		    :rows => 5,
-		    :id => 'overall_remark_comment_text_area',
-		    :onkeypress => "$('overall_remark_comment_submit').enable();" %>
+		    cols: 50,
+		    rows: 5,
+		    id: 'overall_remark_comment_text_area',
+		    onkeypress: "$('overall_remark_comment_submit').enable();" %>
     <div>
       <%= f.submit t(:save_changes),
       	   :'data-disable-with' => I18n.t('working'),
-		   :disabled => true,
-		   :id => "overall_remark_comment_submit" %>
+		   disabled: true,
+		   id: "overall_remark_comment_submit" %>
     </div>
   <% end -%>
 </div>

--- a/app/views/results/marker/_remark_request.html.erb
+++ b/app/views/results/marker/_remark_request.html.erb
@@ -5,14 +5,14 @@
 	<div id="remark_request_text">
     <%= I18n.t("marker.remark_submitted_on") %>:
     <% if submission.remark_request_timestamp %>
-      <%= I18n.l(submission.remark_request_timestamp, :format => :long_date) %>
+      <%= I18n.l(submission.remark_request_timestamp, format: :long_date) %>
     <% end %><br><br>
     <%= submission.remark_request %>
   </div>
   <div id="overall_remark_comment">
     <h3><%= I18n.t("marker.overall_comments") %></h3>
     <% if !result.released_to_students %>
-      <%= render :partial => 'results/marker/overall_remark_comment', :locals => {:result => result} %>
+      <%= render partial: 'results/marker/overall_remark_comment', locals: {result: result} %>
     <% else %>
       <div id="overall_remark_comment_show">
         <%= result.overall_comment %>

--- a/app/views/results/marker/add_extra_mark.rjs
+++ b/app/views/results/marker/add_extra_mark.rjs
@@ -1,1 +1,1 @@
-page.insert_html :bottom, 'extra_marks_list', :partial => 'results/marker/new_extra_mark', :locals => {:result => @result}
+page.insert_html :bottom, 'extra_marks_list', partial: 'results/marker/new_extra_mark', locals: {result: @result}

--- a/app/views/results/marker/add_extra_mark_error.rjs
+++ b/app/views/results/marker/add_extra_mark_error.rjs
@@ -1,2 +1,2 @@
-page.replace_html 'new_extra_mark_error', :partial => 'results/marker/extra_mark_errors_list', :locals => {:extra_mark => @extra_mark}
+page.replace_html 'new_extra_mark_error', partial: 'results/marker/extra_mark_errors_list', locals: {extra_mark: @extra_mark}
 page.show 'new_extra_mark_error'

--- a/app/views/results/marker/insert_extra_mark.rjs
+++ b/app/views/results/marker/insert_extra_mark.rjs
@@ -1,4 +1,4 @@
-page.replace 'add_extra_mark_prompt', :partial => 'results/marker/extra_mark', :locals => {:extra_mark => @extra_mark}
+page.replace 'add_extra_mark_prompt', partial: 'results/marker/extra_mark', locals: {extra_mark: @extra_mark}
 page.replace_html 'total_extra_points', @result.get_total_extra_points
 page.call "update_total_mark", @result.total_mark
 

--- a/app/views/results/student/_annotation_summary.html.erb
+++ b/app/views/results/student/_annotation_summary.html.erb
@@ -1,7 +1,7 @@
 <% annots.each do |annot| %>
   <li class="<%= cycle('annotations1', 'annotations2') %>">
 
-    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render :partial => annot.annotation_list_link_partial, :locals => {:annot => annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
+    <p class="lineNumber">#<%= annot.annotation_number %> - <%= render partial: annot.annotation_list_link_partial, locals: {annot: annot} %><%=I18n.t("marker.annotation.remark_flag") if (annot.is_remark) %></p>
     <p class="annotationContent" id="annotation_text_content_display_<%=(annot.annotation_text.id)%>">
     <%=simple_format(annot.annotation_text.content)%>
     </p>

--- a/app/views/results/student/_extra_marks_table.html.erb
+++ b/app/views/results/student/_extra_marks_table.html.erb
@@ -5,9 +5,9 @@
   </thead>
   <tbody id="extra_marks_list" >
     <% extra_marks_points.each do |extra_mark| -%>
-      <%= render :partial => "results/student/extra_mark",
-                 :locals => {:extra_mark => extra_mark,
-                             :result_id => result_id} %>
+      <%= render partial: "results/student/extra_mark",
+                 locals: {extra_mark: extra_mark,
+                          result_id: result_id} %>
     <% end -%>
   </tbody>
 </table>

--- a/app/views/results/student/_extra_percentage_table.html.erb
+++ b/app/views/results/student/_extra_percentage_table.html.erb
@@ -6,7 +6,7 @@
   </thead>
   <tbody id="extra_percentage_list" >
      <% extra_marks_percentage.each do |extra_percentage| -%>
-       <%= render :partial => "results/student/extra_percentage", :locals => {:extra_percentage => extra_percentage, :result_id=>result_id} %>
+       <%= render partial: "results/student/extra_percentage", locals: {extra_percentage: extra_percentage, result_id:result_id} %>
      <% end -%>
    </tbody>
 </table>

--- a/app/views/results/student/_remark_request.html.erb
+++ b/app/views/results/student/_remark_request.html.erb
@@ -18,11 +18,11 @@
     <% if student_can_edit_remark_request(submission) %>
       <%= I18n.t("marker.remark_due_date") %>:
       <% if assignment.remark_due_date %>
-        <%= I18n.l(assignment.remark_due_date, :format => :long_date) %>
+        <%= I18n.l(assignment.remark_due_date, format: :long_date) %>
       <% else %>
         <%= I18n.t("marker.no_remark_due_date") %>
       <% end %>
-      <%= render :partial => 'results/student/remark_request_form', :locals => {:submission => submission, :assignment => assignment} %>
+      <%= render partial: 'results/student/remark_request_form', locals: {submission: submission, assignment: assignment} %>
       <p class='information'><%= I18n.t("marker.about_remark_save") %>
             <%= I18n.t("marker.about_remark_submission") %>
             <%= I18n.t("marker.cancel_remark_to_change") %></p>

--- a/app/views/results/student/_remark_request_form.html.erb
+++ b/app/views/results/student/_remark_request_form.html.erb
@@ -1,24 +1,24 @@
 <%= javascript_include_tag "effects.js", "jquery-ui.min.js" %>
 <div id="remark_request_edit">
     <%= form_for submission,
-          :url => { :controller => 'results',
-            :action => 'update_remark_request',
-            :id => submission.id,
-            :assignment_id => assignment.id},
-          :html => { :method => :get },
-          :remote => true do |f| %>
-    <%= f.text_area :remark_request, :cols => 50, :rows => 5,
-                    :id => 'remark_request_text_area',
-                    :onkeydown => "enableRemarkRequestButtons();" %>
+          url: { controller: 'results',
+            action: 'update_remark_request',
+            id: submission.id,
+            assignment_id: assignment.id},
+          html: { method: :get },
+          remote: true do |f| %>
+    <%= f.text_area :remark_request, cols: 50, rows: 5,
+                    id: 'remark_request_text_area',
+                    onkeydown: "enableRemarkRequestButtons();" %>
     <div>
       <%= hidden_field_tag "real_commit", "Submit" %>
-      <%= f.submit t(:save_changes), :OnClick => "jQuery('#real_commit').val('Save');",
-                   :disabled => true, :id => "remark_request_save",
+      <%= f.submit t(:save_changes), OnClick: "jQuery('#real_commit').val('Save');",
+                   disabled: true, id: "remark_request_save",
                    :'data-disable-with' => I18n.t('working') %>
       <%= f.submit t(:submit_request),
       			   :'data-disable-with' => I18n.t('working'),
-                   :id => "remark_request_submit",
-                   :confirm => t(:confirm_remark_submit) %>
+                   id: "remark_request_submit",
+                   confirm: t(:confirm_remark_submit) %>
     </div>
   <% end -%>
 </div>

--- a/app/views/results/student/_student_flexible_criterion_li.html.erb
+++ b/app/views/results/student/_student_flexible_criterion_li.html.erb
@@ -1,4 +1,4 @@
 <li id="<%= "flexible_criterion_#{mark_criterion.id}" %>">
-  <%= render :partial => 'results/common/flexible_criterion',
-             :locals => {:mark_criterion => mark_criterion, :mark => mark} %>
+  <%= render partial: 'results/common/flexible_criterion',
+             locals: {mark_criterion: mark_criterion, mark: mark} %>
 </li>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -32,16 +32,16 @@
 
     <div id="remark_request_tab" class="tabbedArea">
       <% if @current_user.student? and assignment.allow_remarks%>
-        <%= render :partial => 'results/student/remark_request',
-                   :locals => {:old_result => old_result,
-                               :result => result,
-                               :submission => submission,
-                               :assignment => assignment} %>
+        <%= render partial: 'results/student/remark_request',
+                   locals: {old_result: old_result,
+                            result: result,
+                            submission: submission,
+                            assignment: assignment} %>
       <% elsif submission.has_remark? %>
-        <%= render :partial => 'results/marker/remark_request',
-                   :locals => {:result => result,
-                               :submission => submission,
-                               :assignment => assignment} %>
+        <%= render partial: 'results/marker/remark_request',
+                   locals: {result: result,
+                            submission: submission,
+                            assignment: assignment} %>
       <% end %>
     </div> <!-- Remark Request -->
   </div> <!-- Code Pane -->
@@ -61,11 +61,11 @@
         <ul id="mark_criteria_pane_list">
           <%# also need to render the mark per criteria (if exist) %>
           <% @mark_criteria.each do |mark_criterion| -%>
-          <%= render :partial => "results/student/student_#{@assignment.marking_scheme_type}_criterion_li",
-                     :locals => {:mark_criterion => mark_criterion,
-                                 :result => result,
-                                 :mark => marks_map[mark_criterion.id],
-                                 :old_mark => @old_marks_map[mark_criterion.id]} %>
+          <%= render partial: "results/student/student_#{@assignment.marking_scheme_type}_criterion_li",
+                     locals: {mark_criterion: mark_criterion,
+                              result: result,
+                              mark: marks_map[mark_criterion.id],
+                              old_mark: @old_marks_map[mark_criterion.id]} %>
             <% end -%>
           </ul> <!-- Criteria Pane List -->
        </div> <!-- Criteria Pane -->
@@ -73,15 +73,15 @@
     </div>  <!-- Criteria Viewer -->
 
     <div id="summary_viewer" class="marks_summary_pane tabbedArea">
-    <%= render :partial => "results/student/student_summary",
-               :locals => {:mark_criteria => @mark_criteria,
-                           :marks_map => marks_map,
-                           :old_marks_map => @old_marks_map,
-                           :assignment => assignment,
-                           :result => result,
-                           :old_result => @old_result,
-                           :extra_marks_points => extra_marks_points,
-                           :extra_marks_percentage => extra_marks_percentage}%>
+    <%= render partial: "results/student/student_summary",
+               locals: {mark_criteria: @mark_criteria,
+                        marks_map: marks_map,
+                        old_marks_map: @old_marks_map,
+                        assignment: assignment,
+                        result: result,
+                        old_result: @old_result,
+                        extra_marks_points: extra_marks_points,
+                        extra_marks_percentage: extra_marks_percentage}%>
     </div>
   <div id="annotation_holder">
   </div>

--- a/app/views/results/student/_student_rubric_criterion_li.html.erb
+++ b/app/views/results/student/_student_rubric_criterion_li.html.erb
@@ -1,6 +1,6 @@
 <li id="<%= "rubric_criterion_#{mark_criterion.id}" %>">
-  <%= render :partial => 'results/common/rubric_criterion',
-             :locals => {:mark_criterion => mark_criterion,
-                         :mark => mark,
-                         :old_mark => old_mark} %>
+  <%= render partial: 'results/common/rubric_criterion',
+             locals: {mark_criterion: mark_criterion,
+                      mark: mark,
+                      old_mark: old_mark} %>
 </li>

--- a/app/views/results/student/_student_summary.html.erb
+++ b/app/views/results/student/_student_summary.html.erb
@@ -4,8 +4,8 @@
   </p>
   <div id="old_summary_criteria_pane">
 
-    <%= render :partial => "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
-               :locals => {:mark_criteria => mark_criteria, :marks_map => old_marks_map} %>
+    <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
+               locals: {mark_criteria: mark_criteria, marks_map: old_marks_map} %>
 
       <div class="mark_subtotal">
         <div class="float_left"><%= I18n.t("marker.marks.old_subtotal") %></div>
@@ -18,8 +18,8 @@
       <div id="extra_marks_pane" class="extra_marks_pane">
         <div class="bonus_deduction"><strong><%= I18n.t("marker.marks.bonus_deductions") %></strong></div>
 
-        <%= render :partial => 'results/student/extra_marks_table',
-        :locals => {:extra_marks_points => old_result.extra_marks.points, :result_id => old_result.id} %>
+        <%= render partial: 'results/student/extra_marks_table',
+        locals: {extra_marks_points: old_result.extra_marks.points, result_id: old_result.id} %>
 
         <div>
           <div class="float_left"><strong><%= I18n.t("marker.marks.bonus_marks").html_safe %></strong></div>
@@ -35,8 +35,8 @@
       <div class="clear"></div>
 
       <div id="extra_percentage_pane" class="extra_percentage_pane">
-        <%= render :partial => 'results/student/extra_percentage_table',
-        :locals => {:extra_marks_percentage => old_result.extra_marks.percentage, :result_id => old_result.id} %>
+        <%= render partial: 'results/student/extra_percentage_table',
+        locals: {extra_marks_percentage: old_result.extra_marks.percentage, result_id: old_result.id} %>
       </div>
       <div class="clear"></div>
       <div class="summary_block">
@@ -49,8 +49,8 @@
     <% end %>
 
     <div id="summary_criteria_pane">
-      <%= render :partial => "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
-      :locals => {:mark_criteria => mark_criteria, :marks_map => marks_map} %>
+      <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
+      locals: {mark_criteria: mark_criteria, marks_map: marks_map} %>
 
       <!-- Summary Criteria Pane -->
 
@@ -65,8 +65,8 @@
       <div id="extra_marks_pane" class="extra_marks_pane">
         <div class="bonus_deduction"><strong><%= I18n.t("marker.marks.bonus_deductions") %></strong></div>
 
-        <%= render :partial => 'results/student/extra_marks_table',
-        :locals => {:extra_marks_points => extra_marks_points, :result_id => result.id} %>
+        <%= render partial: 'results/student/extra_marks_table',
+        locals: {extra_marks_points: extra_marks_points, result_id: result.id} %>
 
         <div>
           <div class="float_left"><strong><%= I18n.t("marker.marks.bonus_marks").html_safe %></strong></div>
@@ -82,8 +82,8 @@
       <div class="clear"></div>
 
       <div id="extra_percentage_pane" class="extra_percentage_pane">
-        <%= render :partial => 'results/student/extra_percentage_table',
-        :locals => {:extra_marks_percentage => extra_marks_percentage, :result_id => result.id} %>
+        <%= render partial: 'results/student/extra_percentage_table',
+        locals: {extra_marks_percentage: extra_marks_percentage, result_id: result.id} %>
       </div>
       <div class="clear"></div>
       <div class="summary_block">
@@ -97,8 +97,8 @@
     <div class="clear"></div>
 
   <div id="extra_percentage_pane" class="extra_percentage_pane">
-    <%= render :partial => 'results/student/extra_percentage_table',
-               :locals => {:extra_marks_percentage => extra_marks_percentage, :result_id => result.id} %>
+    <%= render partial: 'results/student/extra_percentage_table',
+               locals: {extra_marks_percentage: extra_marks_percentage, result_id: result.id} %>
   </div>
   <div class="clear"></div>
   <div class="summary_block">

--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -3,7 +3,7 @@
   <p>
     <em><%= I18n.t("marker.remark_submitted") %></em>
     <% if @submission.remark_request_timestamp %>
-      <%= I18n.l(@submission.remark_request_timestamp, :format => :long_date) %>
+      <%= I18n.l(@submission.remark_request_timestamp, format: :long_date) %>
     <% end %>
   </p>
   <div id="remark_request">
@@ -18,12 +18,12 @@
     <p class="notice"><%= I18n.t("marker.cancel_remark_to_change") %></p>
     <p>
       <%= link_to(I18n.t(:cancel_remark),
-            {:controller => 'results',
-             :action => 'cancel_remark_request',
-             :id => @assignment.id,
-             :submission_id => @submission.id},
-       :disabled => false,
-       :class => "button",
-       :onclick => "return confirm('#{I18n.t(:cancel_remark_request)}');") %>
+            {controller: 'results',
+             action: 'cancel_remark_request',
+             id: @assignment.id,
+             submission_id: @submission.id},
+       disabled: false,
+       class: "button",
+       onclick: "return confirm('#{I18n.t(:cancel_remark_request)}');") %>
    </p>
 </div>

--- a/app/views/submission_rules/grace_period/_grader_tab.html.erb
+++ b/app/views/submission_rules/grace_period/_grader_tab.html.erb
@@ -18,10 +18,10 @@
       <%= button_to(
             t('submission_rules.grace_period_submission_rule.remove_deduction'),
             delete_grace_period_deduction_assignment_submission_result_path(
-                :id => grouping.id, :deduction_id => u[1].first.id),
-            :confirm => t('submission_rules.grace_period_submission_rule.confirm_remove_deduction'),
-            :class => "button_to_delete_deduction",
-            :remote => true) %>
+                id: grouping.id, deduction_id: u[1].first.id),
+            confirm: t('submission_rules.grace_period_submission_rule.confirm_remove_deduction'),
+            class: "button_to_delete_deduction",
+            remote: true) %>
     </td>
   </tr>
 </table>

--- a/app/views/submissions/repo_browser/_directory_row.html.erb
+++ b/app/views/submissions/repo_browser/_directory_row.html.erb
@@ -1,9 +1,9 @@
 <td>
   <%=image_tag('icons/folder.png') %>
-  <%= link_to directory.name, :action => 'repo_browser', :id => @grouping.id, :revision_number => @revision_number, :path => File.join(@path, directory.name) %>
+  <%= link_to directory.name, action: 'repo_browser', id: @grouping.id, revision_number: @revision_number, path: File.join(@path, directory.name) %>
 </td>
 <td>
-  <%= I18n.l(directory.last_modified_date, :format => :long_date) %>
+  <%= I18n.l(directory.last_modified_date, format: :long_date) %>
 </td>
 <td>
   <%= directory.user_id %>

--- a/app/views/submissions/repo_browser/_exit_directory.html.erb
+++ b/app/views/submissions/repo_browser/_exit_directory.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td>
-    <%= link_to '../', :action => 'repo_browser', :id => @grouping.id, :path => @previous_path, :revision_number => @revision_number %>
+    <%= link_to '../', action: 'repo_browser', id: @grouping.id, path: @previous_path, revision_number: @revision_number %>
   </td>
   <td>
   </td>

--- a/app/views/submissions/repo_browser/_filter_table_row.html.erb
+++ b/app/views/submissions/repo_browser/_filter_table_row.html.erb
@@ -1,9 +1,9 @@
 <td>
   <%=image_tag('icons/page_white_text.png') %>
-  <%= link_to file.name, :action => 'download', :id => @assignment.id, :revision_number => @revision_number, :file_name => file.name, :path => @path, :grouping_id => @grouping.id %>
+  <%= link_to file.name, action: 'download', id: @assignment.id, revision_number: @revision_number, file_name: file.name, path: @path, grouping_id: @grouping.id %>
 </td>
 <td>
-  <%= I18n.l(file.last_modified_date, :format => :long_date) %>
+  <%= I18n.l(file.last_modified_date, format: :long_date) %>
 </td>
 <td>
   <%= file.user_id %>

--- a/app/views/submissions/submissions_table_row/_table_row.html.erb
+++ b/app/views/submissions/submissions_table_row/_table_row.html.erb
@@ -67,9 +67,9 @@
     -
     <% else %>
       <%= image_tag 'icons/error.png',
-                    :title => t(:past_due_date_edit_result_warning,
-                                :href => t(:last_commit)) if grouping.past_due_date? %>
-      <%= I18n.l(grouping.current_submission_used.revision_timestamp, :format => :long_date) %>
+                    title: t(:past_due_date_edit_result_warning,
+                             href: t(:last_commit)) if grouping.past_due_date? %>
+      <%= I18n.l(grouping.current_submission_used.revision_timestamp, format: :long_date) %>
     <% end %>
     </td>
   <% end %>
@@ -77,35 +77,35 @@
     <% if !grouping.has_submission? %>
 	<% if assignment.submission_rule.can_collect_now? %>
 	  <%= image_tag('icons/shape_square.png',
-            :alt => I18n.t('marking_state.not_collected'),
-            :title => I18n.t('marking_state.not_collected')) %>
+            alt: I18n.t('marking_state.not_collected'),
+            title: I18n.t('marking_state.not_collected')) %>
 	<% else %>
        	  -
 	<% end %>
     <% else %>
 	<% if !grouping.current_submission_used.has_result? %>
 	    <%= image_tag('icons/pencil.png',
-            :alt => I18n.t('marking_state.in_progress'),
-            :title => I18n.t('marking_state.in_progress')) %>
+            alt: I18n.t('marking_state.in_progress'),
+            title: I18n.t('marking_state.in_progress')) %>
 	<% else %>
       <% if remark_in_progress(grouping.current_submission_used) %>
           <%= image_tag('icons/double_exclamation.png',
-              :alt => I18n.t('marking_state.remark_requested'),
-              :title => I18n.t('marking_state.remark_requested')) %>
+              alt: I18n.t('marking_state.remark_requested'),
+              title: I18n.t('marking_state.remark_requested')) %>
       <% elsif grouping.current_submission_used.get_latest_result.marking_state == Result::MARKING_STATES[:complete] %>
           <% if !grouping.current_submission_used.get_latest_result.released_to_students %>
 		        <%= image_tag('icons/accept.png',
-                :alt => I18n.t('marking_state.completed'),
-                :title => I18n.t('marking_state.completed')) %>
+                alt: I18n.t('marking_state.completed'),
+                title: I18n.t('marking_state.completed')) %>
 		      <% else %>
 		        <%= image_tag('icons/email_go.png',
-                :alt => I18n.t('marking_state.released'),
-                :title => I18n.t('marking_state.released')) %>
+                alt: I18n.t('marking_state.released'),
+                title: I18n.t('marking_state.released')) %>
           <% end %>
       <% else %>
 		     <%= image_tag('icons/pencil.png',
-            :alt => I18n.t('marking_state.in_progress'),
-            :title => I18n.t('marking_state.in_progress')) %>
+            alt: I18n.t('marking_state.in_progress'),
+            title: I18n.t('marking_state.in_progress')) %>
 	    <% end %>
     <% end %>
     <% end %>

--- a/app/views/submissions/table_row/_directory_table_row.html.erb
+++ b/app/views/submissions/table_row/_directory_table_row.html.erb
@@ -1,10 +1,10 @@
 <td>
 <%=image_tag('icons/folder.png') %>
-<%= link_to directory_name, :action => 'file_manager', :id => @assignment.id, :path => File.join(@path, directory_name) %>
+<%= link_to directory_name, action: 'file_manager', id: @assignment.id, path: File.join(@path, directory_name) %>
 </td>
 
 <td>
-<%= I18n.l(directory.last_modified_date, :format => :long_date) %>
+<%= I18n.l(directory.last_modified_date, format: :long_date) %>
 </td>
 
 <td>

--- a/app/views/submissions/table_row/_exit_directory.html.erb
+++ b/app/views/submissions/table_row/_exit_directory.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td>
-    <%= link_to '../', :action => 'file_manager', :id => @assignment.id, :path => @previous_path %>
+    <%= link_to '../', action: 'file_manager', id: @assignment.id, path: @previous_path %>
   </td>
   <td>
   </td>

--- a/app/views/submissions/table_row/_filter_table_row.html.erb
+++ b/app/views/submissions/table_row/_filter_table_row.html.erb
@@ -1,12 +1,12 @@
 <td>
 <%=raw( image_tag('icons/page_white_text.png') )%>
-<%=raw( link_to file_name, :action => 'download', :id => @assignment.id,
- :revision_number => @revision.revision_number, :file_name => file_name,
-  :path => @path )%>
+<%=raw( link_to file_name, action: 'download', id: @assignment.id,
+ revision_number: @revision.revision_number, file_name: file_name,
+  path: @path )%>
 </td>
 
 <td>
-<%=I18n.l(file.last_modified_date, :format => :long_date) %>
+<%=I18n.l(file.last_modified_date, format: :long_date) %>
 </td>
 
 <td>

--- a/app/views/summaries/summaries_table_row/_table_row.html.erb
+++ b/app/views/summaries/summaries_table_row/_table_row.html.erb
@@ -63,9 +63,9 @@
     -
     <% else %>
       <%= image_tag 'icons/error.png',
-                    :title => t(:past_due_date_edit_result_warning,
-                                :href => t(:last_commit)) if grouping.past_due_date? %>
-      <%= I18n.l(grouping.current_submission_used.revision_timestamp, :format => :long_date) %>
+                    title: t(:past_due_date_edit_result_warning,
+                             href: t(:last_commit)) if grouping.past_due_date? %>
+      <%= I18n.l(grouping.current_submission_used.revision_timestamp, format: :long_date) %>
     <% end %>
     </td>
   <% end %>
@@ -73,35 +73,35 @@
     <% if !grouping.has_submission? %>
 	<% if assignment.submission_rule.can_collect_now? %>
 	  <%= image_tag('icons/shape_square.png',
-            :alt => I18n.t('marking_state.not_collected'),
-            :title => I18n.t('marking_state.not_collected')) %>
+            alt: I18n.t('marking_state.not_collected'),
+            title: I18n.t('marking_state.not_collected')) %>
 	<% else %>
        	  -
 	<% end %>
     <% else %>
 	<% if !grouping.current_submission_used.has_result? %>
 	    <%= image_tag('icons/pencil.png',
-            :alt => I18n.t('marking_state.in_progress'),
-            :title => I18n.t('marking_state.in_progress')) %>
+            alt: I18n.t('marking_state.in_progress'),
+            title: I18n.t('marking_state.in_progress')) %>
 	<% else %>
       <% if remark_in_progress(grouping.current_submission_used) %>
           <%= image_tag('icons/double_exclamation.png',
-              :alt => I18n.t('marking_state.remark_requested'),
-              :title => I18n.t('marking_state.remark_requested')) %>
+              alt: I18n.t('marking_state.remark_requested'),
+              title: I18n.t('marking_state.remark_requested')) %>
       <% elsif grouping.current_submission_used.get_latest_result.marking_state == Result::MARKING_STATES[:complete] %>
           <% if !grouping.current_submission_used.get_latest_result.released_to_students %>
 		        <%= image_tag('icons/accept.png',
-                :alt => I18n.t('marking_state.completed'),
-                :title => I18n.t('marking_state.completed')) %>
+                alt: I18n.t('marking_state.completed'),
+                title: I18n.t('marking_state.completed')) %>
 		      <% else %>
 		        <%= image_tag('icons/email_go.png',
-                :alt => I18n.t('marking_state.released'),
-                :title => I18n.t('marking_state.released')) %>
+                alt: I18n.t('marking_state.released'),
+                title: I18n.t('marking_state.released')) %>
           <% end %>
       <% else %>
 		     <%= image_tag('icons/pencil.png',
-            :alt => I18n.t('marking_state.in_progress'),
-            :title => I18n.t('marking_state.in_progress')) %>
+            alt: I18n.t('marking_state.in_progress'),
+            title: I18n.t('marking_state.in_progress')) %>
 	    <% end %>
     <% end %>
     <% end %>

--- a/app/views/users/table_row/_edit.html.erb
+++ b/app/views/users/table_row/_edit.html.erb
@@ -1,2 +1,2 @@
-<%= link_to I18n.t(:edit), :controller => controller, :action =>
-    'edit', :id => user.id %>
+<%= link_to I18n.t(:edit), controller: controller, action:
+    'edit', id: user.id %>

--- a/app/views/users/table_row/_filter_table_row.html.erb
+++ b/app/views/users/table_row/_filter_table_row.html.erb
@@ -26,16 +26,16 @@
         link_to(raw(I18n.t('notes.title') +
                     "(<span id=\"num_notes_#{user.id}\">#{user.notes.size}</span>)"),
                 notes_dialog_note_path(
-                    :id => user.id,
-                    :noteable_id => user.id,
-                    :noteable_type => 'Student',
-                    :action_to => 'note_message',
-                    :controller_to => 'students',
-                    :number_of_notes_field => "num_notes_#{user.id}",
-                    :highlight_field => "notes_highlight_#{user.id}"),
-                :id => "notes_highlight_#{user.id}",
-                :remote => true) + ' | '
+                    id: user.id,
+                    noteable_id: user.id,
+                    noteable_type: 'Student',
+                    action_to: 'note_message',
+                    controller_to: 'students',
+                    number_of_notes_field: "num_notes_#{user.id}",
+                    highlight_field: "notes_highlight_#{user.id}"),
+                id: "notes_highlight_#{user.id}",
+                remote: true) + ' | '
     end %>
-<%= link_to I18n.t(:edit), :controller => controller, :action =>
-    'edit', :id => user.id %>
+<%= link_to I18n.t(:edit), controller: controller, action:
+    'edit', id: user.id %>
 </td>


### PR DESCRIPTION
This is a global search-and-replace that replaces the Ruby 1.8 symbol
key hash rocket syntax to Ruby 1.9 syntax in remaining template files
matched by

```
    app/views/*/*/*.erb
```

Since this is a big change list, the style issues in the changed lines
are not being dealt with so that errors are minimized and code review
is easier. There is one exception though:

If the lines before the change have a good alignment of hash keys that
span multiple lines and the lines after the change do not (because the
change might alters the number of spaces needed for the alignment), then
the alignment is fixed, such that no new style issues are introduced. If
the alignment was not correct to begin with, then it is not fixed.

As a result, please ignore linter comments for this change.

This is for #1498.

Tested:
- rake test:units
- rake test:functionals
- rails s
