### PR TITLE
Issue #39: Results controller refactoring

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -36,13 +36,13 @@ class ResultsController < ApplicationController
     @assignment = @result.submission.assignment
     @submission = @result.submission
 
-    @old_result = nil
     if @submission.remark_submitted?
-      @old_result = Result.all(conditions: ['submission_id = ?', @submission.id],
-                               order: ['id ASC'])[0]
+      @old_result = Result.find_by(submission_id: @submission.id)
+    else
+      @old_result = nil
     end
 
-    @annotation_categories = @assignment.annotation_categories
+    #@annotation_categories = @assignment.annotation_categories
     @grouping = @result.submission.grouping
     @not_associated_tags = get_tags_not_associated_with_grouping(@grouping.id)
     @group = @grouping.group

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -42,7 +42,6 @@ class ResultsController < ApplicationController
       @old_result = nil
     end
 
-    #@annotation_categories = @assignment.annotation_categories
     @grouping = @result.submission.grouping
     @not_associated_tags = get_tags_not_associated_with_grouping(@grouping.id)
     @group = @grouping.group
@@ -76,20 +75,9 @@ class ResultsController < ApplicationController
       @result.update_total_mark
     end
 
-    # Get the previous and the next submission
-    # FIXME right now, the groupings are ordered by grouping's id. Having a
-    # more natural grouping order would be nice.
-    if current_user.ta?
-       groupings = @assignment.ta_memberships.find_all_by_user_id(
-                      current_user.id,
-                      include: [grouping: :group],
-                      order: 'id ASC').collect do |m|
-         m.grouping
-       end
-    elsif current_user.admin?
-      groupings = @assignment.groupings.all(include: :group,
-                                            order: 'id ASC')
-    end
+    groupings = Grouping.get_groupings_for_assignment(@assignment,
+                                                      current_user)
+
 
     # If a grouping's submission's marking_status is complete, we're not going
     # to include them in the next_submission/prev_submission list

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -77,20 +77,7 @@ class ResultsController < ApplicationController
 
     groupings = Grouping.get_groupings_for_assignment(@assignment,
                                                       current_user)
-
-
-    # If a grouping's submission's marking_status is complete, we're not going
-    # to include them in the next_submission/prev_submission list
-
-    # If a grouping doesn't have a submission, and we are past the collection time,
-    # we *DO* want to include them in the list.
-    collection_time = @assignment.submission_rule.calculate_collection_time.localtime
-
-    groupings.delete_if do |grouping|
-      grouping != @grouping && ((!grouping.has_submission? && (Time.zone.now < collection_time)))
-    end
-
-    # We sort by Group name by default
+    # We sort by group name by default
     groupings = groupings.sort do |a, b|
       a.group.group_name <=> b.group.group_name
     end
@@ -100,13 +87,14 @@ class ResultsController < ApplicationController
       @next_grouping = groupings.first
       @previous_grouping = groupings.last
     else
-      unless groupings[current_grouping_index + 1].nil?
+      if current_grouping_index + 1 < groupings.length
         @next_grouping = groupings[current_grouping_index + 1]
       end
       if (current_grouping_index - 1) >= 0
         @previous_grouping = groupings[current_grouping_index - 1]
       end
     end
+
     m_logger = MarkusLogger.instance
     m_logger.log("User '#{current_user.user_name}' viewed submission (id: #{@submission.id})" +
                  "of assignment '#{@assignment.short_identifier}' for group '" +

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -37,7 +37,7 @@ class ResultsController < ApplicationController
     @submission = @result.submission
 
     if @submission.remark_submitted?
-      @old_result = Result.find_by(submission_id: @submission.id)
+      @old_result = Result.where(submission_id: @submission.id).first
     else
       @old_result = nil
     end
@@ -87,7 +87,7 @@ class ResultsController < ApplicationController
       @next_grouping = groupings.first
       @previous_grouping = groupings.last
     else
-      if current_grouping_index + 1 < groupings.length
+      unless groupings[current_grouping_index + 1].nil?
         @next_grouping = groupings[current_grouping_index + 1]
       end
       if (current_grouping_index - 1) >= 0

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -244,12 +244,14 @@ class SubmissionsController < ApplicationController
 
   def browse
     @assignment = Assignment.find(params[:assignment_id])
-    @groupings = Grouping.get_groupings_for_assignment(@assignment, current_user)
+    @groupings = Grouping.get_groupings_for_assignment(@assignment,
+                                                       current_user)
   end
 
   def populate_submissions_table
     @assignment = Assignment.find(params[:assignment_id])
-    @groupings = Grouping.get_groupings_for_assignment(@assignment, current_user)
+    @groupings = Grouping.get_groupings_for_assignment(@assignment,
+                                                       current_user)
 
     render json: get_submissions_table_info(@assignment, @groupings)
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -244,7 +244,7 @@ class SubmissionsController < ApplicationController
 
   def browse
     @assignment = Assignment.find(params[:assignment_id])
-    @groupings = get_groupings_for_assignment(@assignment, current_user)
+    @groupings = Grouping.get_groupings_for_assignment(@assignment, current_user)
   end
 
   def populate_submissions_table

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -249,7 +249,7 @@ class SubmissionsController < ApplicationController
 
   def populate_submissions_table
     @assignment = Assignment.find(params[:assignment_id])
-    @groupings = get_groupings_for_assignment(@assignment, current_user)
+    @groupings = Grouping.get_groupings_for_assignment(@assignment, current_user)
 
     render json: get_submissions_table_info(@assignment, @groupings)
   end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,22 +1,4 @@
 module SubmissionsHelper
-  # Gets relevant groupings for assignment based on
-  # user type (ta or admin)
-  def get_groupings_for_assignment(assignment, user)
-    if user.ta?
-      assignment.ta_memberships.find_all_by_user_id(current_user)
-        .select { |m| m.grouping.is_valid? }
-        .map { |m| m.grouping }
-    else
-      assignment.groupings
-        .includes(:assignment,
-                  :group,
-                  :grace_period_deductions,
-                  current_submission_used: :results,
-                  accepted_student_memberships: :user)
-        .select { |g| g.non_rejected_student_memberships.size > 0 }
-    end
-  end
-
   def find_appropriate_grouping(assignment_id, params)
     if current_user.admin? || current_user.ta?
       Grouping.find(params[:grouping_id])

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -668,6 +668,22 @@ class Grouping < ActiveRecord::Base
     end
   end
 
+  def self.get_groupings_for_assignment(assignment, user)
+    if user.ta?
+      assignment.ta_memberships.find_all_by_user_id(current_user)
+                .select { |m| m.grouping.is_valid? }
+                .map { |m| m.grouping }
+    else
+      assignment.groupings
+                .includes(:assignment,
+                          :group,
+                          :grace_period_deductions,
+                          current_submission_used: :results,
+                          accepted_student_memberships: :user)
+                .select { |g| g.non_rejected_student_memberships.size > 0 }
+    end
+  end
+
   private
 
   # Once a grouping is valid, grant (write) repository permissions for students

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -670,7 +670,7 @@ class Grouping < ActiveRecord::Base
 
   def self.get_groupings_for_assignment(assignment, user)
     if user.ta?
-      assignment.ta_memberships.find_all_by_user_id(current_user)
+      assignment.ta_memberships.find_all_by_user_id(user)
                 .select { |m| m.grouping.is_valid? }
                 .map { |m| m.grouping }
     else

--- a/app/views/annotations/_annotation_categories.html.erb
+++ b/app/views/annotations/_annotation_categories.html.erb
@@ -1,6 +1,6 @@
 <ul class='tags' id='annotation_categories'>
   <%# First, output the list of annotation categories %>
-  <% @annotation_categories.each do |annotation_category| %>
+  <% annotation_categories.each do |annotation_category| %>
     <li class='annotation_category'
         id='annotation_category_<%= annotation_category.id %>'
         onclick='return false;'

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -70,7 +70,8 @@
            formats: [:js] %>
 
 <%= render partial: 'results/marker/setup_annotation_categories',
-           formats: [:js] %>
+           formats: [:js],
+           locals: { categories: @assignment.annotation_categories } %>
 
 <%= render partial: 'results/marker/boot',
            formats: [:js],
@@ -183,7 +184,8 @@
     <%= render partial: 'results/marker/marker_panes',
                locals: { extra_marks_points: @extra_marks_points,
                          extra_marks_percentage: @extra_marks_percentage,
-                         annotation_categories: @annotation_categories,
+                         annotation_categories: 
+                           @assignment.annotation_categories,
                          result: @result,
                          assignment: @assignment,
                          marks_map: @marks_map,

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -133,7 +133,7 @@
             <h3><%= I18n.t('marker.annotation.annotation_category') %></h3>
             <select id='new_annotation_category'>
               <option value=''><%= t('annotations.one_time_only') %></option>
-              <% @annotation_categories.each do |annotation_category| %>
+              <% annotation_categories.each do |annotation_category| %>
                 <option value='<%= annotation_category.id %>'>
                   <%= annotation_category.annotation_category_name %>
                 </option>

--- a/app/views/results/marker/_setup_annotation_categories.js.erb
+++ b/app/views/results/marker/_setup_annotation_categories.js.erb
@@ -3,7 +3,7 @@
   /* Begin Annotation Category dropdown code */
   var drop_down_menus = [];
   function setup_annotation_categories() {
-    <% @annotation_categories.each do |annotation_category| %>
+    <% categories.each do |annotation_category| %>
       drop_down_menus[<%= annotation_category.id %>] =
         new DropDownMenu(jQuery('#annotation_category_<%= annotation_category.id %>'),
                          jQuery('#annotation_text_list_<%= annotation_category.id %>'));

--- a/test/functional/results_controller_test.rb
+++ b/test/functional/results_controller_test.rb
@@ -582,12 +582,17 @@ class ResultsControllerTest < AuthenticatedControllerTest
               3.times do |time|
                 g = Grouping.make(:assignment => @assignment)
                 s = Submission.make(:grouping => g)
+                student = Student.make
                 if time == 2
                   @result = s.get_latest_result
                   @result.marking_state = Result::MARKING_STATES[:complete]
                   @result.released_to_students = true
                   @result.save
                 end
+                StudentMembership.make(grouping: g,
+                                       user: student,
+                                       membership_status:
+                                         StudentMembership::STATUSES[:inviter])
               end
               @groupings = @assignment.groupings.all(:order => 'id ASC')
             end
@@ -627,7 +632,7 @@ class ResultsControllerTest < AuthenticatedControllerTest
                      :assignment_id => 1,
                      :submission_id => 1,
                      :id => @result.id
-              assert assigns(:next_grouping)
+              assert_not_nil assigns(:next_grouping)
               next_grouping = assigns(:next_grouping)
               assert next_grouping.has_submission?
               next_result = next_grouping.current_submission_used.get_latest_result
@@ -648,8 +653,8 @@ class ResultsControllerTest < AuthenticatedControllerTest
                      :submission_id => 1,
                      :id => @result.id
 
-              assert assigns(:next_grouping)
-              assert assigns(:previous_grouping)
+              assert_not_nil assigns(:next_grouping)
+              assert_not_nil assigns(:previous_grouping)
               next_grouping = assigns(:next_grouping)
               previous_grouping = assigns(:previous_grouping)
               assert next_grouping.has_submission?
@@ -678,7 +683,7 @@ class ResultsControllerTest < AuthenticatedControllerTest
                      :id => @result.id
 
               assert_nil assigns(:next_grouping)
-              assert assigns(:previous_grouping)
+              assert_not_nil assigns(:previous_grouping)
               previous_grouping = assigns(:previous_grouping)
               assert previous_grouping.has_submission?
               previous_result = previous_grouping.current_submission_used.get_latest_result


### PR DESCRIPTION
Incidentally, this should simplify our processing for the "Next/Prev Submission" links in the Results edit page. Groupings are ordered by group name, which is also the default in the submissions table.

Groupings should appear in this ordering if and only if they appear in the submissions table.