### PR TITLE
Fix error related to lazy loading and Single-Table Inheritance.

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -235,7 +235,8 @@ class AssignmentsController < ApplicationController
     rescue SubmissionRule::InvalidRuleType => e
       @assignment.errors.add(:base, t('assignment.error', message: e.message))
       flash[:error] = t('assignment.error', message: e.message)
-      render :edit, id: @assignment.id and return
+      render :edit, id: @assignment.id
+      return
     end
 
     if @assignment.save

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,11 +1,6 @@
-# We need to force loading of all submission rules so that methods
-# like .const_defined? work correctly (rails abuse of autoload was
-# causing issues)
-Dir.glob('app/models/*_submission_rule.rb').each do |rule|
-  require File.expand_path(rule)
-end
-
 class AssignmentsController < ApplicationController
+  require_dependency 'submission_rule'
+
   before_filter      :authorize_only_for_admin,
                      except: [:deletegroup,
                               :delete_rejected,
@@ -238,10 +233,9 @@ class AssignmentsController < ApplicationController
         @assignment = process_assignment_form(@assignment)
       end
     rescue SubmissionRule::InvalidRuleType => e
-      @assignment.errors.add(:base, I18n.t('assignment.error',
-                                           message: e.message))
-      render :edit, id: @assignment.id
-      return
+      @assignment.errors.add(:base, t('assignment.error', message: e.message))
+      flash[:error] = t('assignment.error', message: e.message)
+      render :edit, id: @assignment.id and return
     end
 
     if @assignment.save
@@ -639,11 +633,14 @@ class AssignmentsController < ApplicationController
     # First, figure out what kind of rule has been requested
     rule_attributes = params[:assignment][:submission_rule_attributes]
     rule_name       = rule_attributes[:type]
-    potential_rule  = if SubmissionRule.const_defined?(rule_name)
-                        SubmissionRule.const_get(rule_name)
-                      end
 
-    unless potential_rule && potential_rule.ancestors.include?(SubmissionRule)
+    # Force the classes to be loaded so that the following check will
+    # succeed on these inputs.
+    [NoLateSubmissionRule, PenaltyPeriodSubmissionRule,
+     PenaltyDecayPeriodSubmissionRule, GracePeriodSubmissionRule]
+    if SubmissionRule.const_defined?(rule_name)
+      potential_rule = SubmissionRule.const_get(rule_name)
+    else
       raise SubmissionRule::InvalidRuleType, rule_name
     end
 

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -2,16 +2,24 @@ class SubmissionRule < ActiveRecord::Base
 
   class InvalidRuleType < Exception
     def initialize(rule_name)
-      super I18n.t('assignment.not_valid_submission_rule', rule_name)
+      super I18n.t('assignment.not_valid_submission_rule', type: rule_name)
     end
   end
 
   belongs_to :assignment
   has_many :periods, dependent: :destroy, order: 'id'
   accepts_nested_attributes_for :periods, allow_destroy: true
+  attr_accessible :type
 
 #  validates_associated :assignment
 #  validates_presence_of :assignment
+
+  def self.descendants
+    [ NoLateSubmissionRule,
+      PenaltyPeriodSubmissionRule,
+      PenaltyDecayPeriodSubmissionRule,
+      GracePeriodSubmissionRule ]
+  end
 
   def can_collect_now?
     return @can_collect_now if !@can_collect_now.nil?

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -15,10 +15,10 @@ class SubmissionRule < ActiveRecord::Base
 #  validates_presence_of :assignment
 
   def self.descendants
-    [ NoLateSubmissionRule,
-      PenaltyPeriodSubmissionRule,
-      PenaltyDecayPeriodSubmissionRule,
-      GracePeriodSubmissionRule ]
+    [NoLateSubmissionRule,
+     PenaltyPeriodSubmissionRule,
+     PenaltyDecayPeriodSubmissionRule,
+     GracePeriodSubmissionRule]
   end
 
   def can_collect_now?

--- a/app/views/shared/_assignments_dropdown_menu.html.erb
+++ b/app/views/shared/_assignments_dropdown_menu.html.erb
@@ -87,6 +87,8 @@
            # menu for assignments should go to browse, and not repo_browser
            if target_action == 'repo_browser'
           target_action = 'browse'
+           elsif target_action == 'update'
+             target_action = 'edit'
         end %>
         <% # Don't show hidden assignments in the dropdown menu for students
            # either. Append '(hidden)' for TAs and Admins.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,7 @@ en:
         short_identifier:   "Short Identifier<span class='required_field'>*</span>"
         update_success:        "Successfully updated the assignment"
         create_success:        "Successfully created the assignment"
-        error: "Could not assign SubmissionRule: #%{message}"
+        error: "Could not assign SubmissionRule: %{message}"
         not_valid_submission_rule: "%{type} is not a valid SubmissionRule"
         rules:           "Assignment Rules"
         edit:           "Edit Assignment:"

--- a/db/migrate/20150527172828_change_submission_rule_column_default.rb
+++ b/db/migrate/20150527172828_change_submission_rule_column_default.rb
@@ -1,0 +1,9 @@
+class ChangeSubmissionRuleColumnDefault < ActiveRecord::Migration
+  def up
+    change_column_default :submission_rules, :type, 'NoLateSubmissionRule'
+  end
+
+  def down
+    change_column_default :submission_rules, :type, 'NullSubmissionRule'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150326163940) do
+ActiveRecord::Schema.define(:version => 20150527172828) do
 
   create_table "annotation_categories", :force => true do |t|
     t.text     "annotation_category_name"
@@ -372,10 +372,10 @@ ActiveRecord::Schema.define(:version => 20150326163940) do
   add_index "submission_files", ["submission_id"], :name => "index_submission_files_on_submission_id"
 
   create_table "submission_rules", :force => true do |t|
-    t.integer  "assignment_id",                                   :null => false
-    t.string   "type",          :default => "NullSubmissionRule"
-    t.datetime "created_at",                                      :null => false
-    t.datetime "updated_at",                                      :null => false
+    t.integer  "assignment_id",                                     :null => false
+    t.string   "type",          :default => "NoLateSubmissionRule"
+    t.datetime "created_at",                                        :null => false
+    t.datetime "updated_at",                                        :null => false
   end
 
   add_index "submission_rules", ["assignment_id"], :name => "index_submission_rules_on_assignment_id"


### PR DESCRIPTION
During the code sprint and since then, various people have gotten an odd "no method update_assignment_path" error on the assignment edit page, which seemed to be caused sometimes when updating an assignment, or creating a new assignment, when fiddling with the rules around late submissions.

I pinpointed the error (fixing the error handling in the process): lazy loading of classes interferes with inheritance relationships. See http://bjhess.com/blog/when-single-table-inheritance-attacks/. There seemed to be a fix in the code, but it clearly wasn't working all the time. W

There was another problem with the submission rules: the default submission rule (NullSubmissionRule) wasn't a valid subclass of SubmissionRule, leading to an STI error when the default was used. I changed the default to NoLateSubmissionRule.