### PR TITLE
Replace readAttribute with getAttribute

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -11,7 +11,7 @@ jQuery(document).ready(function() {
     }
 
     jQuery.ajax({
-      url:  element.readAttribute('data-action'),
+      url:  element.getAttribute('data-action'),
       type: 'POST',
       data: params
     });
@@ -25,7 +25,7 @@ jQuery(document).ready(function() {
     }
 
     jQuery.ajax({
-      url:  this.readAttribute('data-action'),
+      url:  this.getAttribute('data-action'),
       type: 'POST',
       data: params
     }).done(function() {
@@ -49,7 +49,7 @@ jQuery(document).ready(function() {
       }
 
       jQuery.ajax({
-        url:  this.readAttribute('data-action'),
+        url:  this.getAttribute('data-action'),
         type: 'POST',
         data: params
       });


### PR DESCRIPTION
`readAttribute` is a function monkey-patched by Prototype, so it won't
be available after removing Prototype. The standard function is
`getAttribute`.

Tested:
- local server
