### PR TITLE
Issue 1377 - Missing 'Jump To' drop down on initial load of Grades page

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -137,8 +137,7 @@ class GradeEntryFormsController < ApplicationController
         @grade_entry_form.id.to_s + '_order_sp'
     if !cookies[c_order].blank? && !params[:loc].present?
       @desc = cookies[c_order]
-    end
-    if @desc.blank?
+    elsif @desc.blank?
       cookies[c_order] = ''
     else
       cookies[c_order] = @desc

--- a/app/views/grade_entry_forms/_grades_table_filters.html.erb
+++ b/app/views/grade_entry_forms/_grades_table_filters.html.erb
@@ -1,6 +1,6 @@
 <% # Allow the user to jump to a page containing certain students
 %>
-<% if ['last_name', 'first_name', 'user_name', 'section'].include?(sort_by) #== 'last_name' %>
+<% if sort_by == 'last_name' %>
 <%= label_tag "alpha_category", t('pagination.jump_to'), class: "inline_label" %>
 <%= select_tag "alpha_category",
                 options_for_select(alpha_pagination_options, alpha_category),


### PR DESCRIPTION
The problem was that when the users goes to the Grades tab inside the spreadsheets section, the 'Jump To' drop down is not there. It only shows up when the pagination is modified (i.e. by clicking next on the table)

The cause was that the sort_by variable was not being populated when we first enter the page which the erb file looks at when it tries to render, thus, when we first load the page, there is no 'Jump To' drop down

Modified the code to properly populate the sort_by variable and made a cookie so that it remembers the value

Testing: navigated to the page and ensured that the 'Jump To' drop down shows up upon initial load and continues to show even when navigating through the table
