### PR TITLE
Issue 1488: Fixed, Show page number dropdown in Grades page in Spreadsheets now persistent

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -101,17 +101,10 @@ class GradeEntryFormsController < ApplicationController
     @grade_entry_form = GradeEntryForm.find(params[:id])
     @filter = 'none'
 
-    # Pagination options
-    #if params[:per_page].present?
-    #  @per_page = params[:per_page]
-    #else
-    #  @per_page = 150
-    #end
-
     @current_page = 1
 
     # The cookies are handled here
-    @c_per_page = current_user.id.to_s + '_' + @grade_entry_form.id.to_s + '_per_page'
+    @c_per_page = current_user.id.to_s + '_' + @grade_entry_form.id.to_s + '_per_page_sp'
     if params[:per_page].present?
       cookies[@c_per_page] = params[:per_page]
     elsif cookies[@c_per_page].present?
@@ -161,7 +154,7 @@ class GradeEntryFormsController < ApplicationController
         {grade_entry_form: @grade_entry_form},
         params)
     # During Ajax Request, it is important to set the :per_page cookie here as well
-    @ajx_per_page = current_user.id.to_s + '_' + @grade_entry_form.id.to_s + '_per_page'
+    @ajx_per_page = current_user.id.to_s + '_' + @grade_entry_form.id.to_s + '_per_page_sp'
     if params[:per_page].present?
       cookies[@ajx_per_page] = params[:per_page]
     elsif cookies[@c_per_page].present?


### PR DESCRIPTION
Sorry it took a while chasing this one.

The problem was that in the Grade page in Spreadsheet, the drop down menu for per page was not persistent. When you set it to, say, 30, go to different page and come back, it resets to its default value which was not cool. The root cause of this was there was no code at all that creates a cookie or adds a cookie in order to remember this value (Assignments Submissions page have it)

The fix then was to create the cookie. I got stuck for a long time because the params value for :per_page wasn't there in the beginning but I realized that I can just create it and everything would be fine after that.

So yes, after the changes, the cookie is now successfully being created and it now successfully remembers the value you choose in the drop down.

Testing: Went to Grades page, selected a value in drop down, went to different page, came back and confirmed that it remembered the value selected in the drop down.
