### PR TITLE
Added custom validation messages

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -386,6 +386,13 @@ private
       validation_result[:error] = I18n.t('external_authentication_not_supported')
       return validation_result
     end
+
+    if (defined? VALIDATE_CUSTOM_STATUS_DISPLAY) &&
+       authenticate_response == User::AUTHENTICATE_CUSTOM_MESSAGE
+      validation_result[:error] = VALIDATE_CUSTOM_STATUS_DISPLAY
+      return validation_result
+    end
+
     if authenticate_response == User::AUTHENTICATE_SUCCESS
       # Username/password combination is valid. Check if user is
       # allowed to use MarkUs.
@@ -399,11 +406,19 @@ private
         # not a good idea to report this to the outside world. It makes it
         # easier for attempted break-ins
         # if one can distinguish between existent and non-existent users.
-        validation_result[:error] = I18n.t(:login_failed)
+        if defined? VALIDATE_USER_NOT_ALLOWED_DISPLAY
+          validation_result[:error] = VALIDATE_USER_NOT_ALLOWED_DISPLAY
+        else
+          validation_result[:error] = I18n.t(:login_failed)
+        end
         return validation_result
       end
     else
-      validation_result[:error] = I18n.t(:login_failed)
+      if defined? VALIDATE_LOGIN_INCORRECT_DISPLAY
+        validation_result[:error] = VALIDATE_LOGIN_INCORRECT_DISPLAY
+      else
+        validation_result[:error] = I18n.t(:login_failed)
+      end
       return validation_result
     end
 
@@ -435,7 +450,11 @@ private
       # not a good idea to report this to the outside world. It makes it
       # easier for attempted break-ins
       # if one can distinguish between existent and non-existent users.
-      validation_result[:error] = I18n.t(:login_failed)
+      if defined? VALIDATE_USER_NOT_ALLOWED_DISPLAY
+        validation_result[:error] = VALIDATE_USER_NOT_ALLOWED_DISPLAY
+      else
+        validation_result[:error] = I18n.t(:login_failed)
+      end
       return validation_result
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
   AUTHENTICATE_ERROR =        3   # generic/unknown error
   AUTHENTICATE_BAD_CHAR =     4   # invalid character in username/password
   AUTHENTICATE_BAD_PLATFORM = 5   # external authentication works for *NIX platforms only
+  AUTHENTICATE_CUSTOM_MESSAGE = 6 # custom validate code for custom message
 
   # Verifies if user is allowed to enter MarkUs
   # Returns user object representing the user with the given login.
@@ -74,6 +75,10 @@ class User < ActiveRecord::Base
       pipe.puts("#{login}\n#{password}") # write to stdin of markus_config_validate
       pipe.close
       m_logger = MarkusLogger.instance
+      if (defined? VALIDATE_CUSTOM_EXIT_STATUS) && $?.exitstatus == VALIDATE_CUSTOM_EXIT_STATUS
+        m_logger.log("Login failed. Reason: Custom exit status.", MarkusLogger::ERROR)
+        return AUTHENTICATE_CUSTOM_MESSAGE
+      end
       case $?.exitstatus
         when 0
           m_logger.log("User '#{login}' logged in.", MarkusLogger::INFO)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,23 @@ Markus::Application.configure do
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root.to_s}/config/dummy_validate.sh"
 
+  # Normally exit status 0 means successful, 1 means no such user,
+  # and 2 means wrong password.
+  # The following allows for one additional custom exit status which also
+  # represents a failure to log in, but says so with a custom string.
+  # It is commented out by default because there is no additional custom
+  # exit status by default.
+  #VALIDATE_CUSTOM_EXIT_STATUS = 38
+  #VALIDATE_CUSTOM_STATUS_DISPLAY = 'You are a squid.  Only vertebrates may use MarkUs.'
+
+  # Custom messages for "user not allowed" and "login incorrect",
+  # overriding the default "login failed" message.  By default,
+  # MarkUs does not distinguish these cases for security reasons.
+  # If these variables are not defined (commented out), it uses the
+  # standard "login failed" message for both situations.
+  #VALIDATE_USER_NOT_ALLOWED_DISPLAY = 'That is your correct University of Foo user name and password, but you have not been added to this particular MarkUs database.  Please contact your instructor or check your course web page.'
+  #VALIDATE_LOGIN_INCORRECT_DISPLAY = 'Login incorrect.  You can check your Foo U user name or reset your password at https://www.foo.example.edu/passwords.'
+
   ###################################################################
   # Authentication Settings
   ###################################################################

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,6 +90,23 @@ Markus::Application.configure do
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root.to_s}/config/dummy_validate.sh"
 
+  # Normally exit status 0 means successful, 1 means no such user,
+  # and 2 means wrong password.
+  # The following allows for one additional custom exit status which also
+  # represents a failure to log in, but says so with a custom string.
+  # It is commented out by default because there is no additional custom
+  # exit status by default.
+  #VALIDATE_CUSTOM_EXIT_STATUS = 38
+  #VALIDATE_CUSTOM_STATUS_DISPLAY = 'You are a squid.  Only vertebrates may use MarkUs.'
+
+  # Custom messages for "user not allowed" and "login incorrect",
+  # overriding the default "login failed" message.  By default,
+  # MarkUs does not distinguish these cases for security reasons.
+  # If these variables are not defined (commented out), it uses the
+  # standard "login failed" message for both situations.
+  #VALIDATE_USER_NOT_ALLOWED_DISPLAY = 'That is your correct University of Foo user name and password, but you have not been added to this particular MarkUs database.  Please contact your instructor or check your course web page.'
+  #VALIDATE_LOGIN_INCORRECT_DISPLAY = 'Login incorrect.  You can check your Foo U user name or reset your password at https://www.foo.example.edu/passwords.'
+
   ###################################################################
   # Authentication Settings
   ###################################################################

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,6 +50,23 @@ Markus::Application.configure do
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root.to_s}/config/dummy_validate.sh"
 
+  # Normally exit status 0 means successful, 1 means no such user,
+  # and 2 means wrong password.
+  # The following allows for one additional custom exit status which also
+  # represents a failure to log in, but says so with a custom string.
+  # It is commented out by default because there is no additional custom
+  # exit status by default.
+  #VALIDATE_CUSTOM_EXIT_STATUS = 38
+  #VALIDATE_CUSTOM_STATUS_DISPLAY = 'You are a squid.  Only vertebrates may use MarkUs.'
+
+  # Custom messages for "user not allowed" and "login incorrect",
+  # overriding the default "login failed" message.  By default,
+  # MarkUs does not distinguish these cases for security reasons.
+  # If these variables are not defined (commented out), it uses the
+  # standard "login failed" message for both situations.
+  #VALIDATE_USER_NOT_ALLOWED_DISPLAY = 'That is your correct University of Foo user name and password, but you have not been added to this particular MarkUs database.  Please contact your instructor or check your course web page.'
+  #VALIDATE_LOGIN_INCORRECT_DISPLAY = 'Login incorrect.  You can check your Foo U user name or reset your password at https://www.foo.example.edu/passwords.'
+
   ###################################################################
   # Authentication Settings
   ###################################################################


### PR DESCRIPTION
Basically adding configuration that Alan's done manually before this.

Also adds a custom message for a valid user login but who is not found in the MarkUs database, and an invalid password.