### PR TITLE
Flash an error when a YAML file cannot be parsed

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -178,6 +178,14 @@ class AnnotationCategoriesController < ApplicationController
         redirect_to action: 'index', assignment_id: @assignment.id
         return
       end
+
+      # YAML::load returns a hash if successful
+      unless annotations.is_a? Hash
+        flash[:error] = I18n.t('annotations.upload.unparseable_yaml')
+        redirect_to action: 'index', assignment_id: @assignment.id
+        return
+      end
+
       annotations.each_key do |key|
       result = AnnotationCategory.add_by_array(key, annotations.values_at(key), @assignment, current_user)
       annotation_line += 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -998,6 +998,7 @@ en:
         error:  "Unable to upload category: %{annotation_category} located in line %{annotation_line}"
         syntax_error: "There is an error in the file you uploaded: %{error}"
         flash_error: "Could not recognize %{format} format to download with"
+        unparseable_yaml: "Could not parse YAML file"
       download:
         download_annotations: "Download Annotations"
         download_csv: "Download in CSV Format"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -868,6 +868,7 @@ fr:
         error:  "Impossible d'envoyer les catégories : problème à la catégorie %{annotation_category} située sur la ligne %{annotation_line}"
         syntax_error: "Il y a une erreur de syntaxe dans le fichier que vous venez d'envoyer : %{error}"
         flash_error: "Le format %{format} que vous voulez télécharger n'a pas été reconnu."
+        unparseable_yaml: "Ne pourrait pas analyzer le fichier YAML"
       download:
         download_annotations: "Télécharger les annotations"
         download_csv: "Télécharger au format CSV"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -856,6 +856,7 @@ pt:
         error:  "Não foi possível fazer o upload de categoria: erro com %{annotation_category} localizado na linha %{annotation_line}"
         syntax_error: "Existe um erro no  arquivo carregado: %{error}"
         flash_error: "Não foi possível reconhecer o formato %{format}"
+        unparseable_yaml: "Não foi possível analisar o arquivo YAML"
       download:
         download_annotations: "Baixar anotações"
         download_csv: "Baixar em formato CSV"

--- a/test/functional/annotation_categories_controller_test.rb
+++ b/test/functional/annotation_categories_controller_test.rb
@@ -424,6 +424,18 @@ class AnnotationCategoriesControllerTest < AuthenticatedControllerTest
                      (new_categories_list.length))
       end
 
+      should 'flash error on :yml_upload with unparseable YAML file' do
+        tempfile = fixture_file_upload('files/rubric.csv')
+        post_as @admin,
+                :yml_upload,
+                assignment_id: @assignment.id,
+                annotation_category_list_yml: tempfile
+
+        assert_response :redirect
+        assert_equal(flash[:error],
+                     I18n.t('annotations.upload.unparseable_yaml'))
+      end
+
       should 'on :yml_upload route properly' do
         assert_recognizes({:controller => 'annotation_categories', :assignment_id => '1', :action => 'yml_upload' },
           {:path => 'assignments/1/annotation_categories/yml_upload',  :method => :post})


### PR DESCRIPTION
When uploading a YAML file for annotation categoreis, an error
will be flash if the file cannot be parsed. Fixes #1727.