### PR TITLE
'Download All Files' now actually downloads all files

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -769,8 +769,7 @@ class SubmissionsController < ApplicationController
 
       if no_files != true
         # Send the Zip file
-        send_file zip_path, disposition: 'inline',
-                  filename: zip_name + '.zip'
+        send_file zip_path, disposition: 'inline', filename: zip_name + '.zip'
       end
 
     end


### PR DESCRIPTION
Changed the "Download All Files" functionality so it now recursively follows sub-directories where before it did not.

This is coming from the Git branch, and has been tested to work with SVN as well.
