### PR TITLE
Fixed issue #1718. Removed reference to non-existent js file.

### DIFF
--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -1,5 +1,4 @@
-<%= javascript_include_tag 'submissions_manager',
-                           'help_system' %>
+<%= javascript_include_tag 'help_system' %>
 
 <%= render partial: 'submissions_table', formats: [:'js.jsx'], handlers: [:erb] %>
 


### PR DESCRIPTION
**Issue**: #1718

**Problem**: "Go to the Submissions view of an assignment; we're requesting a missing `submissions_manager.js`."

**Fix**: I removed the file as, currently, the only place that file is referenced in the codebase is in the `javascript_include_tag` for the submissions page. The js file was removed in commit named "Clean up unnecessary stuff", 4ace620fbd4f03cb291b69c710065c3818d34b44, where a lot of partials were also removed.

**Testing**: both tests still work. This is expected as just a missing reference was removed from a client-side file.
