### PR TITLE
Fix HTTP method for downloading spreadsheet CSV

### DIFF
--- a/app/views/marks_graders/index.html.erb
+++ b/app/views/marks_graders/index.html.erb
@@ -160,6 +160,7 @@
                 { controller: 'marks_graders',
                   action: 'download_grader_students_mapping',
                   id: @grade_entry_form.id },
+                method: :get,
                 onclick: 'modalDownload.close();' %>
 
   <section class='dialog-actions'>


### PR DESCRIPTION
`button_to` defaults to use HTTP POST whereas the
`download_grader_students_mapping` action is a GET action.

Tested:
- local server
