### PR TITLE
Fixed issue #1919: User cannot set marking state to 'complete' unless all rubric criteria are marked

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -211,6 +211,7 @@ class ResultsController < ApplicationController
   #Updates the marking state
   def update_marking_state
     @result = Result.find(params[:id])
+    @old_marking_state = @result.marking_state
     @result.marking_state = params[:value]
     if @result.save
       # If marking_state is complete, update the cached distribution

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -118,8 +118,8 @@ class Result < ActiveRecord::Base
     if marks.where(mark: nil).first &&
           marking_state == Result::MARKING_STATES[:complete]
       errors.add(:base, I18n.t('common.criterion_incomplete_error'))
-      false
+      return false
     end
-    true
+    return true
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -120,6 +120,6 @@ class Result < ActiveRecord::Base
       errors.add(:base, I18n.t('common.criterion_incomplete_error'))
       return false
     end
-    return true
+    true
   end
 end

--- a/app/views/results/marker/show_result_error.js.erb
+++ b/app/views/results/marker/show_result_error.js.erb
@@ -2,4 +2,4 @@
 document.getElementById('criterion_incomplete_error').innerHTML = '<%= @result.errors[:base].to_sentence %>';
 document.getElementById('criterion_incomplete_error').style.display = '';
 
-document.getElementById('marking_state').value = '<%= Result::MARKING_STATES[:partial] %>';
+document.getElementById('marking_state').value = '<%= @old_marking_state %>';


### PR DESCRIPTION
Issue #1919 : Marking state of submissions can be set as 'complete' even when not all rubric criteria have been marked.

Fix :
If user attempts to set the submission's marking state to 'complete' when not all rubric criteria have been, the change is not completed and the user is prompted with the following error message:

"Unable to change marking status to complete, marks missing. Check the marking rubric and make sure that each criterion has been given a mark."