### PR TITLE
Add Vagrantfile to project

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,13 @@
+# This Vagrantfile is for development use only.
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "markusproject/debian"
+  # Access the server running on port 3000 on the host on port 42069.
   config.vm.network "forwarded_port", guest: 3000, host: 42069
 
   config.vm.provider "virtualbox" do |vb|
-    # Don't boot with headless mode
+    # Uncomment the following line if you want a GUI.
     # vb.gui = true
     vb.name = "markus"
   end


### PR DESCRIPTION
originally I had just put a link to the Vagrantfile in the wiki, but it's recommended practice to place it along the project as well.
