### PR TITLE
Moved sel_box back into code_holder.

### DIFF
--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -1,6 +1,3 @@
-<%# For image/PDF annotations %>
-<div id='sel_box'></div>
-
 <div id='panes-content'>
   <div id='panes'>
     <div id='left-pane'>
@@ -14,6 +11,9 @@
         </ul>
 
         <div id='code_holder' class='tabbedArea'>
+          <%# For image/PDF annotations %>
+          <div id='sel_box'></div>
+
           <div id='annotation_menu'>
             <button id='new_annotation_button' onclick='make_new_annotation(); return false;'>
               <%= I18n.t('marker.new_annot')%>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -11,6 +11,9 @@
         </ul>
 
         <div id='code_holder' class='tabbedArea'>
+          <%# For image/PDF annotations %>
+          <div id='sel_box'></div>
+
           <div class='clear'></div>
           <div id='codeviewer'></div> <!-- codeviewer -->
         </div> <!-- End of Code holder -->
@@ -87,6 +90,3 @@
     </div>
   </div>
 </div>
-
-<!-- For image/PDF annotations -->
-<div id='sel_box'></div>


### PR DESCRIPTION
Fixes issue https://github.com/MarkUsProject/Markus/issues/1564 (image annotation selection box doesn't go away when switching to different tab).
