### PR TITLE
Fix for issue #1746: corrected parameter hash generation.

### DIFF
--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -4,7 +4,7 @@ module AssignmentsHelper
     link_to_function name do |page|
       assignment_file = render(partial: 'assignment_file', locals: {form: form, assignment_file: AssignmentFile.new})
       page << %{
-        var new_assignment_file_id = "new_" + new Date().getTime();
+        var new_assignment_file_id = new Date().getTime();
         $('assignment_files').insert({bottom: "#{ escape_javascript assignment_file }".replace(/(attributes_\\d+|\[\\d+\])/g, new_assignment_file_id) });
         $('assignment_assignment_files_' + new_assignment_file_id + '_filename').focus();
       }


### PR DESCRIPTION
**Issue**: #1746

**Description**: "When creating/updating an assignment, any required files you set are not persisted when you hit Submit. The Success message is displayed. however."

**Fix**: The new `input` tag that is generated for a required file is created dynamically with javascript. In this js, the input tag's name attribute is set to include `new_<TIMESTAMP>`. the `new_` breaks the functionality. Removing the `new_` from the input tag's attributes does not seem to break anything visually or code-wise.

**Testing**: I ran variations of adding and removing required files.
