### PR TITLE
add apply on late penalty option on manual collection

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -179,9 +179,9 @@ class SubmissionsController < ApplicationController
   def manually_collect_and_begin_grading
     @grouping = Grouping.find(params[:id])
     @revision_number = params[:current_revision_number].to_i
-    @apply_late_penalty = params[:apply_late_penalty]
+    apply_late_penalty = params[:apply_late_penalty]
     submission = SubmissionCollector.instance.manually_collect_submission(
-      @grouping, @revision_number, @apply_late_penalty, false)
+      @grouping, @revision_number, apply_late_penalty, false)
     redirect_to edit_assignment_submission_result_path(
       assignment_id: @grouping.assignment_id,
       submission_id: submission.id,

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -179,8 +179,9 @@ class SubmissionsController < ApplicationController
   def manually_collect_and_begin_grading
     @grouping = Grouping.find(params[:id])
     @revision_number = params[:current_revision_number].to_i
+    @apply_late_penalty = params[:apply_late_penalty]
     submission = SubmissionCollector.instance.manually_collect_submission(
-      @grouping, @revision_number, false)
+      @grouping, @revision_number, @apply_late_penalty, false)
     redirect_to edit_assignment_submission_result_path(
       assignment_id: @grouping.assignment_id,
       submission_id: submission.id,

--- a/app/models/grace_period_submission_rule.rb
+++ b/app/models/grace_period_submission_rule.rb
@@ -110,6 +110,7 @@ class GracePeriodSubmissionRule < SubmissionRule
           deduction.destroy
         end
       end
+      deductions.reload
     end
   end
 

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -195,7 +195,6 @@ class SubmissionCollector < ActiveRecord::Base
       grouping.assignment.submission_rule
                                        .remove_deductions(new_submission)
     end
-    return new_submission
   end
 
   #Use the database to communicate to the child to stop, and restart itself
@@ -230,9 +229,7 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
-    new_submission = apply_penalty_or_add_grace_credits(grouping,
-                                                        apply_late_penalty,
-                                                        new_submission)
+    apply_penalty_or_add_grace_credits(grouping, apply_late_penalty, new_submission)
 
     #This is to help determine the progress of the method.
     self.safely_stop_child_exited = true

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -229,8 +229,8 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
-    apply_penalty_or_add_grace_credits(grouping, 
-                                       apply_late_penalty, 
+    apply_penalty_or_add_grace_credits(grouping,
+                                       apply_late_penalty,
                                        new_submission)
 
     #This is to help determine the progress of the method.

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -187,7 +187,8 @@ class SubmissionCollector < ActiveRecord::Base
   #Use the database to communicate to the child to stop, and restart itself
   #and manually collect the submission
   #The third parameter enables or disables the forking.
-  def manually_collect_submission(grouping, rev_num, apply_late_penalty, async=true)
+  def manually_collect_submission(grouping, rev_num, 
+                                  apply_late_penalty, async = true)
 
     #Since windows doesn't support fork, the main process will have to collect
     #the submissions.
@@ -197,8 +198,8 @@ class SubmissionCollector < ActiveRecord::Base
       grouping.save
       new_submission = Submission.create_by_revision_number(grouping, rev_num)
       if apply_late_penalty
-        new_submission = grouping.assignment.submission_rule.apply_submission_rule(
-          new_submission)
+        new_submission = grouping.assignment.submission_rule
+                                 .apply_submission_rule(new_submission)
       end
       grouping.is_collected = true
       grouping.save
@@ -217,8 +218,8 @@ class SubmissionCollector < ActiveRecord::Base
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
     if apply_late_penalty
-      new_submission = grouping.assignment.submission_rule.apply_submission_rule(
-        new_submission)
+      new_submission = grouping.assignment.submission_rule
+                               .apply_submission_rule(new_submission)
     end
 
     #This is to help determine the progress of the method.

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -184,7 +184,9 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
   end
 
-  def apply_penalty_or_add_grace_credits(grouping, apply_late_penalty, new_submission)
+  def apply_penalty_or_add_grace_credits(grouping,
+                                         apply_late_penalty,
+                                         new_submission)
     if apply_late_penalty
       new_submission = grouping.assignment.submission_rule
                                .apply_submission_rule(new_submission)

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -209,8 +209,8 @@ class SubmissionCollector < ActiveRecord::Base
       remove_grouping_from_queue(grouping)
       grouping.save
       new_submission = Submission.create_by_revision_number(grouping, rev_num)
-      new_submission = apply_penalty_or_add_grace_credits(grouping, 
-                                                          apply_late_penalty, 
+      new_submission = apply_penalty_or_add_grace_credits(grouping,
+                                                          apply_late_penalty,
                                                           new_submission)
       grouping.is_collected = true
       grouping.save
@@ -228,8 +228,8 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
-    new_submission = apply_penalty_or_add_grace_credits(grouping, 
-                                                        apply_late_penalty, 
+    new_submission = apply_penalty_or_add_grace_credits(grouping,
+                                                        apply_late_penalty,
                                                         new_submission)
 
     #This is to help determine the progress of the method.

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -187,7 +187,7 @@ class SubmissionCollector < ActiveRecord::Base
   #Use the database to communicate to the child to stop, and restart itself
   #and manually collect the submission
   #The third parameter enables or disables the forking.
-  def manually_collect_submission(grouping, rev_num, 
+  def manually_collect_submission(grouping, rev_num,
                                   apply_late_penalty, async = true)
 
     #Since windows doesn't support fork, the main process will have to collect

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -210,7 +210,8 @@ class SubmissionCollector < ActiveRecord::Base
       grouping.save
       new_submission = Submission.create_by_revision_number(grouping, rev_num)
       new_submission = apply_penalty_or_add_grace_credits(grouping, 
-        apply_late_penalty, new_submission)
+                                                          apply_late_penalty, 
+                                                          new_submission)
       grouping.is_collected = true
       grouping.save
       return new_submission
@@ -228,7 +229,8 @@ class SubmissionCollector < ActiveRecord::Base
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
     new_submission = apply_penalty_or_add_grace_credits(grouping, 
-      apply_late_penalty, new_submission)
+                                                        apply_late_penalty, 
+                                                        new_submission)
 
     #This is to help determine the progress of the method.
     self.safely_stop_child_exited = true

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -189,7 +189,7 @@ class SubmissionCollector < ActiveRecord::Base
       new_submission = grouping.assignment.submission_rule
                                .apply_submission_rule(new_submission)
     elsif grouping.assignment.submission_rule.is_a?(GracePeriodSubmissionRule)
-      #Return any grace credits previously deducted for this grouping.
+      # Return any grace credits previously deducted for this grouping.
       grouping.assignment.submission_rule
                                        .remove_deductions(new_submission)
     end

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -229,7 +229,9 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
-    apply_penalty_or_add_grace_credits(grouping, apply_late_penalty, new_submission)
+    apply_penalty_or_add_grace_credits(grouping, 
+                                       apply_late_penalty, 
+                                       new_submission)
 
     #This is to help determine the progress of the method.
     self.safely_stop_child_exited = true

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -187,7 +187,7 @@ class SubmissionCollector < ActiveRecord::Base
   #Use the database to communicate to the child to stop, and restart itself
   #and manually collect the submission
   #The third parameter enables or disables the forking.
-  def manually_collect_submission(grouping, rev_num, async=true)
+  def manually_collect_submission(grouping, rev_num, apply_late_penalty, async=true)
 
     #Since windows doesn't support fork, the main process will have to collect
     #the submissions.
@@ -196,6 +196,10 @@ class SubmissionCollector < ActiveRecord::Base
       remove_grouping_from_queue(grouping)
       grouping.save
       new_submission = Submission.create_by_revision_number(grouping, rev_num)
+      if apply_late_penalty
+        new_submission = grouping.assignment.submission_rule.apply_submission_rule(
+          new_submission)
+      end
       grouping.is_collected = true
       grouping.save
       return new_submission
@@ -212,6 +216,10 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
+    if apply_late_penalty
+      new_submission = grouping.assignment.submission_rule.apply_submission_rule(
+        new_submission)
+    end
 
     #This is to help determine the progress of the method.
     self.safely_stop_child_exited = true

--- a/app/models/submission_collector.rb
+++ b/app/models/submission_collector.rb
@@ -209,7 +209,8 @@ class SubmissionCollector < ActiveRecord::Base
       remove_grouping_from_queue(grouping)
       grouping.save
       new_submission = Submission.create_by_revision_number(grouping, rev_num)
-      new_submission = apply_penalty_or_add_grace_credits(grouping, apply_late_penalty, new_submission)
+      new_submission = apply_penalty_or_add_grace_credits(grouping, 
+        apply_late_penalty, new_submission)
       grouping.is_collected = true
       grouping.save
       return new_submission
@@ -226,7 +227,8 @@ class SubmissionCollector < ActiveRecord::Base
     grouping.save
 
     new_submission = Submission.create_by_revision_number(grouping, rev_num)
-    new_submission = apply_penalty_or_add_grace_credits(grouping, apply_late_penalty, new_submission)
+    new_submission = apply_penalty_or_add_grace_credits(grouping, 
+      apply_late_penalty, new_submission)
 
     #This is to help determine the progress of the method.
     self.safely_stop_child_exited = true

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -97,6 +97,8 @@
                    id: @grouping.id,
                    assignment_id: @assignment.id) do %>
       <%= hidden_field_tag 'current_revision_number', @revision_number %>
+      <label><%= check_box_tag(:apply_late_penalty) %><%=t('apply_late_penalty')%></label>
+
       <input type='submit'
              value='<%= t('browse_submissions.collect_and_grab') %>'
              onclick="if (!confirm('<%=t(:collect_and_grade_overwrite_warning)%>')) return false;

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -97,7 +97,8 @@
                    id: @grouping.id,
                    assignment_id: @assignment.id) do %>
       <%= hidden_field_tag 'current_revision_number', @revision_number %>
-      <label><%= check_box_tag(:apply_late_penalty) %><%=t('apply_late_penalty')%></label>
+      <%= check_box_tag 'apply_late_penalty' %>
+      <%= label_tag nil, t('apply_late_penalty') %>
 
       <input type='submit'
              value='<%= t('browse_submissions.collect_and_grab') %>'

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -98,7 +98,7 @@
                    assignment_id: @assignment.id) do %>
       <%= hidden_field_tag 'current_revision_number', @revision_number %>
       <%= check_box_tag 'apply_late_penalty' %>
-      <%= label_tag nil, t('apply_late_penalty') %>
+      <%= label_tag nil, t('collect_submissions.apply_late_penalty') %>
 
       <input type='submit'
              value='<%= t('browse_submissions.collect_and_grab') %>'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       no_submission: "%{group_name} has no submissions"
       result_not_saved: "%{group_name}'s submission result could not be saved"
     collect_submissions:
+      apply_late_penalty: "Apply Late Penalty"
       collect_all: "Collect All Submissions"
       collect_ta: "Collect all your assigned submissions"
       disable_collect: "Collection disabled, more than one TA marking displayed submissions."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,7 +122,7 @@ en:
       no_submission: "%{group_name} has no submissions"
       result_not_saved: "%{group_name}'s submission result could not be saved"
     collect_submissions:
-      apply_late_penalty: "Apply Late Penalty"
+      apply_late_penalty: "Apply late penalty rule (Leaving this box unchecked will remove any existing late penalties.)"
       collect_all: "Collect All Submissions"
       collect_ta: "Collect all your assigned submissions"
       disable_collect: "Collection disabled, more than one TA marking displayed submissions."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -125,7 +125,7 @@ fr:
       no_submission: "%{group_name} n'a pas d'envoi"
       result_not_saved: "Le résultat du groupe %{group_name} n'a pas pu être sauvegardé."
     collect_submissions:
-      apply_late_penalty: "Appliquer pénalité de retard"
+      apply_late_penalty: "Appliquer la règle de pénalité de retard ( Laissant cette case décochée va supprimer toutes les pénalités de retard existants . )"
       collect_all: "Récupérer tous les envois"
       collect_ta: "Récupérer tous les envois qui me sont assignés"
       disable_collect: "Récupération des envois n'est pas disponible, il y a déjà un correcteur assigné aux envois."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -125,6 +125,7 @@ fr:
       no_submission: "%{group_name} n'a pas d'envoi"
       result_not_saved: "Le résultat du groupe %{group_name} n'a pas pu être sauvegardé."
     collect_submissions:
+      apply_late_penalty: "Appliquer pénalité de retard"
       collect_all: "Récupérer tous les envois"
       collect_ta: "Récupérer tous les envois qui me sont assignés"
       disable_collect: "Récupération des envois n'est pas disponible, il y a déjà un correcteur assigné aux envois."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -122,6 +122,7 @@ pt:
       no_submission: "%{group_name} não tem submissões"
       result_not_saved: "O resultado da submissão de %{group_name} não pode ser salvo"
     collect_submissions:
+      apply_late_penalty: "Aplicar pênalti no final"
       collect_all: "Coletar todas as submissões"
       collect_ta: "Coletar todas as submissões atribuidos à você"
       disable_collect: "Coleta de submissões desabilitada, já existe um monitor avaliando as submissões exibidas."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -122,7 +122,7 @@ pt:
       no_submission: "%{group_name} não tem submissões"
       result_not_saved: "O resultado da submissão de %{group_name} não pode ser salvo"
     collect_submissions:
-      apply_late_penalty: "Aplicar pênalti no final"
+      apply_late_penalty: "Aplicar regra pênalti no final ( Deixando esta caixa desmarcada irá remover quaisquer penalidades de atraso existentes. )"
       collect_all: "Coletar todas as submissões"
       collect_ta: "Coletar todas as submissões atribuidos à você"
       disable_collect: "Coleta de submissões desabilitada, já existe um monitor avaliando as submissões exibidas."


### PR DESCRIPTION
This is related to issue 2136 as it involves the late penalty originally not being applied on manual collection, but I haven't yet reproduced the bug where the late penalty was not applied because of a remark request without manual collection.