### PR TITLE
Show "Current marks spreadsheets" subtitle for TAs

### DIFF
--- a/app/views/grade_entry_forms/_list_manage.html.erb
+++ b/app/views/grade_entry_forms/_list_manage.html.erb
@@ -1,11 +1,11 @@
 <%# Display a list of the current grade entry forms %>
 
 <div class='section'>
+  <h3><%= t(:current_grade_entry_forms_title) %></h3>
+
   <% if @grade_entry_forms.empty? %>
     <p><%= t(:no_grade_entry_forms_message) %></p>
   <% else %>
-    <h3><%= t(:current_grade_entry_forms_title) %></h3>
-
     <div class='table'>
       <table>
         <thead>
@@ -18,9 +18,11 @@
           <% @grade_entry_forms.each do |grade_entry_form| %>
             <tr>
               <td>
-                <%= link_to grade_entry_form.short_identifier+": "+grade_entry_form.description,
-                            {controller: 'grade_entry_forms', action: action, id: grade_entry_form},
-                            class: "assignment_list"%>
+                <%= link_to grade_entry_form.short_identifier + ': ' + grade_entry_form.description,
+                            { controller: 'grade_entry_forms',
+                              action: action,
+                              id: grade_entry_form },
+                            class: 'assignment_list' %>
               </td>
               <td>
                 <%= l(grade_entry_form.date, format: :short_date) %>


### PR DESCRIPTION
It previously would only show the subtitle if there were entries, but it made it have a strange visual hierarchy without the subtitle.
