### PR TITLE
Fix javascript error for TA marking view

### DIFF
--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -42,7 +42,8 @@
     // If the mark_description div is empty, that means it isn't marked
     // Hide the criterion that AREN'T empty (i.e. are marked)
     // Check if the marks are released, if they are there is nothing to hide
-    if (!document.getElementById('released').checked) {
+    if (document.getElementById('released') === null ||
+        !document.getElementById('released').checked) {
       jQuery('.mark_description').each(function() {
         if (this.innerHTML.trim()) {
           hide_criterion(parseInt(this.getAttribute('data-id'), 10));


### PR DESCRIPTION
Before this, the TA view wasn't being rendered properly - annotations couldn't be added. There was a Javascript error when the "released" checkbox was removed.