### PR TITLE
Fix for IE

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -115,13 +115,13 @@ function hide_criterion(id) {
   document.getElementById('mark_criterion_inputs_' + id).style.display = 'none';
   document.getElementById('mark_criterion_title_' + id).style.display = '';
   document.getElementById('mark_criterion_title_' + id + '_expand').innerHTML = '+ &nbsp;';
-  document.getElementById('mark_criterion_title_' + id + '_expand').classList.remove('expanded');
+  document.getElementById('mark_criterion_title_' + id + '_expand').removeClass('expanded');
 }
 
 function show_criterion(id) {
   document.getElementById('mark_criterion_title_' + id + '_expand').innerHTML = '- &nbsp;';
   document.getElementById('mark_criterion_inputs_' + id).style.display = '';
-  document.getElementById('mark_criterion_title_' + id + '_expand').classList.add('expanded');
+  document.getElementById('mark_criterion_title_' + id + '_expand').addClass('expanded');
 }
 
 function select_mark(mark_id, mark) {
@@ -132,7 +132,7 @@ function select_mark(mark_id, mark) {
   }
 
   if (mark !== null) {
-    document.getElementById('mark_' + mark_id + '_' + mark).classList.add('rubric_criterion_level_selected');
+    document.getElementById('mark_' + mark_id + '_' + mark).addClass('rubric_criterion_level_selected');
   }
 }
 

--- a/app/assets/javascripts/SourceCodeGlower/ImageAnnotationGrid.js
+++ b/app/assets/javascripts/SourceCodeGlower/ImageAnnotationGrid.js
@@ -106,7 +106,7 @@ ImageAnnotationGrid.prototype.add_to_grid = function(extracted_coords) {
 
   var new_holder = document.createElement('div');
   new_holder.id = 'annotation_holder_' + extracted_coords.id;
-  new_holder.classList.add('annotation_holder');
+  new_holder.addClass('annotation_holder');
   new_holder.onmousemove = this.getImageEventHandler().check_for_annotations.bind(this.getImageEventHandler());
   new_holder.onmousedown = this.getImageEventHandler().start_select_box.bind(this.getImageEventHandler());
 

--- a/app/assets/javascripts/SourceCodeGlower/SourceCodeLine.js
+++ b/app/assets/javascripts/SourceCodeGlower/SourceCodeLine.js
@@ -28,14 +28,14 @@ SourceCodeLine.prototype.glow = function() {
   this.incGlowDepth(1);
 
   // Add the appropriate glow class
-  this.getLineNode().classList.add('source_code_glowing_' + this.getGlowDepth());
+  this.getLineNode().addClass('source_code_glowing_' + this.getGlowDepth());
 }
 
 // Decrease a Source Code Line's glow depth
 SourceCodeLine.prototype.unGlow = function() {
   // Is this line glowing?
   if (this.isGlowing()) {
-    this.getLineNode().classList.remove('source_code_glowing_' + this.getGlowDepth());
+    this.getLineNode().removeClass('source_code_glowing_' + this.getGlowDepth());
   }
 
   // Decrease the glow depth

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,9 @@
 //= require jquery_ujs
 //= require jquery.easyModal
 
+
+/** Modal windows, powered by jQuery.easyModal. */
+
 function ModalMarkus(elem) {
   this.modal_dialog = jQuery(elem).easyModal();
 }
@@ -20,4 +23,22 @@ ModalMarkus.prototype.open = function() {
 
 ModalMarkus.prototype.close = function() {
   this.modal_dialog.trigger('closeModal');
+}
+
+
+/** Helper functions for adding/removing classes to DOM elements
+    via pure JavaScript. */
+
+Element.prototype.addClass = function(className) {
+  if (this.classList)
+    this.classList.add(className);
+  else
+    this.className += ' ' + className;
+}
+
+Element.prototype.removeClass = function(className) {
+  if (this.classList)
+    this.classList.remove(className);
+  else
+    this.className = this.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
 }

--- a/app/views/results/marker/_boot.js.erb
+++ b/app/views/results/marker/_boot.js.erb
@@ -13,7 +13,7 @@
   window.onload = function() {
     <% @mark_criteria.each do |criterion| %>
       <% if criterion.has_associated_ta?(@current_user) %>
-        document.getElementById('#mark_criterion_' + <%= criterion.id %>).classList.add('assigned');
+        document.getElementById('#mark_criterion_' + <%= criterion.id %>).addClass('assigned');
       <% elsif @current_user.type == "Ta" %>
         hide_criterion(<%= criterion.id %>);
       <% end %>


### PR DESCRIPTION
Turns out older versions of IE (9 and lower) don't support the `classList` object in JavaScript, so I made some helper functions to do the adding/removing classes stuff. 

(These `addClass` and `removeClass` functions are for DOM elements! They're not to be confused with jQuery's functions, which are only for jQuery objects!)
