### PR TITLE
Fix pdf-asset url for students

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -474,6 +474,9 @@ class ResultsController < ApplicationController
         @old_marks_map[criterion.id] = oldmark
       end
     end
+
+    @host = Rails.application.config.action_controller.relative_url_root
+
     m_logger = MarkusLogger.instance
     m_logger.log("Student '#{current_user.user_name}' viewed results for assignment " +
                  "'#{@assignment.short_identifier}'.")

--- a/app/views/results/view_marks.html.erb
+++ b/app/views/results/view_marks.html.erb
@@ -5,6 +5,9 @@
 
   <%= javascript_include_tag 'panes.js' %>
   <%= javascript_include_tag 'pdfjs' %>
+  <%= javascript_tag do -%>
+    PDFJS.workerSrc = "<%= @host %>/assets/pdfjs_lib/pdf.worker.js";
+  <% end -%>
 <% end %>
 
 <%= javascript_include_tag 'DropDownMenu/DropDownMenu.js'%>


### PR DESCRIPTION
This corrects the pdfjs asset path in results/view_marks for students. See #1951.

Fixes #2009.
