### PR TITLE
900 single member group display

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -74,18 +74,18 @@ module SubmissionsHelper
     group_name = ''
       if !grouping.has_submission?
         if assignment.submission_rule.can_collect_grouping_now?(grouping)
-          group_name = view_context.link_to(grouping.get_group_name,
+          group_name = view_context.link_to(grouping.group.group_name,
             collect_and_begin_grading_assignment_submission_path(
               assignment.id, grouping.id))
         else
-          group_name = grouping.get_group_name
+          group_name = grouping.group.group_name
         end
       elsif !grouping.is_collected
-        group_name = view_context.link_to(grouping.get_group_name,
+        group_name = view_context.link_to(grouping.group.group_name,
           collect_and_begin_grading_assignment_submission_path(
             assignment.id, grouping.id))
       else
-        group_name = view_context.link_to(grouping.get_group_name,
+        group_name = view_context.link_to(grouping.group.group_name,
           edit_assignment_submission_result_path(
             assignment.id, grouping.current_submission_used.id,
             grouping.current_submission_used.get_latest_result))

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -74,26 +74,23 @@ module SubmissionsHelper
     group_name = ''
       if !grouping.has_submission?
         if assignment.submission_rule.can_collect_grouping_now?(grouping)
-          group_name = view_context.link_to(grouping.group.group_name,
+          group_name = view_context.link_to(grouping.get_group_name,
             collect_and_begin_grading_assignment_submission_path(
               assignment.id, grouping.id))
         else
-          group_name = grouping.group.group_name
+          group_name = grouping.get_group_name
         end
       elsif !grouping.is_collected
-        group_name = view_context.link_to(grouping.group.group_name,
+        group_name = view_context.link_to(grouping.get_group_name,
           collect_and_begin_grading_assignment_submission_path(
             assignment.id, grouping.id))
       else
-        group_name = view_context.link_to(grouping.group.group_name,
+        group_name = view_context.link_to(grouping.get_group_name,
           edit_assignment_submission_result_path(
             assignment.id, grouping.current_submission_used.id,
             grouping.current_submission_used.get_latest_result))
       end
 
-      group_name += ' ('
-      group_name += grouping.accepted_students.collect{ |student| student.user_name}.join(', ')
-      group_name += ')'
       return group_name
   end
 

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -166,17 +166,6 @@ class Grouping < ActiveRecord::Base
 	  student_user_names.join(', ')
   end
 
-  def get_group_name
-    name = group.group_name
-    if accepted_students.size > 1 then
-      name += ' ('
-      name += accepted_students.collect{ |student| student.user_name}.join(', ')
-      name += ')'
-    end
-    name
-  end
-
-
   def group_name_with_student_user_names
 		user_names = get_all_students_in_group
     return group.group_name if user_names == I18n.t('assignment.group.empty')

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -166,6 +166,17 @@ class Grouping < ActiveRecord::Base
 	  student_user_names.join(', ')
   end
 
+  def get_group_name
+    name = group.group_name
+    if accepted_students.size > 1 then
+      name += ' ('
+      name += accepted_students.collect{ |student| student.user_name}.join(', ')
+      name += ')'
+    end
+    name
+  end
+
+
   def group_name_with_student_user_names
 		user_names = get_all_students_in_group
     return group.group_name if user_names == I18n.t('assignment.group.empty')

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -140,7 +140,6 @@
     <%= t('results.title',
           { assignment_name: @assignment.short_identifier,
             group_name: @group.group_name }) %>
-    (<%= @grouping.get_all_students_in_group %>)
   </h1>
 </div>
 


### PR DESCRIPTION
Solves 900. Removed the code to add lists of members when group names are shown in the results view and the submissions table.