### PR TITLE
Cascade table truncation for RSpec config, fixes #2250 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,7 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute("TRUNCATE #{table}") }
+    ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute("TRUNCATE #{table} CASCADE;") }
   end
 
   RSpec::Matchers.define :same_time_within_ms do |e|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,9 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute("TRUNCATE #{table} CASCADE;") }
+    ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.execute("TRUNCATE #{table} CASCADE;")
+    end
   end
 
   RSpec::Matchers.define :same_time_within_ms do |e|


### PR DESCRIPTION
RSpec config was failing due to foreign integrity constraints during our truncation operations. Added `cascade` for those operations.

#### Test Plan
Ran RSpec. Verified suite of tests were executed.