### PR TITLE
Fix for Issue #1729. Allowed for blank first item for first two lines.

### DIFF
--- a/app/models/grade_entry_item.rb
+++ b/app/models/grade_entry_item.rb
@@ -41,10 +41,9 @@ class GradeEntryItem < ActiveRecord::Base
       raise I18n.t('grade_entry_forms.csv.incomplete_header')
     end
 
-    # Make sure the first elements in names and totals are ""
-    unless names.shift == '' && totals.shift == ''
-      raise I18n.t('grade_entry_forms.csv.incomplete_header')
-    end
+    # We ignore the first column.
+    names.shift
+    totals.shift
 
     # Process the question names and totals
     (0..(names.size - 1)).each do |i|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,6 +492,7 @@ en:
         upload_prompt: "Select a CSV file to upload"
         upload_format_html: "<p>The file should have the following format:</p>
                              <ul><li>two lines at the top which specify the question names and totals;</li>
+                             <li>the first item for the first two lines is ignored;</li>
                              <li>one line for each student record;</li>
                              <li>each line should be terminated by a carriage-return line-feed.</li></ul>
                              <code>\"\",q1_name,q2_name,q3_name</code><br>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -481,6 +481,7 @@ fr:
         upload_prompt: "Sélectionner un fichier CSV à envoyer"
         upload_format_html: "<p>Le fichier devra être au format suivant : </p>
                              <ul><li>les deux lignes du haut spécifient le nom de la note et le total ;</li>
+                             <li>le premier objet pour les deux premières lignes est ignoré ;</li>
                              <li>une ligne pour chaque étudiant(e) ;</li>
                              <li>chaque ligne doit être terminée par un retour charriot.</li></ul>
                              <code>\"\",q1_name,q2_name,q3_name</code><br>

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -465,6 +465,7 @@ pt:
         upload_prompt: "Selecione um arquivo CSV para carregar"
         upload_format_html: "<p>O arquivo deve conter o seguinte formato:</p>
                              <ul><li>duas linhas no topo que devem especificar o nome da questão e o total;</li>
+                             <li>o primeiro objeto para as duas primeiras linhas é ignorado;</li>
                              <li>uma linha para cada aluno;</li>
                              <li>cada linha deve ser terminada por um carriage-return line-feed.</li></ul>
                              <code>\"\",q1_name,q2_name,q3_name</code><br>


### PR DESCRIPTION
**Issue**: #1729 

**Description**:  The format for uploading a spreadsheet CSV requires the string `""` as the first entry of the first two lines.

**Fix**: Essentially, `grade_entry_item.rb` was altered to remove the check that raises an error if the header is not compatible. Instead, the `names` and `totals` arrays are shifted forward by one (to simply ignore the first csv value for the first two rows). Additionally, the language files were edited to tell users that the first item for the first two lines of the csv file could be blank. This was done in all available languages.

**Testing**: Several csv files were tested on the spreadsheet uploader to check and see if this item is ignored. The check worked for blank, `""`, and non-blank columns. Each csv file was successfully uploaded and parsed.
