### PR TITLE
Avoid n+1 queries in marks_graders view

### DIFF
--- a/app/helpers/marks_graders_helper.rb
+++ b/app/helpers/marks_graders_helper.rb
@@ -27,15 +27,19 @@ module MarksGradersHelper
   end
 
   def construct_table_row(student, grade_entry_form)
-      grade_entry_student = GradeEntryStudent.find_by_user_id(student.id)
+    grade_entry_student = student.grade_entry_students.find do |entry|
+      entry.grade_entry_form_id == grade_entry_form.id
+    end
 
       table_row = {}
 
       table_row[:id] = student.id
       table_row[:filter_table_row_contents] =
-        render_to_string partial: 'marks_graders/table_row/filter_table_row',
-        formats: [:html], handlers: [:erb],
-        locals: { student: student, grade_entry_form: grade_entry_form }
+        render_to_string(
+          partial: 'marks_graders/table_row/filter_table_row',
+          formats: [:html], handlers: [:erb],
+          locals: { student: student, grade_entry_student: grade_entry_student }
+        )
 
       #These are used for sorting
       table_row[:user_name] = student.user_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
 
   # Group relationships
   has_many :memberships
+  has_many :grade_entry_students
   has_many :groupings, through: :memberships
   has_many :notes, as: :noteable, dependent: :destroy
   has_many :accepted_memberships, class_name: 'Membership', conditions: {membership_status: [StudentMembership::STATUSES[:accepted], StudentMembership::STATUSES[:inviter]]}

--- a/app/views/marks_graders/manage/_member.html.erb
+++ b/app/views/marks_graders/manage/_member.html.erb
@@ -1,4 +1,4 @@
-<% grade_entry_form.grade_entry_students.find_by_user_id(student.id).tas.each do |ta| %>
+<% grade_entry_student.tas.each do |ta| %>
 	<span id="<%= "mbr_#{ta.id}" %>">
 	  <%= check_box_tag "#{student.id}_#{ta.user_name}", true, false,
         class: 'inline_checkbox', onclick:

--- a/app/views/marks_graders/table_row/_filter_table_row.html.erb
+++ b/app/views/marks_graders/table_row/_filter_table_row.html.erb
@@ -10,10 +10,12 @@
   <% end %>
 </td>
 <td>
-  <% if !grade_entry_form.grade_entry_students.nil? and
-    !grade_entry_form.grade_entry_students.find_by_user_id(student.id).nil? %>
+  <% if grade_entry_student %>
     <%= render partial: "marks_graders/manage/member",
-      formats: [:html], handlers: [:erb],
-      locals: { student: student, grade_entry_form: grade_entry_form } %>
+               formats: [:html], handlers: [:erb],
+               locals: {
+                 student: student,
+                 grade_entry_student: grade_entry_student
+               } %>
   <% end %>
 </td>


### PR DESCRIPTION
This mainly improves the performance of the index page of assigning graders to spreadsheet students. There are also some minor refactoring.

Tested:
- rspec
- rake test:units
- rakte test:functionals
- local server
