### PR TITLE
API: Setting marks to nil, and group_ids_by_name function.

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -166,9 +166,12 @@ module Api
                              dict
                            end
       respond_to do |format|
-        format.xml { render xml: reversed.to_xml(root: 'groups',
-                                                 skip_types: 'true') }
-        format.json { render json: reversed.to_json }
+        format.xml do
+          render xml: reversed.to_xml(root: 'groups', skip_types: 'true')
+        end
+        format.json do
+          render json: reversed.to_json
+        end
       end
     end
   end # end GroupsController

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -142,11 +142,33 @@ module Api
 
     def set_mark_by_criteria(criteria, mark_to_change)
       if criteria.is_a?(FlexibleCriterion)
-        mark_to_change.mark = params[criteria.flexible_criterion_name].to_f
+        if params[criteria.flexible_criterion_name] == "nil"
+          mark_to_change.mark = nil
+        else
+          mark_to_change.mark = params[criteria.flexible_criterion_name].to_f
+        end
       else
-        mark_to_change.mark = params[criteria.rubric_criterion_name]
+        if params[criteria.rubric_criterion_name] == "nil"
+          mark_to_change.mark = nil
+        else
+          mark_to_change.mark = params[criteria.rubric_criterion_name]
+        end
       end
       mark_to_change.save
+    end
+
+    # Return key:value pairs of group_name:group_id
+    def group_ids_by_name
+      reversed = Assignment.find_by_id(params[:assignment_id])
+                           .groups
+                           .inject({}) do |dict, group|
+                             dict[group.group_name] = group.id
+                             dict
+                           end
+      respond_to do |format|
+        format.xml{render xml: reversed.to_xml(root: 'groups', skip_types: 'true')}
+        format.json{render json: reversed.to_json}
+      end
     end
   end # end GroupsController
 end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -159,12 +159,9 @@ module Api
 
     # Return key:value pairs of group_name:group_id
     def group_ids_by_name
-      reversed = Assignment.find_by_id(params[:assignment_id])
-                           .groups
-                           .inject({}) do |dict, group|
-                             dict[group.group_name] = group.id
-                             dict
-                           end
+      groups = Assignment.find(params[:assignment_id])
+                        .groups
+      reversed = Hash[groups.map { |g| [g.group_name, g.id] }]
       respond_to do |format|
         format.xml do
           render xml: reversed.to_xml(root: 'groups', skip_types: 'true')

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -142,13 +142,13 @@ module Api
 
     def set_mark_by_criteria(criteria, mark_to_change)
       if criteria.is_a?(FlexibleCriterion)
-        if params[criteria.flexible_criterion_name] == "nil"
+        if params[criteria.flexible_criterion_name] == 'nil'
           mark_to_change.mark = nil
         else
           mark_to_change.mark = params[criteria.flexible_criterion_name].to_f
         end
       else
-        if params[criteria.rubric_criterion_name] == "nil"
+        if params[criteria.rubric_criterion_name] == 'nil'
           mark_to_change.mark = nil
         else
           mark_to_change.mark = params[criteria.rubric_criterion_name]
@@ -166,8 +166,9 @@ module Api
                              dict
                            end
       respond_to do |format|
-        format.xml{render xml: reversed.to_xml(root: 'groups', skip_types: 'true')}
-        format.json{render json: reversed.to_json}
+        format.xml { render xml: reversed.to_xml(root: 'groups',
+                                                 skip_types: 'true') }
+        format.json { render json: reversed.to_json }
       end
     end
   end # end GroupsController

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Markus::Application.routes.draw do
       resources :users, except: [:new, :edit]
       resources :assignments, except: [:new, :edit] do
         resources :groups, except: [:new, :edit] do
+          collection do
+            get 'group_ids_by_name'
+          end
           resources :submission_downloads, except: [:new, :edit]
           resources :test_results, except: [:new, :edit]
           member do


### PR DESCRIPTION
- When updating marks, can now set a mark to nil (unmarked). 

Example: curl --header "Authorization: MarkUsAuth YourAuthKey" -X PUT \
    --data "Lorem%20Ipsum=nil" \
    "http://example.com/api/assignments/1/groups/5/update_marks"

- Added api function 'group_ids_by_name' that returns json/xml consisting of key:value pairs 
  of group_name:group_id for all groups associated with a given assignment.

Example: curl -H "Authorization: MarkUsAuth YourAuthKey" "http://example.com/api/assignments/1/groups/group_ids_by_name"
will return
\<?xml version="1.0" encoding="UTF-8"?>
\<groups>
  \<group_name1>31\</group_name1>
  \<group_name2>32\</group_name2>
  ...
\</groups>