### PR TITLE
Catch malformed csv exceptions when uploading criteria

### DIFF
--- a/app/controllers/flexible_criteria_controller.rb
+++ b/app/controllers/flexible_criteria_controller.rb
@@ -90,6 +90,8 @@ class FlexibleCriteriaController < ApplicationController
               nb_updates: nb_updates)
           end
         end
+      rescue CSV::MalformedCSVError
+        flash[:error] = t('flexible_criteria.upload.malformed')
       end
     end
     redirect_to action: 'index', assignment_id: @assignment.id

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -88,6 +88,8 @@ class RubricsController < ApplicationController
               nb_updates: nb_updates)
           end
         end
+      rescue CSV::MalformedCSVError
+        flash[:error] = t('rubric_criteria.upload.malformed')
       end
     end
     redirect_to action: 'index', id: @assignment.id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1114,6 +1114,7 @@ en:
         <p>The description is optional. Note that if it is not present, the second
         comma should not appear.</p>"
         success: "Flexible criteria successfully uploaded: %{nb_updates} update(s)."
+        malformed: "The selected file was improperly formed. Please ensure the file meets Markus specifications."
       errors:
         messages:
           name_taken: "Criterion name already used."
@@ -1160,6 +1161,7 @@ en:
         error: "Some rubric criteria were invalid:"
         syntax_error: "There is an error in the file you uploaded: %{error}"
         empty_error: "No criteria were found in the provided file."
+        malformed: "The selected file was improperly formed. Please ensure the file meets Markus specifications."
       error_total: "total weight must be positive"
       defaults:
         level_0: "Very Poor"

--- a/spec/controllers/flexible_criteria_controller_spec.rb
+++ b/spec/controllers/flexible_criteria_controller_spec.rb
@@ -518,6 +518,28 @@ describe FlexibleCriteriaController do
           expect(@flexible_criteria[1].position).to eql(2)
         end
       end
+
+      context 'with a file malformed file' do
+        before(:each) do
+          tempfile = fixture_file_upload('/files/malformed.csv')
+          post_as @admin,
+                  :upload,
+                  assignment_id: @assignment.id,
+                  upload: { flexible: tempfile }
+        end
+        it 'should respond with appropriate content' do
+          expect(assigns(:assignment)).to be_truthy
+        end
+
+        it 'should set the flash' do
+          expect(flash[:error]).to(
+            eql(I18n.t('flexible_criteria.upload.malformed')))
+        end
+
+        it 'should respond with redirect' do
+          is_expected.to respond_with(:redirect)
+        end
+      end
     end
 
     it 'should be able to update_positions' do

--- a/spec/fixtures/files/malformed.csv
+++ b/spec/fixtures/files/malformed.csv
@@ -1,0 +1,22 @@
+# This Vagrantfile is for development use only.
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "markusproject/ubuntu"
+  
+  # Allow instance to see project folder.
+  # Warning: This may cause problems with your Vagrant box!
+  #          Enable at your own risk.
+  # config.vm.synced_folder ".", "/home/vagrant/Markus"
+
+  # Access the server running on port 3000 on the host on port 42069.
+  # config.vm.network "forwarded_port", guest: 3000, host: 42069
+  config.vm.network :private_network, ip: '192.168.50.50'
+  config.vm.synced_folder '.', '/home/vagrant/Markus', type: "nfs"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Uncomment the following line if you want a GUI.
+    # vb.gui = true
+    vb.name = "markus"
+  end
+end

--- a/test/fixtures/files/malformed.csv
+++ b/test/fixtures/files/malformed.csv
@@ -1,0 +1,22 @@
+# This Vagrantfile is for development use only.
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "markusproject/ubuntu"
+  
+  # Allow instance to see project folder.
+  # Warning: This may cause problems with your Vagrant box!
+  #          Enable at your own risk.
+  # config.vm.synced_folder ".", "/home/vagrant/Markus"
+
+  # Access the server running on port 3000 on the host on port 42069.
+  # config.vm.network "forwarded_port", guest: 3000, host: 42069
+  config.vm.network :private_network, ip: '192.168.50.50'
+  config.vm.synced_folder '.', '/home/vagrant/Markus', type: "nfs"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Uncomment the following line if you want a GUI.
+    # vb.gui = true
+    vb.name = "markus"
+  end
+end

--- a/test/functional/rubrics_controller_test.rb
+++ b/test/functional/rubrics_controller_test.rb
@@ -119,6 +119,17 @@ class RubricsControllerTest < AuthenticatedControllerTest
       assert_response :redirect
     end
 
+    should 'deal properly with malformed CSV files' do
+      tempfile = fixture_file_upload('files/malformed.csv')
+      post_as @admin,
+              :csv_upload,
+              assignment_id: @assignment.id,
+              csv_upload: { rubric: tempfile }
+      assert_not_nil assigns :assignment
+      assert_equal(flash[:error], I18n.t('rubric_criteria.upload.malformed'))
+      assert_response :redirect
+    end
+
     should 'have valid values in database after an upload of a UTF-8 encoded file parsed as UTF-8' do
       post_as @admin,
               :csv_upload,


### PR DESCRIPTION
This fixes #83 by catching malformed csv exceptions and flashing an error
indicating such. Tests have been written for the added exception handling.

This is the case for both Rubrics and Flexible Criteria.