### PR TITLE
Disable AndOr cop for Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -5,4 +5,8 @@ DotPosition:
 # Prefer single-quoted strings when you don't need string interpolation or
 # special symbols.
 StringLiterals:
-    EnforcedStyle: single_quotes
+  EnforcedStyle: single_quotes
+
+# Disable the cop that enforces the use of &&/|| over and/or.
+AndOr:
+  Enabled: false


### PR DESCRIPTION
Hound has been complaining about people using `and` and `or` instead of `&&` and `||`, but it's a debatable style for Markus. This patch disables the cop that does this kind of check and allow people to use `and` and `or`.

When used within an `if` statement, there is no difference between the two styles. However, `and` and `or` have different precedences than `&&` and `||` in other expressions:

``` ruby
a = true and false # evaluates to `(a = true) and (false)`
a = true or false  # evaluates to `(a = true) or (false)`
a = true && false  # evaluates to `a = (true && false)`
a = true || false  # evaluates to `a = (true || false)`
```

The community-driven style guide recommends using `and` and `or` because not a lot of people know this caveat and such code often lead to surprises. They also argue that the `&&` and `||` operators are known to most programmers, and it will be consistent if they are used everywhere instead of a mix of the `&&/||` and `and/or`.

`and` and `or` can also be used for flow control:

``` ruby
error and return    # equivalent to `return if error`
try_lock or break   # equivalent to `break unless try_lock`
```

I propose 3 styles:
1. Don't use `and` and `or` anywhere in the code. They can always be rewritten to equally-readable code (debatable?)
2. Use `and` and `or` only within an `if`, `unless`, `while` or `until` statement.
3. Style 2, and additionally allow the use of `and` and `or` for flow control.
