### PR TITLE
Replace dataset and ensure parseInt have radices

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -11,7 +11,7 @@ jQuery(document).ready(function() {
     }
 
     jQuery.ajax({
-      url:  element.readAttribute('data-action'),
+      url:  element.getAttribute('data-action'),
       type: 'POST',
       data: params
     });
@@ -25,7 +25,7 @@ jQuery(document).ready(function() {
     }
 
     jQuery.ajax({
-      url:  this.readAttribute('data-action'),
+      url:  this.getAttribute('data-action'),
       type: 'POST',
       data: params
     }).done(function() {
@@ -82,22 +82,22 @@ jQuery(document).ready(function() {
   // Handle the expand/collapse buttons
   jQuery('#expand_all').click(function() {
     jQuery('.mark_description').each(function() {
-      show_criterion(parseInt(this.dataset.id));
+      show_criterion(parseInt(this.getAttribute('data-id'), 10));
     });
   });
 
   jQuery('#collapse_all').click(function() {
     jQuery('.mark_description').each(function() {
-      hide_criterion(parseInt(this.dataset.id));
+      hide_criterion(parseInt(this.getAttribute('data-id'), 10));
     });
   });
 
   jQuery('#expand_unmarked').click(function() {
     jQuery('.mark_description').each(function() {
       if (this.innerHTML.trim()) {
-        hide_criterion(parseInt(this.dataset.id));
+        hide_criterion(parseInt(this.getAttribute('data-id'), 10));
       } else {
-        show_criterion(parseInt(this.dataset.id));
+        show_criterion(parseInt(this.getAttribute('data-id'), 10));
       }
     });
   });

--- a/app/assets/javascripts/SourceCodeGlower/ImageAnnotationGrid.js
+++ b/app/assets/javascripts/SourceCodeGlower/ImageAnnotationGrid.js
@@ -72,12 +72,12 @@ ImageAnnotationGrid.prototype.draw_holders = function() {
     holder = document.getElementById('annotation_holder_' + annot_text_id);
 
     // Left offset of the holder
-    holder_left = image_preview.offsetLeft + parseInt(horiz_range.start);
+    holder_left = image_preview.offsetLeft + parseInt(horiz_range.start, 10);
     // Top offset of the holder
-    holder_top  = image_preview.offsetTop + parseInt(vert_range.start);
+    holder_top  = image_preview.offsetTop + parseInt(vert_range.start, 10);
 
-    holder_width  = parseInt(horiz_range.end) - parseInt(horiz_range.start);
-    holder_height = parseInt(vert_range.end) - parseInt(vert_range.start);
+    holder_width  = parseInt(horiz_range.end, 10) - parseInt(horiz_range.start, 10);
+    holder_height = parseInt(vert_range.end, 10) - parseInt(vert_range.start, 10);
 
     holder.style.left = Math.max(0, holder_left - left_edge) + image_preview.offsetLeft + 'px';
     holder.style.top  = Math.max(0, holder_top - top_edge) + image_preview.offsetTop + 'px';

--- a/app/assets/javascripts/grades_table.js
+++ b/app/assets/javascripts/grades_table.js
@@ -78,14 +78,14 @@ function bindEventToGradeEntry() {
   jQuery('.grade-input').each(function() {
     jQuery(this).change(function() {
       var params = {
-        'updated_grade': this.value,
-        'student_id': this.dataset.studentid,
-        'grade_entry_item_id': this.dataset.gradeentryitemid,
-        'authenticity_token': AUTH_TOKEN
+        'updated_grade':       this.value,
+        'student_id':          this.getAttribute('data-student-id'),
+        'grade_entry_item_id': this.getAttribute('data-grade-entry-item-id'),
+        'authenticity_token':  AUTH_TOKEN
       };
 
       jQuery.ajax({
-        url:  this.dataset.action,
+        url:  this.getAttribute('data-action'),
         data: params,
         type: 'POST'
       });

--- a/app/views/grade_entry_forms/_grades_table.html.erb
+++ b/app/views/grade_entry_forms/_grades_table.html.erb
@@ -41,8 +41,8 @@
                              grade.grade,
                              size: 4,
                              class: 'grade-input',
-                             'data-gradeentryitemid' => grade_entry_item.id,
-                             'data-studentid' => student.id,
+                             'data-grade-entry-item-id' => grade_entry_item.id,
+                             'data-student-id' => student.id,
                              'data-action' => url_for(action: :update_grade,
                                                       id: @grade_entry_form.id) %>
         </td>

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -138,14 +138,14 @@
 
   function get_selection_box() {
     var box = document.getElementById('sel_box');
-    var x1 = parseInt(box.style.left) -
+    var x1 = parseInt(box.style.left, 10) -
                document.getElementById('image_preview').offsetLeft +
                document.getElementById('image_container').scrollLeft;
-    var y1 = parseInt(box.style.top) -
+    var y1 = parseInt(box.style.top, 10) -
                document.getElementById('image_preview').offsetTop +
                document.getElementById('image_container').scrollTop;
-    var x2 = x1 + parseInt(box.style.width);
-    var y2 = y1 + parseInt(box.style.height);
+    var x2 = x1 + parseInt(box.style.width, 10);
+    var y2 = y1 + parseInt(box.style.height, 10);
 
     if ((x2 - x1) < 1 || isNaN(x2 - x1)) {
       alert("<%= I18n.t('marker.annotation.select_an_area') %>");

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -40,7 +40,7 @@
     // Hide the criterion that AREN'T empty (i.e. are marked)
     jQuery('.mark_description').each(function() {
       if (this.innerHTML.trim()) {
-        hide_criterion(parseInt(this.dataset.id));
+        hide_criterion(parseInt(this.getAttribute('data-id'), 10));
       }
     });
   });


### PR DESCRIPTION
Turns out `dataset` wasn't supported in IE until IE11, so I've switched it to `getAttribute()`, which is apparently faster anyway.

Also ensured that any usage of `parseInt` also includes a radix variable, to ensure that they're parsed in base 10.
