### PR TITLE
Test framework save testrun result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Files ignored by git
 # Ignore nncessary mac files
-.DS_Store
+*.DS_Store
 
 /config/database.yml
 /config/local_environment_override.rb

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'ya2yaml'
 gem 'i18n'
 gem 'dynamic_form'
 gem 'exception_notification'
-gem "libxml-ruby" # xml parser library to parse test results
 gem 'activerecord-import'
 gem 'auto_complete'
 gem 'best_in_place'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,6 @@ GEM
     json (1.8.3)
     kgio (2.10.0)
     libv8 (3.16.14.11)
-    libxml-ruby (2.8.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     machinist (1.0.6)
@@ -327,7 +326,6 @@ DEPENDENCIES
   jquery-rails
   json
   libv8
-  libxml-ruby
   machinist (< 2)
   minitest
   mocha

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -140,51 +140,6 @@ class AutomatedTestsController < ApplicationController
     end
   end
 
-  # Download is called when an admin wants to download a test script
-  # or test support file
-  # Check three things:
-  #  1. filename is in DB
-  #  2. file is in the directory it's supposed to be
-  #  3. file exists and is readable
-  def download
-    filedb = nil
-    if params[:type] == 'script'
-      filedb = TestScript.find_by_assignment_id_and_script_name(params[:assignment_id], params[:filename])
-    elsif params[:type] == 'support'
-      filedb = TestSupportFile.find_by_assignment_id_and_file_name(params[:assignment_id], params[:filename])
-    end
-
-    if filedb
-      if params[:type] == 'script'
-        filename = filedb.script_name
-      elsif params[:type] == 'support'
-        filename = filedb.file_name
-      end
-      assn_short_id = Assignment.find(params[:assignment_id]).short_identifier
-
-      # the given file should be in this directory
-      should_be_in = File.join(MarkusConfigurator.markus_config_automated_tests_repository, assn_short_id)
-      should_be_in = File.expand_path(should_be_in)
-      filename = File.expand_path(File.join(should_be_in, filename))
-
-      if should_be_in == File.dirname(filename) and File.readable?(filename)
-        # Everything looks OK. Send the file over to the client.
-        file_contents = IO.read(filename)
-        send_file filename,
-                  :type => ( SubmissionFile.is_binary?(file_contents) ? 'application/octet-stream':'text/plain' ),
-                  :x_sendfile => true
-
-     # print flash error messages
-      else
-        flash[:error] = I18n.t('automated_tests.download_wrong_place_or_unreadable');
-        redirect_to :action => 'manage'
-      end
-    else
-      flash[:error] = I18n.t('automated_tests.download_not_in_db');
-      redirect_to :action => 'manage'
-    end
-  end
-
   private
 
   def assignment_params

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -740,8 +740,8 @@ module AutomatedTestsHelper
   def self.process_result(raw_result)
     result = Hash.from_xml(raw_result)
     repo = @grouping.group.repo
-    @revision = repo.get_latest_revision
-    @revision_number = @revision.revision_number
+    revision = repo.get_latest_revision
+    revision_number = revision.revision_number
     raw_test_scripts = result['testrun']['test_script']
 
     # Hash.from_xml will yield a hash if only one test script
@@ -776,7 +776,7 @@ module AutomatedTestsHelper
     TestResult.create(grouping_id: @grouping.id,
                       test_script_id: test_script.id,
                       name: script_name,
-                      repo_revision: @revision_number,
+                      repo_revision: revision_number,
                       input_description: '',
                       actual_output: result.to_json,
                       expected_output: '',

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -742,7 +742,7 @@ module AutomatedTestsHelper
     repo = @grouping.group.repo
     @revision = repo.get_latest_revision
     @revision_number = @revision.revision_number
-    raw_test_scripts = result["testrun"]["test_script"]
+    raw_test_scripts = result['testrun']['test_script']
 
     # Hash.from_xml will yield a hash if only one test script
     # and an array therwise
@@ -757,7 +757,7 @@ module AutomatedTestsHelper
     # For now, we just use the first test script for the association
     test_result = TestResult.new
     raw_test_script = test_scripts.first
-    script_name = raw_test_script["script_name"]
+    script_name = raw_test_script['script_name']
     test_script = TestScript.find_by(assignment_id: @assignment.id,
       script_name: script_name)
     test_result.grouping_id = @grouping.id
@@ -774,11 +774,11 @@ module AutomatedTestsHelper
     completion_status = 'pass'
 
     test_scripts.each do |script|
-      tests = script["test"]
+      tests = script['test']
       tests.each do |test|
-        test_result.marks_earned += test["marks_earned"].to_i
+        test_result.marks_earned += test['marks_earned'].to_i
         # if any of the tests fail, we consider the completion status to be fail
-        completion_status = 'fail' if test["status"] != 'pass'
+        completion_status = 'fail' if test['status'] != 'pass'
       end
     end
     test_result.completion_status = completion_status

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -737,20 +737,12 @@ module AutomatedTestsHelper
     end
   end
 
-  #make use of @assignment and @grouping
   def self.process_result(raw_result)
     result = Hash.from_xml(raw_result)
     repo = @grouping.group.repo
     @revision = repo.get_latest_revision
     @revision_number = @revision.revision_number
-
-     # use results, go through each test script
-     # create a test sript result, populate it and save
-     # cases to consider
-     # test script doesn't exist, accessing key will give nil
-     # 1 test script, accessing key  will be a hash
-     # 2 test scripts will be an array
-     raw_test_scripts = result["testrun"]["test_script"]
+    raw_test_scripts = result["testrun"]["test_script"]
 
     # Hash.from_xml will yield a hash if only one test script
     # and an array therwise
@@ -768,7 +760,8 @@ module AutomatedTestsHelper
     # raise "#{raw_test_script}"
     script_name = raw_test_script["script_name"]
     # raise "#{script_name} #{raw_test_script} #{test_scripts}"
-    test_script = TestScript.find_by(assignment_id: @assignment.id, script_name: script_name)
+    test_script = TestScript.find_by(assignment_id: @assignment.id,
+      script_name: script_name)
     # raise "grouping #{@grouping} test_script #{test_script}"
     test_result.grouping_id = @grouping.id
     test_result.test_script_id = test_script.id
@@ -778,11 +771,11 @@ module AutomatedTestsHelper
     test_result.input_description = ''
     test_result.actual_output = result.to_json
     test_result.expected_output = ''
-    test_result.submission_id = Submission.last.id #TODO: figure out how to get submission
-
-    test_result.marks_earned = 0  #TODO: put marks earned
-
+    #TODO: HACK. Do we always need a submission id?
+    test_result.submission_id = Submission.last.id
+    test_result.marks_earned = 0
     completion_status = 'pass'
+
     test_scripts.each do |script|
       tests = script["test"]
       tests.each do |test|

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -748,7 +748,7 @@ module AutomatedTestsHelper
     # and an array therwise
     if raw_test_scripts.nil?
       return
-    elsif raw_test_scripts.kind_of?(Array)
+    elsif raw_test_scripts.is_a?(Array)
       test_scripts = raw_test_scripts
     else
       test_scripts = [raw_test_scripts]
@@ -759,7 +759,7 @@ module AutomatedTestsHelper
     raw_test_script = test_scripts.first
     script_name = raw_test_script['script_name']
     test_script = TestScript.find_by(assignment_id: @assignment.id,
-      script_name: script_name)
+                                       script_name: script_name)
     test_result.grouping_id = @grouping.id
     test_result.test_script_id = test_script.id
     test_result.name = script_name
@@ -768,7 +768,7 @@ module AutomatedTestsHelper
     test_result.input_description = ''
     test_result.actual_output = result.to_json
     test_result.expected_output = ''
-    #TODO: HACK. Do we always need a submission id?
+    # TODO: HACK. Do we always need a submission id?
     test_result.submission_id = Submission.last.id
     test_result.marks_earned = 0
     completion_status = 'pass'

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -758,7 +758,7 @@ module AutomatedTestsHelper
     raw_test_script = test_scripts.first
     script_name = raw_test_script['script_name']
     test_script = TestScript.find_by(assignment_id: @assignment.id,
-                                       script_name: script_name)
+                                     script_name: script_name)
 
     completion_status = 'pass'
     marks_earned = 0

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -754,15 +754,12 @@ module AutomatedTestsHelper
       test_scripts = [raw_test_scripts]
     end
 
-    # For now, we assume there is only one test script.
+    # For now, we just use the first test script for the association
     test_result = TestResult.new
     raw_test_script = test_scripts.first
-    # raise "#{raw_test_script}"
     script_name = raw_test_script["script_name"]
-    # raise "#{script_name} #{raw_test_script} #{test_scripts}"
     test_script = TestScript.find_by(assignment_id: @assignment.id,
       script_name: script_name)
-    # raise "grouping #{@grouping} test_script #{test_script}"
     test_result.grouping_id = @grouping.id
     test_result.test_script_id = test_script.id
     test_result.name = script_name


### PR DESCRIPTION
As discussed with @david-yz-liu , putting up this PR

- rewrote `process_result` method to save results of a testrun into the database
- saved it using the TestResult model. A number of the fields in this model don't make the most sense as it was originally intended to save the results of an individual unit test (e.g. completion status). In particular, I hacked a value for  `test_result.submission_id`
- saved `test_result.actual_output` as json so we can move away from XML @reidka 
- removed XML parser from `Gemfile` and recreated `Gemfile.lock`
