### PR TITLE
Fix broken "Download" link on groups view

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -177,9 +177,10 @@
 
 <aside class='dialog' id='download_dialog'>
   <h2><%= t('groups.download.download_groups_file') %></h2>
-  <%= button_to t('groups.download.download_csv'),
+  <%= link_to t('groups.download.download_csv'),
                 { controller: 'groups', action: 'download_grouplist',
                   id: @assignment.id },
+                class: 'button',
                 onclick: 'modal_download.close();' %>
 
   <section class='dialog-actions'>


### PR DESCRIPTION
The parameters using `button_to` weren't correct, generating a route error. For consistency, I've switched this to a `link_to` like all of our other download modals, but kept the button class.
