### PR TITLE
Remove quotes/brackets around error message in results view

### DIFF
--- a/app/views/results/marker/show_result_error.js.erb
+++ b/app/views/results/marker/show_result_error.js.erb
@@ -1,5 +1,5 @@
 <%# Marking state set to complete but there is at least one nil mark %>
-document.getElementById('criterion_incomplete_error').innerHTML = '<%= @result.errors[:base] %>';
+document.getElementById('criterion_incomplete_error').innerHTML = '<%= @result.errors[:base].to_sentence %>';
 document.getElementById('criterion_incomplete_error').style.display = '';
 
 document.getElementById('marking_state').value = '<%= Result::MARKING_STATES[:partial] %>';


### PR DESCRIPTION
Remove the `[" "]` stuff around the error message in the results view (for issue https://github.com/MarkUsProject/Markus/issues/1640).
