### PR TITLE
Added instruction page links for Key Pairs

### DIFF
--- a/app/views/key_pairs/index.html.erb
+++ b/app/views/key_pairs/index.html.erb
@@ -23,3 +23,10 @@
 <br />
 
 <%= link_to t('key_pairs.new_key_pair'), new_key_pair_path %>
+
+<hr>
+<h2>Need help?</h2>
+<br>
+<a href="https://github.com/MarkUsProject/Wiki/blob/master/SSH_Keypair_Instructions_Windows.md" target="_blank">Instructions for users on Windows</a>
+<br>
+<a href="https://github.com/MarkUsProject/Wiki/blob/master/SSH_Keypair_Instructions_Linux-OSX.md" target="_blank">Instructions for users on Mac OS / Linux</a>


### PR DESCRIPTION
Once https://github.com/MarkUsProject/Wiki/pull/73 is merged then the links on the Key Pairs page should work.

When clicked they open a new window to not interrupt the user's MarkUs session.