### PR TITLE
Fix flaky CSV test

### DIFF
--- a/test/functional/marks_graders_controller_test.rb
+++ b/test/functional/marks_graders_controller_test.rb
@@ -111,7 +111,7 @@ class MarksGradersControllerTest < AuthenticatedControllerTest
       get_as @admin, :download_grader_students_mapping,
         :grade_entry_form_id => @grade_entry_form.id
       assert_response :success
-      assert_equal csv, @response.body
+      assert_equal CSV.parse(csv).to_set, CSV.parse(@response.body).to_set
     end
 
     should 'be able to assign a grader to a student on POST :global_actions' do


### PR DESCRIPTION
The test compares the raw CSV string directly, but the actual order of
the objects returned from the database is unspecified and sometimes gives
a test failure:

MarksGradersControllerTest#test_: An authenticated admin should download
a csv on GET :
download_grader_students_mapping.
[/home/su/code/Markus/test/functional/marks_graders_
controller_test.rb:114]:
<"machinist_student1,machinist_ta1,machinist_ta2\nmachinist_student2\nmachinist_student
3\nmachinist_student4\nmachinist_student5\n"> expected but was
<"machinist_student3\nmachinist_student1,machinist_ta1,machinist_ta2\nmachinist_student
2\nmachinist_student4\nmachinist_student5\n">.

This can be fixed by comparing the set of rows.

Tested:
- rake test:functionals
