### PR TITLE
Optimize head ordering

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,7 +1,7 @@
-  <%= csrf_meta_tags %>
-  <%= javascript_tag "const AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery?%>
   <meta charset='UTF-8'>
-  <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
   <meta http-equiv='X-UA-Compatible' content='IE=Edge'>
   <meta http-equiv='X-UA-Compatible' content='chrome=1'>
+  <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
+  <%= csrf_meta_tags %>
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet'>
+  <%= javascript_tag "const AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery?%>

--- a/app/views/main/remote_user_auth_login_fail.html.erb
+++ b/app/views/main/remote_user_auth_login_fail.html.erb
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <meta charset='UTF-8'>
+  <meta http-equiv='X-UA-Compatible' content='IE=Edge'>
+  <meta http-equiv='X-UA-Compatible' content='chrome=1'>
+  <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
   <title>MarkUs Login Failure</title>
 </head>
 <body>
-  <!-- This file lives in public/404.html -->
+  <%# This file lives in public/404.html %>
   <h1>MarkUs: Could not login</h1>
-  <p><%=@login_error%></p>
+  <p><%= @login_error %></p>
 </body>
 </html>

--- a/app/views/shared/http_status.html.erb
+++ b/app/views/shared/http_status.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= code + ' ' + HttpStatusHelper::ERROR_CODE[code] %></title>
     <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
     <meta http-equiv='X-UA-Compatible' content='IE=Edge'>
     <meta http-equiv='X-UA-Compatible' content='chrome=1'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet'>
     <%= stylesheet_link_tag 'main.css', media: 'all' %>
+    <title><%= code + ' ' + HttpStatusHelper::ERROR_CODE[code] %></title>
   </head>
   <body>
     <div id='error'>


### PR DESCRIPTION
Reordered `meta` tags in the `head` so that `charset` and `X-UA-Compatible` tags are defined first, preventing parser restarts and delayed page rendering in IE (and possibly other browsers).
