### PR TITLE
Fixed dashboard links for assignments and spreadsheets

### DIFF
--- a/app/views/assignments/_assignment_summary.html.erb
+++ b/app/views/assignments/_assignment_summary.html.erb
@@ -4,7 +4,7 @@
       <%= link_to I18n.t(:assignment_link,
                          short_id: assignment.short_identifier,
                          description: assignment.description),
-                  edit_assignment_path(id: assignment.id),
+                  browse_assignment_submissions_path(assignment.id),
                   class: 'title' %>
     </h2>
 

--- a/app/views/main/_spreadsheet_list.html.erb
+++ b/app/views/main/_spreadsheet_list.html.erb
@@ -14,7 +14,7 @@
           <tr>
             <td>
               <%= link_to grade_entry_form.short_identifier + ': ' + grade_entry_form.description,
-                          edit_grade_entry_form_path(grade_entry_form),
+                          grades_grade_entry_form_path(grade_entry_form),
                           title: grade_entry_form.description %>
             </td>
           </tr>


### PR DESCRIPTION
issue-1917 indicated that dashboard links for assignments should be point to thesubmission table for that particular assignment. Similarly, dashboard links for spreadsheets should point to the grades table. This has been implmeneted.

This is the first time I've committed to this repo and worked with rails. I wouldn't be surprised if I missed something (rails related, git related, workflow related, etc...) but I don't know what that might be. Would definitely apprciate a more-than-typical thorough review of what I've done.

Link to issue: https://github.com/MarkUsProject/Markus/issues/1917