### PR TITLE
Remove menu_bar spans

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,3 +1,10 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+ *= require_self
+*/
+
 @charset "UTF-8";
 
 // CSS reset

--- a/app/views/annotation_categories/index.html.erb
+++ b/app/views/annotation_categories/index.html.erb
@@ -20,11 +20,9 @@
     <%= link_to t('annotations.add_annotation_category'),
                 'javascript:void(0);',
                  onclick:"add_annotation_category('#{path}')" %>
-    <span class='menu_bar'></span>
     <%= link_to t('download'),
                 'javascript:void(0);',
                 onclick:'modal_download.open();' %>
-    <span class='menu_bar'></span>
     <%= link_to t('upload'),
                 'javascript:void(0);',
                 onclick:'modal_upload.open();' %>

--- a/app/views/assignments/index.html.erb
+++ b/app/views/assignments/index.html.erb
@@ -7,7 +7,6 @@
 
   <div class='heading_buttons'>
     <%= link_to t(:download), '#',  onclick: 'modal_download.open()' %>
-    <span class='menu_bar'></span>
     <%= link_to t(:upload), '#', onclick: 'modal_upload.open()' %>
   </div>
 </div>

--- a/app/views/course_summaries/index.html.erb
+++ b/app/views/course_summaries/index.html.erb
@@ -9,9 +9,8 @@
   <div class='heading_buttons'>
     <%= link_to t('marking_schemes.title'), marking_schemes_path %>
     <% if @current_user.admin? %>
-        <span class='menu_bar'></span>
-        <%= link_to t(:download_csv_grade_report),
-                    download_csv_grades_report_course_summaries_path%>
+      <%= link_to t(:download_csv_grade_report),
+                  download_csv_grades_report_course_summaries_path%>
     <% end %>
   </div>
 </div>

--- a/app/views/flexible_criteria/index.html.erb
+++ b/app/views/flexible_criteria/index.html.erb
@@ -9,7 +9,7 @@
     <%= t('flexible_criteria.criteria_management', identifier: @assignment.short_identifier) %>
   </h1>
   <div class='heading_buttons'>
-    <%= link_to t('add_criterion'), 
+    <%= link_to t('add_criterion'),
           'javascript:void(0);',
           onclick: "if(document.getElementById('new_flexible_criterion') != null) {
           document.getElementById('new_flexible_criterion_prompt').focus();
@@ -19,11 +19,9 @@
             type: 'GET'
           });
         }"%>
-    <span class='menu_bar'></span>
-    <%= link_to t('upload'), 
+    <%= link_to t('upload'),
                 'javascript:void(0);',
                 onclick: 'modal_upload.open();' %>
-    <span class='menu_bar'></span>
     <%= link_to t('download'),
                 'javascript:void(0);',
                 onclick: 'modal_download.open();' %>

--- a/app/views/graders/index.html.erb
+++ b/app/views/graders/index.html.erb
@@ -18,7 +18,6 @@
 
   <div class='heading_buttons'>
     <%= link_to t('download'), '#', onclick:'modal_download.open();' %>
-    <span class='menu_bar'></span>
     <%= link_to t('upload'), '#', onclick:'modal_upload.open();' %>
   </div>
 </div>
@@ -66,7 +65,7 @@
   </ul>
 
   <section class='dialog-actions'>
-    <input type='reset' value='<%= I18n.t(:cancel) %>' onclick='modal_download.close();' />    
+    <input type='reset' value='<%= I18n.t(:cancel) %>' onclick='modal_download.close();' />
   </section>
 </aside>
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -41,12 +41,10 @@
       <%= link_to t('groups.another_assignment_group'),
                   'javascript:void(0);',
                   onclick:'modalAssignmentGroupReUse.open();' %>
-      <span class='menu_bar'></span>
     <% end %>
     <%= link_to t(:download),
                 { controller: 'groups', action: 'download_grouplist',
                   id: @assignment.id } %>
-    <span class='menu_bar'></span>
     <%= link_to t('upload'), 'javascript:void(0);', onclick:'modal_upload.open();' %>
   </div>
 </div>

--- a/app/views/layouts/_heading_buttons_spacer.html.erb
+++ b/app/views/layouts/_heading_buttons_spacer.html.erb
@@ -1,1 +1,0 @@
-<span class='menu_bar'></span>

--- a/app/views/layouts/assignment_content.html.erb
+++ b/app/views/layouts/assignment_content.html.erb
@@ -43,8 +43,7 @@
         <div class='heading_buttons'>
             <%= render partial: "layouts/heading_buttons",
                     collection: @heading_buttons,
-                            as: :heading_button,
-               spacer_template: "layouts/heading_buttons_spacer" %>
+                            as: :heading_button %>
           <%= yield(:additional_headings) %>
         </div>
       </div>

--- a/app/views/marking_schemes/index.html.erb
+++ b/app/views/marking_schemes/index.html.erb
@@ -7,7 +7,6 @@
 
   <div class='heading_buttons'>
     <%= link_to t('marking_schemes.add_new'), new_marking_scheme_path, remote: true %>
-    <span class="menu_bar"></span>
     <%= link_to t('course_summaries.title'), course_summaries_path %>
   </div>
 </div>

--- a/app/views/marks_graders/index.html.erb
+++ b/app/views/marks_graders/index.html.erb
@@ -24,7 +24,6 @@
   <h1><%= t('graders.manage_graders') %></h1>
   <div class='heading_buttons'>
     <%= link_to t('download'), 'javascript:void(0);', onclick: 'modalDownload.open();' %>
-    <span class='menu_bar'></span>
     <%= link_to t('upload'), 'javascript:void(0);', onclick: 'modalUpload.open();' %>
   </div>
 </div>

--- a/app/views/rubrics/index.html.erb
+++ b/app/views/rubrics/index.html.erb
@@ -18,28 +18,25 @@
           identifier: @assignment.short_identifier) %>
   </h1>
   <div class='heading_buttons'>
-  <%= link_to t('add_criterion'),
-      'javascript:void(0);',
-      onclick: "if(document.getElementById('new_rubric_criterion') != null) {
-        document.getElementById('new_rubric_criterion_prompt').focus();
-      } else {
-        jQuery.ajax({
-          url: '" + new_assignment_rubric_path(@assignment) + "',
-          type: 'GET'
-        });
-      } "%>
-  <span class='menu_bar'></span>
-  <%= link_to t(:download),
-              'javascript:void(0);',
-              onclick: 'modal_download.open()' %>
-  <span class='menu_bar'></span>
-  <%= link_to t('rubric_criteria.upload.csv'),
-              'javascript:void(0);',
-              onclick: 'modal_upload_csv.open()' %>
-  <span class='menu_bar'></span>
-  <%= link_to t('rubric_criteria.upload.yml'),
-              'javascript:void(0);',
-              onclick: 'modal_upload_yml.open()' %>
+    <%= link_to t('add_criterion'),
+        'javascript:void(0);',
+        onclick: "if(document.getElementById('new_rubric_criterion') != null) {
+          document.getElementById('new_rubric_criterion_prompt').focus();
+        } else {
+          jQuery.ajax({
+            url: '" + new_assignment_rubric_path(@assignment) + "',
+            type: 'GET'
+          });
+        } "%>
+    <%= link_to t(:download),
+                'javascript:void(0);',
+                onclick: 'modal_do
+    <%= link_to t('rubric_criteria.upload.csv'),
+                'javascript:void(0);',
+                onclick: 'modal_up
+    <%= link_to t('rubric_criteria.upload.yml'),
+                'javascript:void(0);',
+                onclick: 'modal_upload_yml.open()' %>
   </div>
 </div>
 

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -24,11 +24,9 @@
   <div class='heading_buttons'>
     <%= link_to t(:add_new_student),
                 new_student_path() %>
-    <span class='menu_bar'></span>
     <%= link_to t(:upload),
                 '#',
                 onclick: 'modal_upload.open(); return false;' %>
-    <span class='menu_bar'></span>
     <%= link_to t(:download),
                 '#',
                 onclick: 'modal_download.open(); return false;' %>

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -14,8 +14,6 @@
   </div>
 <% end %>
 
-
-
 <% @heading_buttons = [] %>
 
 <% if @current_user.admin? %>
@@ -62,11 +60,8 @@
   }) %>
 <% end %>
 
-
-
 <% content_for :additional_headings do %>
   <% if @current_user.ta? %>
-    <span class='menu_bar'></span>
     <%= t('browse_submissions.how_many_marked',
           num_marked: @assignment.get_num_marked(@current_user.id),
           num_assigned: @assignment.get_num_assigned(@current_user.id)) %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -17,11 +17,8 @@
   <!--The buttons for creating tags, uploading and downloading-->
   <div class='heading_buttons'>
     <%= link_to t('tags.create.create_new'), '#', onclick:'modal_create_new.open()' %>
-    <span class='menu_bar'></span>
     <%= link_to t('tags.download.download'), '#', onclick:'modal_download.open()' %>
-    <span class='menu_bar'></span>
     <%= link_to  t('tags.upload.upload_csv'), '#', onclick:'modal_upload_csv.open()' %>
-    <span class='menu_bar'></span>
     <%= link_to t('tags.upload.upload_yml'), '#', onclick:'modal_upload_yml.open()' %>
   </div>
 </div>

--- a/app/views/tas/index.html.erb
+++ b/app/views/tas/index.html.erb
@@ -17,9 +17,7 @@
 
   <div class='heading_buttons'>
     <%= link_to t(:add_new_grader), new_ta_path %>
-    <span class='menu_bar'></span>
     <%= link_to t(:upload), 'javascript:void(0);', onclick:'modal_upload.open()' %>
-    <span class='menu_bar'></span>
     <%= link_to t(:download), 'javascript:void(0);', onclick:'modal_download.open()' %>
   </div>
 </div>
@@ -81,7 +79,7 @@
                      data: { disable_with: t(:uploading_please_wait) },
                      id: 'upload',
                      disabled: true %>
-      <input type='reset' value='<%= I18n.t(:close) %>' onclick='modal_upload.close();' />      
+      <input type='reset' value='<%= I18n.t(:close) %>' onclick='modal_upload.close();' />
     </section>
   </form>
 </aside>
@@ -98,6 +96,6 @@
   </p>
 
   <section class='dialog-actions'>
-     <input type='reset' value='<%= I18n.t(:close) %>' onclick='modal_download.close();' />    
+     <input type='reset' value='<%= I18n.t(:close) %>' onclick='modal_download.close();' />
   </section>
 </aside>


### PR DESCRIPTION
A previous PR added CSS that automatically adds the separator between adjacent anchors in `heading_buttons` blocks, so these spans are no longer needed.