### PR TITLE
Change Hound style regarding string literal

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,8 @@
 # Multi-line method chaining should be done with leading dots.
 DotPosition:
   EnforcedStyle: leading
+
+# Prefer single-quoted strings when you don't need string interpolation or
+# special symbols.
+StringLiterals:
+    EnforcedStyle: single_quotes


### PR DESCRIPTION
Prefering single quoted-string literal is definitely the most popular
style. This is another difference between the defaults of Hound and
Rubocop configs.
