### PR TITLE
Removed unused rjs files from graders view

### DIFF
--- a/app/views/graders/add_grader_to_grouping.rjs
+++ b/app/views/graders/add_grader_to_grouping.rjs
@@ -1,5 +1,0 @@
-page << render(partial: 'shared/global_action_warning', formats:[:js], handlers: [:erb])
-page.call 'modify_graders', @graders_data.to_json
-page.call 'modify_groupings', @groupings_data.to_json
-page.call 'modify_criteria', @criteria_data.to_json
-page.replace_html 'groups_coverage_dialog', partial: 'graders/modal_dialogs/groups_coverage'

--- a/app/views/graders/csv_upload.rjs
+++ b/app/views/graders/csv_upload.rjs
@@ -1,2 +1,0 @@
-page['current_table'].value = 'groups_table'
-page.reload


### PR DESCRIPTION
I don't believe these files are used anymore. Tables in the graders view now look like they rely on _graders_table.js.jsx.erb and _graders_manager.js.jsx.erb now.