### PR TITLE
Fix flakiness in specs

### DIFF
--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -50,7 +50,7 @@ describe Grouping do
 
       it 'updates criteria coverage counts after randomly bulk assign TAs' do
         expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment, grouping_ids)
+          .with(assignment, match_array(grouping_ids))
         Grouping.randomly_assign_tas(grouping_ids, ta_ids, assignment)
       end
 
@@ -101,7 +101,7 @@ describe Grouping do
 
       it 'updates criteria coverage counts after bulk assign all TAs' do
         expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment, grouping_ids)
+          .with(assignment, match_array(grouping_ids))
         Grouping.assign_all_tas(grouping_ids, ta_ids, assignment)
       end
 
@@ -132,7 +132,7 @@ describe Grouping do
 
       it 'updates criteria coverage counts after bulk unassign TAs' do
         expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment, grouping_ids)
+          .with(assignment, match_array(grouping_ids))
         Grouping.unassign_tas([], grouping_ids, assignment)
       end
 

--- a/spec/support/criterion_spec.rb
+++ b/spec/support/criterion_spec.rb
@@ -54,7 +54,7 @@ shared_examples 'a criterion' do
 
       it 'updates assigned groups counts after randomly bulk assign TAs' do
         expect(Criterion).to receive(:update_assigned_groups_counts)
-          .with(assignment, criterion_ids)
+          .with(assignment, match_array(criterion_ids))
         Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
       end
     end
@@ -105,7 +105,7 @@ shared_examples 'a criterion' do
 
       it 'updates assigned groups counts after bulk assign all TAs' do
         expect(Criterion).to receive(:update_assigned_groups_counts)
-          .with(assignment, criterion_ids)
+          .with(assignment, match_array(criterion_ids))
         Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
       end
     end
@@ -136,7 +136,7 @@ shared_examples 'a criterion' do
 
       it 'updates assigned groups counts after bulk unassign TAs' do
         expect(Criterion).to receive(:update_assigned_groups_counts)
-          .with(assignment, criterion_ids)
+          .with(assignment, match_array(criterion_ids))
         Criterion.unassign_tas([], criterion_ids, assignment)
       end
     end


### PR DESCRIPTION
When updating the counts, The ID arrays used are not the original array
passed to the caller method. They are being returned by ActiveRecord
with no defined order, so an exact equality check sometimes fail (which
is why this was not caught in the first place). The correct way of
doing it would be matching the set of element, hence the `match_array`
calls.

Tested:
- rspec
