### PR TITLE
Markdown Support in Annotation and Other Areas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'responders', '~> 2.0'
 gem 'sprockets', '~> 2.12.0'
 gem 'rails-html-sanitizer'
 gem 'rails-deprecated_sanitizer'
+gem 'redcarpet', '~> 3.0.0'
 
 gem 'tilt', '~> 1.3.7'
 gem 'sass-rails',   '5.0.0.beta1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
+    redcarpet (3.0.0)
     ref (2.0.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -316,6 +317,7 @@ DEPENDENCIES
   rails-observers (~> 0.1.1)
   rails-perftest (~> 0.0.2)
   rdoc
+  redcarpet (~> 3.0.0)
   responders (~> 2.0)
   rspec-rails (~> 3.0)
   rubocop

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -26,7 +26,7 @@ function updateAnnotationPreview() {
     var newAnnotation = document.getElementById('new_annotation_content').value;
 
     var preview = document.getElementById('annotation_preview');
-    preview.innerHTML = newAnnotation;
+    preview.innerHTML = marked(newAnnotation);
 
     showAnnotationPreview();
 

--- a/app/assets/javascripts/SourceCodeGlower/AnnotationTextDisplayer.js
+++ b/app/assets/javascripts/SourceCodeGlower/AnnotationTextDisplayer.js
@@ -38,7 +38,7 @@ AnnotationTextDisplayer.prototype.displayCollection = function(collection, x, y)
 
   // Each element is an AnnotationText object
   collection.forEach(function(element, index, array) {
-    final_string += '<p>' + element.getContent() + '</p>';
+    final_string += '<p>' + marked(element.getContent()) + '</p>';
   });
 
   // Update the Display node (a div, in this case) to be in the right

--- a/app/assets/javascripts/marked.js
+++ b/app/assets/javascripts/marked.js
@@ -1,0 +1,1285 @@
+/**
+ * marked - a markdown parser
+ * Copyright (c) 2011-2014, Christopher Jeffrey. (MIT Licensed)
+ * https://github.com/chjj/marked
+ */
+
+;(function() {
+
+/**
+ * Block-Level Grammar
+ */
+
+var block = {
+  newline: /^\n+/,
+  code: /^( {4}[^\n]+\n*)+/,
+  fences: noop,
+  hr: /^( *[-*_]){3,} *(?:\n+|$)/,
+  heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
+  nptable: noop,
+  lheading: /^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,
+  blockquote: /^( *>[^\n]+(\n(?!def)[^\n]+)*\n*)+/,
+  list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
+  html: /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
+  def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  table: noop,
+  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
+  text: /^[^\n]+/
+};
+
+block.bullet = /(?:[*+-]|\d+\.)/;
+block.item = /^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/;
+block.item = replace(block.item, 'gm')
+  (/bull/g, block.bullet)
+  ();
+
+block.list = replace(block.list)
+  (/bull/g, block.bullet)
+  ('hr', '\\n+(?=\\1?(?:[-*_] *){3,}(?:\\n+|$))')
+  ('def', '\\n+(?=' + block.def.source + ')')
+  ();
+
+block.blockquote = replace(block.blockquote)
+  ('def', block.def)
+  ();
+
+block._tag = '(?!(?:'
+  + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+  + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
+  + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|[^\\w\\s@]*@)\\b';
+
+block.html = replace(block.html)
+  ('comment', /<!--[\s\S]*?-->/)
+  ('closed', /<(tag)[\s\S]+?<\/\1>/)
+  ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
+  (/tag/g, block._tag)
+  ();
+
+block.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ();
+
+/**
+ * Normal Block Grammar
+ */
+
+block.normal = merge({}, block);
+
+/**
+ * GFM Block Grammar
+ */
+
+block.gfm = merge({}, block.normal, {
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
+  paragraph: /^/,
+  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
+});
+
+block.gfm.paragraph = replace(block.paragraph)
+  ('(?!', '(?!'
+    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
+    + block.list.source.replace('\\1', '\\3') + '|')
+  ();
+
+/**
+ * GFM + Tables Block Grammar
+ */
+
+block.tables = merge({}, block.gfm, {
+  nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
+  table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
+});
+
+/**
+ * Block Lexer
+ */
+
+function Lexer(options) {
+  this.tokens = [];
+  this.tokens.links = {};
+  this.options = options || marked.defaults;
+  this.rules = block.normal;
+
+  if (this.options.gfm) {
+    if (this.options.tables) {
+      this.rules = block.tables;
+    } else {
+      this.rules = block.gfm;
+    }
+  }
+}
+
+/**
+ * Expose Block Rules
+ */
+
+Lexer.rules = block;
+
+/**
+ * Static Lex Method
+ */
+
+Lexer.lex = function(src, options) {
+  var lexer = new Lexer(options);
+  return lexer.lex(src);
+};
+
+/**
+ * Preprocessing
+ */
+
+Lexer.prototype.lex = function(src) {
+  src = src
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/\t/g, '    ')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u2424/g, '\n');
+
+  return this.token(src, true);
+};
+
+/**
+ * Lexing
+ */
+
+Lexer.prototype.token = function(src, top, bq) {
+  var src = src.replace(/^ +$/gm, '')
+    , next
+    , loose
+    , cap
+    , bull
+    , b
+    , item
+    , space
+    , i
+    , l;
+
+  while (src) {
+    // newline
+    if (cap = this.rules.newline.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[0].length > 1) {
+        this.tokens.push({
+          type: 'space'
+        });
+      }
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      cap = cap[0].replace(/^ {4}/gm, '');
+      this.tokens.push({
+        type: 'code',
+        text: !this.options.pedantic
+          ? cap.replace(/\n+$/, '')
+          : cap
+      });
+      continue;
+    }
+
+    // fences (gfm)
+    if (cap = this.rules.fences.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'code',
+        lang: cap[2],
+        text: cap[3] || ''
+      });
+      continue;
+    }
+
+    // heading
+    if (cap = this.rules.heading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[1].length,
+        text: cap[2]
+      });
+      continue;
+    }
+
+    // table no leading pipe (gfm)
+    if (top && (cap = this.rules.nptable.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i].split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // lheading
+    if (cap = this.rules.lheading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[2] === '=' ? 1 : 2,
+        text: cap[1]
+      });
+      continue;
+    }
+
+    // hr
+    if (cap = this.rules.hr.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'hr'
+      });
+      continue;
+    }
+
+    // blockquote
+    if (cap = this.rules.blockquote.exec(src)) {
+      src = src.substring(cap[0].length);
+
+      this.tokens.push({
+        type: 'blockquote_start'
+      });
+
+      cap = cap[0].replace(/^ *> ?/gm, '');
+
+      // Pass `top` to keep the current
+      // "toplevel" state. This is exactly
+      // how markdown.pl works.
+      this.token(cap, top, true);
+
+      this.tokens.push({
+        type: 'blockquote_end'
+      });
+
+      continue;
+    }
+
+    // list
+    if (cap = this.rules.list.exec(src)) {
+      src = src.substring(cap[0].length);
+      bull = cap[2];
+
+      this.tokens.push({
+        type: 'list_start',
+        ordered: bull.length > 1
+      });
+
+      // Get each top-level item.
+      cap = cap[0].match(this.rules.item);
+
+      next = false;
+      l = cap.length;
+      i = 0;
+
+      for (; i < l; i++) {
+        item = cap[i];
+
+        // Remove the list item's bullet
+        // so it is seen as the next token.
+        space = item.length;
+        item = item.replace(/^ *([*+-]|\d+\.) +/, '');
+
+        // Outdent whatever the
+        // list item contains. Hacky.
+        if (~item.indexOf('\n ')) {
+          space -= item.length;
+          item = !this.options.pedantic
+            ? item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '')
+            : item.replace(/^ {1,4}/gm, '');
+        }
+
+        // Determine whether the next list item belongs here.
+        // Backpedal if it does not belong in this list.
+        if (this.options.smartLists && i !== l - 1) {
+          b = block.bullet.exec(cap[i + 1])[0];
+          if (bull !== b && !(bull.length > 1 && b.length > 1)) {
+            src = cap.slice(i + 1).join('\n') + src;
+            i = l - 1;
+          }
+        }
+
+        // Determine whether item is loose or not.
+        // Use: /(^|\n)(?! )[^\n]+\n\n(?!\s*$)/
+        // for discount behavior.
+        loose = next || /\n\n(?!\s*$)/.test(item);
+        if (i !== l - 1) {
+          next = item.charAt(item.length - 1) === '\n';
+          if (!loose) loose = next;
+        }
+
+        this.tokens.push({
+          type: loose
+            ? 'loose_item_start'
+            : 'list_item_start'
+        });
+
+        // Recurse.
+        this.token(item, false, bq);
+
+        this.tokens.push({
+          type: 'list_item_end'
+        });
+      }
+
+      this.tokens.push({
+        type: 'list_end'
+      });
+
+      continue;
+    }
+
+    // html
+    if (cap = this.rules.html.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: this.options.sanitize
+          ? 'paragraph'
+          : 'html',
+        pre: !this.options.sanitizer
+          && (cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style'),
+        text: cap[0]
+      });
+      continue;
+    }
+
+    // def
+    if ((!bq && top) && (cap = this.rules.def.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.links[cap[1].toLowerCase()] = {
+        href: cap[2],
+        title: cap[3]
+      };
+      continue;
+    }
+
+    // table (gfm)
+    if (top && (cap = this.rules.table.exec(src))) {
+      src = src.substring(cap[0].length);
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i]
+          .replace(/^ *\| *| *\| *$/g, '')
+          .split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // top-level paragraph
+    if (top && (cap = this.rules.paragraph.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'paragraph',
+        text: cap[1].charAt(cap[1].length - 1) === '\n'
+          ? cap[1].slice(0, -1)
+          : cap[1]
+      });
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      // Top-level should never reach here.
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'text',
+        text: cap[0]
+      });
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return this.tokens;
+};
+
+/**
+ * Inline-Level Grammar
+ */
+
+var inline = {
+  escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
+  autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
+  url: noop,
+  tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
+  link: /^!?\[(inside)\]\(href\)/,
+  reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+  nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+  strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+  em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+  br: /^ {2,}\n(?!\s*$)/,
+  del: noop,
+  text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
+};
+
+inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
+inline._href = /\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
+
+inline.link = replace(inline.link)
+  ('inside', inline._inside)
+  ('href', inline._href)
+  ();
+
+inline.reflink = replace(inline.reflink)
+  ('inside', inline._inside)
+  ();
+
+/**
+ * Normal Inline Grammar
+ */
+
+inline.normal = merge({}, inline);
+
+/**
+ * Pedantic Inline Grammar
+ */
+
+inline.pedantic = merge({}, inline.normal, {
+  strong: /^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
+  em: /^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/
+});
+
+/**
+ * GFM Inline Grammar
+ */
+
+inline.gfm = merge({}, inline.normal, {
+  escape: replace(inline.escape)('])', '~|])')(),
+  url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
+  del: /^~~(?=\S)([\s\S]*?\S)~~/,
+  text: replace(inline.text)
+    (']|', '~]|')
+    ('|', '|https?://|')
+    ()
+});
+
+/**
+ * GFM + Line Breaks Inline Grammar
+ */
+
+inline.breaks = merge({}, inline.gfm, {
+  br: replace(inline.br)('{2,}', '*')(),
+  text: replace(inline.gfm.text)('{2,}', '*')()
+});
+
+/**
+ * Inline Lexer & Compiler
+ */
+
+function InlineLexer(links, options) {
+  this.options = options || marked.defaults;
+  this.links = links;
+  this.rules = inline.normal;
+  this.renderer = this.options.renderer || new Renderer;
+  this.renderer.options = this.options;
+
+  if (!this.links) {
+    throw new
+      Error('Tokens array requires a `links` property.');
+  }
+
+  if (this.options.gfm) {
+    if (this.options.breaks) {
+      this.rules = inline.breaks;
+    } else {
+      this.rules = inline.gfm;
+    }
+  } else if (this.options.pedantic) {
+    this.rules = inline.pedantic;
+  }
+}
+
+/**
+ * Expose Inline Rules
+ */
+
+InlineLexer.rules = inline;
+
+/**
+ * Static Lexing/Compiling Method
+ */
+
+InlineLexer.output = function(src, links, options) {
+  var inline = new InlineLexer(links, options);
+  return inline.output(src);
+};
+
+/**
+ * Lexing/Compiling
+ */
+
+InlineLexer.prototype.output = function(src) {
+  var out = ''
+    , link
+    , text
+    , href
+    , cap;
+
+  while (src) {
+    // escape
+    if (cap = this.rules.escape.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += cap[1];
+      continue;
+    }
+
+    // autolink
+    if (cap = this.rules.autolink.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[2] === '@') {
+        text = cap[1].charAt(6) === ':'
+          ? this.mangle(cap[1].substring(7))
+          : this.mangle(cap[1]);
+        href = this.mangle('mailto:') + text;
+      } else {
+        text = escape(cap[1]);
+        href = text;
+      }
+      out += this.renderer.link(href, null, text);
+      continue;
+    }
+
+    // url (gfm)
+    if (!this.inLink && (cap = this.rules.url.exec(src))) {
+      src = src.substring(cap[0].length);
+      text = escape(cap[1]);
+      href = text;
+      out += this.renderer.link(href, null, text);
+      continue;
+    }
+
+    // tag
+    if (cap = this.rules.tag.exec(src)) {
+      if (!this.inLink && /^<a /i.test(cap[0])) {
+        this.inLink = true;
+      } else if (this.inLink && /^<\/a>/i.test(cap[0])) {
+        this.inLink = false;
+      }
+      src = src.substring(cap[0].length);
+      out += this.options.sanitize
+        ? this.options.sanitizer
+          ? this.options.sanitizer(cap[0])
+          : escape(cap[0])
+        : cap[0]
+      continue;
+    }
+
+    // link
+    if (cap = this.rules.link.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.inLink = true;
+      out += this.outputLink(cap, {
+        href: cap[2],
+        title: cap[3]
+      });
+      this.inLink = false;
+      continue;
+    }
+
+    // reflink, nolink
+    if ((cap = this.rules.reflink.exec(src))
+        || (cap = this.rules.nolink.exec(src))) {
+      src = src.substring(cap[0].length);
+      link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
+      link = this.links[link.toLowerCase()];
+      if (!link || !link.href) {
+        out += cap[0].charAt(0);
+        src = cap[0].substring(1) + src;
+        continue;
+      }
+      this.inLink = true;
+      out += this.outputLink(cap, link);
+      this.inLink = false;
+      continue;
+    }
+
+    // strong
+    if (cap = this.rules.strong.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.strong(this.output(cap[2] || cap[1]));
+      continue;
+    }
+
+    // em
+    if (cap = this.rules.em.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.em(this.output(cap[2] || cap[1]));
+      continue;
+    }
+
+    // code
+    if (cap = this.rules.code.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.codespan(escape(cap[2], true));
+      continue;
+    }
+
+    // br
+    if (cap = this.rules.br.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.br();
+      continue;
+    }
+
+    // del (gfm)
+    if (cap = this.rules.del.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.del(this.output(cap[1]));
+      continue;
+    }
+
+    // text
+    if (cap = this.rules.text.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.renderer.text(escape(this.smartypants(cap[0])));
+      continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Compile Link
+ */
+
+InlineLexer.prototype.outputLink = function(cap, link) {
+  var href = escape(link.href)
+    , title = link.title ? escape(link.title) : null;
+
+  return cap[0].charAt(0) !== '!'
+    ? this.renderer.link(href, title, this.output(cap[1]))
+    : this.renderer.image(href, title, escape(cap[1]));
+};
+
+/**
+ * Smartypants Transformations
+ */
+
+InlineLexer.prototype.smartypants = function(text) {
+  if (!this.options.smartypants) return text;
+  return text
+    // em-dashes
+    .replace(/---/g, '\u2014')
+    // en-dashes
+    .replace(/--/g, '\u2013')
+    // opening singles
+    .replace(/(^|[-\u2014/(\[{"\s])'/g, '$1\u2018')
+    // closing singles & apostrophes
+    .replace(/'/g, '\u2019')
+    // opening doubles
+    .replace(/(^|[-\u2014/(\[{\u2018\s])"/g, '$1\u201c')
+    // closing doubles
+    .replace(/"/g, '\u201d')
+    // ellipses
+    .replace(/\.{3}/g, '\u2026');
+};
+
+/**
+ * Mangle Links
+ */
+
+InlineLexer.prototype.mangle = function(text) {
+  if (!this.options.mangle) return text;
+  var out = ''
+    , l = text.length
+    , i = 0
+    , ch;
+
+  for (; i < l; i++) {
+    ch = text.charCodeAt(i);
+    if (Math.random() > 0.5) {
+      ch = 'x' + ch.toString(16);
+    }
+    out += '&#' + ch + ';';
+  }
+
+  return out;
+};
+
+/**
+ * Renderer
+ */
+
+function Renderer(options) {
+  this.options = options || {};
+}
+
+Renderer.prototype.code = function(code, lang, escaped) {
+  if (this.options.highlight) {
+    var out = this.options.highlight(code, lang);
+    if (out != null && out !== code) {
+      escaped = true;
+      code = out;
+    }
+  }
+
+  if (!lang) {
+    return '<pre><code>'
+      + (escaped ? code : escape(code, true))
+      + '\n</code></pre>';
+  }
+
+  return '<pre><code class="'
+    + this.options.langPrefix
+    + escape(lang, true)
+    + '">'
+    + (escaped ? code : escape(code, true))
+    + '\n</code></pre>\n';
+};
+
+Renderer.prototype.blockquote = function(quote) {
+  return '<blockquote>\n' + quote + '</blockquote>\n';
+};
+
+Renderer.prototype.html = function(html) {
+  return html;
+};
+
+Renderer.prototype.heading = function(text, level, raw) {
+  return '<h'
+    + level
+    + ' id="'
+    + this.options.headerPrefix
+    + raw.toLowerCase().replace(/[^\w]+/g, '-')
+    + '">'
+    + text
+    + '</h'
+    + level
+    + '>\n';
+};
+
+Renderer.prototype.hr = function() {
+  return this.options.xhtml ? '<hr/>\n' : '<hr>\n';
+};
+
+Renderer.prototype.list = function(body, ordered) {
+  var type = ordered ? 'ol' : 'ul';
+  return '<' + type + '>\n' + body + '</' + type + '>\n';
+};
+
+Renderer.prototype.listitem = function(text) {
+  return '<li>' + text + '</li>\n';
+};
+
+Renderer.prototype.paragraph = function(text) {
+  return '<p>' + text + '</p>\n';
+};
+
+Renderer.prototype.table = function(header, body) {
+  return '<table>\n'
+    + '<thead>\n'
+    + header
+    + '</thead>\n'
+    + '<tbody>\n'
+    + body
+    + '</tbody>\n'
+    + '</table>\n';
+};
+
+Renderer.prototype.tablerow = function(content) {
+  return '<tr>\n' + content + '</tr>\n';
+};
+
+Renderer.prototype.tablecell = function(content, flags) {
+  var type = flags.header ? 'th' : 'td';
+  var tag = flags.align
+    ? '<' + type + ' style="text-align:' + flags.align + '">'
+    : '<' + type + '>';
+  return tag + content + '</' + type + '>\n';
+};
+
+// span level renderer
+Renderer.prototype.strong = function(text) {
+  return '<strong>' + text + '</strong>';
+};
+
+Renderer.prototype.em = function(text) {
+  return '<em>' + text + '</em>';
+};
+
+Renderer.prototype.codespan = function(text) {
+  return '<code>' + text + '</code>';
+};
+
+Renderer.prototype.br = function() {
+  return this.options.xhtml ? '<br/>' : '<br>';
+};
+
+Renderer.prototype.del = function(text) {
+  return '<del>' + text + '</del>';
+};
+
+Renderer.prototype.link = function(href, title, text) {
+  if (this.options.sanitize) {
+    try {
+      var prot = decodeURIComponent(unescape(href))
+        .replace(/[^\w:]/g, '')
+        .toLowerCase();
+    } catch (e) {
+      return '';
+    }
+    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
+      return '';
+    }
+  }
+  var out = '<a href="' + href + '"';
+  if (title) {
+    out += ' title="' + title + '"';
+  }
+  out += '>' + text + '</a>';
+  return out;
+};
+
+Renderer.prototype.image = function(href, title, text) {
+  var out = '<img src="' + href + '" alt="' + text + '"';
+  if (title) {
+    out += ' title="' + title + '"';
+  }
+  out += this.options.xhtml ? '/>' : '>';
+  return out;
+};
+
+Renderer.prototype.text = function(text) {
+  return text;
+};
+
+/**
+ * Parsing & Compiling
+ */
+
+function Parser(options) {
+  this.tokens = [];
+  this.token = null;
+  this.options = options || marked.defaults;
+  this.options.renderer = this.options.renderer || new Renderer;
+  this.renderer = this.options.renderer;
+  this.renderer.options = this.options;
+}
+
+/**
+ * Static Parse Method
+ */
+
+Parser.parse = function(src, options, renderer) {
+  var parser = new Parser(options, renderer);
+  return parser.parse(src);
+};
+
+/**
+ * Parse Loop
+ */
+
+Parser.prototype.parse = function(src) {
+  this.inline = new InlineLexer(src.links, this.options, this.renderer);
+  this.tokens = src.reverse();
+
+  var out = '';
+  while (this.next()) {
+    out += this.tok();
+  }
+
+  return out;
+};
+
+/**
+ * Next Token
+ */
+
+Parser.prototype.next = function() {
+  return this.token = this.tokens.pop();
+};
+
+/**
+ * Preview Next Token
+ */
+
+Parser.prototype.peek = function() {
+  return this.tokens[this.tokens.length - 1] || 0;
+};
+
+/**
+ * Parse Text Tokens
+ */
+
+Parser.prototype.parseText = function() {
+  var body = this.token.text;
+
+  while (this.peek().type === 'text') {
+    body += '\n' + this.next().text;
+  }
+
+  return this.inline.output(body);
+};
+
+/**
+ * Parse Current Token
+ */
+
+Parser.prototype.tok = function() {
+  switch (this.token.type) {
+    case 'space': {
+      return '';
+    }
+    case 'hr': {
+      return this.renderer.hr();
+    }
+    case 'heading': {
+      return this.renderer.heading(
+        this.inline.output(this.token.text),
+        this.token.depth,
+        this.token.text);
+    }
+    case 'code': {
+      return this.renderer.code(this.token.text,
+        this.token.lang,
+        this.token.escaped);
+    }
+    case 'table': {
+      var header = ''
+        , body = ''
+        , i
+        , row
+        , cell
+        , flags
+        , j;
+
+      // header
+      cell = '';
+      for (i = 0; i < this.token.header.length; i++) {
+        flags = { header: true, align: this.token.align[i] };
+        cell += this.renderer.tablecell(
+          this.inline.output(this.token.header[i]),
+          { header: true, align: this.token.align[i] }
+        );
+      }
+      header += this.renderer.tablerow(cell);
+
+      for (i = 0; i < this.token.cells.length; i++) {
+        row = this.token.cells[i];
+
+        cell = '';
+        for (j = 0; j < row.length; j++) {
+          cell += this.renderer.tablecell(
+            this.inline.output(row[j]),
+            { header: false, align: this.token.align[j] }
+          );
+        }
+
+        body += this.renderer.tablerow(cell);
+      }
+      return this.renderer.table(header, body);
+    }
+    case 'blockquote_start': {
+      var body = '';
+
+      while (this.next().type !== 'blockquote_end') {
+        body += this.tok();
+      }
+
+      return this.renderer.blockquote(body);
+    }
+    case 'list_start': {
+      var body = ''
+        , ordered = this.token.ordered;
+
+      while (this.next().type !== 'list_end') {
+        body += this.tok();
+      }
+
+      return this.renderer.list(body, ordered);
+    }
+    case 'list_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.token.type === 'text'
+          ? this.parseText()
+          : this.tok();
+      }
+
+      return this.renderer.listitem(body);
+    }
+    case 'loose_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.tok();
+      }
+
+      return this.renderer.listitem(body);
+    }
+    case 'html': {
+      var html = !this.token.pre && !this.options.pedantic
+        ? this.inline.output(this.token.text)
+        : this.token.text;
+      return this.renderer.html(html);
+    }
+    case 'paragraph': {
+      return this.renderer.paragraph(this.inline.output(this.token.text));
+    }
+    case 'text': {
+      return this.renderer.paragraph(this.parseText());
+    }
+  }
+};
+
+/**
+ * Helpers
+ */
+
+function escape(html, encode) {
+  return html
+    .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function unescape(html) {
+  return html.replace(/&([#\w]+);/g, function(_, n) {
+    n = n.toLowerCase();
+    if (n === 'colon') return ':';
+    if (n.charAt(0) === '#') {
+      return n.charAt(1) === 'x'
+        ? String.fromCharCode(parseInt(n.substring(2), 16))
+        : String.fromCharCode(+n.substring(1));
+    }
+    return '';
+  });
+}
+
+function replace(regex, opt) {
+  regex = regex.source;
+  opt = opt || '';
+  return function self(name, val) {
+    if (!name) return new RegExp(regex, opt);
+    val = val.source || val;
+    val = val.replace(/(^|[^\[])\^/g, '$1');
+    regex = regex.replace(name, val);
+    return self;
+  };
+}
+
+function noop() {}
+noop.exec = noop;
+
+function merge(obj) {
+  var i = 1
+    , target
+    , key;
+
+  for (; i < arguments.length; i++) {
+    target = arguments[i];
+    for (key in target) {
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        obj[key] = target[key];
+      }
+    }
+  }
+
+  return obj;
+}
+
+
+/**
+ * Marked
+ */
+
+function marked(src, opt, callback) {
+  if (callback || typeof opt === 'function') {
+    if (!callback) {
+      callback = opt;
+      opt = null;
+    }
+
+    opt = merge({}, marked.defaults, opt || {});
+
+    var highlight = opt.highlight
+      , tokens
+      , pending
+      , i = 0;
+
+    try {
+      tokens = Lexer.lex(src, opt)
+    } catch (e) {
+      return callback(e);
+    }
+
+    pending = tokens.length;
+
+    var done = function(err) {
+      if (err) {
+        opt.highlight = highlight;
+        return callback(err);
+      }
+
+      var out;
+
+      try {
+        out = Parser.parse(tokens, opt);
+      } catch (e) {
+        err = e;
+      }
+
+      opt.highlight = highlight;
+
+      return err
+        ? callback(err)
+        : callback(null, out);
+    };
+
+    if (!highlight || highlight.length < 3) {
+      return done();
+    }
+
+    delete opt.highlight;
+
+    if (!pending) return done();
+
+    for (; i < tokens.length; i++) {
+      (function(token) {
+        if (token.type !== 'code') {
+          return --pending || done();
+        }
+        return highlight(token.text, token.lang, function(err, code) {
+          if (err) return done(err);
+          if (code == null || code === token.text) {
+            return --pending || done();
+          }
+          token.text = code;
+          token.escaped = true;
+          --pending || done();
+        });
+      })(tokens[i]);
+    }
+
+    return;
+  }
+  try {
+    if (opt) opt = merge({}, marked.defaults, opt);
+    return Parser.parse(Lexer.lex(src, opt), opt);
+  } catch (e) {
+    e.message += '\nPlease report this to https://github.com/chjj/marked.';
+    if ((opt || marked.defaults).silent) {
+      return '<p>An error occured:</p><pre>'
+        + escape(e.message + '', true)
+        + '</pre>';
+    }
+    throw e;
+  }
+}
+
+/**
+ * Options
+ */
+
+marked.options =
+marked.setOptions = function(opt) {
+  merge(marked.defaults, opt);
+  return marked;
+};
+
+marked.defaults = {
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: false,
+  sanitizer: null,
+  mangle: true,
+  smartLists: false,
+  silent: false,
+  highlight: null,
+  langPrefix: 'lang-',
+  smartypants: false,
+  headerPrefix: '',
+  renderer: new Renderer,
+  xhtml: false
+};
+
+/**
+ * Expose
+ */
+
+marked.Parser = Parser;
+marked.parser = Parser.parse;
+
+marked.Renderer = Renderer;
+
+marked.Lexer = Lexer;
+marked.lexer = Lexer.lex;
+
+marked.InlineLexer = InlineLexer;
+marked.inlineLexer = InlineLexer.output;
+
+marked.parse = marked;
+
+if (typeof module !== 'undefined' && typeof exports === 'object') {
+  module.exports = marked;
+} else if (typeof define === 'function' && define.amd) {
+  define(function() { return marked; });
+} else {
+  this.marked = marked;
+}
+
+}).call(function() {
+  return this || (typeof window !== 'undefined' ? window : global);
+}());

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,6 @@ module ApplicationHelper
     extensions = { autolink: true }
     renderer = Redcarpet::Render::HTML.new(options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
-    markdown.render(text).html_safe
+    return markdown.render(text).html_safe unless text.nil?
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,11 +30,10 @@ module ApplicationHelper
   end
 
   def markdown(text)
-    options = { filter_html:     false, hard_wrap:       true,
+    options = { filter_html: false, hard_wrap: true,
                 link_attributes: { rel: 'nofollow', target: '_blank' },
                 space_after_headers: true, fenced_code_blocks: true }
-    extensions = { autolink: true, superscript: true,
-                   disable_indented_code_blocks: true }
+    extensions = { autolink: true }
     renderer = Redcarpet::Render::HTML.new(options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
     markdown.render(text).html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,15 @@ module ApplicationHelper
       flash.now[type].push(text)
     end
   end
+
+  def markdown(text)
+    options = { filter_html:     false, hard_wrap:       true,
+                link_attributes: { rel: 'nofollow', target: '_blank' },
+                space_after_headers: true, fenced_code_blocks: true }
+    extensions = { autolink: true, superscript: true,
+                   disable_indented_code_blocks: true }
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
+  end
 end

--- a/app/views/annotation_categories/_annotation_text.html.erb
+++ b/app/views/annotation_categories/_annotation_text.html.erb
@@ -1,6 +1,6 @@
 <li id='annotation_text_<%= annotation_text.id %>'>
   <div id='annotation_text_<%= annotation_text.id %>_control'>
-    <p><%= simple_format(annotation_text.content) %></p>
+    <p><%= markdown(annotation_text.content) %></p>
 
     <div class='annotation_text_details'>
       <%= link_to t(:edit),

--- a/app/views/annotations/add_existing_annotation.js.erb
+++ b/app/views/annotations/add_existing_annotation.js.erb
@@ -1,5 +1,5 @@
 <% if @annotation.is_a?(TextAnnotation) %>
-  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(simple_format(@text.html_content)) %>');
+  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(markdown(@text.html_content)) %>');
   add_annotation('<%= @annotation.id %>',
                  { start: '<%= @annotation.line_start %>',
                    end: '<%= @annotation.line_end %>',
@@ -7,11 +7,11 @@
                    column_end: '<%= @annotation.column_end %>'},
                  '<%= @text.id %>');
 <% elsif @annotation.is_a?(ImageAnnotation) %>
-  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(simple_format(@text.html_content)) %>');
+  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(markdown(@text.html_content)) %>');
   add_to_annotation_grid('<%= @annotation.extract_coords.to_json().html_safe %>');
 <% elsif @annotation.is_a?(PdfAnnotation) %>
   add_pdf_annotation('<%= @text.id %>',
-                     '<%= escape_javascript(simple_format(@text.html_content)) %>',
+                     '<%= escape_javascript(markdown(@text.html_content)) %>',
                      '<%= @annotation.extract_coords.to_json().html_safe %>');
 <% end %>
 

--- a/app/views/annotations/create.js.erb
+++ b/app/views/annotations/create.js.erb
@@ -10,7 +10,7 @@ document.getElementById('annotation_summary_list').innerHTML =
 <% end %>
 
 <% if @annotation.is_a?(TextAnnotation) %>
-  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(simple_format(@text.html_content)) %>');
+  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(markdown(@text.html_content)) %>');
   add_annotation('<%= @annotation.id %>',
                  { start: '<%= @annotation.line_start %>',
                    end: '<%= @annotation.line_end %>',
@@ -18,12 +18,12 @@ document.getElementById('annotation_summary_list').innerHTML =
                    column_end: '<%= @annotation.column_end %>' },
                  '<%= @text.id %>');
 <% elsif @annotation.is_a?(ImageAnnotation) %>
-  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(simple_format(@text.html_content)) %>');
+  add_annotation_text('<%= @text.id %>', '<%= escape_javascript(markdown(@text.html_content)) %>');
   add_to_annotation_grid('<%= @annotation.extract_coords.to_json().html_safe %>');
 
 <% elsif @annotation.is_a?(PdfAnnotation) %>
   add_pdf_annotation('<%= @text.id %>',
-                     '<%= escape_javascript(simple_format(@text.html_content)) %>',
+                     '<%= escape_javascript(markdown(@text.html_content)) %>',
                      '<%= @annotation.extract_coords.to_json().html_safe %>');
 <% end %>
 

--- a/app/views/annotations/update_annotation.js.erb
+++ b/app/views/annotations/update_annotation.js.erb
@@ -9,6 +9,7 @@ document.getElementById('annotation_summary_list').innerHTML =
                                   locals: { annotation_category: @annotation_text.annotation_category }) %>';
 <% end %>
 
-update_annotation_text('<%= @annotation_text.id %>', '<%= escape_javascript(simple_format(@annotation_text.content)) %>');
+update_annotation_text('<%= @annotation_text.id %>', marked('<%= escape_javascript(simple_format(@annotation_text.content)) %>'));
 hide_all_annotation_content_editors();
+convert_markdown();
 reloadDOM();

--- a/app/views/annotations/update_annotation.js.erb
+++ b/app/views/annotations/update_annotation.js.erb
@@ -9,6 +9,6 @@ document.getElementById('annotation_summary_list').innerHTML =
                                   locals: { annotation_category: @annotation_text.annotation_category }) %>';
 <% end %>
 
-update_annotation_text('<%= @annotation_text.id %>', marked('<%= escape_javascript(simple_format(@annotation_text.content)) %>'));
+update_annotation_text('<%= @annotation_text.id %>', '<%= escape_javascript(markdown(@annotation_text.content)) %>');
 hide_all_annotation_content_editors();
 reloadDOM();

--- a/app/views/annotations/update_annotation.js.erb
+++ b/app/views/annotations/update_annotation.js.erb
@@ -11,5 +11,4 @@ document.getElementById('annotation_summary_list').innerHTML =
 
 update_annotation_text('<%= @annotation_text.id %>', marked('<%= escape_javascript(simple_format(@annotation_text.content)) %>'));
 hide_all_annotation_content_editors();
-convert_markdown();
 reloadDOM();

--- a/app/views/assignments/_list.html.erb
+++ b/app/views/assignments/_list.html.erb
@@ -67,7 +67,7 @@
                     <strong><%= t('assignment.overall_comment') %></strong>
                   </p>
                   <p>
-                    <%= simple_format(sanitize(@a_id_results[assignment.id].overall_comment)) %>
+                    <%= markdown(@a_id_results[assignment.id].overall_comment) %>
                   </p>
                   <%= link_to t('results.results_name'),
                               view_marks_assignment_submission_result_path(

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -116,6 +116,8 @@
     }
   }
 
+
+
   function get_mouse_positions() {
     var mouseSelection = window.getSelection();
 

--- a/app/views/results/common/_annotations.js.erb
+++ b/app/views/results/common/_annotations.js.erb
@@ -116,8 +116,6 @@
     }
   }
 
-
-
   function get_mouse_positions() {
     var mouseSelection = window.getSelection();
 

--- a/app/views/results/common/_image_codeviewer.html.erb
+++ b/app/views/results/common/_image_codeviewer.html.erb
@@ -22,7 +22,7 @@
     <% if (defined? annots) %>
       <% annots.each do |annot| %>
           add_annotation_text(<%= annot.annotation_text.id %>,
-                              '<%= escape_javascript(simple_format(annot.annotation_text.html_content)) %>');
+                              '<%= escape_javascript(markdown(annot.annotation_text.html_content)) %>');
       <% end %>
     <% end %>
   </script>

--- a/app/views/results/common/_pdf_codeviewer.html.erb
+++ b/app/views/results/common/_pdf_codeviewer.html.erb
@@ -158,7 +158,7 @@
     <% if (defined? annots) %>
       <% annots.each do |annot| %>
         add_pdf_annotation('<%= annot.annotation_text.id %>',
-                           '<%= escape_javascript(simple_format(annot.annotation_text.html_content)) %>',
+                           '<%= escape_javascript(markdown(annot.annotation_text.html_content)) %>',
                            '<%= annot.extract_coords.to_json().html_safe %>');
       <% end %>
     <% end %>

--- a/app/views/results/common/_syntax_highlighter_brushes.html.erb
+++ b/app/views/results/common/_syntax_highlighter_brushes.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'marked' %>
 <% # SOURCE CODE GLOWER AND IMAGE ANNOTATION MANAGER %>
 <%= javascript_include_tag 'SourceCodeGlower/AnnotationText',
                            'SourceCodeGlower/AnnotationTextDisplayer',

--- a/app/views/results/common/_syntax_highlighter_brushes.html.erb
+++ b/app/views/results/common/_syntax_highlighter_brushes.html.erb
@@ -1,3 +1,4 @@
+<% # MARKDOWN SUPPORTED WITH Marked.js %>
 <%= javascript_include_tag 'marked' %>
 <% # SOURCE CODE GLOWER AND IMAGE ANNOTATION MANAGER %>
 <%= javascript_include_tag 'SourceCodeGlower/AnnotationText',

--- a/app/views/results/common/_text_codeviewer.html.erb
+++ b/app/views/results/common/_text_codeviewer.html.erb
@@ -23,7 +23,7 @@
     <% if annots.respond_to?('each') %>
       <% annots.each do |annot| %>
         add_annotation_text(<%= annot.annotation_text.id %>,
-                            '<%= escape_javascript(simple_format(annot.annotation_text.content.to_s)) %>');
+                            '<%= escape_javascript(markdown(annot.annotation_text.content.to_s)) %>');
         add_annotation(<%= annot.id %>,
                        { start: <%= annot.line_start %>,
                          end: <%= annot.line_end %>,

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -1,5 +1,3 @@
-
-
 <% annots.each do |annot| %>
   <li>
     <p class='lineNumber'>

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag 'marked' %>
+
 
 <% annots.each do |annot| %>
   <li>
@@ -46,7 +46,3 @@
     </div>
   </li>
 <% end %>
-
-<script>
-  convert_markdown();
-</script>

--- a/app/views/results/marker/_annotation_summary.html.erb
+++ b/app/views/results/marker/_annotation_summary.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag 'marked' %>
+
 <% annots.each do |annot| %>
   <li>
     <p class='lineNumber'>
@@ -5,7 +7,7 @@
       <%= t('marker.annotation.remark_flag') if (annot.is_remark) %>
     </p>
     <div class='annotationContent' id='annotation_text_content_display_<%= annot.annotation_text.id %>'>
-      <%= simple_format(annot.annotation_text.content) %>
+      <%= markdown(annot.annotation_text.content) %>
     </div>
 
     <%= button_tag t('edit'),
@@ -44,3 +46,7 @@
     </div>
   </li>
 <% end %>
+
+<script>
+  convert_markdown();
+</script>

--- a/app/views/results/marker/_remark_request.html.erb
+++ b/app/views/results/marker/_remark_request.html.erb
@@ -7,7 +7,7 @@
     <% if submission.remark_request_timestamp %>
       <%= I18n.l(submission.remark_request_timestamp, format: :long_date) %>
     <% end %><br><br>
-    <%= simple_format(submission.remark_request) %>
+    <%= markdown(submission.remark_request) %>
   </div>
   <div id="overall_remark_comment">
     <h3><%= I18n.t("marker.overall_comments") %></h3>

--- a/app/views/results/student/_annotation_summary.html.erb
+++ b/app/views/results/student/_annotation_summary.html.erb
@@ -5,7 +5,7 @@
       <%= t('marker.annotation.remark_flag') if (annot.is_remark) %>
     </p>
     <p class='annotationContent' id='annotation_text_content_display_<%= annot.annotation_text.id %>'>
-      <%= simple_format(annot.annotation_text.content) %>
+      <%= markdown(annot.annotation_text.content) %>
     </p>
   </li>
 <% end %>

--- a/app/views/results/student/_remark_request.html.erb
+++ b/app/views/results/student/_remark_request.html.erb
@@ -4,7 +4,7 @@
       <p class='notice'><%= t('marker.past_remark_due_date') %></p>
     <% else %>
       <div id='remark_request_show_results'>
-        <%= simple_format(submission.remark_request) %>
+        <%= markdown(submission.remark_request) %>
           <div id='overall_comments_show'>
             <h3><%= t('marker.overall_comments') %></h3>
             <%= result.overall_comment %>
@@ -35,7 +35,7 @@
       </p>
     <% else %>
       <div id='remark_request_show'>
-        <%= simple_format(submission.remark_request) %>
+        <%= markdown(submission.remark_request) %>
           <div id='overall_comments_show'>
             <h3><%= t('marker.overall_comments') %></h3>
             <%= result.overall_comment %>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -25,7 +25,7 @@
             <h3><%= t('marker.overall_comments') %></h3>
 
             <% comment = ( old_result ? old_result.overall_comment : result.overall_comment )%>
-            <p><%= simple_format(comment) %></p>
+            <p><%= markdown(comment) %></p>
 
             <h3><%= t('marker.current_annotations') %></h3>
             <p><%= t('marker.across_all_submission_files') %></p>

--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -11,7 +11,7 @@
     <%= @assignment.remark_message %>
     <h3><%= t('marker.remark_request') %></h3>
     <div id="remark_request_text">
-      <%= simple_format(@submission.remark_request) %>
+      <%= markdown(@submission.remark_request) %>
     </div>
   </div>
   <div>


### PR DESCRIPTION
Closes #2305. Switched simple_format everywhere to use new `markdown(text)` view helper. Started with annotations, but then made a global switch (i.e. remark requests, overall comments).