### PR TITLE
fix url paths for ajax calls

### DIFF
--- a/app/views/admins/_admins_table.js.jsx.erb
+++ b/app/views/admins/_admins_table.js.jsx.erb
@@ -48,7 +48,6 @@
 
       jQuery.ajax({
         method: 'GET',
-        url: '/admins',
         dataType: 'json',
         success: function(data) {
           document.getElementById('working').style.display = 'none';

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -67,7 +67,6 @@
       //              this is actually a hash.
       jQuery.ajax({
         method: 'GET',
-        url: 'graders',
         dataType: 'json',
         success: function(data) {
           document.getElementById('working').style.display = 'none';

--- a/app/views/groups/_groups_manager.js.jsx.erb
+++ b/app/views/groups/_groups_manager.js.jsx.erb
@@ -63,7 +63,6 @@
 
       jQuery.ajax({
         method: 'GET',
-        url: 'groups',
         dataType: 'json',
         success: function(data) {
           document.getElementById('working').style.display = 'none';

--- a/app/views/students/_students_table.js.jsx.erb
+++ b/app/views/students/_students_table.js.jsx.erb
@@ -90,7 +90,6 @@
 
       jQuery.ajax({
         method: 'GET',
-        url: '/students',
         dataType: 'json',
         success: function(data) {
           this.setState({
@@ -286,7 +285,7 @@
 
       jQuery.ajax({
         method: 'POST',
-        url: '/students/bulk_modify',
+        url: 'students/bulk_modify',
         data: dataLoad,
         success: function(data) {
           this.props.errorThrown(null);

--- a/app/views/submissions/_submissions_table.js.jsx.erb
+++ b/app/views/submissions/_submissions_table.js.jsx.erb
@@ -115,7 +115,6 @@
 
       jQuery.ajax({
         method: 'GET',
-        url: 'browse',
         dataType: 'json',
         success: function(data) {
           this.setState({

--- a/app/views/summaries/_summaries_table.js.jsx.erb
+++ b/app/views/summaries/_summaries_table.js.jsx.erb
@@ -103,7 +103,6 @@
       document.getElementById('working').style.display = '';
       jQuery.ajax({
         method: 'GET',
-        url: 'summaries',
         dataType: 'json',
         success: function(data) {
           this.setState({

--- a/app/views/tas/_tas_table.js.jsx.erb
+++ b/app/views/tas/_tas_table.js.jsx.erb
@@ -47,7 +47,6 @@
 
       jQuery.ajax({
         method: 'GET',
-        url: '/tas',
         dataType: 'json',
         success: function(data) {
           document.getElementById('working').style.display = 'none';


### PR DESCRIPTION
The url paths that were being used used absolute paths rather than relative paths.
