### PR TITLE
Avoid n+1 queries when downloading all submissions

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -750,13 +750,18 @@ class SubmissionsController < ApplicationController
       return
     end
 
-    groupings = Grouping.find(grouping_ids)
+    groupings = Grouping.where(id: grouping_ids)
+      .includes(:group,
+                current_submission_used: {
+                  submission_files: {
+                    submission: { grouping: :group }
+                  }
+                })
 
     ## build the zip file
     Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
 
-      groupings.map do |grouping|
-
+      groupings.each do |grouping|
         ## retrieve the submitted files
         submission = grouping.current_submission_used
         next unless submission


### PR DESCRIPTION
Lots of queries are redundant in the logic of downloading all
submissions and can be avoided by eagerly loading the associations.

This deals with #1484.

Tested:
- rspec
- rake test:units
- rake test:functionals
