### PR TITLE
Fix error reporting bug when uploading group CSV

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -144,7 +144,6 @@ class GroupsController < ApplicationController
   # repository name. If MarkUs is not repository admin, the repository name as
   # specified by the second field will be used instead.
   def csv_upload
-    flash[:error] = nil # reset from previous errors
     file = params[:group][:grouplist]
     @assignment = Assignment.find(params[:assignment_id])
     encoding = params[:encoding]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
     # type, and :notice is the most neutral of the four
     type = :notice if !available_types.include?(type)
     # If a flash with that type doesn't exist, create a new array
-    flash[type] = [] if !flash.key?(type)
+    flash[type] ||= []
     # If the message doesn't already exist, add it
     unless flash[type].include?(text)
       flash[type].push(text)


### PR DESCRIPTION
This patch deals with two issues:
1. flash data don't need to be "reset from previous errors". They are
   automatically reset by Rails for each request. Manually setting it to
   nil causes the current error reporting code to skip the
   `if !flash.key?(type)` check because the key exists, but flash[type]
   is still nil and will trigger an exception later.
2. It's safer to test nilness of flash data than to test the existence
   of keys.

Tested:
- bundle exec rake test
- bundle exec rspec
