### PR TITLE
vagrant can now see Markus folder on home machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ lib/repo/test/svn_repos/svn_authz
 
 # RubyMine generated project folder
 .idea
+
+#Ignore files for Vagrant instance
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,10 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "markusproject/debian"
+  
+  # Allow instance to see project folder
+  config.vm.synced_folder "../Markus", "/Markus"
+
   # Access the server running on port 3000 on the host on port 42069.
   config.vm.network "forwarded_port", guest: 3000, host: 42069
 


### PR DESCRIPTION
Added to .gitignore to ignore config files that are generated by vagrant
