### PR TITLE
Fix assignment factory associations and ID

### DIFF
--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -2,7 +2,7 @@ require 'faker'
 
 FactoryGirl.define do
   factory :assignment do
-    short_identifier { Faker::Lorem.word }
+    sequence(:short_identifier) { |i| "A#{i}" }
     description { Faker::Lorem.sentence }
     message { Faker::Lorem.sentence }
     group_min 1
@@ -15,8 +15,8 @@ FactoryGirl.define do
     marking_scheme_type Assignment::MARKING_SCHEME_TYPE[:rubric]
     allow_web_submits true
     display_grader_names_to_students false
-    submission_rule NoLateSubmissionRule.new
-    assignment_stat AssignmentStat.new
+    submission_rule { NoLateSubmissionRule.new }
+    assignment_stat { AssignmentStat.new }
 
     factory :flexible_assignment do
       marking_scheme_type Assignment::MARKING_SCHEME_TYPE[:flexible]


### PR DESCRIPTION
The short ID must be unique but the words generated by Faker are not.

The two associations should be lazily loaded, or else in some cases an
assignment might get created with null values for these associations.

Tested:
- rspec
