### PR TITLE
Mobile menu cleanup/enhancement

### DIFF
--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -14,11 +14,6 @@ function initMenu() {
       body_classes.remove('show_menu');
     } else {
       body_classes.add('show_menu');
-
-      // Prevent native touch scrolling
-      // jQuery('#content, footer').on('touchstart touchmove', function(e){
-      //   e.preventDefault();
-      // });
     }
   }, false);
 

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -64,6 +64,14 @@
           transform: $value;
 }
 
+@mixin transform-origin($value...) {
+  -webkit-transform-origin: $value;
+     -moz-transform-origin: $value;
+      -ms-transform-origin: $value;
+       -o-transform-origin: $value;
+          transform-origin: $value;
+}
+
 /* For easier size breakpoints. */
 $breakpoints: (
   'tiny':   ( max-width:  360px ),

--- a/app/assets/stylesheets/_navigation.scss
+++ b/app/assets/stylesheets/_navigation.scss
@@ -29,16 +29,32 @@
   }
 
   #menu_icon {
-    color: $blue;
     cursor: pointer;
     display: inline-block;
-    font-size: 2.5em;
-    height: 2.75rem;
-    line-height: 1.25em;
-    padding: 0 0.5em;
+    height: 2em;
+    width: 2em;
+    margin: 0.5em 0 0 0.5em;
+
+    &::before,
+    &::after {
+      @include transition(all, $time-quick);
+      content: "";
+      position: absolute;
+      left: 1em;
+      width: 1.5em;
+    }
 
     &::before {
-      content: "≡";
+      top: 1em;
+      height: 1.5em;
+      border-top: 0.2em solid $blue;
+    }
+
+    &::after {
+      top: 1.65em;
+      height: 0.8em;
+      border-top: 0.2em solid $blue;
+      border-bottom: 0.2em solid $blue;
     }
   }
 }
@@ -86,9 +102,19 @@
     opacity: 1;
   }
 
-  #mobile_menu #menu_icon::before {
-    content: "✕";
-    font-size: 0.8em;
+  #mobile_menu #menu_icon {
+    &::before {
+      @include transform(rotate(45deg));
+      @include transform-origin(top left);
+      width: 1.8em;
+    }
+
+    &::after {
+      @include transform(rotate(-45deg));
+      @include transform-origin(bottom left);
+      border-top: 0;
+      width: 1.8em;
+    }
   }
 
   #mobile_menu,

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,6 +1,6 @@
   <%= csrf_meta_tags %>
   <%= javascript_tag "const AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery?%>
-  <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+  <meta charset='UTF-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
   <meta http-equiv='X-UA-Compatible' content='IE=Edge'>
   <meta http-equiv='X-UA-Compatible' content='chrome=1'>


### PR DESCRIPTION
Removed unused touch-prevention code. Changed mobile menu icon to use borders/pseudo-elements so it doesn't rely on encoding (which didn't work anyway). It's also nice and animated now because of this.
