### PR TITLE
Grace period collection problem

### DIFF
--- a/app/models/grace_period_submission_rule.rb
+++ b/app/models/grace_period_submission_rule.rb
@@ -43,7 +43,6 @@ class GracePeriodSubmissionRule < SubmissionRule
     collection_time = submission.revision_timestamp
     due_date = assignment.due_date
 
-
     overtime_hours = calculate_overtime_hours_from(collection_time)
     # Now we need to figure out how many Grace Credits to deduct
     deduction_amount = calculate_deduction_amount(overtime_hours)
@@ -110,6 +109,7 @@ class GracePeriodSubmissionRule < SubmissionRule
           deduction.destroy
         end
       end
+      student_membership.user.grace_period_deductions.reload
     end
   end
 


### PR DESCRIPTION
We saw a problem where the grace period was apparently not calculated correctly and the wrong revision was collected.

The logs showed that the instructor collected all the submissions more than
once. Ultimately the problem was that rows were being deleted from the
grace_period_deduction table, but the cached object didn't change when
computing the available grace credits.

The fix is to reload the grace_period_deductions so that the available
grace credits is correctly computed.