### PR TITLE
Fix invalid submission bug #1897

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -470,6 +470,7 @@ class SubmissionsController < ApplicationController
 
     if current_user.ta?
       @groupings = @assignment.ta_memberships.find_all_by_user_id(current_user)
+                              .select { |m| m.grouping.is_valid? }
                               .map { |m| m.grouping }
     else
       @groupings = @assignment.groupings


### PR DESCRIPTION
This should fix the bug that causes the TA submissions table to not load. I forgot to filter out the invalid groupings when the TA was loading the submissions.
Sorry about that...
