### PR TITLE
Add Rubocop to the project

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,8 +1,1 @@
-# Multi-line method chaining should be done with leading dots.
-DotPosition:
-  EnforcedStyle: leading
-
-# Prefer single-quoted strings when you don't need string interpolation or
-# special symbols.
-StringLiterals:
-    EnforcedStyle: single_quotes
+.rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+# Multi-line method chaining should be done with leading dots.
+DotPosition:
+  EnforcedStyle: leading
+
+# Prefer single-quoted strings when you don't need string interpolation or
+# special symbols.
+StringLiterals:
+    EnforcedStyle: single_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ group :offline do
   gem 'rdoc'
   gem 'railroady'
   gem 'thin'
+  gem 'rubocop'
 end
 
 # If you  plan to use unicorn servers for production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
+    ast (2.0.0)
     auto_complete (0.0.1)
       rails (>= 3.1)
     better_errors (1.1.0)
@@ -95,8 +96,12 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     mysql2 (0.3.16)
+    parser (2.2.0.pre.3)
+      ast (>= 1.1, < 3.0)
+      slop (~> 3.4, >= 3.4.5)
     pg (0.17.1)
     polyglot (0.3.5)
+    powerpack (0.0.9)
     prototype-rails (3.2.1)
       rails (~> 3.2)
     quiet_assets (1.0.2)
@@ -124,6 +129,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
+    rainbow (2.0.0)
     raindrops (0.13.0)
     rake (10.3.2)
     rdoc (3.12.2)
@@ -146,6 +152,13 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
+    rubocop (0.24.1)
+      json (>= 1.7.7, < 2)
+      parser (>= 2.2.0.pre.3, < 3.0)
+      powerpack (~> 0.0.6)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.5.1)
     rubyzip (1.1.4)
     sass (3.3.8)
     sass-rails (3.2.6)
@@ -163,6 +176,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slop (3.6.0)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -226,6 +240,7 @@ DEPENDENCIES
   rdoc
   rghost (<= 0.9.3)
   rspec-rails (~> 3.0)
+  rubocop
   rubyzip
   sass-rails (~> 3.2.3)
   shoulda


### PR DESCRIPTION
Those of us that were at the sprint in May will remember that Hound CI was brought up because we wanted to try and automate the use of Rubocop. However, we completely forgot to add Rubocop to the project.

Hound does style checking in the PR, but that can be incredibly noisy ~~sometimes~~ a lot of the time. Though we cannot force someone to use Rubocop before opening a PR, having Rubocop in the default project configuration might act as a reminder.

I've linked the Hound and Rubocop configuration files, so you _should_ be able to just run `rubocop` on a file or directory and get the same results that Hound would give you. In practice, the results might be different due to the Gemfile locking onto an older version of Rubocop than what Hound is using.
