### PR TITLE
Add awesome_print to development mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development do
   gem 'quiet_assets'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'awesome_print'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     arel (3.0.3)
     auto_complete (0.0.1)
       rails (>= 3.1)
+    awesome_print (1.2.0)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -199,6 +200,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   auto_complete
+  awesome_print
   better_errors
   binding_of_caller
   byebug


### PR DESCRIPTION
To help print out database records in rails console nicely (sanely). This may or may not be something to include in the default Gemfile, but I found it helpful when printing out some of the more complex database records.
