### PR TITLE
Render heading buttons in browse submissions using partials, for #2264

### DIFF
--- a/app/views/layouts/_heading_buttons.html.erb
+++ b/app/views/layouts/_heading_buttons.html.erb
@@ -1,0 +1,3 @@
+<%= link_to heading_button[:link_text],
+            heading_button[:link_path],
+            heading_button[:html_options] %>

--- a/app/views/layouts/_heading_buttons_spacer.html.erb
+++ b/app/views/layouts/_heading_buttons_spacer.html.erb
@@ -1,0 +1,1 @@
+<span class='menu_bar'></span>

--- a/app/views/layouts/assignment_content.erb
+++ b/app/views/layouts/assignment_content.erb
@@ -45,7 +45,11 @@
           <%= yield(:title) %>
         </h1>
         <div class='heading_buttons'>
-          <%= yield(:heading_buttons) %>
+            <%= render partial: "layouts/heading_buttons",
+                    collection: @heading_buttons,
+                            as: :heading_button,
+               spacer_template: "layouts/heading_buttons_spacer" %>
+          <%= yield(:additional_headings) %>
         </div>
       </div>
 

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -22,27 +22,26 @@
   <% @heading_buttons +=
   [
     {
-         link_text: t('collect_submissions.collect_all'),
-         link_path: collect_all_submissions_assignment_submissions_path(
-                    @assignment.id),
+      link_text: t('collect_submissions.collect_all'),
+      link_path: collect_all_submissions_assignment_submissions_path(@assignment.id),
       html_options: { confirm: t('collect_submissions.results_loss_warning') }
-     },
-     {
-         link_text: t('browse_submissions.csv_report'),
-         link_path: download_simple_csv_report_assignment_submissions_path(@assignment)
-     },
-     {
-         link_text: t('browse_submissions.detailed_csv_report'),
-         link_path: download_detailed_csv_report_assignment_submissions_path(@assignment)
-     },
-     {
-         link_text: t('browse_submissions.subversion_repo_list'),
-         link_path: download_svn_repo_list_assignment_submissions_path(@assignment)
-     },
-     {
-         link_text: t('browse_submissions.subversion_checkout_file'),
-         link_path: download_svn_checkout_commands_assignment_submissions_path(@assignment)
-     }
+    },
+    {
+      link_text: t('browse_submissions.csv_report'),
+      link_path: download_simple_csv_report_assignment_submissions_path(@assignment)
+    },
+    {
+      link_text: t('browse_submissions.detailed_csv_report'),
+      link_path: download_detailed_csv_report_assignment_submissions_path(@assignment)
+    },
+    {
+      link_text: t('browse_submissions.subversion_repo_list'),
+      link_path: download_svn_repo_list_assignment_submissions_path(@assignment)
+    },
+    {
+      link_text: t('browse_submissions.subversion_checkout_file'),
+      link_path: download_svn_checkout_commands_assignment_submissions_path(@assignment)
+    }
   ] %>
 <% end %>
 
@@ -52,18 +51,19 @@
       @groupings.all? {|grouping| grouping.get_ta_names.size == 1} %>
   <% @heading_buttons.push(
     {
-         link_text: t('collect_submissions.collect_ta'),
-         link_path: collect_ta_submissions_assignment_submissions_path(@assignment),
+      link_text: t('collect_submissions.collect_ta'),
+      link_path: collect_ta_submissions_assignment_submissions_path(@assignment),
       html_options: { confirm: t('collect_submissions.results_loss_warning') }
-   }) %>
+    }) %>
   <span class='menu_bar'></span>
 <% elsif @current_user.ta? and @assignment.past_collection_date? %>
   <% @heading_buttons.push(
   {
-       link_text: t('collect_submissions.collect_ta'),
-       link_path: '#',
-    html_options: {   id: 'disable',
-                   title: t('collect_submissions.disable_collect')
+    link_text: t('collect_submissions.collect_ta'),
+    link_path: '#',
+    html_options: {
+                    id: 'disable',
+                    title: t('collect_submissions.disable_collect')
                   }
   }) %>
 <% end %>
@@ -71,16 +71,16 @@
 <% if all_assignments_marked? %>
   <% @heading_buttons.push(
   {
-   link_text: t('browse_submissions.download_groupings_files'),
-   link_path: download_groupings_files_assignment_submissions_path(
-              groupings: @groupings)
+    link_text: t('browse_submissions.download_groupings_files'),
+    link_path: download_groupings_files_assignment_submissions_path(
+               groupings: @groupings)
   }) %>
 <% else %>
   <% @heading_buttons.push(
   {
-       link_text: t('browse_submissions.download_groupings_files'),
-       link_path: download_groupings_files_assignment_submissions_path(
-                  groupings: @groupings),
+    link_text: t('browse_submissions.download_groupings_files'),
+    link_path: download_groupings_files_assignment_submissions_path(
+               groupings: @groupings),
     html_options: {confirm: t('collect_submissions.marking_incomplete_warning')}
   }) %>
 <% end %>
@@ -91,7 +91,7 @@
   <% if @current_user.ta? %>
     <span class='menu_bar'></span>
     <%= t('browse_submissions.how_many_marked',
-            num_marked: @current_user.get_num_marked(@assignment),
+          num_marked: @current_user.get_num_marked(@assignment),
           num_assigned: @current_user.get_num_assigned(@assignment)) %>
   <% end %>
 <% end %>

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -14,58 +14,73 @@
   </div>
 <% end %>
 
-<% content_for :heading_buttons do %>
-  <% if @current_user.admin? %>
-    <%= link_to t('collect_submissions.collect_all'),
-                collect_all_submissions_assignment_submissions_path(
-                  @assignment.id),
-                confirm: t('collect_submissions.results_loss_warning') %>
-    <span class='menu_bar'></span>
-    <%= link_to t('browse_submissions.csv_report'),
-                download_simple_csv_report_assignment_submissions_path(
-                  @assignment) %>
-    <span class='menu_bar'></span>
-    <%= link_to t('browse_submissions.detailed_csv_report'),
-                download_detailed_csv_report_assignment_submissions_path(
-                  @assignment) %>
-    <span class='menu_bar'></span>
-    <%= link_to t('browse_submissions.subversion_repo_list'),
-                download_svn_repo_list_assignment_submissions_path(
-                  @assignment) %>
-    <span class='menu_bar'></span>
-    <%= link_to t('browse_submissions.subversion_checkout_file'),
-                download_svn_checkout_commands_assignment_submissions_path(
-                  @assignment) %>
-    <span class='menu_bar'></span>
-  <% end %>
 
-  <% # Allow TA submission collection only if all the submissions are
-     # assignment to exactly one TA. %>
-  <% if @current_user.ta? and @assignment.past_collection_date? and
-        @groupings.all? {|grouping| grouping.get_ta_names.size == 1} %>
-    <%= link_to t('collect_submissions.collect_ta'),
-                collect_ta_submissions_assignment_submissions_path(
-                  @assignment),
-                confirm: t('collect_submissions.results_loss_warning') %>
-    <span class='menu_bar'></span>
-  <% elsif @current_user.ta? and @assignment.past_collection_date? %>
-    <a id='disable' title='<%= t('collect_submissions.disable_collect') %>'>
-      <%= t('collect_submissions.collect_ta') %>
-    </a>
-    <span class='menu_bar'></span>
-  <% end %>
 
-  <% if all_assignments_marked? %>
-    <%= link_to t('browse_submissions.download_groupings_files'),
-                download_groupings_files_assignment_submissions_path(
-                  groupings: @groupings) %>
-  <% else %>
-    <%= link_to t('browse_submissions.download_groupings_files'),
-                download_groupings_files_assignment_submissions_path(
-                  groupings: @groupings),
-                confirm: t('collect_submissions.marking_incomplete_warning') %>
-  <% end %>
+<% @heading_buttons = [] %>
 
+<% if @current_user.admin? %>
+  <% @heading_buttons += [{
+                           link_text: t('collect_submissions.collect_all'),
+                           link_path: collect_all_submissions_assignment_submissions_path(
+                                         @assignment.id),
+                           html_options: {confirm: t('collect_submissions.results_loss_warning')}
+                           },
+                           {
+                            link_text: t('browse_submissions.csv_report'),
+                            link_path: download_simple_csv_report_assignment_submissions_path(@assignment)
+                           },
+                           {
+                            link_text: t('browse_submissions.detailed_csv_report'),
+                            link_path: download_detailed_csv_report_assignment_submissions_path(@assignment)
+                           },
+                           {
+                            link_text: t('browse_submissions.subversion_repo_list'),
+                           link_path: download_svn_repo_list_assignment_submissions_path(@assignment)
+                           },
+                           {
+                            link_text: t('browse_submissions.subversion_checkout_file'),
+                            link_path: download_svn_checkout_commands_assignment_submissions_path(@assignment)
+                           }] %>
+<% end %>
+
+<% # Allow TA submission collection only if all the submissions are
+   # assignment to exactly one TA. %>
+<% if @current_user.ta? and @assignment.past_collection_date? and
+      @groupings.all? {|grouping| grouping.get_ta_names.size == 1} %>
+  <% @heading_buttons.push({
+                             link_text: t('collect_submissions.collect_ta'),
+                             link_path: collect_ta_submissions_assignment_submissions_path(@assignment),
+                          html_options: {confirm: t('collect_submissions.results_loss_warning')}
+                           }) %>
+  <span class='menu_bar'></span>
+<% elsif @current_user.ta? and @assignment.past_collection_date? %>
+  <% @heading_buttons.push({
+                             link_text: t('collect_submissions.collect_ta'),
+                             link_path: '#',
+                          html_options: {   id: 'disable',
+                                         title: t('collect_submissions.disable_collect')
+                                        }
+                            }) %>
+<% end %>
+
+<% if all_assignments_marked? %>
+  <% @heading_buttons.push({
+                             link_text: t('browse_submissions.download_groupings_files'),
+                             link_path: download_groupings_files_assignment_submissions_path(groupings: @groupings)
+                           }) %>
+
+
+<% else %>
+  <% @heading_buttons.push({
+                             link_text: t('browse_submissions.download_groupings_files'),
+                             link_path: download_groupings_files_assignment_submissions_path(groupings: @groupings),
+                             html_options: {confirm: t('collect_submissions.marking_incomplete_warning')}
+                           }) %>
+<% end %>
+
+
+
+<% content_for :additional_headings do %>
   <% if @current_user.ta? %>
     <span class='menu_bar'></span>
     <%= t('browse_submissions.how_many_marked',

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -19,63 +19,70 @@
 <% @heading_buttons = [] %>
 
 <% if @current_user.admin? %>
-  <% @heading_buttons += [{
-                           link_text: t('collect_submissions.collect_all'),
-                           link_path: collect_all_submissions_assignment_submissions_path(
-                                         @assignment.id),
-                           html_options: {confirm: t('collect_submissions.results_loss_warning')}
-                           },
-                           {
-                            link_text: t('browse_submissions.csv_report'),
-                            link_path: download_simple_csv_report_assignment_submissions_path(@assignment)
-                           },
-                           {
-                            link_text: t('browse_submissions.detailed_csv_report'),
-                            link_path: download_detailed_csv_report_assignment_submissions_path(@assignment)
-                           },
-                           {
-                            link_text: t('browse_submissions.subversion_repo_list'),
-                           link_path: download_svn_repo_list_assignment_submissions_path(@assignment)
-                           },
-                           {
-                            link_text: t('browse_submissions.subversion_checkout_file'),
-                            link_path: download_svn_checkout_commands_assignment_submissions_path(@assignment)
-                           }] %>
+  <% @heading_buttons +=
+  [
+    {
+         link_text: t('collect_submissions.collect_all'),
+         link_path: collect_all_submissions_assignment_submissions_path(
+                    @assignment.id),
+      html_options: { confirm: t('collect_submissions.results_loss_warning') }
+     },
+     {
+         link_text: t('browse_submissions.csv_report'),
+         link_path: download_simple_csv_report_assignment_submissions_path(@assignment)
+     },
+     {
+         link_text: t('browse_submissions.detailed_csv_report'),
+         link_path: download_detailed_csv_report_assignment_submissions_path(@assignment)
+     },
+     {
+         link_text: t('browse_submissions.subversion_repo_list'),
+         link_path: download_svn_repo_list_assignment_submissions_path(@assignment)
+     },
+     {
+         link_text: t('browse_submissions.subversion_checkout_file'),
+         link_path: download_svn_checkout_commands_assignment_submissions_path(@assignment)
+     }
+  ] %>
 <% end %>
 
 <% # Allow TA submission collection only if all the submissions are
    # assignment to exactly one TA. %>
 <% if @current_user.ta? and @assignment.past_collection_date? and
       @groupings.all? {|grouping| grouping.get_ta_names.size == 1} %>
-  <% @heading_buttons.push({
-                             link_text: t('collect_submissions.collect_ta'),
-                             link_path: collect_ta_submissions_assignment_submissions_path(@assignment),
-                          html_options: {confirm: t('collect_submissions.results_loss_warning')}
-                           }) %>
+  <% @heading_buttons.push(
+    {
+         link_text: t('collect_submissions.collect_ta'),
+         link_path: collect_ta_submissions_assignment_submissions_path(@assignment),
+      html_options: { confirm: t('collect_submissions.results_loss_warning') }
+   }) %>
   <span class='menu_bar'></span>
 <% elsif @current_user.ta? and @assignment.past_collection_date? %>
-  <% @heading_buttons.push({
-                             link_text: t('collect_submissions.collect_ta'),
-                             link_path: '#',
-                          html_options: {   id: 'disable',
-                                         title: t('collect_submissions.disable_collect')
-                                        }
-                            }) %>
+  <% @heading_buttons.push(
+  {
+       link_text: t('collect_submissions.collect_ta'),
+       link_path: '#',
+    html_options: {   id: 'disable',
+                   title: t('collect_submissions.disable_collect')
+                  }
+  }) %>
 <% end %>
 
 <% if all_assignments_marked? %>
-  <% @heading_buttons.push({
-                             link_text: t('browse_submissions.download_groupings_files'),
-                             link_path: download_groupings_files_assignment_submissions_path(groupings: @groupings)
-                           }) %>
-
-
+  <% @heading_buttons.push(
+  {
+   link_text: t('browse_submissions.download_groupings_files'),
+   link_path: download_groupings_files_assignment_submissions_path(
+              groupings: @groupings)
+  }) %>
 <% else %>
-  <% @heading_buttons.push({
-                             link_text: t('browse_submissions.download_groupings_files'),
-                             link_path: download_groupings_files_assignment_submissions_path(groupings: @groupings),
-                             html_options: {confirm: t('collect_submissions.marking_incomplete_warning')}
-                           }) %>
+  <% @heading_buttons.push(
+  {
+       link_text: t('browse_submissions.download_groupings_files'),
+       link_path: download_groupings_files_assignment_submissions_path(
+                  groupings: @groupings),
+    html_options: {confirm: t('collect_submissions.marking_incomplete_warning')}
+  }) %>
 <% end %>
 
 
@@ -84,7 +91,7 @@
   <% if @current_user.ta? %>
     <span class='menu_bar'></span>
     <%= t('browse_submissions.how_many_marked',
-          num_marked: @current_user.get_num_marked(@assignment),
+            num_marked: @current_user.get_num_marked(@assignment),
           num_assigned: @current_user.get_num_assigned(@assignment)) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
For #2264 

Continued building on top of browse submission's layout file, extracting heading buttons and rendering them using a partial and a spacer template.

@david-yz-liu  - Hound is going to complain about the line length. I'm not sure how I can make things a little neater. It seems like breaking things up would just be more verbose in this case.

If this approach looks alright, we can use the same partial to render heading buttons on other pages.
