### PR TITLE
move http links to https

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -4,5 +4,5 @@
   <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
   <%= csrf_meta_tags %>
   <%= favicon_link_tag 'favicon.ico' %>
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet'>
   <%= javascript_tag "const AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery?%>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -4,8 +4,8 @@
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name %></title>
   <%# React stuff (compressed version + JSX transformer) %>
-  <%= javascript_include_tag 'http://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/react.min.js',
-                             'http://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/JSXTransformer.js' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/react.min.js',
+                             'https://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/JSXTransformer.js' %>
   <%= javascript_include_tag 'application', 'prototype' %>
   <%= stylesheet_link_tag params[:controller], media: 'all' %>
   <%= favicon_link_tag 'favicon.ico' %>


### PR DESCRIPTION
our actual MarkUs instances run on https, and many browsers have a security feature where external links using http will not be loaded (since it is considered insecure). This patch fixes this by moving the links over to https.
