### PR TITLE
fixes issue-2290

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -117,7 +117,8 @@ class SubmissionsController < ApplicationController
     last_rev = @grouping.submissions
     @last_submission = nil
     if !last_rev.empty?
-      selected = @revisions_history.select {|rev| rev[:num] == last_rev.last.revision_number}
+      selected = @revisions_history.select { |rev| rev[:num] == 
+                                             last_rev.last.revision_number }
       @last_submission = selected.empty? ? nil : last_rev.last
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -117,8 +117,10 @@ class SubmissionsController < ApplicationController
     last_rev = @grouping.submissions
     @last_submission = nil
     if !last_rev.empty?
-      selected = @revisions_history.select { |rev| rev[:num] == 
-                                             last_rev.last.revision_number }
+      selected = @revisions_history.select do |rev| 
+        rev[:num] == last_rev.last.revision_number 
+      end
+
       @last_submission = selected.empty? ? nil : last_rev.last
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -117,8 +117,8 @@ class SubmissionsController < ApplicationController
     last_rev = @grouping.submissions
     @last_submission = nil
     if !last_rev.empty?
-      selected = @revisions_history.select do |rev| 
-        rev[:num] == last_rev.last.revision_number 
+      selected = @revisions_history.select do |rev|
+        rev[:num] == last_rev.last.revision_number
       end
 
       @last_submission = selected.empty? ? nil : last_rev.last

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -74,7 +74,7 @@ class SubmissionsController < ApplicationController
     #                         date: revision.timestamp}
     rev_number = repo.get_latest_revision.revision_number + 1
     assign_path = File.join(@assignment.repository_folder, @path)
-    rev_number.times.each do |rev|
+    rev_number.times do |rev|
       begin
         revision = repo.get_revision(rev)
         unless revision.path_exists?(assign_path)
@@ -94,7 +94,7 @@ class SubmissionsController < ApplicationController
     end
 
     if @revisions_history.empty?
-      rev_number.times.each do |rev|
+      rev_number.times do |rev|
         begin
           revision = repo.get_revision(rev)
           unless revision.path_exists?(assign_path)
@@ -112,6 +112,13 @@ class SubmissionsController < ApplicationController
           end
         end
       end
+    end
+
+    last_rev = @grouping.submissions
+    @last_submission = nil
+    if !last_rev.empty?
+      selected = @revisions_history.select {|rev| rev[:num] == last_rev.last.revision_number}
+      @last_submission = selected.empty? ? nil : last_rev.last
     end
 
     respond_to do |format|

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -65,7 +65,13 @@
         <br>
         <%= t('browse_submissions.currently_collected') %> 
         <% if @grouping.is_collected %>
-           <%= "#" + @grouping.submissions.last.revision_number.to_s + " ( " + 
+           <% if @last_submission %>
+               <%= "#" +  @last_submission.revision_number.to_s +
+          " (" + l(@last_submission.revision_timestamp, format: :long_date) + " )"  %>
+           <% else %>
+               <%= t('browse_submissions.no_rev_before_deadline') %>
+           <% end %>
+           <%#= "#" + @grouping.submissions.last.revision_number.to_s + " ( " + 
                l((@revisions_history.select {|rev| rev[:num] == @grouping.submissions.last.revision_number }).first[:date], 
              format: :long_date) + " )" %>
         <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -406,6 +406,7 @@ en:
       find_by_revision_number:    "Find by Revision Number"
       viewing_revision:           "Viewing Revision: #<span id=\"current_revision_number_display\">%{revision_number}</span>"
       currently_collected:  "Collected version:"
+      no_rev_before_deadline: 	"No revision submitted before deadline"
       current_path:         "Current Path:"
       download_all_files:   "Download all files"
       root:                 "[root]"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -402,6 +402,7 @@ fr:
       find_by_revision_number:    "Par numéro de révision"
       viewing_revision:           "Révision : #<span id=\"current_revision_number_display\">%{revision_number}</span>"
       currently_collected:  "Version recueillies:"
+      no_rev_before_deadline:   "Aucune révision soumise avant la date limite"
       current_path:         "Chemin actuel : "
       download_all_files:   "Télécharger tous les fichiers"
       root:                 "[racine]"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -384,6 +384,7 @@ pt:
       find_by_revision_number:    "Encontrar revisão por número"
       viewing_revision:           "Vendo revisão: #<span id=\"current_revision_number_display\">%{revision_number}</span>"
       currently_collected:  "Versão coletada:"
+      no_rev_before_deadline: 	"Nenhuma revisão apresentado antes do prazo"
       current_path:         "Caminho atual:"
       download_all_files:   "Baixar todos os arquivos"
       root:                 "[root]"


### PR DESCRIPTION
This fixes the problem where a student logs into MarkUs and navigates to an assignment after deadline has passed.  The repo browser view was getting a traceback.

The problem I haven't solved with this PR is that if the admin chooses to collect files submitted after the deadline, there is no way to go back and collect the version at the deadline (which would be empty).