### PR TITLE
FINALLY get rails to reload /repo every request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
+# This lets rails autoreload the lib/repo files on every request
+# Should be taken out before production.
+require_dependency Rails.root.join('lib', 'repo', 'repository').to_s
+
 # Filters added to this controller apply to all controllers in the application.
 # Likewise, all the methods added will be available for all controllers.
-
 class ApplicationController < ActionController::Base
   include ApplicationHelper, SessionHandler
 

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -325,9 +325,9 @@ module Repository
   end
 
   # A repository factory
-  require File.join(File.dirname(__FILE__),'memory_repository')
-  require File.join(File.dirname(__FILE__),'subversion_repository')
-  require File.join(File.dirname(__FILE__),'git_repository')
+  require_dependency File.join(File.dirname(__FILE__), 'memory_repository')
+  require_dependency File.join(File.dirname(__FILE__), 'subversion_repository')
+  require_dependency File.join(File.dirname(__FILE__), 'git_repository')
   # Returns a repository class of the requested type,
   # which implements AbstractRepository
 


### PR DESCRIPTION
We can remove the require_dependency from application_controller before production, but for now this is the best way to reload code from /repo without too much surgery.
