### PR TITLE
Fixed #1768: API for adding users doesn't work for REMOTE_USER_AUTH

### DIFF
--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -1,5 +1,3 @@
-require 'base64'
-
 # Scripting API handlers for MarkUs
 module Api
 


### PR DESCRIPTION
Fixed #1768

**Problem**: When `REMOTE_USER_AUTH` is `true`, the API does not work.

**Solution**: The API is normally accessed manually (eg. via a script), and `REMOTE_USER_AUTH` being set expects that there will some sort of external authentication. Since there will be no external authentication, only the presence of an API key should be considered for authentication. Therefore, remote authentication has been removed from the REST API.

**Testing**: rake and rspecs all pass. Manual testing was also done.
