### PR TITLE
Fixed issue #1747

### DIFF
--- a/app/assets/javascripts/ReactComponents/table.js
+++ b/app/assets/javascripts/ReactComponents/table.js
@@ -49,8 +49,8 @@ var Table = React.createClass({displayName: 'Table',
     search_placeholder: React.PropTypes.string,
     columns: React.PropTypes.array,
     filters: React.PropTypes.array, // Optional: pass null
-    filter_type: React.PropTypes.bool, // True for select filter, false for simple
-    selectable: React.PropTypes.bool, // True if you want checkbox elements
+    filter_type: React.PropTypes.bool, // True for select filter, falsy for simple
+    selectable: React.PropTypes.bool, // True if you want checkboxed elements
     onSelectedRowsChange: React.PropTypes.func // function to call when selected rows change
   },
   getInitialState: function() {


### PR DESCRIPTION
Issue: #1747

Summary: Descending Column Icon doesn't appear in bottom headers

When sorting a table column in descending order, the descending icon only appears in the table header, but not the footer. Sorting by ascending shows the ascending icon in header and footer, as desired.

Fix:

As discussed in https://github.com/MarkUsProject/Markus/commit/9e34e1f44359214c9bc2bf2863e03c48dc3c4787

a space was necessary before appending the sort direction style class defined in the render function. In this case, a space was present before the ascending case, but not the descending case, so a space was added to fix the bug.

~~I also adjusted some misspelled words in some comments.~~

Test:
Visual check on Manage Graders table on Assignments->Graders; descending sort icon appears in table footer as desired.
