### PR TITLE
Fix flaky user name uniqueness in specs

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    user_name { Faker::Internet.user_name }
+    sequence(:user_name) { |n| Faker::Internet.user_name + n.to_s }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
   end


### PR DESCRIPTION
Apparently Faker doesn't generate unique user names in a sequence of
calls and I sometimes get an uniquess violation error because of this.
This can be fixed by using FactoryGirl's sequence.

Tested:
- rspec
