### PR TITLE
Remove unused object from sections view

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -16,8 +16,6 @@ class SectionsController < ApplicationController
 
   # Creates a new section
   def create
-    @user = Student.new(params[:user])
-
     @section = Section.new(params[:section])
     if @section.save
       @sections = Section.all


### PR DESCRIPTION
As far as I can tell, this object allocation does nothing. The `@user` attribute is not used anywhere, and removing does not cause any tests to fail, nor does it cause stop me from creating new sections and assigning students into the section when I run a local server. I would guess it was just forgotten about in a previous refactoring.
