### PR TITLE
Migrate mass-assignment security to strong_parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'coffee-script'
 gem 'jquery-rails'
 gem 'prototype-rails' # FIXME: Will be needed with Rails3.1
 gem 'activerecord-import'
+gem 'strong_parameters' # NOTE: this goes away when upgrading to Rails 4
 
 group :assets do
   gem 'tilt', '~> 1.3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,11 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.9)
+    strong_parameters (0.2.3)
+      actionpack (~> 3.0)
+      activemodel (~> 3.0)
+      activesupport (~> 3.0)
+      railties (~> 3.0)
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
@@ -231,6 +236,7 @@ DEPENDENCIES
   shoulda
   simplecov
   sqlite3
+  strong_parameters
   therubyracer
   thin
   tilt (~> 1.3.7)

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -19,14 +19,13 @@ class AdminsController < ApplicationController
   end
 
   def new
-    @user = Admin.new(params[:user])
+    @user = Admin.new(user_params)
   end
 
   def update
     @user = Admin.find(params[:id])
-    attrs = params[:user]
     # update_attributes supplied by ActiveRecords
-    if @user.update_attributes(attrs).nil?
+    if @user.update_attributes(user_params).nil?
       flash[:error] = I18n.t('admins.update.error')
       render :edit
     else
@@ -41,7 +40,7 @@ class AdminsController < ApplicationController
     # Default attributes: role = TA or role = STUDENT
     # params[:user] is a hash of values passed to the controller
     # by the HTML form with the help of ActiveView::Helper::
-    @user = Admin.new(params[:user])
+    @user = Admin.new(user_params)
     # Return unless the save is successful; save inherted from
     # active records--creates a new record if the model is new, otherwise
     # updates the existing record
@@ -54,5 +53,11 @@ class AdminsController < ApplicationController
       flash[:error] = I18n.t('admins.create.error')
       render 'new'
     end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:user_name, :first_name, :last_name)
   end
 end

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -21,7 +21,7 @@ class AnnotationCategoriesController < ApplicationController
       # Attempt to add Annotation Category
       @annotation_categories = @assignment.annotation_categories
       @annotation_category = AnnotationCategory.new
-      @annotation_category.update_attributes(params[:annotation_category])
+      @annotation_category.update_attributes(annotation_category_params)
       @annotation_category.assignment = @assignment
       unless @annotation_category.save
         render :new_annotation_category_error
@@ -35,7 +35,7 @@ class AnnotationCategoriesController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     @annotation_category = AnnotationCategory.find(params[:id])
 
-    @annotation_category.update_attributes(params[:annotation_category])
+    @annotation_category.update_attributes(annotation_category_params)
     if @annotation_category.save
       flash.now[:success] = I18n.t('annotations.update.annotation_category_success')
     else
@@ -45,7 +45,7 @@ class AnnotationCategoriesController < ApplicationController
 
   def update_annotation
     @annotation_text = AnnotationText.find(params[:id])
-    @annotation_text.update_attributes(params[:annotation_text])
+    @annotation_text.update_attributes(annotation_text_params)
     @annotation_text.last_editor_id = current_user.id
     @annotation_text.save
   end
@@ -55,7 +55,7 @@ class AnnotationCategoriesController < ApplicationController
     if request.post?
       # Attempt to add Annotation Text
       @annotation_text = AnnotationText.new
-      @annotation_text.update_attributes(params[:annotation_text])
+      @annotation_text.update_attributes(annotation_text_params)
       @annotation_text.annotation_category = @annotation_category
       @annotation_text.creator_id = current_user.id
       @annotation_text.last_editor_id = current_user.id
@@ -186,5 +186,17 @@ class AnnotationCategoriesController < ApplicationController
      end
     end
     redirect_to action: 'index', assignment_id: @assignment.id
+  end
+
+  private
+
+  def annotation_category_params
+    # we do not want to allow :position to be given directly
+    params.require(:annotation_category)
+          .permit(:annotation_category_name, :assignment_id)
+  end
+
+  def annotation_text_params
+    params.require(:annotation_text).permit(:content)
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,3 +1,7 @@
+Dir.glob("app/models/*_submission_rule.rb").each do |rule|
+  require File.expand_path(rule)
+end
+
 class AssignmentsController < ApplicationController
   before_filter      :authorize_only_for_admin,
                      except: [:deletegroup,
@@ -226,11 +230,13 @@ class AssignmentsController < ApplicationController
     end
 
     begin
-      @assignment = process_assignment_form(@assignment, params)
-      rescue Exception, RuntimeError => e
-        @assignment.errors.add(:base, I18n.t('assignment.error',
-                                              message: e.message))
-        render :edit, id: @assignment.id
+      @assignment.transaction do
+        @assignment = process_assignment_form(@assignment)
+      end
+    rescue SubmissionRule::InvalidRuleType => e
+      @assignment.errors.add(:base, I18n.t('assignment.error',
+                                           message: e.message))
+      render :edit, id: @assignment.id
       return
     end
 
@@ -264,9 +270,10 @@ class AssignmentsController < ApplicationController
   def create
     @assignment = Assignment.new
     @assignment.build_assignment_stat
+    @assignment.build_submission_rule
     @assignment.transaction do
       begin
-        @assignment = process_assignment_form(@assignment, params)
+        @assignment = process_assignment_form(@assignment)
       rescue Exception, RuntimeError => e
         @assignment.errors.add(:base, e.message)
       end
@@ -599,8 +606,8 @@ class AssignmentsController < ApplicationController
       flash[:success] = t('assignment.create_success')
     end
 
-  def process_assignment_form(assignment, params)
-    assignment.attributes = params[:assignment]
+  def process_assignment_form(assignment)
+    assignment.update_attributes(assignment_params)
 
     # if there are no section due dates, destroy the objects that were created
     if params[:assignment][:section_due_dates_type] == '0'
@@ -610,34 +617,44 @@ class AssignmentsController < ApplicationController
     else
       assignment.section_due_dates_type = true
       assignment.section_groups_only = true
+      due_dates = params[:assignment][:section_due_dates_attributes]
+      if due_dates
+        due_dates.each_pair do |section, attributes|
+          assignment.section_due_dates[section.to_i] =
+            SectionDueDate.new(attributes)
+        end
+      end
     end
 
     # Some protective measures here to make sure we haven't been duped...
-    rule_name = params[:assignment][:submission_rule_attributes][:type]
-    potential_rule = Module.const_get(rule_name) rescue nil
+    rule_attributes = params[:assignment][:submission_rule_attributes]
+    rule_name       = rule_attributes[:type]
+    potential_rule  = if SubmissionRule.const_defined?(rule_name)
+                        SubmissionRule.const_get(rule_name)
+                      end
 
     unless potential_rule && potential_rule.ancestors.include?(SubmissionRule)
-      raise I18n.t('assignment.not_valid_submission_rule',
-        type: params[:assignment][:submission_rule_attributes][:type])
+      raise SubmissionRule::InvalidRuleType.new(rule_name)
     end
 
-    # Was the SubmissionRule changed?  If so, switch the type of the SubmissionRule.
-    # This little conditional has to do some hack-y workarounds, since
-    # accepts_nested_attributes_for is a little...dumb.
-    if assignment.submission_rule.attributes['type'] !=
-         params[:assignment][:submission_rule_attributes][:type]
+    # Was the SubmissionRule changed?  If so, switch the type of the
+    # SubmissionRule. This little conditional has to do some hack-y
+    # workarounds, since accepts_nested_attributes_for is a little...dumb.
+    if assignment.submission_rule.attributes['type'] != rule_attributes[:type]
 
       # delete all the previously created periods for the given submission_rule
       # note that we should not delete this if the current submission rule
       # cannot be saved ( not valid )
       # otherwise we would end up with no periods!
       if assignment.submission_rule.valid?
-        assignment.submission_rule.periods.where('id != ?',
-                                                 assignment.submission_rule.id).
-                                                 delete_all
+        assignment.submission_rule
+                  .periods.where('id != ?', assignment.submission_rule.id)
+                  .delete_all
       end
 
-      assignment.submission_rule.type = params[:assignment][:submission_rule_attributes][:type]
+      assignment.submission_rule.type = rule_attributes[:type]
+      assignment.submission_rule.update_attributes(submission_rule_params)
+
       # add the submission type for validate in the model
       assignment.submission_rule.periods.each do |period|
         period.submission_rule_type = assignment.submission_rule.type
@@ -646,7 +663,7 @@ class AssignmentsController < ApplicationController
 
     if params[:is_group_assignment] == 'true'
       # Is the instructor forming groups?
-      if params[:assignment][:student_form_groups] == '0'
+      if assignment_params[:student_form_groups] == '0'
         assignment.invalid_override = true
       else
         assignment.student_form_groups = true
@@ -659,6 +676,7 @@ class AssignmentsController < ApplicationController
       assignment.group_min = 1
       assignment.group_max = 1
     end
+
     assignment
   end
 
@@ -698,4 +716,42 @@ class AssignmentsController < ApplicationController
     end
   end
 
+  private
+
+  def assignment_params
+    params.require(:assignment).permit(
+        :short_identifier,
+        :description,
+        :message,
+        :repository_folder,
+        :due_date,
+        :allow_web_submits,
+        :display_grader_names_to_students,
+        :is_hidden,
+        :marking_scheme_type,
+        :group_min,
+        :group_max,
+        :student_form_groups,
+        :group_name_autogenerated,
+        :allow_remarks,
+        :remark_due_date,
+        :remark_message,
+        :section_groups_only,
+        :enable_test,
+        :assign_graders_to_criteria,
+        :tokens_per_day,
+        :group_name_displayed,
+        :invalid_override,
+        :section_groups_only,
+        assignment_files_attributes: [:id, :filename, :_destroy]
+    )
+  end
+
+  def submission_rule_params
+    params.require(:assignment)
+          .require(:submission_rule_attributes)
+          .permit(:id, periods_attributes: [:deduction,
+                                            :interval,
+                                            :hours])
+  end
 end

--- a/app/controllers/flexible_criteria_controller.rb
+++ b/app/controllers/flexible_criteria_controller.rb
@@ -19,7 +19,7 @@ class FlexibleCriteriaController < ApplicationController
 
   def update
     @criterion = FlexibleCriterion.find(params[:id])
-    unless @criterion.update_attributes(params[:flexible_criterion])
+    unless @criterion.update_attributes(flexible_criterion_params)
       render :errors
       return
     end
@@ -43,7 +43,7 @@ class FlexibleCriteriaController < ApplicationController
     @criterion.assignment = @assignment
     @criterion.max = FlexibleCriterion::DEFAULT_MAX
     @criterion.position = new_position
-    unless @criterion.update_attributes(params[:flexible_criterion])
+    unless @criterion.update_attributes(flexible_criterion_params)
       @errors = @criterion.errors
       render :add_criterion_error
       return
@@ -115,4 +115,12 @@ class FlexibleCriteriaController < ApplicationController
     # end
   end
 
+  private
+
+  def flexible_criterion_params
+    params.require(:flexible_criterion).permit(:flexible_criterion_name,
+                                               :description,
+                                               :position,
+                                               :max)
+  end
 end

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -62,7 +62,7 @@ class GradeEntryFormsController < ApplicationController
     # Process input properties
     @grade_entry_form.transaction do
       # Edit params before updating model
-      new_params = update_grade_entry_form_params params[:grade_entry_form]
+      new_params = update_grade_entry_form_params grade_entry_form_params
       if @grade_entry_form.update_attributes(new_params)
         # Success message
         flash[:success] = I18n.t('grade_entry_forms.create.success')
@@ -85,7 +85,7 @@ class GradeEntryFormsController < ApplicationController
     @grade_entry_form.transaction do
 
       # Edit params before updating model
-      new_params = update_grade_entry_form_params params[:grade_entry_form]
+      new_params = update_grade_entry_form_params grade_entry_form_params
       if @grade_entry_form.update_attributes(new_params)
         # Success message
         flash[:success] = I18n.t('grade_entry_forms.edit.success')
@@ -337,7 +337,16 @@ class GradeEntryFormsController < ApplicationController
         end
       end
     end
-  redirect_to action: 'grades', id: @grade_entry_form.id
+    redirect_to action: 'grades', id: @grade_entry_form.id
   end
 
+  private
+
+  def grade_entry_form_params
+    params.require(:grade_entry_form).permit(:description,
+                                             :message,
+                                             :date,
+                                             :show_total,
+                                             :short_identifier)
+  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -54,7 +54,7 @@ class NotesController < ApplicationController
   end
 
   def create
-    @note = Note.new(params[:note])
+    @note = Note.new(notes_params)
     @note.noteable_type = params[:noteable_type]
     @note.creator_id = @current_user.id
 
@@ -96,7 +96,7 @@ class NotesController < ApplicationController
   end
 
   def update
-    if @note.update_attributes(params[:note])
+    if @note.update_attributes(notes_params)
       flash[:success] = I18n.t('notes.update.success')
       redirect_to action: 'index'
     else
@@ -116,6 +116,7 @@ class NotesController < ApplicationController
   end
 
   private
+
     def retrieve_groupings(assignment)
       if assignment.nil?
         @groupings = Array.new
@@ -142,4 +143,7 @@ class NotesController < ApplicationController
       end
     end
 
+  def notes_params
+    params.require(:note).permit(:notes_message, :noteable_id)
+  end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -421,7 +421,7 @@ class ResultsController < ApplicationController
       @extra_mark = ExtraMark.new
       @extra_mark.result = @result
       @extra_mark.unit = ExtraMark::UNITS[:points]
-      if @extra_mark.update_attributes(params[:extra_mark])
+      if @extra_mark.update_attributes(extra_mark_params)
         # need to re-calculate total mark
         @result.update_total_mark
         render template: 'results/marker/insert_extra_mark'
@@ -534,5 +534,13 @@ class ResultsController < ApplicationController
 
   def update_remark_request_count
     Assignment.find(params[:assignment_id]).update_remark_request_count
+  end
+
+  private
+
+  def extra_mark_params
+    params.require(:extra_mark).permit(:result,
+                                       :description,
+                                       :extra_mark)
   end
 end

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -14,7 +14,7 @@ class RubricsController < ApplicationController
 
   def update
     @criterion = RubricCriterion.find(params[:id])
-    unless @criterion.update_attributes(params[:rubric_criterion])
+    unless @criterion.update_attributes(rubric_criterion_params)
       render :errors
       return
     end
@@ -40,7 +40,7 @@ class RubricsController < ApplicationController
     @criterion.weight = RubricCriterion::DEFAULT_WEIGHT
     @criterion.set_default_levels
     @criterion.position = new_position
-    unless @criterion.update_attributes(params[:rubric_criterion])
+    unless @criterion.update_attributes(rubric_criterion_params)
       @errors = @criterion.errors
       render 'add_criterion_error', formats: [:js]
       return
@@ -173,4 +173,22 @@ class RubricsController < ApplicationController
     end
   end
 
+  private
+
+  def rubric_criterion_params
+    params.require(:rubric_criterion).permit(:rubric_criterion_name,
+                                             :assignment,
+                                             :position,
+                                             :level_0_name,
+                                             :level_0_description,
+                                             :level_1_name,
+                                             :level_1_description,
+                                             :level_2_name,
+                                             :level_2_description,
+                                             :level_3_name,
+                                             :level_3_description,
+                                             :level_4_name,
+                                             :level_4_description,
+                                             :weight)
+  end
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -16,7 +16,7 @@ class SectionsController < ApplicationController
 
   # Creates a new section
   def create
-    @section = Section.new(params[:section])
+    @section = Section.new(section_params)
     if @section.save
       @sections = Section.all
       flash[:success] = I18n.t('section.create.success', name: @section.name)
@@ -43,7 +43,7 @@ class SectionsController < ApplicationController
 
   def update
     @section = Section.find(params[:id])
-    if @section.update_attributes(params[:section])
+    if @section.update_attributes(section_params)
       flash[:success] = I18n.t('section.update.success', name: @section.name)
       redirect_to action: 'index'
     else
@@ -67,5 +67,11 @@ class SectionsController < ApplicationController
       flash[:error] = I18n.t('section.delete.error_permissions')
     end
     redirect_to action: :index
+  end
+
+  private
+
+  def section_params
+    params.require(:section).permit(:name)
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -39,9 +39,8 @@ class StudentsController < ApplicationController
 
   def update
     @user = Student.find_by_id(params[:id])
-    attrs = params[:user]
     # update_attributes supplied by ActiveRecords
-    if @user.update_attributes(attrs)
+    if @user.update_attributes(user_params)
       flash[:success] = I18n.t('students.update.success',
                                user_name: @user.user_name)
       redirect_to action: 'index'
@@ -80,7 +79,7 @@ class StudentsController < ApplicationController
   end
 
   def new
-    @user = Student.new(params[:user])
+    @user = Student.new(user_params)
     @sections = Section.all(order: 'name')
   end
 
@@ -88,7 +87,7 @@ class StudentsController < ApplicationController
     # Default attributes: role = TA or role = STUDENT
     # params[:user] is a hash of values passed to the controller
     # by the HTML form with the help of ActiveView::Helper::
-    @user = Student.new(params[:user])
+    @user = Student.new(user_params)
     if @user.save
       flash[:success] = I18n.t('students.create.success',
                                user_name: @user.user_name)
@@ -151,4 +150,13 @@ class StudentsController < ApplicationController
     @grace_period_deductions = student.grace_period_deductions
   end
 
+  private
+
+  def user_params
+    params.require(:user).permit(:user_name,
+                                 :last_name,
+                                 :first_name,
+                                 :grace_credits,
+                                 :section_id)
+  end
 end

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -25,9 +25,8 @@ class TasController < ApplicationController
 
   def update
     @user = Ta.find_by_id(params[:user][:id])
-    attrs = params[:user]
     # update_attributes supplied by ActiveRecords
-    if @user.update_attributes(attrs)
+    if @user.update_attributes(user_params)
       flash[:success] = I18n.t('tas.update.success',
                                user_name: @user.user_name)
 
@@ -42,7 +41,7 @@ class TasController < ApplicationController
     # Default attributes: role = TA or role = STUDENT
     # params[:user] is a hash of values passed to the controller
     # by the HTML form with the help of ActiveView::Helper::
-    @user = Ta.new(params[:user])
+    @user = Ta.new(user_params)
     # Return unless the save is successful; save inherted from
     # active records--creates a new record if the model is new, otherwise
     # updates the existing record
@@ -89,5 +88,11 @@ class TasController < ApplicationController
       flash[:notice] = result[:upload_notice]
     end
     redirect_to action: 'index'
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:user_name, :last_name, :first_name)
   end
 end

--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -44,39 +44,36 @@ module GradeEntryFormsHelper
   # Removes items that have empty names (so they don't get updated)
   def update_grade_entry_form_params(attributes)
 
-    @grade_entry_items = attributes[:grade_entry_items_attributes]
+    grade_entry_items =
+      params[:grade_entry_form][:grade_entry_items_attributes]
 
-    if @grade_entry_items == nil
+    if grade_entry_items == nil
       return attributes
     end
 
     # Find the largest position that has been set
     max_position = 0
-    @grade_entry_items.each do |key, value|
-      unless value == nil
-        this_position = value[:position]
-        if this_position && this_position.to_i > max_position
-          max_position = this_position.to_i
-        end
-      end
+    grade_entry_items.each do |key, value|
+      next unless value
+      this_position = value[:position]
+      next unless this_position && this_position.to_i > max_position
+      max_position = this_position.to_i
     end
 
     # Update the attributes hash
     max_position += 1
-    @grade_entry_items.sort.each do |item|
+    grade_entry_items.sort.each do |item|
       # Items not added don't have a name
       # Some items are being deleted so don't update those
-      if item[1][:name] and item[1][:destroy] != 1
-        # If the set position is not valid, update it
-        unless @grade_entry_items[item[0]][:position].to_i > 0
-          @grade_entry_items[item[0]][:position] = max_position
-          max_position += 1
-        end
-      end
+      next if item[1][:name] && item[1][:destroy] == 1
+      # If the set position is not valid, update it
+      next if grade_entry_items[item[0]][:position].to_i > 0
+      grade_entry_items[item[0]][:position] = max_position
+      max_position += 1
     end
 
-    attributes[:grade_entry_items_attributes] = @grade_entry_items
-    return attributes
+    attributes[:grade_entry_items_attributes] = grade_entry_items
+    attributes
   end
 
   def sort_items_by_position(items)

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -1,10 +1,14 @@
 class SubmissionRule < ActiveRecord::Base
 
+  class InvalidRuleType < Exception
+    def initialize(rule_name)
+      super I18n.t('assignment.not_valid_submission_rule', rule_name)
+    end
+  end
+
   belongs_to :assignment
   has_many :periods, dependent: :destroy, order: 'id'
   accepts_nested_attributes_for :periods, allow_destroy: true
-
-  attr_accessible :type, :periods_attributes
 
 #  validates_associated :assignment
 #  validates_presence_of :assignment

--- a/app/models/test_file.rb
+++ b/app/models/test_file.rb
@@ -1,9 +1,6 @@
 class TestFile < ActiveRecord::Base
   belongs_to :assignment
 
-  # Restrict updates to filename, filetype and is_private columns
-  attr_accessible :filename, :filetype, :is_private
-
   # Run sanitize_filename before saving to the database
   before_save :sanitize_filename
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,9 @@ module Markus
   # Javascripts files always loaded in views
   config.action_view.javascript_expansions[:defaults] = %w(prototype rails application )
 
+  # NOTE: this should be removed when upgrading to Rails 4
+  config.active_record.whitelist_attributes = false
+
   # Set this if MarkUs is not hosted under / of your Web-host.
   # E.g. if MarkUs should be accessible by http://yourhost.com/markus/instance0
   # then set the below directive to "/markus/instance0".

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,6 @@ Markus::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   config.active_record.auto_explain_threshold_in_seconds = 1.0

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,9 +28,6 @@ Markus::Application.configure do
   # Show Deprecated Warnings (to :log or to :stderr)
   config.active_support.deprecation = :stderr
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   config.active_record.auto_explain_threshold_in_seconds = 1.0

--- a/test/functional/admins_controller_test.rb
+++ b/test/functional/admins_controller_test.rb
@@ -25,7 +25,7 @@ class AdminsControllerTest < AuthenticatedControllerTest
     end
 
     should 'be able to get :new' do
-      get_as @admin, :new
+      get_as @admin, :new, user_params
       assert_response :success
     end
 

--- a/test/functional/annotation_categories_controller_test.rb
+++ b/test/functional/annotation_categories_controller_test.rb
@@ -124,9 +124,15 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
       @category = AnnotationCategory.make
       @assignment = @category.assignment
       @annotation_text = AnnotationText.make(
-                :annotation_category => @category,
-                :creator_id => @admin.id,
-                :last_editor_id => @admin.id)
+                                             annotation_category: @category,
+                                             creator_id: @admin.id,
+                                             last_editor_id: (@admin.id + 1))
+      @annotation_text_params = {
+        id: @annotation_text.id,
+        annotation_category: @annotation_text.annotation_category,
+        creator_id: @annotation_text.creator_id,
+        last_editor_id: @annotation_text.last_editor_id
+      }
     end
 
     should 'on :index' do
@@ -166,9 +172,10 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
       should 'update properly' do
         get_as @admin,
                :update_annotation_category,
-               :assignment_id => @assignment.id,
-               :id => @category.id,
-               :format => :js
+               assignment_id: @assignment.id,
+               id: @category.id,
+               annotation_category: { annotation_category_name: 'Test' },
+               format: :js
         assert_response :success
         assert_not_nil assigns :annotation_category
         assert_equal I18n.t('annotations.update.annotation_category_success'),
@@ -179,10 +186,11 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
         AnnotationCategory.any_instance.stubs(:save).returns(false)
 
         get_as @admin,
-                :update_annotation_category,
-                :assignment_id => @assignment.id,
-                :id => @category.id,
-                :format => :js
+               :update_annotation_category,
+               assignment_id: @assignment.id,
+               id: @category.id,
+               annotation_category: { annotation_category_name: 'Test' },
+               format: :js
         assert_response :success
         assert_not_nil flash[:error]
         assert_nil flash[:success]
@@ -191,28 +199,27 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
     end
 
     should 'on :update_annotation' do
-      AnnotationText.any_instance.expects(:update_attributes).with(
-            @annotation_text)
-      AnnotationText.any_instance.expects(:save).once
+      refute_equal @admin.id,
+                   AnnotationText.find(@annotation_text.id).last_editor_id
       get_as @admin,
-              :update_annotation,
-              :assignment_id => 1,
-              :id => @annotation_text.id,
-              :annotation_text => @annotation_text,
-              :format => :js
+             :update_annotation,
+             assignment_id: 1,
+             id: @annotation_text.id,
+             annotation_text: @annotation_text_params,
+             format: :js
       assert_response :success
+      assert_equal @admin.id,
+                   AnnotationText.find(@annotation_text.id).last_editor_id
     end
 
     context 'As another admin' do
-        should 'update last_editor_id with editor.id' do
-            AnnotationText.any_instance.expects(:update_attributes).with(
-              @annotation_text)
-            get_as @editor,
-                :update_annotation,
-                :assignment_id => 1,
-                :id => @annotation_text.id,
-                :annotation_text => @annotation_text,
-                :format => :js
+      should 'update last_editor_id with editor.id' do
+        get_as @editor,
+               :update_annotation,
+               assignment_id: 1,
+               id: @annotation_text.id,
+               annotation_text: @annotation_text_params,
+               format: :js
         @annotation_text = AnnotationText.find(@annotation_text.id)
         assert_response :success
         assert_equal @editor.id, @annotation_text.last_editor_id
@@ -301,6 +308,7 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
         post_as @admin,
                 :add_annotation_category,
                 assignment_id: @assignment.id,
+                annotation_category: { annotation_category_name: 'Test' },
                 format: :js
         assert_response :success
         assert_not_nil assigns :assignment
@@ -326,9 +334,10 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
       should 'with errors on save' do
         AnnotationText.any_instance.stubs(:save).returns(false)
         post_as @admin, :add_annotation_text,
-                :assignment_id => 1,
-                :id => @category.id,
-                :format => :js
+                assignment_id: 1,
+                id: @category.id,
+                annotation_text: @annotation_text_params,
+                format: :js
         assert_response :success
         assert render_template 'new_annotation_text_error'
         assert_not_nil assigns :annotation_category

--- a/test/functional/assignments_controller_test.rb
+++ b/test/functional/assignments_controller_test.rb
@@ -57,7 +57,7 @@ class AssignmentsControllerTest < AuthenticatedControllerTest
         post_as @admin, :create, @attributes
         new_assignment = Assignment.find_by_short_identifier(@short_identifier)
         assert_not_nil new_assignment
-        assert redirect_to(:action => 'edit', :id => new_assignment)
+        assert redirect_to(action: 'edit', id: new_assignment)
       end
 
       should 'have an assignment stat object associated' do
@@ -71,7 +71,7 @@ class AssignmentsControllerTest < AuthenticatedControllerTest
       should "set the flash's success message" do
         post_as @admin, :create, @attributes
         new_assignment = Assignment.find_by_short_identifier(@short_identifier)
-        assert_equal flash[:success], 'Successfully created the assignment'
+        assert_equal 'Successfully created the assignment', flash[:success]
       end
 
       context 'with section due dates' do
@@ -249,7 +249,7 @@ class AssignmentsControllerTest < AuthenticatedControllerTest
         assert_equal @assignment.submission_rule.type.to_s,
                      a.submission_rule.type.to_s
         assert_not_nil assigns(:assignment)
-        assert !assigns(:assignment).errors.empty?
+        refute_empty assigns(:assignment).errors
       end
 
       should 'be able to add periods to submission rule class' do
@@ -317,15 +317,18 @@ class AssignmentsControllerTest < AuthenticatedControllerTest
         assert @assignment.submission_rule.is_a?(GracePeriodSubmissionRule)
 
         put_as @admin,
-                :update,
-                {:id => @assignment.id,
-                 :assignment => {
-                   :submission_rule_attributes => {
-                     :type => 'NoLateSubmissionRule',
-                     :periods_attributes => {
-                        '1' => { :id => period.id } },
-                     :id => @assignment.submission_rule.id,
-                     }}}
+               :update,
+               id: @assignment.id,
+               assignment: {
+                 submission_rule_attributes: {
+                   type: 'NoLateSubmissionRule',
+                   periods_attributes: {
+                     '1' => { id: period.id, hours: 1 }
+                   },
+                   id: @assignment.submission_rule.id,
+                 }
+               }
+
         assert_response :redirect
         # no errors should have been produced
         assert_equal [], assigns(:assignment).errors[:base]

--- a/test/functional/authenticated_controller_test.rb
+++ b/test/functional/authenticated_controller_test.rb
@@ -4,6 +4,13 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test_helper'))
 # overrides common request types with authentication
 class AuthenticatedControllerTest < ActionController::TestCase
 
+  def user_params(attrs = {})
+    args = { user_name:  'test',
+             first_name: 'Mark',
+             last_name:  'Us' }.merge(attrs)
+    ActionController::Parameters.new(user: args)
+  end
+
   # Performs GET request as the supplied user for authentication
   def get_as(user, action, params=nil, flash=nil)
     session_vars = { 'uid' => user.id, 'timeout' => 3.days.from_now }

--- a/test/functional/students_controller_test.rb
+++ b/test/functional/students_controller_test.rb
@@ -42,7 +42,7 @@ class StudentsControllerTest < AuthenticatedControllerTest
     end
 
     should 'be able to get :new' do
-      get_as @admin, :new
+      get_as @admin, :new, user_params
       assert_response :success
     end
 
@@ -128,10 +128,11 @@ class StudentsControllerTest < AuthenticatedControllerTest
       should 'be able to update student (and change his section)' do
         put_as @admin,
                :update,
-               :id => @student.id,
-               :user => {:last_name => 'Doe',
-                         :first_name => 'John',
-                         :section_id => @section.id }
+               id: @student.id,
+               user: {  user_name:  'machinist_student1',
+                        last_name:  'Doe',
+                        first_name: 'John',
+                        section_id: @section.id }
         assert_response :redirect
         assert_equal I18n.t('students.update.success',
                             :user_name => @student.user_name),


### PR DESCRIPTION
Ahead of the upgrade to Rails 4, this change removes the use of
attr_accessible and attr_protected as mass assignment protection
mechanisms in favour of whitelisting input attributes at the
controller level.

See http://blog.markusproject.org/?p=5588 for more details.

All tests are passing, and limited playing around with a local server seemed to work correctly. However, I am not confident that I have get the assignments controller completely working and there may be cases that the tests do not cover. So, I am opening this PR for review only at this time.
