### PR TITLE
Fixing several problems with svn permissions:

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -172,7 +172,7 @@ class Student < User
       # after memberships have been established.
       @grouping.update_repository_permissions
       # Add permissions for TAs and admins.  This completely rerwrites the auth file
-      # but that should be a big deal in this case.
+      # but that shouldn't be a big deal in this case.
       @group.set_repo_permissions
     end
     return true

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -171,6 +171,9 @@ class Student < User
       # Update repo permissions if need be. This has to happen
       # after memberships have been established.
       @grouping.update_repository_permissions
+      # Add permissions for TAs and admins.  This completely rerwrites the auth file
+      # but that should be a big deal in this case.
+      @group.set_repo_permissions
     end
     return true
   end

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -32,6 +32,7 @@ namespace :db do
               StudentMembership::STATUSES[:inviter],
               invoked_by_admin = true)
           end
+          group.set_repo_permissions
         end
 
         file_dir  = File.join(File.dirname(__FILE__), '/../../db/data')
@@ -49,5 +50,7 @@ namespace :db do
         end
       end
     end
+    # This really should be done in a more generic way
+    Repository::SubversionRepository.__generate_authz_file
   end
 end


### PR DESCRIPTION
- when an individual creates a group, the permissions for TAs and admins was not added
- the auth file was still being written multiple times when csv_upload was used.  This
has been fixed by moving the auth file generation out of the transaction, and by
changing how the membership was created (grouping.add_member writes to the auth file,
and probably should continue.)
- removed a couple of methods that are no longer being called
- fixed an issue with seeding the development environment where TAs and admins were
not being added to repos