### PR TITLE
Restrict matched routes to accept explicitly listed verbs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Markus::Application.routes.draw do
   # Install the default routes as the lowest priority.
-  root controller: "main", action: "login", via: [:post, :get]
+  root controller: 'main', action: 'login', via: [:post, :get]
 
   # optional path scope (denoted by the parentheses)
   scope "(:locale)", locale: /en|fr|pt/  do


### PR DESCRIPTION
Rails 4 will refuse to boot with `match` routes that do not explicitly list the HTTP verbs that are accepted.

The catch-all route at the end does not seem to work correctly with the `:all` option on Rails 3, but I think that catching only `GET` requests is sufficient in the interim.
