### PR TITLE
close #2320

### DIFF
--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -408,20 +408,7 @@
       alert("<%= I18n.t('marker.annotation.provide_text') %>");
       return false;
     }
-    var current_word_len = 0;
-    for (var i = 0; i < content.length; i++)
-    {
-      if (content[i] == ' ' || content[i] == '\n')
-      {
-        current_word_len = 0;
-      }
-      else if (++current_word_len > 50) //make sure there is at least one space every 50 characters
-      {
-        content = content.slice(0, i) + " " + content.slice(i, content.length);
-        current_word_len = 0;
-        i++;
-      }
-    }
+
     // Close the dialog
     modal.close();
 

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -408,7 +408,20 @@
       alert("<%= I18n.t('marker.annotation.provide_text') %>");
       return false;
     }
-
+    var current_word_len = 0;
+    for (var i = 0; i < content.length; i++)
+    {
+      if (content[i] == ' ' || content[i] == '\n')
+      {
+        current_word_len = 0;
+      }
+      else if (++current_word_len > 50) //make sure there is at least one space every 50 characters
+      {
+        content = content.slice(0, i) + " " + content.slice(i, content.length);
+        current_word_len = 0;
+        i++;
+      }
+    }
     // Close the dialog
     modal.close();
 

--- a/app/views/results/marker/_remark_request.html.erb
+++ b/app/views/results/marker/_remark_request.html.erb
@@ -7,7 +7,7 @@
     <% if submission.remark_request_timestamp %>
       <%= I18n.l(submission.remark_request_timestamp, format: :long_date) %>
     <% end %><br><br>
-    <%= submission.remark_request %>
+    <%= simple_format(submission.remark_request) %>
   </div>
   <div id="overall_remark_comment">
     <h3><%= I18n.t("marker.overall_comments") %></h3>

--- a/app/views/results/student/_remark_request.html.erb
+++ b/app/views/results/student/_remark_request.html.erb
@@ -4,7 +4,7 @@
       <p class='notice'><%= t('marker.past_remark_due_date') %></p>
     <% else %>
       <div id='remark_request_show_results'>
-        <%= submission.remark_request %>
+        <%= simple_format(submission.remark_request) %>
           <div id='overall_comments_show'>
             <h3><%= t('marker.overall_comments') %></h3>
             <%= result.overall_comment %>
@@ -35,7 +35,7 @@
       </p>
     <% else %>
       <div id='remark_request_show'>
-        <%= submission.remark_request %>
+        <%= simple_format(submission.remark_request) %>
           <div id='overall_comments_show'>
             <h3><%= t('marker.overall_comments') %></h3>
             <%= result.overall_comment %>

--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -11,7 +11,7 @@
     <%= @assignment.remark_message %>
     <h3><%= t('marker.remark_request') %></h3>
     <div id="remark_request_text">
-      <%= @submission.remark_request %>
+      <%= simple_format(@submission.remark_request) %>
     </div>
   </div>
   <div>


### PR DESCRIPTION
This simple_format function should probably be called on some other strings as well. The problem was that when we have <%=...%> in a div, the new lines in the string just cause new lines in the generated html, which doesn't do anything. simple_format causes those new lines to turn into p tags.