### PR TITLE
Fix for funky persist bug

### DIFF
--- a/app/assets/javascripts/create_assignment.js
+++ b/app/assets/javascripts/create_assignment.js
@@ -17,10 +17,10 @@ jQuery(document).ready(function() {
 
   jQuery('#persist_groups_assignment').change(function() {
     jQuery.ajax({
-      url: "<%= update_group_properties_on_persist_assignments_path() %>",
-      async: true,
+      url:  this.getAttribute('data-path'),
       type: 'POST',
-      data: "assignment_id=" + this.value
+      data: 'assignment_id=' + this.value +
+            '&authenticity_token=' + AUTH_TOKEN
     });
   });
 

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -206,6 +206,7 @@
                     class: 'checkbox_label' %>
       <select id='persist_groups_assignment'
               name='persist_groups_assignment'
+              data-path='<%= update_group_properties_on_persist_assignments_path %>'
               disabled>
         <% @assignments.each do |assignment| %>
           <option value='<%= assignment.id %>'>


### PR DESCRIPTION
The bug that we just recently discovered (making a new assignment without having chosen to persist groups, or even to have students work in groups, resulted in it persisting groups anyway) has been patched in this PR.

It's likely due to it seeing an item being chosen in the `select` dropdown for the persist groups option, despite it not being checked. This has been resolved by having the `select` tag `disabled` unless the option has been checked.

Also moved an AJAX call from the HTML file to the JS file.
