### PR TITLE
Fix security warning from Rails 4 related to regepx anchors

### DIFF
--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -5,7 +5,7 @@ class AssignmentFile < ActiveRecord::Base
   validates_presence_of :filename
   validates_uniqueness_of :filename, scope: :assignment_id
   validates_format_of :filename,
-          with: /^[0-9a-zA-Z\.\-_]+$/,
+          with: /\A[0-9a-zA-Z\.\-_]+\z/,
           message: I18n.t('validation_messages.format_of_assignment_file')
 
 end


### PR DESCRIPTION
`^` and `$` allow for multiline strings to slip unsanitized lines through:

```
2.1.2 :001 > "hello\nthere".match(/^[a-z]+$/)
 => #<MatchData "hello"> 
```

We obviously don't want students to submit [Bobby Tables](http://xkcd.com/327/). `\A` and `\z` match the entire string and is the recommended way to sanitize the input in Rails 4.
