### PR TITLE
fix #1920

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,7 +280,7 @@ Markus::Application.routes.draw do
         post 'add_existing_annotation'
         put 'update_annotation'
         post 'update_comment'
-        delete 'destroy'
+        delete '/' => 'annotations#destroy'
       end
     end
 


### PR DESCRIPTION
In rails 3 the annotation route was:

```
 annotations DELETE   (/:locale)/annotations(.:format)            annotations#destroy {:locale=>/en|fr|pt/}
             GET      (/:locale)/annotations(.:format)            annotations#index {:locale=>/en|fr|pt/}
             POST     (/:locale)/annotations(.:format)            annotations#create {:locale=>/en|fr|pt/}

```

In rails 4 the annotation route becomes:

```
 annotations DELETE   (/:locale)/annotations/destroy(.:format)    annotations#destroy {:locale=>/en|fr|pt/}
             GET      (/:locale)/annotations(.:format)            annotations#index {:locale=>/en|fr|pt/}
             POST     (/:locale)/annotations(.:format)            annotations#create {:locale=>/en|fr|pt/}
```

I modified the annotation route so that it looks like the one in rails 3.
