### PR TITLE
make session store point to config settings

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Markus::Application.config.secret_token = '5c1360bb535c3b38b24af9863a59c91a4e2655f69cd64fa827fce470ce651ec04160f86aa4daf8dae46709c9f5e2588b9dd447b4d439678cf427ae70a67ae8ba'
+Markus::Application.config.secret_token = MarkusConfigurator.markus_config_session_cookie_secret

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Markus::Application.config.session_store :cookie_store, key: '_markus_session'
+Markus::Application.config.session_store :cookie_store, key: MarkusConfigurator.markus_config_session_cookie_name
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
I spoke with Alan Rosenthal, our sysadmin, and he pointed out that the values for the session cookie name and secret tokens were hard-coded when they should point to config/environments/{development.rb, test.rb, production.rb}.
