### PR TITLE
Remove link to Review Board in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Please see the INSTALL file for installation instructions.
 - Blog: http://blog.markusproject.org/
 - Sandbox: http://www.markusproject.org/admin-demo
 - Source Code: http://github.com/MarkUsProject/Markus
-- Review Board: http://review.markusproject.org/r/
 - MarkUs RDoc: http://www.markusproject.org/dev/app_doc/
 - Test Coverage: http://www.markusproject.org/dev/test_coverage/
 - Units Test Report: http://www.markusproject.org/dev/unit_tests_report.html


### PR DESCRIPTION
Updated link per example in https://github.com/MarkUsProject/Markus/wiki/HowToReviewBoard

When I follow the link, I receive a 404 response. If you'd prefer to handle this differently, I'd be happy to help. :smiley: 
