### PR TITLE
Fix styling for student grade entry form list view

### DIFF
--- a/app/views/grade_entry_forms/student_interface.html.erb
+++ b/app/views/grade_entry_forms/student_interface.html.erb
@@ -4,50 +4,50 @@
   <h1><%= t('grade_entry_forms.grades.student_title') + ' ' + @grade_entry_form.short_identifier %></h1>
 </div>
 
-<% if @grade_entry_form.grade_entry_items.empty? %>
-  <div class='wrapper'>
+<div class='wrapper'>
+  <% if @grade_entry_form.grade_entry_items.empty? %>
     <p><%= t('grade_entry_forms.students.no_results') %></p>
-  </div>
-<% else %>
-  <% grade_entry_student = @grade_entry_form.grade_entry_students.find_by_user_id(@student.id) %>
-  <% if grade_entry_student.nil?  or !grade_entry_student.released_to_student %>
-    <%= t('grade_entry_forms.students.no_results') %>
   <% else %>
-    <div class='table'>
-      <table>
-        <thead>
-          <%= render partial: 'grades_table_column_names' %>
-        </thead>
-        <tbody>
-          <tr>
-            <td class='grades_table_cell'><%= @student.user_name %></td>
-            <td class='grades_table_cell'><%= @student.last_name %></td>
-            <td class='grades_table_cell'><%= @student.first_name %></td>
+    <% grade_entry_student = @grade_entry_form.grade_entry_students.find_by_user_id(@student.id) %>
+    <% if grade_entry_student.nil?  or !grade_entry_student.released_to_student %>
+      <%= t('grade_entry_forms.students.no_results') %>
+    <% else %>
+      <div class='table'>
+        <table>
+          <thead>
+            <%= render partial: 'grades_table_column_names' %>
+          </thead>
+          <tbody>
+            <tr>
+              <td class='grades_table_cell'><%= @student.user_name %></td>
+              <td class='grades_table_cell'><%= @student.last_name %></td>
+              <td class='grades_table_cell'><%= @student.first_name %></td>
 
-            <% @grade_entry_form.grade_entry_items.each do |grade_entry_item| %>
-              <% grade = grade_entry_student.grades.find_by_grade_entry_item_id(grade_entry_item.id) %>
+              <% @grade_entry_form.grade_entry_items.each do |grade_entry_item| %>
+                <% grade = grade_entry_student.grades.find_by_grade_entry_item_id(grade_entry_item.id) %>
+                  <td class='grade'>
+                    <% if !grade.nil? && !grade.grade.nil? %>
+                      <%= grade.grade %>
+                    <% else %>
+                      <%= t('grade_entry_forms.grades.no_mark') %>
+                    <% end %>
+                  </td>
+              <% end %>
+
+              <% if @grade_entry_form.show_total %>
                 <td class='grade'>
-                  <% if !grade.nil? && !grade.grade.nil? %>
-                    <%= grade.grade %>
+                  <% total = grade_entry_student.total_grade %>
+                  <% if !total.nil? %>
+                    <%= total %>
                   <% else %>
                     <%= t('grade_entry_forms.grades.no_mark') %>
                   <% end %>
                 </td>
-            <% end %>
-
-            <% if @grade_entry_form.show_total %>
-              <td class='grade'>
-                <% total = grade_entry_student.total_grade %>
-                <% if !total.nil? %>
-                  <%= total %>
-                <% else %>
-                  <%= t('grade_entry_forms.grades.no_mark') %>
-                <% end %>
-              </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-    </div>
+              <% end %>
+            </tr>
+          </tbody>
+       </table>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>


### PR DESCRIPTION
When a student had no marks available for a term mark/grade entry form/spreadsheet (why are there so many terms for the same thing?), it had borders on either side of a single `<p>`.
