### PR TITLE
Removed Periodic Assignment Submission Checks

### DIFF
--- a/app/views/assignments/_list_manage.html.erb
+++ b/app/views/assignments/_list_manage.html.erb
@@ -81,18 +81,3 @@
     </div>
   <% end %>
 </div>
-
-<script>
-  (function periodic() {
-    jQuery.ajax({
-      url:  '<%= update_collected_submissions_assignments_path %>',
-      data: 'authenticity_token=' + AUTH_TOKEN ,
-      type: 'POST',
-      dataType: "script",
-      complete: function() {
-        // Schedule the next request when the current one's complete
-        var timer = setTimeout(periodic, 4000);
-      }
-    });
-  })();
-</script>


### PR DESCRIPTION
Quick fix for the issue from last week's meeting, where the assignments page keeps checking for new submissions, and along the way, resetting the session timeout so that you can't timeout when sitting on the assignments page.