### PR TITLE
Git Branch: Fix failing rspec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ before_install:
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
   - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
+  - sudo cp ~/.ssh/id_rsa /home/git/.ssh/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
   - sudo -H -u git bash -c 'mkdir /home/git/bin'
   - sudo -H -u git bash -c '/home/git/gitolite/install -ln'
   - sudo -H -u git bash -c 'export PATH="~/bin:$PATH"'
-  - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/vagrant.pub'
+  - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/git.pub'
   - sudo apt-get install -y cmake libssh2* libgit2* ruby1.9.1-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/vagrant.pub'
   - eval $(ssh-agent -s)
   - ssh-add ~/.ssh/id_rsa
-  - ssh git@localhost
+  - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no git@localhost
   - sudo apt-get install -y cmake libssh2* libgit2* ruby1.9.1-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,17 @@ before_install:
   - sudo adduser -disabled-password --gecos "" git
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
-  - sudo cp ~/.ssh/id_rsa.pub /home/git/git.pub
-  - sudo cp /home/travis/.ssh/id_rsa /home/git/id_rsa
+  - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
+  - sudo cp ~/.ssh/id_rsa /home/git/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
   - sudo -H -u git bash -c 'mkdir /home/git/bin'
   - sudo -H -u git bash -c '/home/git/gitolite/install -ln'
   - sudo -H -u git bash -c 'export PATH="~/bin:$PATH"'
-  - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/git.pub'
+  - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/vagrant.pub'
+  - eval $(ssh-agent -s)
+  - ssh-add ~/.ssh/id_rsa
+  - ssh git@localhost
   - sudo apt-get install -y cmake libssh2* libgit2* ruby1.9.1-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,19 @@ rvm:
 
 before_install:
   - sudo apt-get update -qq
+  - sudo apt-get install -y sshpass
+  - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
+  - sudo adduser -disabled-password --gecos "" git
+  - echo "git:password" | sudo chpasswd
+  - sudo adduser git sudo
+  - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
+  - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
+  - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
+  - sudo -H -u git bash -c 'mkdir /home/git/bin'
+  - sudo -H -u git bash -c '/home/git/gitolite/install -ln'
+  - sudo -H -u git bash -c 'export PATH="~/bin:$PATH"'
+  - sudo -H -u git bash -c '/home/git/bin/gitolite setup -pk /home/git/vagrant.pub'
+  - sudo apt-get install -y cmake libssh2* libgit2* ruby1.9.1-dev
 
 install:
   - bundle install --path=~/.bundle --without development production console

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo adduser -disabled-password --gecos "" git
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
-  - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
+  - sudo cp ~/.ssh/id_rsa.pub /home/git/git.pub
   - sudo mkdir /home/git/.ssh
   - sudo cp /home/travis/.ssh/id_rsa /home/git/.ssh/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
   - sudo cp ~/.ssh/id_rsa.pub /home/git/git.pub
-  - sudo mkdir /home/git/.ssh
   - sudo cp /home/travis/.ssh/id_rsa /home/git/.ssh/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
   - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
-  - sudo cp ~/.ssh/id_rsa /home/git/.ssh/id_rsa
+  - sudo mkdir /home/git/.ssh
+  - sudo cp /home/travis/.ssh/id_rsa /home/git/.ssh/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
   - sudo -H -u git bash -c 'mkdir /home/git/bin'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
   - sudo cp ~/.ssh/id_rsa.pub /home/git/git.pub
-  - sudo cp /home/travis/.ssh/id_rsa /home/git/.ssh/id_rsa
+  - sudo cp /home/travis/.ssh/id_rsa /home/git/id_rsa
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
   - sudo -H -u git bash -c 'mkdir /home/git/bin'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_install:
   - echo "git:password" | sudo chpasswd
   - sudo adduser git sudo
   - sudo cp ~/.ssh/id_rsa.pub /home/git/vagrant.pub
-  - sudo cp ~/.ssh/id_rsa /home/git/id_rsa
+  - sudo cp ~/.ssh/id_rsa /home/git/vagrant
+  - cp ~/.ssh/id_rsa ~/vagrant
+  - cp ~/.ssh/id_rsa.pub ~/vagrant.pub
   - sudo -H -u git bash -c 'echo "I am $USER, with uid $UID"' 
   - sudo -H -u git bash -c 'git clone git://github.com/sitaramc/gitolite /home/git/gitolite'
   - sudo -H -u git bash -c 'mkdir /home/git/bin'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,8 +109,8 @@ Markus::Application.configure do
 
   ###################################################################
   # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/travis/git.pub',
-                        private_key: '/home/travis/id_rsa',
+  GITOLITE_SETTINGS = { public_key: '/home/travis/.ssh/id_rsa.pub',
+                        private_key: '/home/travis/.ssh/id_rsa',
                         host: 'localhost' }
 
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,8 +109,8 @@ Markus::Application.configure do
 
   ###################################################################
   # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/travis/.ssh/id_rsa.pub',
-                        private_key: '/home/travis/.ssh/id_rsa',
+  GITOLITE_SETTINGS = { public_key: '/home/travis/vagrant.pub',
+                        private_key: '/home/travis/vagrant',
                         host: 'localhost' }
 
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -110,7 +110,7 @@ Markus::Application.configure do
   ###################################################################
   # Location of the public and private key for the git user on the system
   GITOLITE_SETTINGS = { public_key: '/home/git/git.pub',
-                        private_key: '/home/git/.ssh/id_rsa',
+                        private_key: '/home/git/id_rsa',
                         host: 'localhost' }
 
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,8 +109,8 @@ Markus::Application.configure do
 
   ###################################################################
   # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/git/vagrant.pub',
-                        private_key: '/home/git/id_rsa',
+  GITOLITE_SETTINGS = { public_key: '/home/travis/git.pub',
+                        private_key: '/home/travis/id_rsa',
                         host: 'localhost' }
 
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,8 +109,8 @@ Markus::Application.configure do
 
   ###################################################################
   # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/vagrant/git.pub',
-                        private_key: '/home/vagrant/.ssh/id_rsa',
+  GITOLITE_SETTINGS = { public_key: '/home/git/git.pub',
+                        private_key: '/home/git/.ssh/id_rsa',
                         host: 'localhost' }
 
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,7 +109,7 @@ Markus::Application.configure do
 
   ###################################################################
   # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/git/git.pub',
+  GITOLITE_SETTINGS = { public_key: '/home/git/vagrant.pub',
                         private_key: '/home/git/id_rsa',
                         host: 'localhost' }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -105,7 +105,7 @@ Markus::Application.configure do
   ###################################################################
   # Directory where Repositories will be created. Make sure MarkUs is allowed
   # to write to this directory
-  REPOSITORY_STORAGE = "#{::Rails.root.to_s}/data/test/repos"
+  REPOSITORY_STORAGE = "#{::Rails.root}/data/test/repos"
 
   ###################################################################
   # Location of the public and private key for the git user on the system

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -105,7 +105,13 @@ Markus::Application.configure do
   ###################################################################
   # Directory where Repositories will be created. Make sure MarkUs is allowed
   # to write to this directory
-  REPOSITORY_STORAGE = "#{::Rails.root.to_s}/data/test/dummy" # unused, because of type memory
+  REPOSITORY_STORAGE = "#{::Rails.root.to_s}/data/test/repos"
+
+  ###################################################################
+  # Location of the public and private key for the git user on the system
+  GITOLITE_SETTINGS = { public_key: '/home/vagrant/git.pub',
+                        private_key: '/home/vagrant/.ssh/id_rsa',
+                        host: 'localhost' }
 
   ###################################################################
   # Directory where authentication keys will be uploaded.
@@ -116,12 +122,6 @@ Markus::Application.configure do
   # Directory where converted PDF files will be stored as JPEGs. Make sure MarkUs
   # is allowed to write to this directory
   PDF_STORAGE = "#{::Rails.root.to_s}/data/test/pdfs"
-
-  ###################################################################
-  # Location of the public and private key for the git user on the system
-  GITOLITE_SETTINGS = { public_key: '/home/git/git.pub',
-                        private_key: '/home/git/.ssh/id_rsa',
-                        host: 'localhost' }
 
   ###################################################################
   # Directory where the Automated Testing Repositories will be created.

--- a/spec/factories/git_repositories.rb
+++ b/spec/factories/git_repositories.rb
@@ -3,15 +3,13 @@ FactoryGirl.define do
     initialize_with do
       repository_config = Hash.new
       repository_config['REPOSITORY_STORAGE'] =
-        "#{::Rails.root.to_s}/data/test/repos"
+        "#{::Rails.root}/data/test/repos"
       repository_config['REPOSITORY_PERMISSION_FILE'] =
         REPOSITORY_STORAGE + '/conf'
       repository_config['IS_REPOSITORY_ADMIN'] = true
-
-    repo = Repository.get_class('git', repository_config)
-
-    # Open the repo that was cloned from Gitolite in git_revision_spec.rb
-    repo.open("#{::Rails.root.to_s}/data/test/workdir")
+      repo = Repository.get_class('git', repository_config)
+      # Open the repo that was cloned from Gitolite in git_revision_spec.rb
+      repo.open("#{::Rails.root}/data/test/workdir")
     end
   end
 end

--- a/spec/factories/git_repositories.rb
+++ b/spec/factories/git_repositories.rb
@@ -3,14 +3,15 @@ FactoryGirl.define do
     initialize_with do
       repository_config = Hash.new
       repository_config['REPOSITORY_STORAGE'] =
-        "#{::Rails.root}/data/test/repos/test_repo"
+        "#{::Rails.root.to_s}/data/test/repos"
       repository_config['REPOSITORY_PERMISSION_FILE'] =
         REPOSITORY_STORAGE + '/conf'
       repository_config['IS_REPOSITORY_ADMIN'] = true
 
-      repo = Repository.get_class('git', repository_config)
-      repo.create(repository_config['REPOSITORY_STORAGE'])
-      repo.new(repository_config['REPOSITORY_STORAGE'])
+    repo = Repository.get_class('git', repository_config)
+
+    # Open the repo that was cloned from Gitolite in git_revision_spec.rb
+    repo.open("#{::Rails.root.to_s}/data/test/workdir")
     end
   end
 end

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -45,7 +45,7 @@ describe Repository::GitRevision do
       # Repo is created by gitolite, proceed to clone it in
       # the repository storage location
       Git.clone('git@localhost:' + "test_repo",
-       "#{::Rails.root}/data/test/workdir")
+                "#{::Rails.root}/data/test/workdir")
     end
 
     let!(:repo) { build(:git_repository) }

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -4,11 +4,7 @@ describe Repository::GitRevision do
   context 'with a git repo' do
     before(:context) do
       
-      ###################################################################
-      # Location of the public and private key for the git user on the system
-      GITOLITE_SETTINGS = { public_key: '/home/git/vagrant.pub',
-                            private_key: '/home/git/id_rsa',
-                            host: 'localhost' }
+     
       
       # Make sure gitolite-admin repo is cloned in test environment
       ga_repo = Gitolite::GitoliteAdmin.new(

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -3,10 +3,18 @@ require 'spec_helper'
 describe Repository::GitRevision do
   context 'with a git repo' do
     before(:context) do
+      
+      ###################################################################
+      # Location of the public and private key for the git user on the system
+      GITOLITE_SETTINGS = { public_key: '/home/git/vagrant.pub',
+                            private_key: '/home/git/id_rsa',
+                            host: 'localhost' }
+      
       # Make sure gitolite-admin repo is cloned in test environment
       ga_repo = Gitolite::GitoliteAdmin.new(
         "#{::Rails.root}/data/test/repos/gitolite-admin", GITOLITE_SETTINGS)
 
+      puts 123
       puts GITOLITE_SETTINGS
       
       # Bring the repo up to date

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -2,11 +2,10 @@ require 'spec_helper'
 
 describe Repository::GitRevision do
   context 'with a git repo' do
-
     before(:context) do
-
       # Make sure gitolite-admin repo is cloned in test environment
-      ga_repo = Gitolite::GitoliteAdmin.new("#{::Rails.root.to_s}/data/test/repos/gitolite-admin", GITOLITE_SETTINGS)
+      ga_repo = Gitolite::GitoliteAdmin.new(
+        "#{::Rails.root}/data/test/repos/gitolite-admin", GITOLITE_SETTINGS)
 
       # Bring the repo up to date
       ga_repo.reload!
@@ -15,16 +14,16 @@ describe Repository::GitRevision do
       conf = ga_repo.config
 
       # Remove test repo from Gitolite conf
-      conf.rm_repo("test_repo")
-      
+      conf.rm_repo('test_repo')
+
       # Make sure repo was deleted, then remake it
-      repo = ga_repo.config.get_repo("test_repo")
+      repo = ga_repo.config.get_repo('test_repo')
       if !repo.nil?
-        raise "Gitolite failed to delete the test_repo before test context!"
+        raise 'Gitolite failed to delete the test_repo before test context!'
       end
 
       # Generate new test repo
-      repo = Gitolite::Config::Repo.new("test_repo")
+      repo = Gitolite::Config::Repo.new('test_repo')
 
       # Add permissions for git user
       repo.add_permission('RW+', '', 'git')
@@ -41,12 +40,12 @@ describe Repository::GitRevision do
       ga_repo.save_and_apply
 
       # Remove workdir (cloned version of the test_repo from Gitolite)
-      FileUtils.rm_rf("#{::Rails.root.to_s}/data/test/workdir")
+      FileUtils.rm_rf("#{::Rails.root}/data/test/workdir")
 
       # Repo is created by gitolite, proceed to clone it in
       # the repository storage location
-      cloned_repo = Git.clone('git@localhost:' + "test_repo", "#{::Rails.root.to_s}/data/test/workdir")
-
+      Git.clone('git@localhost:' + "test_repo",
+       "#{::Rails.root}/data/test/workdir")
     end
 
     let!(:repo) { build(:git_repository) }

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -7,6 +7,8 @@ describe Repository::GitRevision do
       ga_repo = Gitolite::GitoliteAdmin.new(
         "#{::Rails.root}/data/test/repos/gitolite-admin", GITOLITE_SETTINGS)
 
+      puts GITOLITE_SETTINGS
+      
       # Bring the repo up to date
       ga_repo.reload!
 

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -3,6 +3,52 @@ require 'spec_helper'
 describe Repository::GitRevision do
   context 'with a git repo' do
 
+    before(:context) do
+
+      # Make sure gitolite-admin repo is cloned in test environment
+      ga_repo = Gitolite::GitoliteAdmin.new("#{::Rails.root.to_s}/data/test/repos/gitolite-admin", GITOLITE_SETTINGS)
+
+      # Bring the repo up to date
+      ga_repo.reload!
+
+      # Grab the gitolite admin repo config
+      conf = ga_repo.config
+
+      # Remove test repo from Gitolite conf
+      conf.rm_repo("test_repo")
+      
+      # Make sure repo was deleted, then remake it
+      repo = ga_repo.config.get_repo("test_repo")
+      if !repo.nil?
+        raise "Gitolite failed to delete the test_repo before test context!"
+      end
+
+      # Generate new test repo
+      repo = Gitolite::Config::Repo.new("test_repo")
+
+      # Add permissions for git user
+      repo.add_permission('RW+', '', 'git')
+
+      # Add the repo to the gitolite admin config
+      conf.add_repo(repo)
+
+      # Readd the 'git' public key to the gitolite admin repo after changes
+      admin_key = Gitolite::SSHKey.from_file(
+        GITOLITE_SETTINGS[:public_key])
+      ga_repo.add_key(admin_key)
+
+      # Stage and push the changes to the gitolite admin repo
+      ga_repo.save_and_apply
+
+      # Remove workdir (cloned version of the test_repo from Gitolite)
+      FileUtils.rm_rf("#{::Rails.root.to_s}/data/test/workdir")
+
+      # Repo is created by gitolite, proceed to clone it in
+      # the repository storage location
+      cloned_repo = Git.clone('git@localhost:' + "test_repo", "#{::Rails.root.to_s}/data/test/workdir")
+
+    end
+
     let!(:repo) { build(:git_repository) }
 
     describe '#files_at_path' do


### PR DESCRIPTION
The previous git rspec tests were failing because Gitolite changed the way repos are created.
I added a "before(:context)" to cleanup a previous "test_repo" (if one was created), create a new one, and clone the new test_repo to a place that rspec can access them and run tests.