### PR TITLE
Implemented Issue-2114 - Overwrite option for CSV Grades Upload

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -417,7 +417,7 @@ class GradeEntryFormsController < ApplicationController
       end
     end
 
-    # If the request is a post type and the abort flag is down 
+    # If the request is a post type and the abort flag is down
     # (operation can continue)
     if request.post? && !abort_upload
       grades_file = params[:upload][:grades_file]

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -389,6 +389,7 @@ class GradeEntryFormsController < ApplicationController
 
     encoding = params[:encoding]
     upload = params[:upload]
+    overwrite = params[:overwrite]
 
     #flag to check whether upload should continue. True if upload should be aborted
     abort_upload = false
@@ -416,7 +417,7 @@ class GradeEntryFormsController < ApplicationController
       end
     end
 
-    #If the request is a post type and the abort flag is down (operation can continue)
+    # If the request is a post type and the abort flag is down (operation can continue)
     if request.post? && !abort_upload
       grades_file = params[:upload][:grades_file]
       begin
@@ -425,7 +426,7 @@ class GradeEntryFormsController < ApplicationController
           num_updates = GradeEntryForm.parse_csv(grades_file,
                                                  @grade_entry_form,
                                                  invalid_lines,
-                                                 encoding)
+                                                 encoding, overwrite)
           unless invalid_lines.empty?
             flash[:error] = I18n.t('csv_invalid_lines') + invalid_lines.join(', ')
           end

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -417,7 +417,8 @@ class GradeEntryFormsController < ApplicationController
       end
     end
 
-    # If the request is a post type and the abort flag is down (operation can continue)
+    # If the request is a post type and the abort flag is down 
+    # (operation can continue)
     if request.post? && !abort_upload
       grades_file = params[:upload][:grades_file]
       begin

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -243,7 +243,8 @@ class GradeEntryForm < ActiveRecord::Base
   # grades_file is the CSV file to be parsed
   # grade_entry_form is the grade entry form that is being updated
   # invalid_lines will store all problematic lines from the CSV file
-  def self.parse_csv(grades_file, grade_entry_form, invalid_lines, encoding, overwrite)
+  def self.parse_csv(grades_file, grade_entry_form, invalid_lines, encoding,
+                     overwrite)
     num_updates = 0
     num_lines_read = 0
     names = []

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -243,7 +243,7 @@ class GradeEntryForm < ActiveRecord::Base
   # grades_file is the CSV file to be parsed
   # grade_entry_form is the grade entry form that is being updated
   # invalid_lines will store all problematic lines from the CSV file
-  def self.parse_csv(grades_file, grade_entry_form, invalid_lines, encoding)
+  def self.parse_csv(grades_file, grade_entry_form, invalid_lines, encoding, overwrite)
     num_updates = 0
     num_lines_read = 0
     names = []
@@ -284,7 +284,7 @@ class GradeEntryForm < ActiveRecord::Base
           GradeEntryStudent.create_or_update_from_csv_row(row,
                                                           grade_entry_form,
                                                           grade_entry_form.grade_entry_items,
-                                                          names)
+                                                          names, overwrite)
           num_updates += 1
         end
         num_lines_read += 1

--- a/app/models/grade_entry_student.rb
+++ b/app/models/grade_entry_student.rb
@@ -111,7 +111,8 @@ class GradeEntryStudent < ActiveRecord::Base
   # username,q1mark,q2mark,...,
   # create or update the GradeEntryStudent and Grade objects that
   # correspond to the student
-  def self.create_or_update_from_csv_row(row, grade_entry_form, grade_entry_items, names, overwrite)
+  def self.create_or_update_from_csv_row(row, grade_entry_form,
+                                         grade_entry_items, names, overwrite)
     working_row = row.clone
     user_name = working_row.shift
 
@@ -130,29 +131,32 @@ class GradeEntryStudent < ActiveRecord::Base
       grade_entry_item = grade_entry_items.where(name: grade_entry_name).first
 
       # Don't add empty grades and remove grades that did exist but are now empty
-      old_grade =
-        grade_entry_student.grades
-                           .where(grade_entry_item_id: grade_entry_item.id)
-                           .first
+      old_grade = grade_entry_student.grades
+                  .where(grade_entry_item_id: grade_entry_item.id)
+                  .first
 
       if overwrite
-          if !grade_for_grade_entry_item || grade_for_grade_entry_item.empty?
-            
-            unless old_grade.nil?
-              old_grade.destroy
-            end
-          else
-            grade = grade_entry_student.grades.find_or_create_by_grade_entry_item_id(grade_entry_item.id)
-            grade.grade = grade_for_grade_entry_item
+        if !grade_for_grade_entry_item || grade_for_grade_entry_item.empty?
 
-            unless grade.save
-              raise RuntimeError.new(grade.errors)
-            end
+          unless old_grade.nil?
+            old_grade.destroy
           end
-      else
-        if old_grade.nil? && (grade_for_grade_entry_item || !grade_for_grade_entry_item.empty?)
+        else
+          grade = grade_entry_student.grades
+                  .find_or_create_by_grade_entry_item_id(grade_entry_item.id)
+          grade.grade = grade_for_grade_entry_item
 
-          grade = grade_entry_student.grades.find_or_create_by_grade_entry_item_id(grade_entry_item.id)
+          unless grade.save
+            raise RuntimeError.new(grade.errors)
+          end
+        end
+
+      else
+        if old_grade.nil? && 
+           (grade_for_grade_entry_item || !grade_for_grade_entry_item.empty?)
+
+          grade = grade_entry_student.grades
+                  .find_or_create_by_grade_entry_item_id(grade_entry_item.id)
           grade.grade = grade_for_grade_entry_item
 
           unless grade.save

--- a/app/models/grade_entry_student.rb
+++ b/app/models/grade_entry_student.rb
@@ -152,7 +152,7 @@ class GradeEntryStudent < ActiveRecord::Base
         end
 
       else
-        if old_grade.nil? && 
+        if old_grade.nil? &&
            (grade_for_grade_entry_item || !grade_for_grade_entry_item.empty?)
 
           grade = grade_entry_student.grades

--- a/app/views/grade_entry_forms/grades.html.erb
+++ b/app/views/grade_entry_forms/grades.html.erb
@@ -162,6 +162,10 @@
       <%= t('encoding') %>
       <%= select_tag(:encoding, options_for_select(@encodings)) %>
     </p>
+    <span>
+      <%= t('grade_entry_forms.csv.overwrite') %>
+      <%= check_box_tag(:overwrite)%>
+    </span>
 
     <section class='dialog-actions'>
       <%= f.submit t(:upload), data: { disable_with: t(:uploading_please_wait) } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -516,6 +516,7 @@ en:
         no_results: "There are no marks available yet."
         detailed_marks_message: "Detailed marks are available."
       csv:
+        overwrite: "Overwrite existing grades?"
         incomplete_header: "Incomplete grade entry item names or totals."
         incomplete_row: "Contains too little information."
         invalid_user_name: "Invalid user name."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -491,6 +491,7 @@ fr:
         no_results: "Il n'y a pas encore de résultats pour cette feuille de notes."
         detailed_marks_message: "Les notes détaillées sont disponibles."
       csv:
+        overwrite: "Remplacer les notes existantes?"
         incomplete_header: "Totaux ou noms manquants."
         incomplete_row: "Ne contient pas assez d'informations."
         invalid_user_name: "Nom d'utilisateur invalide."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -477,6 +477,7 @@ pt:
         no_results: "Não há notas disponíveis ainda..."
         detailed_marks_message: "Notas detalhadas estão disponíveis."
       csv:
+        overwrite: "Substituir notas existentes?"
         incomplete_header: "Os totais ou os nomes dos itens estão faltando"
         incomplete_row: "Contém pouca informação."
         invalid_user_name: "Nome de usuário inválido."


### PR DESCRIPTION
Overwrite option for CSV Grades Upload. 

New checkbox in grades upload modal that allows user to indicate if they want the CSV data to overwrite existing grades or not.