### PR TITLE
Preview new annotation with math

### DIFF
--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -4,6 +4,7 @@ function reloadDOM() {
     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
 }
 
+var timeout;
 function updateAnnotationPreview(){
     var updatedAnnotation = document.getElementById("new_annotation_content").value;
 
@@ -18,8 +19,17 @@ function updateAnnotationPreview(){
         previewParagraph.show();
         previewParagraph.innerHTML = updatedAnnotation;
 
+        if(timeout){
+            clearTimeout(timeout)
+            timeout = null
+        }
+
         // typeset the preview
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub, previewParagraph]);
+        timeout = setTimeout(function() {
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, previewParagraph]);
+            clearTimeout(timeout)
+        }, 3000);
+
     }else{
         title.hide();
         previewParagraph.hide()

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -1,59 +1,41 @@
 // function that reloads the DOM for
 // MathJax (http://www.mathjax.org/docs/1.1/typeset.html)
 function reloadDOM() {
-    MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
 }
 
-function hideAnnotationPreview(){
-    document.getElementById("annotation_preview").hide();
-    document.getElementById("annotation_preview_title").hide();
+function hideAnnotationPreview() {
+    document.getElementById('annotation_preview').hide();
+    document.getElementById('annotation_preview_title').hide();
 
     // recenter dialog
-    var dialog = jQuery("#create_annotation_dialog");
-    dialog.css("margin-left", -1 * dialog.width() / 2);
+    var dialog = jQuery('#create_annotation_dialog');
+    dialog.css('margin-left', -1 * dialog.width() / 2);
 }
 
-function showAnnotationPreview(){
-    document.getElementById("annotation_preview").show();
-    document.getElementById("annotation_preview_title").show();
+function showAnnotationPreview() {
+    document.getElementById('annotation_preview').show();
+    document.getElementById('annotation_preview_title').show();
 
     // recenter dialog
-    var dialog = jQuery("#create_annotation_dialog");
-    dialog.css("margin-left", -1 * dialog.width() / 2);
+    var dialog = jQuery('#create_annotation_dialog');
+    dialog.css('margin-left', -1 * dialog.width() / 2);
 }
 
-function setPreviewMaxWidth(){
-    jQuery("#annotation_preview")
-        .css("max-width", jQuery("#annotation_preview_title").width());
+function setPreviewMaxWidth() {
+    jQuery('#annotation_preview')
+        .css('max-width', jQuery('#annotation_preview_title').width());
 }
 
-var timeout;
-function updateAnnotationPreview(){
-    var newAnnotation = document.getElementById("new_annotation_content").value;
+function updateAnnotationPreview() {
+    var newAnnotation = document.getElementById('new_annotation_content').value;
 
-    var preview = document.getElementById("annotation_preview");
+    var preview = document.getElementById('annotation_preview');
+    preview.innerHTML = newAnnotation;
 
-    var firstIndex = newAnnotation.indexOf("$$");
-    var secondIndex = newAnnotation.indexOf("$$", firstIndex + 1);
+    setPreviewMaxWidth();
+    showAnnotationPreview();
 
-    if(firstIndex != -1 && secondIndex != -1 && firstIndex != secondIndex){
-        preview.innerHTML = newAnnotation;
-
-        setPreviewMaxWidth();
-        showAnnotationPreview();
-
-        if(timeout){
-            clearTimeout(timeout);
-            timeout = null;
-        }
-
-        // typeset the preview
-        timeout = setTimeout(function() {
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, preview]);
-            clearTimeout(timeout);
-        }, 3000);
-
-    }else{
-        hideAnnotationPreview();
-    }
+    // typeset the preview
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
 }

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -4,34 +4,56 @@ function reloadDOM() {
     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
 }
 
+function hideAnnotationPreview(){
+    document.getElementById("annotation_preview").hide();
+    document.getElementById("annotation_preview_title").hide();
+
+    // recenter dialog
+    var dialog = jQuery("#create_annotation_dialog");
+    dialog.css("margin-left", -1 * dialog.width() / 2);
+}
+
+function showAnnotationPreview(){
+    document.getElementById("annotation_preview").show();
+    document.getElementById("annotation_preview_title").show();
+
+    // recenter dialog
+    var dialog = jQuery("#create_annotation_dialog");
+    dialog.css("margin-left", -1 * dialog.width() / 2);
+}
+
+function setPreviewMaxWidth(){
+    jQuery("#annotation_preview")
+        .css("max-width", jQuery("#annotation_preview_title").width());
+}
+
 var timeout;
 function updateAnnotationPreview(){
-    var updatedAnnotation = document.getElementById("new_annotation_content").value;
+    var newAnnotation = document.getElementById("new_annotation_content").value;
 
-    var previewParagraph = document.getElementById("annotation_preview");
-    var title = document.getElementById("annotation_preview_title");
+    var preview = document.getElementById("annotation_preview");
 
-    var firstIndex = updatedAnnotation.indexOf("$$");
-    var secondIndex = updatedAnnotation.indexOf("$$", firstIndex + 1);
+    var firstIndex = newAnnotation.indexOf("$$");
+    var secondIndex = newAnnotation.indexOf("$$", firstIndex + 1);
 
     if(firstIndex != -1 && secondIndex != -1 && firstIndex != secondIndex){
-        title.show();
-        previewParagraph.show();
-        previewParagraph.innerHTML = updatedAnnotation;
+        preview.innerHTML = newAnnotation;
+
+        setPreviewMaxWidth();
+        showAnnotationPreview();
 
         if(timeout){
-            clearTimeout(timeout)
-            timeout = null
+            clearTimeout(timeout);
+            timeout = null;
         }
 
         // typeset the preview
         timeout = setTimeout(function() {
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, previewParagraph]);
-            clearTimeout(timeout)
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, preview]);
+            clearTimeout(timeout);
         }, 3000);
 
     }else{
-        title.hide();
-        previewParagraph.hide()
+        hideAnnotationPreview();
     }
 }

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -3,3 +3,25 @@
 function reloadDOM() {
     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
 }
+
+function updateAnnotationPreview(){
+    var updatedAnnotation = document.getElementById("new_annotation_content").value;
+
+    var previewParagraph = document.getElementById("annotation_preview");
+    var title = document.getElementById("annotation_preview_title");
+
+    var firstIndex = updatedAnnotation.indexOf("$$");
+    var secondIndex = updatedAnnotation.indexOf("$$", firstIndex + 1);
+
+    if(firstIndex != -1 && secondIndex != -1 && firstIndex != secondIndex){
+        title.show();
+        previewParagraph.show();
+        previewParagraph.innerHTML = updatedAnnotation;
+
+        // typeset the preview
+        MathJax.Hub.Queue(["Typeset", MathJax.Hub, previewParagraph]);
+    }else{
+        title.hide();
+        previewParagraph.hide()
+    }
+}

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -130,8 +130,9 @@
               <h2><%= I18n.t('marker.annotation.new_annotation') %></h2>
               </p>
               <p>
-                <textarea id='new_annotation_content' onkeyup="updateAnnotationPreview()"></textarea>
+                <textarea id='new_annotation_content' onkeyup="hideAnnotationPreview()"></textarea>
               </p>
+              <button onclick="updateAnnotationPreview()"><%= t('marker.annotation.preview') %></button>
 
               <p style="float:left;">
               <h3><%= I18n.t('marker.annotation.annotation_category') %></h3>

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -127,8 +127,11 @@
             <h2><%= I18n.t('marker.annotation.new_annotation') %></h2>
           </p>
           <p>
-            <textarea id='new_annotation_content'></textarea>
+            <textarea id='new_annotation_content' onkeyup="updateAnnotationPreview()"></textarea>
           </p>
+          <h2 id="annotation_preview_title" style="display: none"> <%= t('marker.annotation.preview_title') %></h2>
+          <p id="annotation_preview" style="display: none;"></p>
+
           <p>
             <h3><%= I18n.t('marker.annotation.annotation_category') %></h3>
             <select id='new_annotation_category'>

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -123,40 +123,53 @@
           <input type='hidden' id='y1' value=''>
           <input type='hidden' id='y2' value=''>
           <input type='hidden' id='annot_dialog_page' value=''> <%# For use in PDF's %>
-          <p>
-            <h2><%= I18n.t('marker.annotation.new_annotation') %></h2>
-          </p>
-          <p>
-            <textarea id='new_annotation_content' onkeyup="updateAnnotationPreview()"></textarea>
-          </p>
-          <h2 id="annotation_preview_title" style="display: none"> <%= t('marker.annotation.preview_title') %></h2>
-          <p id="annotation_preview" style="display: none;"></p>
+          <div>
+            <div style="float: left;">
+              <p>
 
-          <p>
-            <h3><%= I18n.t('marker.annotation.annotation_category') %></h3>
-            <select id='new_annotation_category'>
-              <option value=''><%= t('annotations.one_time_only') %></option>
-              <% annotation_categories.each do |annotation_category| %>
-                <option value='<%= annotation_category.id %>'>
-                  <%= annotation_category.annotation_category_name %>
-                </option>
-              <% end %>
-            </select>
-          </p>
+              <h2><%= I18n.t('marker.annotation.new_annotation') %></h2>
+              </p>
+              <p>
+                <textarea id='new_annotation_content' onkeyup="updateAnnotationPreview()"></textarea>
+              </p>
 
-          <section class='dialog-actions'>
-            <button id='new_annotation_modal_button' onclick="submit_new_annotation(
-                              jQuery('#new_annotation_content').val(),
-                              jQuery('#new_annotation_category').val(),
-                              jQuery('#x1').val(),
-                              jQuery('#x2').val(),
-                              jQuery('#y1').val(),
-                              jQuery('#y2').val(),
-                              jQuery('#annot_dialog_page').val());">
-              <%= I18n.t('marker.annotation.new_annotation') %>
-            </button>
-            <%= button_to_function t('cancel'), 'modal.close();' %>
-          </section>
+              <p style="float:left;">
+              <h3><%= I18n.t('marker.annotation.annotation_category') %></h3>
+              <select id='new_annotation_category'>
+                <option value=''><%= t('annotations.one_time_only') %></option>
+                <% annotation_categories.each do |annotation_category| %>
+                    <option value='<%= annotation_category.id %>'>
+                      <%= annotation_category.annotation_category_name %>
+                    </option>
+                <% end %>
+              </select>
+              </p>
+
+              <section class='dialog-actions'>
+                <button id='new_annotation_modal_button' onclick="hideAnnotationPreview();
+                        submit_new_annotation(
+                            jQuery('#new_annotation_content').val(),
+                            jQuery('#new_annotation_category').val(),
+                            jQuery('#x1').val(),
+                            jQuery('#x2').val(),
+                            jQuery('#y1').val(),
+                            jQuery('#y2').val(),
+                            jQuery('#annot_dialog_page').val());">
+                  <%= I18n.t('marker.annotation.new_annotation') %>
+                </button>
+                <%= button_to_function t('cancel'), 'modal.close(); hideAnnotationPreview();' %>
+              </section>
+            </div>
+            <div style="float: right">
+              <p>
+              <h2 id="annotation_preview_title" style="display: none"> <%= t('marker.annotation.preview_title') %></h2>
+              </p>
+              <p id="annotation_preview" style="display: none; word-wrap: break-word;"></p>
+            </div>
+            <div style="clear:both;"></div>
+          </div>
+
+
         </aside>
       </div> <!-- Mark pane -->
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,7 @@ en:
         no_annotation_in_this_category: "There are no annotations in this category"
         new_annotation: "Create new annotation"
         annotation_category: "Annotation Category"
+        preview_title: "Here's how the annotation will look:"
         sure_to_remove: "Are you sure you want to remove this annotation?"
         submit_edit: "Submit Edit"
         change_across_submissions: "This change will propogate across all submissions marked with this annotation.  Is this OK?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,7 @@ en:
         no_annotation_in_this_category: "There are no annotations in this category"
         new_annotation: "Create new annotation"
         annotation_category: "Annotation Category"
+        preview: "Preview"
         preview_title: "Here's how the annotation will look:"
         sure_to_remove: "Are you sure you want to remove this annotation?"
         submit_edit: "Submit Edit"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -325,6 +325,7 @@ fr:
         no_annotation_in_this_category: "Il n'y a pas d'annotation dans cette catégorie"
         new_annotation: "Nouvelle annotation"
         annotation_category: "Catégorie de l'annotation"
+        preview_title: "Voici l'apparence de l'annotation:"
         sure_to_remove: "Êtes-vous sûr de vouloir supprimer cette annotation ?"
         submit_edit: "Sauvegarder"
         change_across_submissions: "Ce changement sera propagé à toutes les notes comportant cette annotation, même celles déjà affichées. Êtes-vous sûr de vouloir continuer ?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -325,6 +325,7 @@ fr:
         no_annotation_in_this_category: "Il n'y a pas d'annotation dans cette catégorie"
         new_annotation: "Nouvelle annotation"
         annotation_category: "Catégorie de l'annotation"
+        preview: "Avant-première"
         preview_title: "Voici l'apparence de l'annotation:"
         sure_to_remove: "Êtes-vous sûr de vouloir supprimer cette annotation ?"
         submit_edit: "Sauvegarder"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -322,6 +322,7 @@ pt:
         no_annotation_in_this_category: "Existem anotações nessa categoria"
         new_annotation: "Criar nova anotação"
         annotation_category: "Categoria de anotação"
+        preview: "Visualização"
         preview_title: "Veja como a anotação vai olhar:"
         sure_to_remove: "Tem certeza que quer remover essa anotação?"
         submit_edit: "Enviar mudanças"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -322,6 +322,7 @@ pt:
         no_annotation_in_this_category: "Existem anotações nessa categoria"
         new_annotation: "Criar nova anotação"
         annotation_category: "Categoria de anotação"
+        preview_title: "Veja como a anotação vai olhar:"
         sure_to_remove: "Tem certeza que quer remover essa anotação?"
         submit_edit: "Enviar mudanças"
         change_across_submissions: "Essa mudança irá propagar por todas as submissões com essa anotação. Você tem certeza disso?"


### PR DESCRIPTION
When a marker creates a new annotation with math in it,
a preview of the annotation will be shown to the marker
in the create-an-annotation popup.

This preview will only be shown if there is math content. ie: if there exists something to the effect of ```$$\sum$$```. Specifically, there need to be at least two sets of ```$$```.