### PR TITLE
Fix issue with PDF annotations missing less than sign

### DIFF
--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -24,4 +24,10 @@ class AnnotationText < ActiveRecord::Base
   def html_content
     content.gsub(/\n/, '<br/>').html_safe
   end
+
+  # Fixes the bug in PDF annotation where '<=' is stripped
+  def html_content_symbols
+    content.gsub(/\n/, '<br/>').html_safe
+    content.gsub('<=', '&lt;=')
+  end
 end

--- a/app/views/results/common/_pdf_codeviewer.html.erb
+++ b/app/views/results/common/_pdf_codeviewer.html.erb
@@ -158,7 +158,7 @@
     <% if (defined? annots) %>
       <% annots.each do |annot| %>
         add_pdf_annotation('<%= annot.annotation_text.id %>',
-                           '<%= escape_javascript(simple_format(annot.annotation_text.html_content)) %>',
+                           '<%= escape_javascript(simple_format(annot.annotation_text.html_content_symbols)) %>',
                            '<%= annot.extract_coords.to_json().html_safe %>');
       <% end %>
     <% end %>


### PR DESCRIPTION
For https://github.com/MarkUsProject/Markus/issues/2335

@david-yz-liu, @reidka wanted to get your thoughts on this for a fix. Doesn't seem super elegant but seems to fix the problem. This is the first point when I traced the stacktrace in which the `<=` sign is lost. Doesn't seem like the javascript causes it to be lost at any point. I created the super method as I didn't want the user to see the `&lt;` when they go to edit the annotation later.

I thought about sanitizing the input as well, but it seems like the suggested method is to sanitize the output. It would also result in `&lt;` showing up when you go to edit an annotation.