### PR TITLE
Refactor flash message for browse submissions to use partial, closes #2258

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -270,9 +270,9 @@ class SubmissionsController < ApplicationController
     if @assignment.past_collection_date?
       notice_text = t('browse_submissions.grading_can_begin')
     else
+      collection_time = @assignment.submission_rule.calculate_collection_time
       notice_text = t('browse_submissions.grading_can_begin_after',
-           time: I18n.l(@assignment.submission_rule.calculate_collection_time,
-           format: :long_date))
+                      time: I18n.l(collection_time, format: :long_date))
     end
 
     flash_now(:notice, notice_text)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,6 +2,8 @@ require 'zip'
 
 class SubmissionsController < ApplicationController
   include SubmissionsHelper
+  include PaginationHelper
+  include ApplicationHelper
 
   helper_method :all_assignments_marked?
 
@@ -264,6 +266,16 @@ class SubmissionsController < ApplicationController
     else
       @grace_credit_column = ''
     end
+
+    if @assignment.past_collection_date?
+      notice_text = t('browse_submissions.grading_can_begin')
+    else
+      notice_text = t('browse_submissions.grading_can_begin_after',
+           time: I18n.l(@assignment.submission_rule.calculate_collection_time,
+           format: :long_date))
+    end
+
+    flash_now(:notice, notice_text)
   end
 
   def populate_submissions_table

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,7 +2,6 @@ require 'zip'
 
 class SubmissionsController < ApplicationController
   include SubmissionsHelper
-  include PaginationHelper
   include ApplicationHelper
 
   helper_method :all_assignments_marked?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,7 +2,6 @@ require 'zip'
 
 class SubmissionsController < ApplicationController
   include SubmissionsHelper
-  include ApplicationHelper
 
   helper_method :all_assignments_marked?
 

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -1,15 +1,5 @@
 <%= render partial: 'submissions_table', formats: [:'js.jsx'], handlers: [:erb] %>
 
-<div class='notice'>
-  <% if @assignment.past_collection_date? %>
-     <%= t('browse_submissions.grading_can_begin') %>
-  <% else %>
-     <%= t('browse_submissions.grading_can_begin_after',
-           time: I18n.l(@assignment.submission_rule.calculate_collection_time,
-           format: :long_date)) %>
-  <% end %>
-</div>
-
 <div class='title_bar'>
   <h1>
     <%= t('browse_submissions.submissions',


### PR DESCRIPTION
Switch to use `ApplicationHelper` to set our flash notice message. 

Moved logic for determining the notice message into the controller, use shared partial for flash messages to render.


**Test Plan**
Manual testing. Verified notice messages appropriate to the assignment's status appeared.