### PR TITLE
Fix highlighting for multi-line haskell comments

### DIFF
--- a/app/assets/javascripts/syntaxhighlighter/shBrushHaskell.js
+++ b/app/assets/javascripts/syntaxhighlighter/shBrushHaskell.js
@@ -29,7 +29,7 @@ dp.sh.Brushes.Haskell = function()
  
         this.regexList = [
                 { regex: new RegExp('--.*$', 'gm'), css: 'comment' },                      			// one line comments
-                { regex: new RegExp('\{-[^]*-}', 'gm'), css: 'comment' },                      	        // multiline comments
+                { regex: new RegExp('\{-[^]*?-}', 'gm'), css: 'comment' },                      	        // multiline comments
                 { regex: dp.sh.RegexLib.DoubleQuotedString,  css: 'string' },   		// double quoted strings
                 { regex: dp.sh.RegexLib.SingleQuotedString,  css: 'string' },   		// single quoted strings
                 { regex: new RegExp(this.GetKeywords(keywords), 'g'), css: 'keyword' },     	// keyword


### PR DESCRIPTION
My bad - the previous matching was greedy, which is terrible for comments.
