### PR TITLE
Fix error when toggling "assign criteria"

### DIFF
--- a/app/assets/javascripts/manage_graders.js
+++ b/app/assets/javascripts/manage_graders.js
@@ -9,7 +9,7 @@ jQuery(document).ready(function() {
     };
 
     jQuery.ajax({
-      url:  element.readAttribute('data-action'),
+      url:  this.getAttribute('data-action'),
       type: 'POST',
       data: params
     });


### PR DESCRIPTION
The current JavaScript throws an error when clicking on the checkbox
"Assign Graders to Criteria" because it is trying to use an undefined
variable `element`, which should really be `this`.

Tested:
- local server
