### PR TITLE
Mark api update

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -126,9 +126,8 @@ module Api
       end
 
       matched_criteria.each do |crit|
-        mark_to_change = result.marks
-                               .where(markable_id: crit.id)
-                               .first
+        mark_to_change = result.marks.find_or_create_by(markable_id: crit.id,
+                                                        markable_type: crit.class.name)
         unless set_mark_by_criteria(crit, mark_to_change)
           # Some error occurred (including invalid mark)
           render 'shared/http_status', locals: { code: '500', message:

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -170,5 +170,24 @@ module Api
         end
       end
     end
+
+    # Allow user to set marking state to complete
+    def update_marking_state
+      assignment = Assignment.find(params[:assignment_id])
+      group = Group.find(params[:id])
+      result = group.grouping_for_assignment(params[:assignment_id])
+                    .current_submission_used
+                    .get_latest_result
+      result.marking_state = params[:marking_state]
+      if result.save
+        result.submission.assignment.assignment_stat.refresh_grade_distribution
+        result.submission.assignment.update_results_stats
+        render 'shared/http_status', locals: { code: '200', message:
+          HttpStatusHelper::ERROR_CODE['message']['200'] }, status: 200
+      else
+        render 'shared/http_status', locals: { code: '500', message:
+          result.errors.full_messages.first }, status: 500
+      end
+    end
   end # end GroupsController
 end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -126,8 +126,9 @@ module Api
       end
 
       matched_criteria.each do |crit|
-        mark_to_change = result.marks.find_or_create_by(markable_id: crit.id,
-                                                        markable_type: crit.class.name)
+        mark_to_change = result.marks.find_or_create_by(
+          markable_id: crit.id,
+          markable_type: crit.class.name)
         unless set_mark_by_criteria(crit, mark_to_change)
           # Some error occurred (including invalid mark)
           render 'shared/http_status', locals: { code: '500', message:
@@ -173,7 +174,6 @@ module Api
 
     # Allow user to set marking state to complete
     def update_marking_state
-      assignment = Assignment.find(params[:assignment_id])
       group = Group.find(params[:id])
       result = group.grouping_for_assignment(params[:assignment_id])
                     .current_submission_used

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -103,7 +103,7 @@ class Result < ActiveRecord::Base
     num_criteria = submission.assignment.rubric_criteria.count +
                    submission.assignment.flexible_criteria.count
     # Check that the marking state is incomplete or all marks are entered
-    if (marks.where(mark: nil).first || marks.count != num_criteria) &&
+    if (marks.find(mark: nil) || marks.count != num_criteria) &&
        marking_state == Result::MARKING_STATES[:complete]
 
       errors.add(:base, I18n.t('common.criterion_incomplete_error'))

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -100,9 +100,12 @@ class Result < ActiveRecord::Base
   end
 
   def check_for_nil_marks
-    # Check that the marking state is not no mark is nil or
-    if marks.where(mark: nil).first &&
-          marking_state == Result::MARKING_STATES[:complete]
+    num_criteria = submission.assignment.rubric_criteria.count +
+                   submission.assignment.flexible_criteria.count
+    # Check that the marking state is incomplete or all marks are entered
+    if (marks.where(mark: nil).first || marks.count != num_criteria) &&
+       marking_state == Result::MARKING_STATES[:complete]
+
       errors.add(:base, I18n.t('common.criterion_incomplete_error'))
       return false
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Markus::Application.routes.draw do
           resources :test_results, except: [:new, :edit]
           member do
             put 'update_marks'
+            put 'update_marking_state'
           end
         end
       end


### PR DESCRIPTION
Add two pieces of functionality to the API:

1) Allow API to create marks rather than just update
2) Allow API to set result state to complete.

These two together allow for completely automarked assignments on MarkUs.