### PR TITLE
Fix "(invalid)" markup in summary view

### DIFF
--- a/app/views/summaries/summaries_table_row/_table_row.html.erb
+++ b/app/views/summaries/summaries_table_row/_table_row.html.erb
@@ -31,7 +31,9 @@
                      grouping.current_submission_used.get_latest_result) %>
     <% end %>
       (<%= grouping.accepted_students.collect{ |student| student.user_name}.join(',') %>)
-    <%='<span class="invalid">' + t(:invalid_grouping) + '</span>' if !grouping.is_valid? %>
+    <% unless grouping.is_valid? %>
+      <span class="invalid"><%= t(:invalid_grouping) %></span>
+    <% end %>
     </td>
     <% if !@details.nil? %>
       <% assignment.rubric_criteria.each do |criterion| %>


### PR DESCRIPTION
The markup of "(invalid)" is rendered as plain text due to the fact that
they are produced in a ERB tag without the use of `String#html_safe` or
the `raw` method.
