### PR TITLE
Hide unmarked criteria

### DIFF
--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -66,8 +66,15 @@
     });
 
     // Only show unmarked criteria
-    jQuery('#collapse_all').click();
-    jQuery('#expand_unmarked').click();
+    jQuery.ajax({
+      url: "<%= collapse_criteria_assignment_submission_results_path(assignment_id: @assignment.id) %>",
+      type: 'GET'
+    });
+
+    jQuery.ajax({
+      url: "<%= expand_unmarked_criteria_assignment_submission_results_path(assignment_id: @assignment.id, id: @result.id) %>",
+      type: 'GET'
+    });
   });
 
   function check_working() {

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -63,22 +63,19 @@
         <% #FIXME:  Use :form-class for styling of button_to once available in current version of rails.
         %>
         <%= button_to(I18n.t("marker.marks.expand_all"),
-                       expand_criteria_assignment_submission_results_path(assignment_id: @assignment.id),
+                      expand_criteria_assignment_submission_results_path(assignment_id: @assignment.id),
                       method: :get,
                       class: "button_to_criteria_expansion",
-                      id: 'expand_all',
                       remote: true) %>
         <%= button_to(I18n.t("marker.marks.collapse_all"),
                       collapse_criteria_assignment_submission_results_path(assignment_id: @assignment.id),
                       method: :get,
                       class: "button_to_criteria_expansion",
-                      id: 'collapse_all',
                       remote: true) %>
         <%= button_to(I18n.t("marker.marks.expand_unmarked"),
                       expand_unmarked_criteria_assignment_submission_results_path(assignment_id: @assignment.id, id: @result.id),
                       method: :get,
                       class: "button_to_criteria_expansion",
-                      id: 'expand_unmarked',
                       remote: true) %>
       </div>
       <div class="clear"></div> <!-- Criterion Tools -->


### PR DESCRIPTION
This deals with the request in issue https://github.com/MarkUsProject/Markus/issues/61 : only having the unmarked criteria expanded and the rest (marked criteria) collapsed in the marker's view.
