### PR TITLE
Tell Hound to allow use of #find

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -6,3 +6,15 @@ DotPosition:
 # special symbols.
 StringLiterals:
     EnforcedStyle: single_quotes
+
+# Prefer specific method aliases over others
+Style/CollectionMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `detect` over `find`:
+  #
+  # CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
+  PreferredMethods:
+    find:
+    detect: 'find'


### PR DESCRIPTION
And also prefer #find over #detect.

This is related to PR #1609.
