### PR TITLE
Fix for issue 1735: Manually set available locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,5 +61,6 @@ module Markus
 
   # Validate passed locales
   I18n.enforce_available_locales = true
+  I18n.available_locales = [:en, :fr, :pt]
   end
 end


### PR DESCRIPTION
Problem: The server log shows "pt is an invalid locale" when user select "pt" language in footer. The language falls back to default en locale, but the url still shows /pt/ which causes the problem. 

Fix: Manually set available locales [:en, :fr, :pt]

Testing: Manual tests on different pages.

bundle exec rake test
=> 982 tests, 3066 assertions, 2 failures, 0 errors, 0 skips
bundle exec rspec
=> 141 examples, 0 failures
