### PR TITLE
Remove API key from TA view

### DIFF
--- a/app/views/assignments/grader_index.html.erb
+++ b/app/views/assignments/grader_index.html.erb
@@ -9,9 +9,4 @@
 
   <%= render partial: 'grade_entry_forms/list_manage',
              locals: { action: 'grades' } %>
-
-  <div class='section api_key'>
-    <%= render partial: 'api/key_display',
-               locals: { user: @current_user } %>
-  </div>
 </div>


### PR DESCRIPTION
Removed the API key from TA's assignment index view. This sort of deals with issue https://github.com/MarkUsProject/Markus/issues/1847, and also prevents TAs from creating admin users via the RESTful API.
