### PR TITLE
Fix downloading flexible criteria

### DIFF
--- a/app/views/flexible_criteria/index.html.erb
+++ b/app/views/flexible_criteria/index.html.erb
@@ -74,10 +74,10 @@
   <h2><%= t('flexible_criteria.download.title') %></h2>
   <p><%= t('flexible_criteria.download.prompt') %></p>
 
-  <%= button_to t('flexible_criteria.download.link'),
-                { controller:'flexible_criteria',
-                  action:'download',
-                  id: @assignment.id } %>
+  <%= link_to t('flexible_criteria.download.link'),
+              { controller:'flexible_criteria',
+                action:'download',
+                id: @assignment.id } %>
 
   <section class='dialog-actions'>
     <input type='reset'


### PR DESCRIPTION
Fixes #1884. There was a problem with downloading the flexible
criteria of an assignment as a CSV file. A POST request was being
generated (because of button_to) instead of the expected GET
request. This has been fixed.