### PR TITLE
High z-index to ensure help message boxes are visible

### DIFF
--- a/app/assets/stylesheets/common/_core.scss
+++ b/app/assets/stylesheets/common/_core.scss
@@ -154,6 +154,7 @@ input[type='radio'] {
   position: relative;
   top: -15px;
   width: 350px;
+  z-index: 10000;
 }
 
 .help-message-title {


### PR DESCRIPTION
For issue #1778: try to ensure that help message boxes aren't behind other elements by giving it a high `z-index` value.
