### PR TITLE
All group creation bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   ya2yaml
-
-BUNDLED WITH
-   1.11.2

--- a/app/jobs/create_individual_groups_for_all_students_job.rb
+++ b/app/jobs/create_individual_groups_for_all_students_job.rb
@@ -38,6 +38,10 @@ class CreateIndividualGroupsForAllStudentsJob < ActiveJob::Base
 
       # Generate the permissions file for all valid groups
       Repository::SubversionRepository.__generate_authz_file
+      m_logger = MarkusLogger.instance
+      m_logger.log("Creating all individual groups completed",
+                   MarkusLogger::INFO)
+      puts "Creating all groups complete"
 
     end
   end

--- a/app/jobs/create_individual_groups_for_all_students_job.rb
+++ b/app/jobs/create_individual_groups_for_all_students_job.rb
@@ -39,9 +39,9 @@ class CreateIndividualGroupsForAllStudentsJob < ActiveJob::Base
       # Generate the permissions file for all valid groups
       Repository::SubversionRepository.__generate_authz_file
       m_logger = MarkusLogger.instance
-      m_logger.log("Creating all individual groups completed",
+      m_logger.log('Creating all individual groups completed',
                    MarkusLogger::INFO)
-      puts "Creating all groups complete"
+      puts 'Creating all groups complete'
 
     end
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -57,6 +57,8 @@ class Group < ActiveRecord::Base
     MarkusConfigurator.markus_config_repository_admin?
   end
 
+
+  # TODO: Get rid of this funcion and re-write Repository.get_class
   # Returns configuration for repository
   # configuration
   def repository_config

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -57,7 +57,6 @@ class Group < ActiveRecord::Base
     MarkusConfigurator.markus_config_repository_admin?
   end
 
-
   # TODO: Get rid of this funcion and re-write Repository.get_class
   # Returns configuration for repository
   # configuration

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -2,6 +2,7 @@ module Repository
 
   # Configuration for the repository library,
   # which is set via Repository.get_class
+  # TODO: Get rid of Repository.conf
   @CONF = {}
   def Repository.conf
     return @CONF
@@ -344,7 +345,9 @@ module Repository
   #                        to create repositories and manage its permissions.
   #  REPOSITORY_PERMISSION_FILE: This is the absolute path to the permission file
   #                              of repositories.
+  # TODO: Get rid of second argument
   def Repository.get_class(repo_type, conf_hash)
+    # TODO: Remove from here
     if conf_hash.nil?
       raise ConfigurationError.new("Configuration must not be nil")
     end
@@ -360,9 +363,10 @@ module Repository
     # Check if configuration is in order
     config_keys.each do |c|
       if Repository.conf[c.to_sym].nil?
-        raise ConfigurationError.new("Required config '#{c}' not set")
+        raise ConfigurationError.new("get_class: Required config '#{c}' not set")
       end
     end
+    # TODO: Remove above
 
     case repo_type
       when "svn"

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -363,7 +363,7 @@ module Repository
     # Check if configuration is in order
     config_keys.each do |c|
       if Repository.conf[c.to_sym].nil?
-        raise ConfigurationError.new("get_class: " \
+        raise ConfigurationError.new('get_class: ' \
                                      "Required config '#{c}' not set")
       end
     end

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -363,7 +363,8 @@ module Repository
     # Check if configuration is in order
     config_keys.each do |c|
       if Repository.conf[c.to_sym].nil?
-        raise ConfigurationError.new("get_class: Required config '#{c}' not set")
+        raise ConfigurationError.new("get_class: " \
+                                     "Required config '#{c}' not set")
       end
     end
     # TODO: Remove above

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -35,7 +35,7 @@ module Repository
     # created using SubversionRepository.create(), it it is not yet existent
     def initialize(connect_string)
       # Check if configuration is in order
-      if !MarkusConfigurator.markus_config_repository_admin?
+      unless MarkusConfigurator.markus_config_repository_admin?
         raise ConfigurationError.new("Init: Required config " \
                                      "'IS_REPOSITORY_ADMIN' not set")
       end
@@ -49,8 +49,8 @@ module Repository
       @repos_path = connect_string
       @closed = false
       @repos_auth_file = MarkusConfigurator.
-                           markus_config_repository_permission_file 
-                         || File.dirname(connect_string) + '/svn_authz'
+                           markus_config_repository_permission_file ||
+                         File.dirname(connect_string) + '/svn_authz'
       @repos_admin = MarkusConfigurator.markus_config_repository_admin?
       if (SubversionRepository.repository_exists?(@repos_path))
         @repos = Svn::Repos.open(@repos_path)
@@ -491,7 +491,7 @@ module Repository
     # permissions on a single repository.
     def self.set_bulk_permissions(repo_names, user_id_permissions_map)
       # Check if configuration is in order
-      if !MarkusConfigurator.markus_config_repository_admin?
+      unless MarkusConfigurator.markus_config_repository_admin?
         raise NotAuthorityError.new("Unable to set bulk permissions:  Not in authoritative mode!");
       end
 
@@ -569,7 +569,7 @@ module Repository
                                     'Not in authoritative mode!')
       end
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config " \ 
+        raise ConfigurationError.new("Required config " \
                                      "'REPOSITORY_PERMISSION_FILE' not set")
       end
       if !File.exist?(MarkusConfigurator.
@@ -580,12 +580,13 @@ module Repository
       end
       # Load up the Permissions:
       file_content = ""
+      # Hound is complaining about the do block so I'm trying it with braces
       File.open(MarkusConfigurator.markus_config_repository_permission_file, 
-                'r+') do |auth_file|
+                'r+') { |auth_file|
         auth_file.flock(File::LOCK_EX)
         file_content = auth_file.read()
         auth_file.flock(File::LOCK_UN) # release lock
-      end
+      } 
       return file_content
     end
 

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -35,10 +35,10 @@ module Repository
     # created using SubversionRepository.create(), it it is not yet existent
     def initialize(connect_string)
       # Check if configuration is in order
-      if Repository.conf[:IS_REPOSITORY_ADMIN].nil?
-        raise ConfigurationError.new("Required config 'IS_REPOSITORY_ADMIN' not set")
+      if !MarkusConfigurator.markus_config_repository_admin?
+        raise ConfigurationError.new("Init: Required config 'IS_REPOSITORY_ADMIN' not set")
       end
-      if Repository.conf[:REPOSITORY_PERMISSION_FILE].nil?
+      if MarkusConfigurator.markus_config_repository_permission_file.nil?
         raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
       end
       begin
@@ -46,8 +46,8 @@ module Repository
       rescue NotImplementedError; end
       @repos_path = connect_string
       @closed = false
-      @repos_auth_file = Repository.conf[:REPOSITORY_PERMISSION_FILE] || File.dirname(connect_string) + "/svn_authz"
-      @repos_admin = Repository.conf[:IS_REPOSITORY_ADMIN]
+      @repos_auth_file =  MarkusConfigurator.markus_config_repository_permission_file || File.dirname(connect_string) + "/svn_authz"
+      @repos_admin = MarkusConfigurator.markus_config_repository_admin?
       if (SubversionRepository.repository_exists?(@repos_path))
         @repos = Svn::Repos.open(@repos_path)
       else
@@ -487,11 +487,7 @@ module Repository
     # permissions on a single repository.
     def self.set_bulk_permissions(repo_names, user_id_permissions_map)
       # Check if configuration is in order
-      if Repository.conf[:IS_REPOSITORY_ADMIN].nil?
-        raise ConfigurationError.new("Required config 'IS_REPOSITORY_ADMIN' not set")
-      end
-      # If we're not in authoritative mode, bail out
-      if !Repository.conf[:IS_REPOSITORY_ADMIN] # Are we admin?
+      if !MarkusConfigurator.markus_config_repository_admin?
         raise NotAuthorityError.new("Unable to set bulk permissions:  Not in authoritative mode!");
       end
 
@@ -522,11 +518,7 @@ module Repository
     # permissions of a single repository.
     def self.delete_bulk_permissions(repo_names, user_ids)
       # Check if configuration is in order
-      if Repository.conf[:IS_REPOSITORY_ADMIN].nil?
-        raise ConfigurationError.new("Required config 'IS_REPOSITORY_ADMIN' not set")
-      end
-      # If we're not in authoritative mode, bail out
-      if !Repository.conf[:IS_REPOSITORY_ADMIN] # Are we admin?
+      if !MarkusConfigurator.markus_config_repository_admin?
         raise NotAuthorityError.new("Unable to delete bulk permissions:  Not in authoritative mode!");
       end
 
@@ -565,18 +557,21 @@ module Repository
     ##  this class).
     ####################################################################
 
-    # Semi-private class method: Reads in Repository.conf[:REPOSITORY_PERMISSION_FILE]
+    # Semi-private class method
     def self.__read_in_authz_file
       # Check if configuration is in order
-      if Repository.conf[:REPOSITORY_PERMISSION_FILE].nil?
+      if !MarkusConfigurator.markus_config_repository_admin?
+        raise NotAuthorityError.new("Unable to read authsz file:  Not in authoritative mode!");
+      end
+      if MarkusConfigurator.markus_config_repository_permission_file.nil?
         raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
       end
-      if !File.exist?(Repository.conf[:REPOSITORY_PERMISSION_FILE])
-        File.open(Repository.conf[:REPOSITORY_PERMISSION_FILE], "w").close() # create file if not existent
+      if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
+        File.open(MarkusConfigurator.markus_config_repository_permission_file, "w").close() # create file if not existent
       end
       # Load up the Permissions:
       file_content = ""
-      File.open(Repository.conf[:REPOSITORY_PERMISSION_FILE], "r+") do |auth_file|
+      File.open(MarkusConfigurator.markus_config_repository_permission_file, "r+") do |auth_file|
         auth_file.flock(File::LOCK_EX)
         file_content = auth_file.read()
         auth_file.flock(File::LOCK_UN) # release lock
@@ -584,25 +579,23 @@ module Repository
       return file_content
     end
 
-    # Semi-private class method: Writes out Repository.conf[:REPOSITORY_PERMISSION_FILE]
+    # Semi-private class method
     def self.__write_out_authz_file(authz_file_contents)
       # Check if configuration is in order
-      if Repository.conf[:IS_REPOSITORY_ADMIN].nil?
-        raise ConfigurationError.new("Required config 'IS_REPOSITORY_ADMIN' not set")
-      end
-      if Repository.conf[:REPOSITORY_PERMISSION_FILE].nil?
-        raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
-      end
-      # If we're not in authoritative mode, bail out
-      if !Repository.conf[:IS_REPOSITORY_ADMIN] # Are we admin?
-        raise NotAuthorityError.new("Unable to write out repo permissions:  Not in authoritative mode!");
+  
+      if !MarkusConfigurator.markus_config_repository_admin?
+        raise NotAuthorityError.new("Unable to write authsz file:  Not in authoritative mode!");
       end
 
-      if !File.exist?(Repository.conf[:REPOSITORY_PERMISSION_FILE])
-        File.open(Repository.conf[:REPOSITORY_PERMISSION_FILE], "w").close() # create file if not existent
+      if MarkusConfigurator.markus_config_repository_permission_file.nil?
+        raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
+      end
+
+      if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
+        File.open(MarkusConfigurator.markus_config_repository_permission_file, "w").close() # create file if not existent
       end
       result = false
-      File.open(Repository.conf[:REPOSITORY_PERMISSION_FILE], "w+") do |auth_file|
+      File.open(MarkusConfigurator.markus_config_repository_permission_file, "w+") do |auth_file|
         auth_file.flock(File::LOCK_EX)
         # Blast out the string to the file
         result = (auth_file.write(authz_file_contents) == authz_file_contents.length)

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -36,17 +36,21 @@ module Repository
     def initialize(connect_string)
       # Check if configuration is in order
       if !MarkusConfigurator.markus_config_repository_admin?
-        raise ConfigurationError.new("Init: Required config 'IS_REPOSITORY_ADMIN' not set")
+        raise ConfigurationError.new("Init: Required config " \
+                                     "'IS_REPOSITORY_ADMIN' not set")
       end
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
+        raise ConfigurationError.new("Required config " \
+                                     "'REPOSITORY_PERMISSION_FILE' not set")
       end
       begin
         super(connect_string) # dummy call to super
       rescue NotImplementedError; end
       @repos_path = connect_string
       @closed = false
-      @repos_auth_file =  MarkusConfigurator.markus_config_repository_permission_file || File.dirname(connect_string) + "/svn_authz"
+      @repos_auth_file = MarkusConfigurator.
+                           markus_config_repository_permission_file 
+                         || File.dirname(connect_string) + '/svn_authz'
       @repos_admin = MarkusConfigurator.markus_config_repository_admin?
       if (SubversionRepository.repository_exists?(@repos_path))
         @repos = Svn::Repos.open(@repos_path)
@@ -561,17 +565,23 @@ module Repository
     def self.__read_in_authz_file
       # Check if configuration is in order
       if !MarkusConfigurator.markus_config_repository_admin?
-        raise NotAuthorityError.new("Unable to read authsz file:  Not in authoritative mode!");
+        raise NotAuthorityError.new('Unable to read authsz file:' \
+                                    'Not in authoritative mode!')
       end
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
+        raise ConfigurationError.new("Required config " \ 
+                                     "'REPOSITORY_PERMISSION_FILE' not set")
       end
-      if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
-        File.open(MarkusConfigurator.markus_config_repository_permission_file, "w").close() # create file if not existent
+      if !File.exist?(MarkusConfigurator.
+                        markus_config_repository_permission_file)
+        # create file if it doesn't exist
+        File.open(MarkusConfigurator.
+                    markus_config_repository_permission_file, "w").close
       end
       # Load up the Permissions:
       file_content = ""
-      File.open(MarkusConfigurator.markus_config_repository_permission_file, "r+") do |auth_file|
+      File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+                'r+') do |auth_file|
         auth_file.flock(File::LOCK_EX)
         file_content = auth_file.read()
         auth_file.flock(File::LOCK_UN) # release lock
@@ -582,20 +592,24 @@ module Repository
     # Semi-private class method
     def self.__write_out_authz_file(authz_file_contents)
       # Check if configuration is in order
-  
       if !MarkusConfigurator.markus_config_repository_admin?
-        raise NotAuthorityError.new("Unable to write authsz file:  Not in authoritative mode!");
+        raise NotAuthorityError.new(
+          "Unable to write authsz file: Not in authoritative mode!")
       end
 
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config 'REPOSITORY_PERMISSION_FILE' not set")
+        raise ConfigurationError.new("Required config " \
+                                     "'REPOSITORY_PERMISSION_FILE' not set")
       end
 
       if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
-        File.open(MarkusConfigurator.markus_config_repository_permission_file, "w").close() # create file if not existent
+        # create file if not existent
+        File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+                  'w').close
       end
       result = false
-      File.open(MarkusConfigurator.markus_config_repository_permission_file, "w+") do |auth_file|
+      File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+                'w+') do |auth_file|
         auth_file.flock(File::LOCK_EX)
         # Blast out the string to the file
         result = (auth_file.write(authz_file_contents) == authz_file_contents.length)

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -36,11 +36,11 @@ module Repository
     def initialize(connect_string)
       # Check if configuration is in order
       unless MarkusConfigurator.markus_config_repository_admin?
-        raise ConfigurationError.new("Init: Required config " \
+        raise ConfigurationError.new('Init: Required config ' \
                                      "'IS_REPOSITORY_ADMIN' not set")
       end
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config " \
+        raise ConfigurationError.new('Required config ' \
                                      "'REPOSITORY_PERMISSION_FILE' not set")
       end
       begin
@@ -49,7 +49,7 @@ module Repository
       @repos_path = connect_string
       @closed = false
       @repos_auth_file = MarkusConfigurator.
-                           markus_config_repository_permission_file ||
+                         markus_config_repository_permission_file ||
                          File.dirname(connect_string) + '/svn_authz'
       @repos_admin = MarkusConfigurator.markus_config_repository_admin?
       if (SubversionRepository.repository_exists?(@repos_path))
@@ -564,52 +564,52 @@ module Repository
     # Semi-private class method
     def self.__read_in_authz_file
       # Check if configuration is in order
-      if !MarkusConfigurator.markus_config_repository_admin?
-        raise NotAuthorityError.new('Unable to read authsz file:' \
+      unless MarkusConfigurator.markus_config_repository_admin?
+        raise NotAuthorityError.new('Unable to read authsz file: ' \
                                     'Not in authoritative mode!')
       end
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config " \
+        raise ConfigurationError.new('Required config ' \
                                      "'REPOSITORY_PERMISSION_FILE' not set")
       end
-      if !File.exist?(MarkusConfigurator.
-                        markus_config_repository_permission_file)
+      unless File.exist?(MarkusConfigurator
+                         .markus_config_repository_permission_file)
         # create file if it doesn't exist
-        File.open(MarkusConfigurator.
-                    markus_config_repository_permission_file, "w").close
+        File.open(MarkusConfigurator
+                    .markus_config_repository_permission_file, 'w').close
       end
       # Load up the Permissions:
       file_content = ""
       # Hound is complaining about the do block so I'm trying it with braces
-      File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+      File.open(MarkusConfigurator.markus_config_repository_permission_file,
                 'r+') { |auth_file|
         auth_file.flock(File::LOCK_EX)
         file_content = auth_file.read()
         auth_file.flock(File::LOCK_UN) # release lock
-      } 
+      }
       return file_content
     end
 
     # Semi-private class method
     def self.__write_out_authz_file(authz_file_contents)
       # Check if configuration is in order
-      if !MarkusConfigurator.markus_config_repository_admin?
+      unless MarkusConfigurator.markus_config_repository_admin?
         raise NotAuthorityError.new(
-          "Unable to write authsz file: Not in authoritative mode!")
+          'Unable to write authsz file: Not in authoritative mode!')
       end
 
       if MarkusConfigurator.markus_config_repository_permission_file.nil?
-        raise ConfigurationError.new("Required config " \
+        raise ConfigurationError.new('Required config ' \
                                      "'REPOSITORY_PERMISSION_FILE' not set")
       end
 
       if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
         # create file if not existent
-        File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+        File.open(MarkusConfigurator.markus_config_repository_permission_file,
                   'w').close
       end
       result = false
-      File.open(MarkusConfigurator.markus_config_repository_permission_file, 
+      File.open(MarkusConfigurator.markus_config_repository_permission_file,
                 'w+') do |auth_file|
         auth_file.flock(File::LOCK_EX)
         # Blast out the string to the file

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -48,8 +48,8 @@ module Repository
       rescue NotImplementedError; end
       @repos_path = connect_string
       @closed = false
-      @repos_auth_file = MarkusConfigurator.
-                         markus_config_repository_permission_file ||
+      @repos_auth_file = MarkusConfigurator
+                         .markus_config_repository_permission_file ||
                          File.dirname(connect_string) + '/svn_authz'
       @repos_admin = MarkusConfigurator.markus_config_repository_admin?
       if (SubversionRepository.repository_exists?(@repos_path))
@@ -580,13 +580,12 @@ module Repository
       end
       # Load up the Permissions:
       file_content = ""
-      # Hound is complaining about the do block so I'm trying it with braces
       File.open(MarkusConfigurator.markus_config_repository_permission_file,
-                'r+') { |auth_file|
+                'r+') do |auth_file|
         auth_file.flock(File::LOCK_EX)
         file_content = auth_file.read()
         auth_file.flock(File::LOCK_UN) # release lock
-      }
+      end
       return file_content
     end
 
@@ -603,7 +602,8 @@ module Repository
                                      "'REPOSITORY_PERMISSION_FILE' not set")
       end
 
-      if !File.exist?(MarkusConfigurator.markus_config_repository_permission_file)
+      unless File.exist?(MarkusConfigurator
+                         .markus_config_repository_permission_file)
         # create file if not existent
         File.open(MarkusConfigurator.markus_config_repository_permission_file,
                   'w').close


### PR DESCRIPTION
This fixes a bug where clicking on create all groups the second time (after the groups have been created) fails.  It has to do with when the Repository.conf hash gets created.

The solution is to remove the Repository.conf hash and always use MarkusConfigurator to check global settings.  This is partially accomplished in this PR.  There are still some tests that need to be changed so that they start passing again.