### PR TITLE
Fix for issue 1455: Students cannot access other students repos anymore.

### DIFF
--- a/app/views/assignments/student_interface.html.erb
+++ b/app/views/assignments/student_interface.html.erb
@@ -236,10 +236,17 @@
         <% if @grouping.inviter == @current_user &&
               @assignment.student_form_groups &&
               !@assignment.past_collection_date? %>
+          <% # Student not reached the group max and is not working alone %>
           <% if @grouping.student_membership_number < @assignment.group_max &&
-                # Student wants to work alone.
-                @group.group_name != @current_user.user_name %>
+                @group.group_name != @current_user.user_name
+          %>
             <%= button_to_function I18n.t(:invite), 'invite(); return false;' %>
+          <% # Student has reached the group max and is not working alone %>
+          <% elsif @grouping.student_membership_number ==
+                   @assignment.group_max &&
+                   @group.group_name != @current_user.user_name
+          %>
+            <%= button_to_function I18n.t(:invite), disabled: true %>
           <% end %>
         <% end %>
         <%


### PR DESCRIPTION
Students who previously paired up for an assignment were able to access their partners individual repos after the assignment was over. This was because the invite button was being displayed even when a student chose to work alone, thus inviting students to their individual repos. 
I added a check to see if the student has chosen to work alone (their group name is the same as their user name) and if they did the invite button is not displayed.
