### PR TITLE
Change to larger page sizes in spreadsheets

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -23,7 +23,7 @@ class GradeEntryFormsController < ApplicationController
   # Filters will be added as the student UI is implemented (eg. Show Released,
   # Show All,...)
   G_TABLE_PARAMS = {model: GradeEntryStudent,
-                    per_pages: [15, 30, 50, 100, 150, 500, 1000],
+                    per_pages: [100, 150, 500, 1000],
                     filters: {
                         'none' => {
                             display: 'Show All',
@@ -111,7 +111,7 @@ class GradeEntryFormsController < ApplicationController
       params[:per_page] = cookies[c_per_page]
     else
       # Set params to default and make the cookie!
-      params[:per_page] = 15
+      params[:per_page] = 100
       cookies[c_per_page] = params[:per_page]
     end
 


### PR DESCRIPTION
**Change to larger page sizes in grade spreadsheets**

**Summary**
Instructors want to see larger page sizes (more students per page) in grade spreadsheets

**Fix**
- Remove [15, 30,50] from list of options
- Change default page size to 100 students per page

**Tests**
- Ran test suite. There was one error that is associated with user permission that was present on a clean repo clone.
- Manual tests
  - Open spreadsheet and saw that the default page size was set at 100. Checked to see that the dropdown is in the range 100 to 1000.
  - Created a new spreadsheet and checked page sizes.
