### PR TITLE
Issue 2050

### DIFF
--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -191,7 +191,7 @@ class GradersController < ApplicationController
         if found_empty_submission
           assign_all_graders(filtered_grouping_ids, grader_ids)
           render text: I18n.t('assignment.group.group_submission_no_files'),
-          status: 200
+                 status: 200
         else
           assign_all_graders(grouping_ids, grader_ids)
           head :ok

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -177,12 +177,13 @@ class GradersController < ApplicationController
       case params[:global_actions]
       when 'assign'
         if grader_ids.blank?
-          render text: I18n.t('assignment.group.select_a_grader'), status: 400
+          render text: I18n.t('assignment.group.select_a_grader'),
+                 status: 400
         end        
-        # If the instructor wants to skip empty submissions, remove those groups
-        # from the list of grouping_ids to assign graders to
         if params[:skip_empty_submissions] == 'true'
-          @found_empty_submission = false;
+          # If the instructor wants to skip empty submissions, remove those groups
+          # from the list of grouping_ids to assign graders to
+          @found_empty_submission = false
           grouping_ids = find_empty_submissions(grouping_ids)
         end
         assign_all_graders(grouping_ids, grader_ids)
@@ -191,7 +192,6 @@ class GradersController < ApplicationController
         else
           head :ok
         end
-        
       when 'unassign'
         if params[:grader_memberships].blank?
           render text: I18n.t('assignment.group.select_a_grader'), status: 400
@@ -204,12 +204,13 @@ class GradersController < ApplicationController
           render text: I18n.t('assignment.group.select_a_grader'), status: 400
         else
           if params[:skip_empty_submissions] == 'true'
-            @found_empty_submission = false;
+            @found_empty_submission = false
             grouping_ids = find_empty_submissions(grouping_ids)
           end
           randomly_assign_graders(grouping_ids, grader_ids)
           if @found_empty_submission == true
-            render text: I18n.t('assignment.group.group_submission_no_files'), status: 200
+            render text: I18n.t('assignment.group.group_submission_no_files'), 
+                   status: 200
           else
             head :ok
           end
@@ -306,13 +307,12 @@ class GradersController < ApplicationController
   end
 
   def find_empty_submissions(grouping_ids)
-     grouping_ids.each do |grouping_id|
+    grouping_ids.each do |grouping_id|
       submission = Submission.find_by_grouping_id(grouping_id)
       if !submission || !SubmissionFile.where(submission_id: submission.id).exists?
         grouping_ids.delete(grouping_id)
         @found_empty_submission = true;
       end
     end
-    return grouping_ids
   end
 end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -178,7 +178,7 @@ class GradersController < ApplicationController
       when 'assign'
         if grader_ids.blank?
           render text: I18n.t('assignment.group.select_a_grader'),
-                status: 400
+                 status: 400
         end        
         if params[:skip_empty_submissions] == 'true'
           # If the instructor wants to skip empty submissions, remove those groups

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -178,7 +178,7 @@ class GradersController < ApplicationController
       when 'assign'
         if grader_ids.blank?
           render text: I18n.t('assignment.group.select_a_grader'),
-                 status: 400
+                status: 400
         end        
         if params[:skip_empty_submissions] == 'true'
           # If the instructor wants to skip empty submissions, remove those groups
@@ -209,7 +209,7 @@ class GradersController < ApplicationController
           end
           randomly_assign_graders(grouping_ids, grader_ids)
           if @found_empty_submission == true
-            render text: I18n.t('assignment.group.group_submission_no_files'), 
+            render text: I18n.t('assignment.group.group_submission_no_files'),
                    status: 200
           else
             head :ok

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -190,7 +190,8 @@ class GradersController < ApplicationController
         end
         if found_empty_submission
           assign_all_graders(filtered_grouping_ids, grader_ids)
-          render text: I18n.t('assignment.group.group_submission_no_files'), status: 200
+          render text: I18n.t('assignment.group.group_submission_no_files'),
+          status: 200
         else
           assign_all_graders(grouping_ids, grader_ids)
           head :ok

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -309,8 +309,9 @@ class GradersController < ApplicationController
   def find_empty_submissions(grouping_ids)
     grouping_ids.each do |grouping_id|
       submission = Submission.find_by_grouping_id(grouping_id)
-      if !submission || 
-         !SubmissionFile.where(submission_id: submission.id).exists?
+      if !submission
+        next
+      elsif !SubmissionFile.where(submission_id: submission.id).exists?
         grouping_ids.delete(grouping_id)
         @found_empty_submission = true
       end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -178,7 +178,7 @@ class GradersController < ApplicationController
       when 'assign'
         if grader_ids.blank?
           render text: I18n.t('assignment.group.select_a_grader'),
-                 status: 400
+                  status: 400
         end        
         if params[:skip_empty_submissions] == 'true'
           # If the instructor wants to skip empty submissions, filter
@@ -315,13 +315,9 @@ class GradersController < ApplicationController
 
   # Returns array of grouping ids with non empty submissions
   def filter_empty_submissions(grouping_ids)
-    filtered_grouping_ids = Array.new
-    grouping_ids.each do |grouping_id|
+    filtered_grouping_ids = grouping_ids.select do |grouping_id|
       submission = Submission.find_by(grouping_id: grouping_id)
-      if submission && SubmissionFile.where(submission_id: submission.id).exists?
-        filtered_grouping_ids << grouping_id
-      end
+      submission && SubmissionFile.where(submission_id: submission.id).exists?
     end
-    filtered_grouping_ids
   end
 end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -309,9 +309,10 @@ class GradersController < ApplicationController
   def find_empty_submissions(grouping_ids)
     grouping_ids.each do |grouping_id|
       submission = Submission.find_by_grouping_id(grouping_id)
-      if !submission || !SubmissionFile.where(submission_id: submission.id).exists?
+      if !submission || 
+         !SubmissionFile.where(submission_id: submission.id).exists?
         grouping_ids.delete(grouping_id)
-        @found_empty_submission = true;
+        @found_empty_submission = true
       end
     end
   end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -179,11 +179,13 @@ class GradersController < ApplicationController
         if grader_ids.blank?
           render text: I18n.t('assignment.group.select_a_grader'), status: 400
         end        
+        # If the instructor wants to skip empty submissions, remove those groups
+        # from the list of grouping_ids to assign graders to
         if params[:skip_empty_submissions] == 'true'
           found_empty_submission = false;
           grouping_ids.each do |grouping_id|
             submission = Submission.find_by_grouping_id(grouping_id)
-            if !SubmissionFile.where(submission_id: submission.id).exists?
+            if !submission || !SubmissionFile.where(submission_id: submission.id).exists?
               grouping_ids.delete(grouping_id)
               found_empty_submission = true;
             end
@@ -191,7 +193,7 @@ class GradersController < ApplicationController
         end
         assign_all_graders(grouping_ids, grader_ids)
         if found_empty_submission == true
-          render text: I18n.t('assignment.group.group_submission_no_files'), status: 400
+          render text: I18n.t('assignment.group.group_submission_no_files'), status: 200
         else
           head :ok
         end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -315,7 +315,7 @@ class GradersController < ApplicationController
 
   # Returns array of grouping ids with non empty submissions
   def filter_empty_submissions(grouping_ids)
-    filtered_grouping_ids = grouping_ids.select do |grouping_id|
+    grouping_ids.select do |grouping_id|
       submission = Submission.find_by(grouping_id: grouping_id)
       submission && SubmissionFile.where(submission_id: submission.id).exists?
     end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -61,14 +61,13 @@ module SubmissionsHelper
             r.id == submission.remark_result_id
           end).first
         end
-        has_files = SubmissionFile.where(submission_id: submission.id).exists?
         final_due_date = assignment.submission_rule.get_collection_time
         g[:name] = grouping.get_group_name
         g[:id] = grouping.id
         g[:section] = grouping.section
         g[:tags] = grouping.tags
-        g[:has_files] = has_files
         g[:commit_date] = grouping.last_commit_date
+        g[:has_files] = grouping.has_files_in_submission
         g[:late_commit] = grouping.past_due_date?
         g[:name_url] = get_grouping_name_url(grouping, final_due_date, result)
         g[:class_name] = get_tr_class(grouping)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -61,11 +61,13 @@ module SubmissionsHelper
             r.id == submission.remark_result_id
           end).first
         end
+        has_files = SubmissionFile.where(submission_id: submission.id).exists?
         final_due_date = assignment.submission_rule.get_collection_time
         g[:name] = grouping.get_group_name
         g[:id] = grouping.id
         g[:section] = grouping.section
         g[:tags] = grouping.tags
+        g[:has_files] = has_files
         g[:commit_date] = grouping.last_commit_date
         g[:late_commit] = grouping.past_due_date?
         g[:name_url] = get_grouping_name_url(grouping, final_due_date, result)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -67,7 +67,7 @@ module SubmissionsHelper
         g[:section] = grouping.section
         g[:tags] = grouping.tags
         g[:commit_date] = grouping.last_commit_date
-        g[:has_files] = grouping.has_files_in_submission
+        g[:has_files] = grouping.has_files_in_submission?
         g[:late_commit] = grouping.past_due_date?
         g[:name_url] = get_grouping_name_url(grouping, final_due_date, result)
         g[:class_name] = get_tr_class(grouping)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -698,7 +698,8 @@ class Grouping < ActiveRecord::Base
   # Helper for populate_submission_table
   # Returns boolean value based on if the submission has files or not
   def has_files_in_submission?
-    return !has_submission? || SubmissionFile.where(submission_id: current_submission_used.id).exists?
+    !has_submission? ||
+    SubmissionFile.where(submission_id: current_submission_used.id).exists?
   end
 
   # Helper for populate_submissions_table.

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -698,12 +698,7 @@ class Grouping < ActiveRecord::Base
   # Helper for populate_submission_table
   # Returns boolean value based on if the submission has files or not
   def has_files_in_submission?
-    if has_submission?
-      SubmissionFile.where(submission_id: current_submission_used.id).exists?
-    else
-      # If there is no submission yet, default to true to avoid errors
-      true
-    end
+    return !has_submission? || SubmissionFile.where(submission_id: current_submission_used.id).exists?
   end
 
   # Helper for populate_submissions_table.

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -697,7 +697,7 @@ class Grouping < ActiveRecord::Base
 
   # Helper for populate_submission_table
   # Returns boolean value based on if the submission has files or not
-  def has_files_in_submission
+  def has_files_in_submission?
     if has_submission?
       SubmissionFile.where(submission_id: current_submission_used.id).exists?
     else

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -695,6 +695,17 @@ class Grouping < ActiveRecord::Base
     end
   end
 
+  # Helper for populate_submission_table
+  # Returns boolean value based on if the submission has files or not
+  def has_files_in_submission
+    if has_submission?
+      SubmissionFile.where(submission_id: current_submission_used.id).exists?
+    else
+      # If there is no submission yet, default to true to avoid errors
+      true
+    end
+  end
+
   # Helper for populate_submissions_table.
   # Returns the final grade for this grouping.
   def final_grade(result)

--- a/app/views/graders/_graders_action_column.js.jsx.erb
+++ b/app/views/graders/_graders_action_column.js.jsx.erb
@@ -24,7 +24,8 @@
         groupings: this.props.selected_groups,
         grader_memberships: this.props.selected_graders_in_groups,
         criteria: this.props.selected_criteria,
-        criterion_associations: this.props.selected_graders_in_criteria
+        criterion_associations: this.props.selected_graders_in_criteria,
+        skip_empty_submissions: this.props.skip_empty_submissions
       };
       jQuery.ajax({
         method: 'POST',

--- a/app/views/graders/_graders_action_column.js.jsx.erb
+++ b/app/views/graders/_graders_action_column.js.jsx.erb
@@ -36,7 +36,7 @@
           this.props.updateSelectedGroups([]);
           this.props.updateSelectedCriteria([]);
           this.props.updateSelectedGradersInGroups([]);
-          this.props.setError(null);
+          this.props.setError(data);
           this.props.refresh();
         }.bind(this),
         error: function(xhr, status, text) {

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -9,6 +9,7 @@
     getInitialState: function() {
       return {
         assign_to_criteria: false,
+        skip_empty_submissions: false,
         error: null,
         current_table: 'groups_table',
         groups_and_criteria: {groups: [], criteria: []},
@@ -53,6 +54,14 @@
         }.bind(this)
       });
     },
+    skipEmptySubmissionsClicked: function(event) {
+      var value = event.currentTarget.checked;
+      if (value) {
+        this.setState({skip_empty_submissions: true});
+      } else {
+        this.setState({skip_empty_submissions: false});
+      }
+    },
     componentWillMount: function() {
       this.refresh();
     },
@@ -80,7 +89,7 @@
             assign_to_criteria: data[0],
             sections: data[1],
             graders: data[2],
-            groups_and_criteria: data[3],
+            groups_and_criteria: data[3]
           });
         }.bind(this)
       });
@@ -88,9 +97,13 @@
     render: function() {
       var to_render = [];
       var graders_to_criteria = [];
+      var skip_empty_submissions = [];
       graders_to_criteria.push(<input type='checkbox'
         checked={this.state.assign_to_criteria}
         onChange={this.criteriaCheckboxClicked}> <%= j raw I18n.t('graders.assign_to_criteria') %></input>);
+      skip_empty_submissions.push(<input type='checkbox'
+        checked={this.state.skip_empty_submissions}
+        onChange={this.skipEmptySubmissionsClicked}> <%= j raw I18n.t('graders.skip_empty_submissions') %></input>);
       to_render.push(<GradersTable graders={this.state.graders}
         selected_graders={this.state.selected_graders}
         onSelectedGradersChange={this.updateSelectedGraders} />);
@@ -107,6 +120,7 @@
         updateSelectedCriteria={this.updateSelectedCriteria}
         updateSelectedGradersInGroups={this.updateSelectedGradersInGroups}
         updateSelectedGradersInCriteria={this.updateSelectedGradersInCriteria}
+        skip_empty_submissions={this.state.skip_empty_submissions}
         setError={this.setError}
       />);
       to_render.push(<GroupsTableManager
@@ -131,6 +145,9 @@
           <div className='graders-to-criteria'>
             {graders_to_criteria}
           </div>
+          <div className='skip-empty-submissions'>
+            {skip_empty_submissions}
+          </div>
           <div className='columns'>
             {to_render}
           </div>
@@ -144,6 +161,7 @@
   var GroupsTableManager = React.createClass({
     propTypes: {
       assign_to_criteria: React.PropTypes.bool,
+      skip_empty_submissions: React.PropTypes.bool,
       groups_and_criteria: React.PropTypes.object,
       selected_groups: React.PropTypes.array,
       onSelectedGroupsChange: React.PropTypes.func,

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -55,12 +55,7 @@
       });
     },
     skipEmptySubmissionsClicked: function(event) {
-      var value = event.currentTarget.checked;
-      if (value) {
-        this.setState({skip_empty_submissions: true});
-      } else {
-        this.setState({skip_empty_submissions: false});
-      }
+     this.setState({skip_empty_submissions: event.currentTarget.checked});
     },
     componentWillMount: function() {
       this.refresh();

--- a/app/views/submissions/_submissions_table.js.jsx.erb
+++ b/app/views/submissions/_submissions_table.js.jsx.erb
@@ -201,7 +201,15 @@
           }
 
           s['class_name'] = submission.class_name;
-          s['repository'] = <a href={submission.repo_url}>{submission.repo_name}</a>;
+          if (!submission.has_files) {
+            s['repository'] = (<span>
+              <%= image_tag('icons/error.png',
+                            title: t(:no_files_submitted)) %>
+              <a href={submission.repo_url}>{submission.repo_name}</a>
+            </span>);
+          } else {
+            s['repository'] = <a href={submission.repo_url}>{submission.repo_name}</a>;
+          }
           if (submission.late_commit) {
             s['commit_date'] = (<span>
               <%= image_tag('icons/error.png',
@@ -217,6 +225,7 @@
           s['tags'] = <div className='tag_list'>{tag_list}</div>;
           s['final_grade'] = submission.final_grade;
           s['section'] = submission.section;
+          s['has_files'] = submission.has_files;
         }
         return s;
       }.bind(this));

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
             select_a_group: "Select a group"
             select_a_student: "Select a student"
             select_a_grader: "Select a grader"
+            group_submission_no_files: "One or more of the groups selected has no files in their submission. Grader not assigned."
             select_only_one_group: "You may only assign each student to one group."
             deleted: "Group has been deleted"
             work_in_groups:  "Students can work in groups"
@@ -784,6 +785,7 @@ en:
       search_criteria:    "Search Criteria"
       assign_to_criteria: "Assign Graders to Criteria"
       lines_not_processed: "The following lines could not be processed:"
+      skip_empty_submissions: "Do not assign Graders to groups with empty submissions"
       upload:
         select_csv_file: "Select a CSV file of the following form: <code>user_name,last_name,first_name</code>"
         grader_same_user: "If a TA with the same user_name exists, then that TA's information is updated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,7 @@ en:
 
     marks_released_notice:  "The marks have been released. You cannot change the grades."
     commit_after_due_date: "This commit is after the due date."
+    no_files_submitted: "This submission has no files."
     past_due_date_edit_warning:  "WARNING:  The due date you have selected is in the past."
     past_due_date_edit_result_warning: "The %{href} of this group is after the due date."
     last_commit: "last commit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -785,7 +785,7 @@ en:
       search_criteria:    "Search Criteria"
       assign_to_criteria: "Assign Graders to Criteria"
       lines_not_processed: "The following lines could not be processed:"
-      skip_empty_submissions: "Do not assign Graders to groups with empty submissions"
+      skip_empty_submissions: "Do not assign Graders to groups with empty submissions (requires that submissions are collected)"
       upload:
         select_csv_file: "Select a CSV file of the following form: <code>user_name,last_name,first_name</code>"
         grader_same_user: "If a TA with the same user_name exists, then that TA's information is updated."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -168,6 +168,7 @@ fr:
             select_a_group: "Sélectionner un groupe"
             select_a_student: "Sélectionner un(e) étudiant(e)"
             select_a_grader: "Sélectionner un correcteur"
+            group_submission_no_files: "Un ou plusieurs des groupes sélectionnés ne contient aucun fichier dans leur soumission. Grader pas affecté."
             select_only_one_group: "Vous ne pouvez assigner un(e) étudiant(e) qu'à un seul groupe."
             deleted: "Le groupe a été supprimé"
             work_in_groups:  "Les étudiants peuvent travailler en groupe"
@@ -262,6 +263,7 @@ fr:
 
     marks_released_notice:  "Les notes sont maintenant affichées. Vous ne pouvez plus les changer."
     commit_after_due_date: "Ce commit est postérieur à la date de rendu."
+    no_files_submitted: "Cette présentation n'a pas de fichiers."
     past_due_date_edit_warning:  "ATTENTION ! La date de retour que vous avez choisie est antérieure à la date actuelle."
     past_due_date_edit_result_warning: "La date du %{href} de ce groupe est postérieure à la date de retour."
     last_commit: "dernier rendu"
@@ -762,6 +764,7 @@ fr:
       search_criteria:    "Rechercher les critères"
       assign_to_criteria: "Attribuer les correcteurs aux critères"
       lines_not_processed: "Les lignes suivantes n'ont pas pu être traitées : "
+      skip_empty_submission: "Ne pas attribuer trieurs à des groupes dont les demandes sont vides"
       upload:
         select_csv_file: "Sélectionner un fichier CSV formaté comme suit : <code>user_name,last_name,first_name</code>"
         grader_same_user: "Si un correcteur avec le même nom d'utilisateur existe, ses informations seront mises à jour."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -764,7 +764,7 @@ fr:
       search_criteria:    "Rechercher les critères"
       assign_to_criteria: "Attribuer les correcteurs aux critères"
       lines_not_processed: "Les lignes suivantes n'ont pas pu être traitées : "
-      skip_empty_submission: "Ne pas attribuer trieurs à des groupes dont les demandes sont vides"
+      skip_empty_submissions: "Ne pas attribuer trieurs à des groupes dont les demandes sont vides (exige que les soumissions sont collectées)"
       upload:
         select_csv_file: "Sélectionner un fichier CSV formaté comme suit : <code>user_name,last_name,first_name</code>"
         grader_same_user: "Si un correcteur avec le même nom d'utilisateur existe, ses informations seront mises à jour."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -737,7 +737,7 @@ pt:
       search_criteria:    "Pesquisar os critérios"
       assign_to_criteria: "Atribuir avaliador aos critérios"
       lines_not_processed: "As linhas a seguir não puderam ser processadas:"
-      skip_empty_submission: "Não atribua Graders a grupos com apresentações vazias"
+      skip_empty_submissions: "Não atribua Graders a grupos com apresentações vazias (requer que as candidaturas são recolhidas)"
       upload:
         select_csv_file: "Selecione um arquivo CSV no seguinte formato: <code>user_name,last_name,first_name</code>"
         grader_same_user: "Se existir um avaliador com o mesmo user_name, suas informações serão atualizadas."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -165,6 +165,7 @@ pt:
             select_a_group: "Selecione um grupo"
             select_a_student: "Selecione um aluno"
             select_a_grader: "Selecione um avaliador"
+            group_submission_no_files: "Um ou mais dos grupos selecionados não possui arquivos em sua apresentação. Grader não atribuído."
             select_only_one_group: "Você pode indicar cada estudante a somente um grupo."
             deleted: "Grupo foi apagado"
             work_in_groups:  "Alunos podem trabalhar em grupos"
@@ -736,6 +737,7 @@ pt:
       search_criteria:    "Pesquisar os critérios"
       assign_to_criteria: "Atribuir avaliador aos critérios"
       lines_not_processed: "As linhas a seguir não puderam ser processadas:"
+      skip_empty_submission: "Não atribua Graders a grupos com apresentações vazias"
       upload:
         select_csv_file: "Selecione um arquivo CSV no seguinte formato: <code>user_name,last_name,first_name</code>"
         grader_same_user: "Se existir um avaliador com o mesmo user_name, suas informações serão atualizadas."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -259,6 +259,7 @@ pt:
 
     marks_released_notice:  "As notas foram liberadas. Você não pode alterá-las."
     commit_after_due_date: "O envio foi fora do prazo."
+    no_files_submitted: "Esta apresentação não tem arquivos."
     past_due_date_edit_warning:  "Alerta:  O data selecionada está no passado."
     past_due_date_edit_result_warning: "O %{href} desse grupo está depois do prazo."
     last_commit: "Último envio"


### PR DESCRIPTION
Closes #2050 

Instructors can optionally choose to disallow adding graders to groups with no submission. If this is the case, a message will be displayed to them and all other valid grader -> group assignments will go through.

After submissions are collected, those with empty submissions will be flagged with an icon.