### PR TITLE
Fixed 404 error when saving overall comment while marking

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Markus::Application.routes.draw do
             get 'next_grouping'
             post 'remove_extra_mark'
             post 'set_released_to_students'
-            patch 'update_overall_comment'
+            post 'update_overall_comment'
             post 'update_marking_state'
             patch 'update_remark_request'
             get 'update_positions'


### PR DESCRIPTION
Found this while working on issue 2263. Submitting an overall comment resulted in a 404 error.