### PR TITLE
Fixed buggy code in models/user.rb

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ActiveRecord::Base
     # are delimited by \n and C programs use \0 to terminate strings
     not_allowed_regexp = Regexp.new(/[\n\0]+/)
     if not_allowed_regexp.match(login) || not_allowed_regexp.match(password)
+      m_logger = MarkusLogger.instance
       m_logger.log("User '#{login}' failed to log in. Username/password contained " +
                        'illegal characters', MarkusLogger::ERROR)
       AUTHENTICATE_BAD_CHAR


### PR DESCRIPTION
Frontend input fields don't allow characters like newlines and null-terminators and hence requests made from the browser would never really contain these characters. 

However, an attacker can easily bypass this using a program like `curl` and craft a request sending a newline character in the either the username or password field. When this happens, the condition at `line 52` evaluates to true and it's body begins to get executed. It seems that this scenario was never tested, because performing it causes the app to produce an error because  `m_logger` was never instantiated. 

Implications of un-handled errors should be obvious. DoS, back-traces etc.