### PR TITLE
Move JSON endpoint for table data to `populate`

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -2,12 +2,10 @@ class AdminsController < ApplicationController
   include AdminsHelper
   before_filter  :authorize_only_for_admin
   def index
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: get_admins_table_info
-      end
-    end
+  end
+
+  def populate
+    render json: get_admins_table_info
   end
 
   def edit

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -53,23 +53,23 @@ class GradersController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:assignment_id])
+  end
+
+  def populate
+    @assignment = Assignment.find(params[:assignment_id])
     @sections = Section.all
-    respond_to do |format|
-      format.html
-      format.json do
-        assign_to_criteria = @assignment.assign_graders_to_criteria
-        if assign_to_criteria
-          graders_table_info = get_graders_table_info_with_criteria(@assignment)
-          groups_table_info = get_groups_table_info_with_criteria(@assignment)
-        else
-          graders_table_info = get_graders_table_info_no_criteria(@assignment)
-          groups_table_info = get_groups_table_info_no_criteria(@assignment)
-        end
-        # better to use a hash?
-        render json: [assign_to_criteria, @sections,
-                      graders_table_info, groups_table_info]
-      end
+
+    assign_to_criteria = @assignment.assign_graders_to_criteria
+    if assign_to_criteria
+      graders_table_info = get_graders_table_info_with_criteria(@assignment)
+      groups_table_info = get_groups_table_info_with_criteria(@assignment)
+    else
+      graders_table_info = get_graders_table_info_no_criteria(@assignment)
+      groups_table_info = get_groups_table_info_no_criteria(@assignment)
     end
+    # better to use a hash?
+    render json: [assign_to_criteria, @sections,
+                  graders_table_info, groups_table_info]
   end
 
   # Assign TAs to Groupings via a csv file

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -125,17 +125,15 @@ class GroupsController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:assignment_id])
-    respond_to do |format|
-      format.html do
-        @all_assignments = Assignment.all(order: :id)
-        render 'index'
-      end
-      format.json do
-        students_table_info = get_students_table_info
-        groupings_table_info = get_groupings_table_info
-        render json: [students_table_info, groupings_table_info]
-      end
-    end
+    @all_assignments = Assignment.all(order: :id)
+    render 'index'
+  end
+
+  def populate
+    @assignment = Assignment.find(params[:assignment_id])
+    students_table_info = get_students_table_info
+    groupings_table_info = get_groupings_table_info
+    render json: [students_table_info, groupings_table_info]
   end
 
   # Allows the user to upload a csv file listing groups. If group_name is equal

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -13,14 +13,11 @@ class StudentsController < ApplicationController
   end
 
   def index
-    respond_to do |format|
-      format.html do
-        @sections = Section.all
-      end
-      format.json do
-        render json: get_students_table_info
-      end
-    end
+    @sections = Section.all
+  end
+
+  def populate
+    render json: get_students_table_info
   end
 
   def edit

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -236,27 +236,14 @@ class SubmissionsController < ApplicationController
 
   def browse
     @assignment = Assignment.find(params[:assignment_id])
+    @groupings = get_groupings_for_assignment(@assignment, current_user)
+  end
 
-    if current_user.ta?
-      @groupings = @assignment.ta_memberships.find_all_by_user_id(current_user)
-                              .select { |m| m.grouping.is_valid? }
-                              .map { |m| m.grouping }
-    else
-      @groupings = @assignment.groupings
-        .includes(:assignment,
-                  :group,
-                  :grace_period_deductions,
-                  current_submission_used: :results,
-                  accepted_student_memberships: :user)
-        .select { |g| g.non_rejected_student_memberships.size > 0 }
-    end
+  def populate_submissions_table
+    @assignment = Assignment.find(params[:assignment_id])
+    @groupings = get_groupings_for_assignment(@assignment, current_user)
 
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: get_submissions_table_info(@assignment, @groupings)
-      end
-    end
+    render json: get_submissions_table_info(@assignment, @groupings)
   end
 
   def index

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -8,16 +8,16 @@ class SummariesController < ApplicationController
     else
       @criteria = @assignment.flexible_criteria
     end
-    respond_to do |format|
-      format.html
-      if @current_user.ta?
-        format.json do
-          render json: get_summaries_table_info(@assignment,
-                                                @current_user.id)
-        end
-      else
-        format.json { render json: get_summaries_table_info(@assignment) }
-      end
+  end
+
+  def populate
+    @assignment = Assignment.find(params[:assignment_id])
+
+    if @current_user.ta?
+      render json: get_summaries_table_info(@assignment,
+                                            @current_user.id)
+    else
+      render json: get_summaries_table_info(@assignment)
     end
   end
 end

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -3,12 +3,10 @@ class TasController < ApplicationController
   before_filter  :authorize_only_for_admin
 
   def index
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: get_tas_table_info
-      end
-    end
+  end
+
+  def populate
+    render json: get_tas_table_info
   end
 
   def new

--- a/app/views/admins/_admins_table.js.jsx.erb
+++ b/app/views/admins/_admins_table.js.jsx.erb
@@ -47,6 +47,7 @@
       document.getElementById('working').style.display = '';
 
       jQuery.ajax({
+        url: 'admins/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -66,6 +66,7 @@
       // 4rd element: Info for groups table + criteria (if we are using crit.)
       //              this is actually a hash.
       jQuery.ajax({
+        url: 'graders/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/app/views/groups/_groups_manager.js.jsx.erb
+++ b/app/views/groups/_groups_manager.js.jsx.erb
@@ -37,7 +37,7 @@
         students_to_remove: this.state.selected_students_in_groups,
         groupings: this.state.selected_groups
       };
-      
+
       jQuery.ajax({
         method: 'POST',
         url: 'groups/global_actions',
@@ -62,6 +62,7 @@
       document.getElementById('working').style.display = '';
 
       jQuery.ajax({
+        url: 'groups/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/app/views/students/_students_table.js.jsx.erb
+++ b/app/views/students/_students_table.js.jsx.erb
@@ -90,6 +90,7 @@
       document.getElementById('working').style.display = '';
 
       jQuery.ajax({
+        url: 'students/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {
@@ -127,7 +128,7 @@
         s['section'] = student.section_name ? student.section_name : '-';
         s['grace_credits'] = student.grace_credits_remaining + ' / ' + student.grace_credits;
         s['notes'] = <span>
-          <a key={student.edit_link} 
+          <a key={student.edit_link}
             href={student.edit_link}><%= j raw I18n.t(:'edit') %></a>
           | 
           <a key={student.notes_link}

--- a/app/views/submissions/_submissions_table.js.jsx.erb
+++ b/app/views/submissions/_submissions_table.js.jsx.erb
@@ -146,6 +146,7 @@
       document.getElementById('working').style.display = '';
 
       jQuery.ajax({
+        url: 'populate_submissions_table',
         method: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/app/views/summaries/_summaries_table.js.jsx.erb
+++ b/app/views/summaries/_summaries_table.js.jsx.erb
@@ -108,6 +108,7 @@
     refresh: function() {
       document.getElementById('working').style.display = '';
       jQuery.ajax({
+        url: 'summaries/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {
@@ -127,7 +128,7 @@
       });
     },
     render: function() {
-      
+
       var summaries_data = this.state.summaries.map(function(summary) {
         var s = {};
         s['id'] = summary.id;

--- a/app/views/tas/_tas_table.js.jsx.erb
+++ b/app/views/tas/_tas_table.js.jsx.erb
@@ -46,6 +46,7 @@
       document.getElementById('working').style.display = '';
 
       jQuery.ajax({
+        url: 'tas/populate',
         method: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Markus::Application.routes.draw do
       resources :main_api
     end
 
-    resources :admins
+    resources :admins do
+      collection do
+        get 'populate'
+      end
+    end
 
     resources :assignments do
 
@@ -102,6 +106,7 @@ Markus::Application.routes.draw do
         end
 
         collection do
+          get 'populate'
           get 'add_group'
           get 'use_another_assignment_groups'
           get 'manage'
@@ -121,6 +126,7 @@ Markus::Application.routes.draw do
 
       resources :submissions do
         collection do
+          get 'populate_submissions_table'
           get 'file_manager'
           get 'browse'
           post 'populate_file_manager'
@@ -184,10 +190,15 @@ Markus::Application.routes.draw do
         end
       end
 
-      resources :summaries
+      resources :summaries, only: :index do
+        collection do
+          get 'populate'
+        end
+      end
 
       resources :graders do
         collection do
+          get 'populate'
           get 'add_grader_to_grouping'
           post 'csv_upload_grader_groups_mapping'
           post 'csv_upload_grader_criteria_mapping'
@@ -302,6 +313,7 @@ Markus::Application.routes.draw do
 
     resources :students do
       collection do
+        get 'populate'
         post 'bulk_modify'
         get 'manage'
         get 'add_new_section'
@@ -316,6 +328,7 @@ Markus::Application.routes.draw do
 
     resources :tas  do
       collection do
+        get 'populate'
         post 'upload_ta_list'
         get 'download_ta_list'
       end


### PR DESCRIPTION
This fixes issue #1882. The calls to retrieve table data are now like `graders/populate`, instead of asking for JSON from `graders`, which was cached by the browser (the data), causing only the data to show on refreshes/backs.