### PR TITLE
Remove custom WebKit scrollbars

### DIFF
--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -33,46 +33,6 @@ pre,
 }
 
 
-/** Custom scrollbars in WebKit-based browsers */
-
-::-webkit-scrollbar {
-  height: 8px;
-  width: 8px;
-}
-
-::-webkit-scrollbar-button {
-  &:start:decrement,
-  &:end:increment {
-    background-color: $white;
-    display: block;
-    height: 0;
-    width: 0;
-  }
-}
-
-::-webkit-scrollbar-track-piece {
-  border-radius: 8px;
-  background-color: $white;
-}
-
-::-webkit-scrollbar-thumb {
-  background-color: $grey;
-  border-radius: 8px;
-
-  &:hover {
-    background-color: $blue;
-  }
-
-  &:vertical {
-    height: 50px;
-  }
-
-  &:horizontal {
-    width: 50px;
-  }
-}
-
-
 /** Headings */
 
 h1 {


### PR DESCRIPTION
While they look sort of pretty, I discovered that they look really annoying on mobile devices (e.g. in mobile Chrome or Safari) since scrollbars are usually less intrusive on those devices.
