### PR TITLE
Remove save button from remark request

### DIFF
--- a/app/views/results/student/_remark_request_form.html.erb
+++ b/app/views/results/student/_remark_request_form.html.erb
@@ -12,11 +12,12 @@
 
     <div>
       <%= hidden_field_tag 'real_commit', 'Submit' %>
-      <%= f.submit t(:save_changes),
-                   onclick: "jQuery('#real_commit').val('Save');",
-                   disabled: true,
-                   id: 'remark_request_save',
-                   data: { disable_with: t('working') } %>
+      <%=# f.submit t(:save_changes),
+         #          onclick: "jQuery('#real_commit').val('Save');",
+         #          disabled: true,
+         #          id: 'remark_request_save',
+         #          data: { disable_with: t('working') } 
+      %>
       <%= f.submit t(:submit_request),
                    data: { disable_with: t('working') },
                    id: 'remark_request_submit',


### PR DESCRIPTION
This is a temporary fix; see #1933.
