### PR TITLE
Fix for issue 1740: switching roles 

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -199,12 +199,14 @@ class MainController < ApplicationController
   def login_as
     validation_result = nil
     if MarkusConfigurator.markus_config_remote_user_auth
-      validation_result = validate_user_without_login(params[:effective_user_login],
-                                                      User.find_by_id(session[:uid]).user_name)
+      validation_result = validate_user_without_login(
+                             params[:effective_user_login],
+                             User.find_by_id(session[:uid]).user_name)
     else
-      validation_result = validate_user(params[:effective_user_login],
-                                        User.find_by_id(session[:uid]).user_name,
-                                        params[:admin_password])
+      validation_result = validate_user(
+                             params[:effective_user_login],
+                             User.find_by_id(session[:uid]).user_name,
+                             params[:admin_password])
     end
     unless validation_result[:error].nil?
       # There were validation errors


### PR DESCRIPTION
The argument for the real user id was not being passed to validate_user correctly.  Because we were using dummy_validate.sh which always returns true, this error was completely masked.
