### PR TITLE
Refactor Grouping#add_tas

### DIFF
--- a/spec/factories/ta_memberships.rb
+++ b/spec/factories/ta_memberships.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :ta_membership, class: TaMembership, parent: :membership
+end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -167,7 +167,7 @@ describe Grouping do
         let!(:tas) { Array.new(2) { create(:ta) } }
 
         before :each do
-          grouping.add_tas(tas)
+          create_ta_memberships(grouping, tas)
         end
 
         context 'with no assigned criteria' do
@@ -231,7 +231,7 @@ describe Grouping do
                 criterion = create(:rubric_criterion,
                                    assignment: grouping.assignment)
                 criterion.add_tas(tas)
-                grouping.add_tas(tas)
+                create_ta_memberships(grouping, tas)
               end
 
               it 'updates criteria coverage count to `tas.size`' do
@@ -252,8 +252,7 @@ describe Grouping do
       end
 
       before :each do
-        grouping.add_tas(ta)
-        another_grouping.add_tas(ta)
+        create_ta_memberships([grouping, another_grouping], ta)
         criterion.add_tas(ta)
         another_criterion.add_tas(ta)
         # Update only `grouping` not `another_grouping`.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,9 @@ RSpec.configure do |config|
   # Include Factory Girl syntax to simplify calls to factory.
   config.include FactoryGirl::Syntax::Methods
 
+  # Include generic helpers.
+  config.include Helpers
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/criterion_spec.rb
+++ b/spec/support/criterion_spec.rb
@@ -189,7 +189,7 @@ shared_examples 'a criterion' do
           end
 
           context 'when only one is assigned a TA' do
-            before(:each) { groupings[0].add_tas(tas[0]) }
+            before(:each) { create_ta_memberships(groupings[0], tas[0]) }
 
             it 'updates assigned groups count to 1' do
               expect_updated_assigned_groups_count_to_eq 1
@@ -197,7 +197,7 @@ shared_examples 'a criterion' do
           end
 
           context 'when only one is assigned multiple TAs' do
-            before(:each) { groupings[0].add_tas(tas) }
+            before(:each) { create_ta_memberships(groupings[0], tas) }
 
             it 'updates assigned groups count to 1' do
               expect_updated_assigned_groups_count_to_eq 1
@@ -206,7 +206,7 @@ shared_examples 'a criterion' do
 
           context 'when `tas.size` are assigned unique TAs' do
             before :each do
-              tas.size.times { |i| groupings[i].add_tas(tas[i]) }
+              tas.size.times { |i| create_ta_memberships(groupings[i], tas[i]) }
             end
 
             it 'updates assigned groups count to `tas.size`' do
@@ -215,7 +215,9 @@ shared_examples 'a criterion' do
           end
 
           context 'when `tas.size` are assigned non-unique TAs' do
-            before(:each) { tas.size.times { |i| groupings[i].add_tas(tas) } }
+            before(:each) do
+              tas.size.times { |i| create_ta_memberships(groupings[i], tas) }
+            end
 
             it 'updates assigned groups count to `tas.size`' do
               expect_updated_assigned_groups_count_to_eq tas.size
@@ -228,7 +230,7 @@ shared_examples 'a criterion' do
                 criterion = create(criterion_factory_name)
                 grouping = create(:grouping, assignment: criterion.assignment)
                 criterion.add_tas(tas)
-                grouping.add_tas(tas)
+                create_ta_memberships(grouping, tas)
               end
 
               it 'updates assigned groups count to `tas.size`' do
@@ -251,8 +253,7 @@ shared_examples 'a criterion' do
       before :each do
         criterion.add_tas(ta)
         another_criterion.add_tas(ta)
-        grouping.add_tas(ta)
-        another_grouping.add_tas(ta)
+        create_ta_memberships([grouping, another_grouping], ta)
         # Update only `criterion` not `another_criterion`.
         Criterion.update_assigned_groups_counts(assignment, criterion.id)
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,13 @@
+# Generic helpers common to all specs.
+module Helpers
+  # Assigns all TAs in +tas+ to all +grouping+ without updating counts (e.g.,
+  # the criteria coverage count) so that tests can verify the counts are
+  # updated independently.
+  def create_ta_memberships(groupings, tas)
+    Array(groupings).each do |grouping|
+      Array(tas).each do |ta|
+        create(:ta_membership, grouping: grouping, user: ta)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `add_tas` method is just a special case of the new mass assign
method `assign_all_tas`.

Tested:
- rspec
- rake test:units
- rake test:functionals
