### PR TITLE
Fix method name in markus:load:results

### DIFF
--- a/lib/tasks/results.rake
+++ b/lib/tasks/results.rake
@@ -96,7 +96,7 @@ namespace :markus do
         end
       end
   		# compute summary statistics for a1
-  		a1.set_results_statistics
+  		a1.update_results_stats
       puts "Done!"
     end
   end


### PR DESCRIPTION
The method has been renamed to `update_results_stats`, but the invocation in the task is not updated.

This fixes number 2 in #1706.
