### PR TITLE
Made the remarks able to have marks added

### DIFF
--- a/app/views/results/marker/_marker_summary.html.erb
+++ b/app/views/results/marker/_marker_summary.html.erb
@@ -4,44 +4,6 @@
       <%= t("marker.marks.show_old_marks") %>
     </a>
   </p>
-  <div id='old_summary_criteria_pane'>
-
-    <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
-               locals: { mark_criteria: mark_criteria,
-                         marks_map: old_marks_map } %>
-
-    <div class='summary_block'>
-      <span><strong><%= t('marker.marks.old_subtotal') %></strong></span>
-      <span id='old_subtotal_div'> <%= old_result.get_subtotal %></span>
-      <span> /<%= assignment.total_mark %></span>
-    </div>
-
-    <div id='extra_marks_pane' class='extra_marks_pane'>
-      <div class='bonus_deduction'><strong><%= t('marker.marks.bonus_deductions') %></strong></div>
-      <%= render partial: 'results/student/extra_marks_table',
-                 locals: { extra_marks_points: old_result.extra_marks.points,
-                           result_id: old_result.id } %>
-    </div>
-
-    <div class='summary_block'>
-      <strong class='total_extra_points_label'>
-        <%= t('marker.marks.total_extra_marks').html_safe %>
-      </strong>
-      <span id='total_extra_points'><%= old_result.get_total_extra_points %></span>
-    </div>
-    <div id='extra_percentage_pane' class='extra_percentage_pane'>
-      <%= render partial: 'results/student/extra_percentage_table',
-                 locals: { extra_marks_percentage: old_result.extra_marks.percentage,
-                           result_id: old_result.id } %>
-    </div>
-
-    <div class='summary_block'>
-      <strong><%= t('marker.marks.total_extra_percentages').html_safe %></strong>
-      <span id='total_extra_percentage'><%= old_result.get_total_extra_percentage %></span><br />
-      <strong><%= t('marker.marks.translated_to_points') %></strong>
-      <span id='total_extra_percentage_as_points'><%= old_result.get_total_extra_percentage_as_points %></span> <br />
-    </div>
-  </div>
 <% end %>
 
 <div id='summary_criteria_pane'>
@@ -89,6 +51,50 @@
     <span id='total_extra_percentage_as_points'><%= result.get_total_extra_percentage_as_points %></span>
   </div>
 </div>
+
+<% if old_result %>
+  <div id='old_summary_criteria_pane'>
+
+    <%= render partial: "results/common/#{@assignment.marking_scheme_type}_marks_summary_table",
+               locals: { mark_criteria: mark_criteria,
+                         marks_map: old_marks_map } %>
+
+    <div class='summary_block'>
+      <span><strong><%= t('marker.marks.old_subtotal') %></strong></span>
+      <span id='old_subtotal_div'> <%= old_result.get_subtotal %></span>
+      <span> /<%= assignment.total_mark %></span>
+    </div>
+
+    <div id='extra_marks_pane' class='extra_marks_pane'>
+      <div class='bonus_deduction'><strong><%= t('marker.marks.bonus_deductions') %></strong></div>
+      <%= render partial: 'results/student/extra_marks_table',
+                 locals: { extra_marks_points: old_result.extra_marks.points,
+                           result_id: old_result.id } %>
+    </div>
+
+    <div class='summary_block'>
+      <strong class='total_extra_points_label'>
+        <%= t('marker.marks.total_extra_marks').html_safe %>
+      </strong>
+      <span id='total_extra_points'><%= old_result.get_total_extra_points %></span>
+    </div>
+    <div id='extra_percentage_pane' class='extra_percentage_pane'>
+      <%= render partial: 'results/student/extra_percentage_table',
+                 locals: { extra_marks_percentage: old_result.extra_marks.percentage,
+                           result_id: old_result.id } %>
+    </div>
+
+    <div class='summary_block'>
+      <strong><%= t('marker.marks.total_extra_percentages').html_safe %></strong>
+      <span id='total_extra_percentage'><%= old_result.get_total_extra_percentage %></span><br />
+      <strong><%= t('marker.marks.translated_to_points') %></strong>
+      <span id='total_extra_percentage_as_points'><%= old_result.get_total_extra_percentage_as_points %></span> <br />
+    </div>
+  </div>
+  <script>
+    hide_old_marks();
+  </script>
+<% end %>
 
 <% if old_result %>
   <div class='mark_total'>

--- a/app/views/results/student/_student_summary.html.erb
+++ b/app/views/results/student/_student_summary.html.erb
@@ -145,3 +145,7 @@
   </span>
   <span><%= t('marker.marks.final_mark').html_safe %></span>
 </div>
+
+<script>
+  hide_old_marks();
+</script>


### PR DESCRIPTION
...re two extra marks lists - the old list, and the remark. When there's a remark, the old marks list appears before the new one in the html, so the add extra mark button puts the dialogue on that html (you'll have to look at the source of the page to see it. So, I swapped their order. Also, made the old marks hidden by default, since they weren't before.

Fixes issue 1869.