### PR TITLE
use view_context for generating helper URLs

### DIFF
--- a/app/helpers/graders_helper.rb
+++ b/app/helpers/graders_helper.rb
@@ -35,8 +35,8 @@ module GradersHelper
       g[:full_name] = "#{grader.first_name} #{grader.last_name}"
       g[:groups] = grader.get_membership_count_by_assignment(assignment)
       g[:criteria] = grader.get_criterion_associations_count_by_assignment(@assignment).to_s
-      g[:criteria] += ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:criteria] += view_context.link_to(
+        view_context.image_tag(
           'icons/comment.png',
           alt: I18n.t('criteria'),
           title: I18n.t('criteria')),
@@ -67,8 +67,8 @@ module GradersHelper
       total_criteria_count = assignment.criteria_count
       g[:coverage] = "#{assigned_count} / #{total_criteria_count}"
       if assigned_count == total_criteria_count
-        g[:coverage] += ActionController::Base.helpers.link_to(
-          ActionController::Base.helpers.image_tag(
+        g[:coverage] += view_context.link_to(
+          view_context.image_tag(
             'icons/tick.png',
             alt: I18n.t('graders.covered'),
             title: I18n.t('graders.covered')),
@@ -77,8 +77,8 @@ module GradersHelper
             grouping: grouping.id),
           remote: true)
       else
-        g[:coverage] += ActionController::Base.helpers.link_to(
-          ActionController::Base.helpers.image_tag(
+        g[:coverage] += view_context.link_to(
+          view_context.image_tag(
             'icons/cross.png',
             alt: I18n.t('graders.not_covered'),
             title: I18n.t('graders.not_covered')),
@@ -108,12 +108,12 @@ module GradersHelper
       assigned_length = criterion.assigned_groups_count
       c[:coverage] = "#{assigned_length} / #{assignment.groupings.size}"
       if assigned_length == assignment.groupings.size
-        c[:coverage] += ActionController::Base.helpers.image_tag(
+        c[:coverage] += view_context.image_tag(
           'icons/tick.png',
           alt: I18n.t('graders.covered'),
           title: I18n.t('graders.covered'))
       else
-        c[:coverage] += ActionController::Base.helpers.image_tag(
+        c[:coverage] += view_context.image_tag(
           'icons/cross.png',
           alt: I18n.t('graders.not_covered'),
           title: I18n.t('graders.not_covered'))

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -29,8 +29,8 @@ module GroupsHelper
       g[:name] = grouping.group.group_name
       g[:members] = grouping.students
       g[:valid] = grouping.is_valid?
-      g[:validate_link] = ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:validate_link] = view_context.link_to(
+        view_context.image_tag(
           'icons/cross.png',
           alt: I18n.t('groups.is_not_valid'),
           title: I18n.t('groups.is_not_valid')),
@@ -39,8 +39,8 @@ module GroupsHelper
           confirm:  I18n.t('groups.validate_confirm'),
         remote: true)
 
-      g[:invalidate_link] = ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:invalidate_link] = view_context.link_to(
+        view_context.image_tag(
           'icons/tick.png',
           alt: I18n.t('groups.is_valid'),
           title: I18n.t('groups.is_valid')),
@@ -49,16 +49,16 @@ module GroupsHelper
           confirm:  I18n.t('groups.invalidate_confirm'),
         remote: true)
 
-      g[:rename_link] = ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:rename_link] = view_context.link_to(
+        view_context.image_tag(
           'icons/pencil.png',
           alt: I18n.t('groups.rename_group.link'),
           title: I18n.t('groups.rename_group.link')),
         rename_group_dialog_assignment_group_path(@assignment, grouping),
         remote: true)
 
-      g[:note_link] = ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:note_link] = view_context.link_to(
+        view_context.image_tag(
           'icons/note.png',
           alt: I18n.t('notes.title'),
           title: I18n.t('notes.title')),
@@ -70,8 +70,8 @@ module GroupsHelper
           controller_to: 'groups'),
         remote: true)
 
-      g[:delete_link] = ActionController::Base.helpers.link_to(
-        ActionController::Base.helpers.image_tag(
+      g[:delete_link] = view_context.link_to(
+        view_context.image_tag(
           'icons/bin_closed.png',
           alt: I18n.t('groups.delete')),
         remove_group_assignment_groups_path(

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -65,18 +65,18 @@ module SubmissionsHelper
     group_name = ''
       if !grouping.has_submission?
         if assignment.submission_rule.can_collect_grouping_now?(grouping)
-          group_name = ActionController::Base.helpers.link_to(grouping.group.group_name,
+          group_name = view_context.link_to(grouping.group.group_name,
             collect_and_begin_grading_assignment_submission_path(
               assignment.id, grouping.id))
         else
           group_name = grouping.group.group_name
         end
       elsif !grouping.is_collected
-        group_name = ActionController::Base.helpers.link_to(grouping.group.group_name,
+        group_name = view_context.link_to(grouping.group.group_name,
           collect_and_begin_grading_assignment_submission_path(
             assignment.id, grouping.id))
       else
-        group_name = ActionController::Base.helpers.link_to(grouping.group.group_name,
+        group_name = view_context.link_to(grouping.group.group_name,
           edit_assignment_submission_result_path(
             assignment.id, grouping.current_submission_used.id,
             grouping.current_submission_used.get_latest_result))
@@ -93,7 +93,7 @@ module SubmissionsHelper
   end
 
   def get_grouping_repository(assignment, grouping)
-    ActionController::Base.helpers.link_to(grouping.group.repository_name,
+    view_context.link_to(grouping.group.repository_name,
       repo_browser_assignment_submission_path(assignment, grouping))
   end
 
@@ -103,7 +103,7 @@ module SubmissionsHelper
     else
       repo = ''
       if grouping.past_due_date?
-        repo += ActionController::Base.helpers.image_tag('icons/error.png',
+        repo += view_context.image_tag('icons/error.png',
             title: t(:past_due_date_edit_result_warning,
             href: t(:last_commit)))
       end
@@ -115,7 +115,7 @@ module SubmissionsHelper
   def get_grouping_marking_state(assignment, grouping)
     if !grouping.has_submission?
       if assignment.submission_rule.can_collect_now?
-        return ActionController::Base.helpers.image_tag('icons/shape_square.png',
+        return view_context.image_tag('icons/shape_square.png',
           alt: I18n.t('marking_state.not_collected'),
           title: I18n.t('marking_state.not_collected'))
       else
@@ -123,26 +123,26 @@ module SubmissionsHelper
       end
     else
       if !grouping.current_submission_used.has_result?
-        return ActionController::Base.helpers.image_tag('icons/pencil.png',
+        return view_context.image_tag('icons/pencil.png',
           alt: I18n.t('marking_state.in_progress'),
           title: I18n.t('marking_state.in_progress'))
       else
         if remark_in_progress(grouping.current_submission_used)
-          return ActionController::Base.helpers.image_tag('icons/double_exclamation.png',
+          return view_context.image_tag('icons/double_exclamation.png',
             alt: I18n.t('marking_state.remark_requested'),
             title: I18n.t('marking_state.remark_requested'))
         elsif grouping.current_submission_used.get_latest_result.marking_state == Result::MARKING_STATES[:complete]
           if !grouping.current_submission_used.get_latest_result.released_to_students
-            return ActionController::Base.helpers.image_tag('icons/accept.png',
+            return view_context.image_tag('icons/accept.png',
               alt: I18n.t('marking_state.completed'),
               title: I18n.t('marking_state.completed'))
           else
-            return ActionController::Base.helpers.image_tag('icons/email_go.png',
+            return view_context.image_tag('icons/email_go.png',
               alt: I18n.t('marking_state.released'),
               title: I18n.t('marking_state.released'))
           end
         else
-          return ActionController::Base.helpers.image_tag('icons/pencil.png',
+          return view_context.image_tag('icons/pencil.png',
             alt: I18n.t('marking_state.in_progress'),
             title: I18n.t('marking_state.in_progress'))
         end
@@ -181,9 +181,9 @@ module SubmissionsHelper
 
   def get_grouping_can_begin_grading(assignment, grouping)
     if assignment.submission_rule.can_collect_grouping_now?(grouping)
-      return ActionController::Base.helpers.image_tag('icons/tick.png')
+      return view_context.image_tag('icons/tick.png')
     else
-      return ActionController::Base.helpers.image_tag('icons/cross.png')
+      return view_context.image_tag('icons/cross.png')
     end
   end
 


### PR DESCRIPTION
The helpers were not generating the correct URLs when running MarkUs in a subdirectory. Using view_context ensures that they now do.
