### PR TITLE
Replace FasterCSV with CSV in lib/benchmarking

### DIFF
--- a/lib/benchmarking/submission_files/annotation_categories_controller.rb
+++ b/lib/benchmarking/submission_files/annotation_categories_controller.rb
@@ -1,5 +1,3 @@
-require 'fastercsv'
-
 class AnnotationCategoriesController < ApplicationController
   include AnnotationCategoriesHelper
   def index
@@ -89,8 +87,8 @@ class AnnotationCategoriesController < ApplicationController
     end
     annotation_category_list = params[:annotation_category_list]
     annotation_category_number = 0
-    FasterCSV.parse(annotation_category_list) do |row|
-      next if FasterCSV.generate_line(row).strip.empty?
+    CSV.parse(annotation_category_list) do |row|
+      next if CSV.generate_line(row).strip.empty?
       if AnnotationCategory.add_by_row(row, @assignment)
         annotation_category_number += 1
       else

--- a/lib/benchmarking/submission_files/assignments_controller.rb
+++ b/lib/benchmarking/submission_files/assignments_controller.rb
@@ -1,4 +1,3 @@
-require 'fastercsv'
 class AssignmentsController < ApplicationController
   before_filter      :authorize_only_for_admin, except: [:deletegroup, :delete_rejected, :disinvite_member, :invite_member,
   :creategroup, :join_group, :decline_invitation, :index, :student_interface]
@@ -186,7 +185,7 @@ class AssignmentsController < ApplicationController
   def download_csv_grades_report
     assignments = Assignment.all
     students = Student.all
-    csv_string = FasterCSV.generate do |csv|
+    csv_string = CSV.generate do |csv|
       students.each do |student|
         row = []
         row.push(student.user_name)

--- a/lib/benchmarking/submission_files/groups_controller.rb
+++ b/lib/benchmarking/submission_files/groups_controller.rb
@@ -1,4 +1,3 @@
-require 'fastercsv'
 require 'auto_complete'
 
 # Manages actions relating to editing and modifying
@@ -193,7 +192,7 @@ class GroupsController < ApplicationController
           # Loop over each row, which lists the members to be added to the group.
           line_nr = 1
           flash[:users_not_found] = [] # contains a list of user_name(s) not found in DB
-          FasterCSV.parse(params[:group][:grouplist]) do |row|
+          CSV.parse(params[:group][:grouplist]) do |row|
             retval = @assignment.add_csv_group(row)
             if retval == nil || retval.instance_of?(Array)
               if retval
@@ -225,7 +224,7 @@ class GroupsController < ApplicationController
     #get all the groups
     groupings = assignment.groupings #FIXME: optimize with eager loading
 
-    file_out = FasterCSV.generate do |csv|
+    file_out = CSV.generate do |csv|
        groupings.each do |grouping|
          group_array = [grouping.group.group_name, grouping.group.repo_name]
          # csv format is group_name, repo_name, user1_name, user2_name, ... etc

--- a/lib/benchmarking/submission_files/rubrics_controller.rb
+++ b/lib/benchmarking/submission_files/rubrics_controller.rb
@@ -1,5 +1,3 @@
-require 'fastercsv'
-
 class RubricsController < ApplicationController
 
   before_filter      :authorize_only_for_admin
@@ -76,7 +74,7 @@ class RubricsController < ApplicationController
    end
 
    def create_csv_rubric(assignment)
-     FasterCSV.generate do |csv|
+     CSV.generate do |csv|
        #first line is level names
        levels_array = get_level_names(assignment)
        csv << levels_array
@@ -158,8 +156,8 @@ class RubricsController < ApplicationController
     # flag
     first_line = true
     levels = nil
-    FasterCSV.parse(file.read) do |row|
-     next if FasterCSV.generate_line(row).strip.empty?
+    CSV.parse(file.read) do |row|
+     next if CSV.generate_line(row).strip.empty?
      begin
        if first_line #get the row of levels
          levels = row

--- a/lib/benchmarking/submission_files/submissions_controller.rb
+++ b/lib/benchmarking/submission_files/submissions_controller.rb
@@ -1,5 +1,3 @@
-require 'fastercsv'
-
 class SubmissionsController < ApplicationController
   include SubmissionsHelper
 
@@ -339,7 +337,7 @@ class SubmissionsController < ApplicationController
   def download_simple_csv_report
     assignment = Assignment.find(params[:id])
     students = Student.all
-    csv_string = FasterCSV.generate do |csv|
+    csv_string = CSV.generate do |csv|
        students.each do |student|
          final_result = []
          final_result.push(student.user_name)
@@ -361,7 +359,7 @@ class SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:id])
     students = Student.all
     rubric_criteria = assignment.rubric_criteria
-    csv_string = FasterCSV.generate do |csv|
+    csv_string = CSV.generate do |csv|
        students.each do |student|
          final_result = []
          final_result.push(student.user_name)


### PR DESCRIPTION
I was looking for ways to autoload the whole lib library when I noticed that the benchmarking folder still used fastercsv which we deprecated in #1459.
