### PR TITLE
Added ability to collect submissions for students not in a section

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -239,8 +239,8 @@ class SubmissionsController < ApplicationController
     successes = Array.new
     noSubmissions = Array.new
     section_ids.each do |id|
-      if id != "0"
-        if !Section.exists?(id)
+      unless id == '0'
+        unless Section.exists?(id)
           errors.push(I18n.t('collect_submissions.could_not_find_section'))
           next
         end
@@ -296,7 +296,7 @@ class SubmissionsController < ApplicationController
                                                        current_user)
     @available_sections = Hash.new
     if @assignment.submission_rule.can_collect_now?
-      @available_sections[t('groups.unassigned_students')] = 0;
+      @available_sections[t('groups.unassigned_students')] = 0
     end
     if Section.all.size > 0
       @section_column = "{

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -239,7 +239,12 @@ class SubmissionsController < ApplicationController
     successes = Array.new
     noSubmissions = Array.new
     section_ids.each do |id|
-      unless id == '0'
+      if id == '0'
+        submission_collector = SubmissionCollector.instance
+        submission_collector.push_groupings_to_queue(
+          assignment.sectionless_groupings)
+        successes.push(t('groups.unassigned_students'))
+      else
         unless Section.exists?(id)
           errors.push(I18n.t('collect_submissions.could_not_find_section'))
           next
@@ -249,11 +254,6 @@ class SubmissionsController < ApplicationController
         else
           noSubmissions.push(Section.find(id).name)
         end
-      else
-        submission_collector = SubmissionCollector.instance
-        submission_collector.push_groupings_to_queue(
-          assignment.sectionless_groupings)
-        successes.push(t('groups.unassigned_students'))
       end
     end
     if successes.length > 0

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -239,15 +239,21 @@ class SubmissionsController < ApplicationController
     successes = Array.new
     noSubmissions = Array.new
     section_ids.each do |id|
-      if !Section.exists?(id)
-        errors.push(I18n.t('collect_submissions.could_not_find_section'))
-        next
-      end
-        
-      if collect_submissions_for_section(id, assignment, errors) > 0
-        successes.push(Section.find(id).name)
+      if id != "0"
+        if !Section.exists?(id)
+          errors.push(I18n.t('collect_submissions.could_not_find_section'))
+          next
+        end
+        if collect_submissions_for_section(id, assignment, errors) > 0
+          successes.push(Section.find(id).name)
+        else
+          noSubmissions.push(Section.find(id).name)
+        end
       else
-        noSubmissions.push(Section.find(id).name)
+        submission_collector = SubmissionCollector.instance
+        submission_collector.push_groupings_to_queue(
+          assignment.sectionless_groupings)
+        successes.push(t('groups.unassigned_students'))
       end
     end
     if successes.length > 0
@@ -289,6 +295,9 @@ class SubmissionsController < ApplicationController
     @groupings = Grouping.get_groupings_for_assignment(@assignment,
                                                        current_user)
     @available_sections = Hash.new
+    if @assignment.submission_rule.can_collect_now?
+      @available_sections[t('groups.unassigned_students')] = 0;
+    end
     if Section.all.size > 0
       @section_column = "{
         id: 'section',

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -907,6 +907,14 @@ class Assignment < ActiveRecord::Base
       grouping.inviter.section.id == section.id
     end
   end
+
+  # Returns the groupings of this assignment that have no associated section
+  def sectionless_groupings
+    self.groupings.select do |grouping|
+      grouping.inviter.present? and
+      !grouping.inviter.has_section?
+    end
+  end
   
   private
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -902,8 +902,8 @@ class Assignment < ActiveRecord::Base
   # Returns the groupings of this assignment associated with the given section
   def section_groupings(section)
     groupings.select do |grouping|
-      grouping.inviter.present? && 
-      grouping.inviter.has_section? && 
+      grouping.inviter.present? &&
+      grouping.inviter.has_section? &&
       grouping.inviter.section.id == section.id
     end
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -901,17 +901,17 @@ class Assignment < ActiveRecord::Base
 
   # Returns the groupings of this assignment associated with the given section
   def section_groupings(section)
-    self.groupings.select do |grouping|
-      grouping.inviter.present? and 
-      grouping.inviter.has_section? and 
+    groupings.select do |grouping|
+      grouping.inviter.present? && 
+      grouping.inviter.has_section? && 
       grouping.inviter.section.id == section.id
     end
   end
 
   # Returns the groupings of this assignment that have no associated section
   def sectionless_groupings
-    self.groupings.select do |grouping|
-      grouping.inviter.present? and
+    groupings.select do |grouping|
+      grouping.inviter.present? &&
       !grouping.inviter.has_section?
     end
   end

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -20,10 +20,11 @@ class SubmissionRule < ActiveRecord::Base
      GracePeriodSubmissionRule]
   end
 
-  def can_collect_now?(section)
+  def can_collect_now?(section=nil)
     reset_collection_time if @can_collect_now.nil?
-    return @can_collect_now[section.id] if !@can_collect_now[section.id].nil?
-    @can_collect_now[section.id] = Time.zone.now >= get_collection_time(section)
+    section_id = section.nil? ? 0 : section.id
+    return @can_collect_now[section_id] if !@can_collect_now[section_id].nil?
+    @can_collect_now[section_id] = Time.zone.now >= get_collection_time(section)
   end
 
   def can_collect_all_now?

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -20,15 +20,15 @@ class SubmissionRule < ActiveRecord::Base
      GracePeriodSubmissionRule]
   end
 
-  def can_collect_now?(section=nil)
+  def can_collect_now?(section = nil)
     reset_collection_time if @can_collect_now.nil?
     section_id = section.nil? ? 0 : section.id
-    return @can_collect_now[section_id] if !@can_collect_now[section_id].nil?
+    return @can_collect_now[section_id] unless @can_collect_now[section_id].nil?
     @can_collect_now[section_id] = Time.zone.now >= get_collection_time(section)
   end
 
   def can_collect_all_now?
-    return @can_collect_all_now if !@can_collect_all_now.nil?
+    return @can_collect_all_now unless @can_collect_all_now.nil?
     @can_collect_all_now = Time.zone.now >= assignment.latest_due_date
   end
 
@@ -39,11 +39,11 @@ class SubmissionRule < ActiveRecord::Base
   # Cache that allows us to quickly get collection time
   def get_collection_time(section=nil)
     if section.nil?
-      return @get_global_collection_time if !@get_global_collection_time.nil?
+      return @get_global_collection_time unless @get_global_collection_time.nil?
       @get_global_collection_time = calculate_collection_time
     else
       reset_collection_time if @get_collection_time.nil?
-      return @get_collection_time[section.id] if !@get_collection_time[section.id].nil?
+      return @get_collection_time[section.id] unless @get_collection_time[section.id].nil?
       @get_collection_time[section.id] = calculate_collection_time(section)
     end
   end

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -43,7 +43,9 @@ class SubmissionRule < ActiveRecord::Base
       @get_global_collection_time = calculate_collection_time
     else
       reset_collection_time if @get_collection_time.nil?
-      return @get_collection_time[section.id] unless @get_collection_time[section.id].nil?
+      unless @get_collection_time[section.id].nil?
+        return @get_collection_time[section.id]
+      end
       @get_collection_time[section.id] = calculate_collection_time(section)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
       apply_late_penalty: "Apply late penalty/Deduct grace tokens (Leaving this box unchecked means the submission will not be penalized, regardless of submission time.)"
       collect_all: "Collect All Submissions"
       collect_section: "Collect Section Submissions"
-      all_available: "All Available Sections"
+      all_available: "All Available Submissions"
       collect_ta: "Collect all your assigned submissions"
       disable_collect: "Collection disabled, more than one TA marking displayed submissions."
       could_not_collect: "Could not collect submissions for assignment %{assignment_identifier} - the collection date has not been reached"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -129,7 +129,7 @@ fr:
       apply_late_penalty: "Appliquer pénalité de retard / Déduire jetons de grâce ( Laissant cette case cochée signifie la soumission ne sera pas pénalisé , indépendamment du moment de la soumission . )"
       collect_all: "Récupérer tous les envois"
       collect_section: "Récupérer les envois de la section"
-      all_available: "Tous les sections à disposition"
+      all_available: "Tous les envois à disposition"
       collect_ta: "Récupérer tous les envois qui me sont assignés"
       disable_collect: "Récupération des envois n'est pas disponible, il y a déjà un correcteur assigné aux envois."
       could_not_collect: "Les envois du projet %{assignment_identifier} ne peuvent pas être récupérés : la date de récupération n'est pas encore passée."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -127,7 +127,7 @@ pt:
 Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa desmarcada , a apresentação não será penalizado , independentemente do tempo de apresentação . )"
       collect_all: "Coletar todas as submissões"
       collect_section: "Coletar as submissões de seção"
-      all_available: "Todas as seções disponíveis"
+      all_available: "Todas as submissões disponíveis"
       collect_ta: "Coletar todas as submissões atribuidos à você"
       disable_collect: "Coleta de submissões desabilitada, já existe um monitor avaliando as submissões exibidas."
       could_not_collect: "Não foi possível coletar todas as submissões para o projeto %{assignment_identifier} - a data da coleta não foi atingida"


### PR DESCRIPTION
Added ability to collect submissions for students not in a section
As mentioned by @david-yz-liu in #1676 
Dropdown now has an 'Unassigned' option, which will collect the submissions of students without a section. The 'All Available Submissions' now collects the submissions for all sections that are available along with the students who are not assigned a section, if they're available to collect (i.e. past the global due date)
![screen shot 2016-03-04 at 4 14 12 pm](https://cloud.githubusercontent.com/assets/6303087/13539133/df5dafac-e224-11e5-8683-8a13aa2d1819.png)
Note: I changed the option from 'All Available Sections' to 'All Available Submissions' after this screenshot.