### PR TITLE
Orders Sections by due date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,3 +368,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   ya2yaml
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   ya2yaml
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -202,9 +202,6 @@ class AssignmentsController < ApplicationController
                                    .where.not(id: @assignment.id)
                                    .order(:id)
     @sections = Section.all
-    @section_due_dates = SectionDueDate.joins(:section)
-                                       .where(assignment: @assignment)
-                                       .order(:due_date, "sections.name")
 
     unless @past_date.nil? || @past_date.empty?
       flash.now[:notice] = t('past_due_date_notice') + @past_date.join(', ')
@@ -216,6 +213,8 @@ class AssignmentsController < ApplicationController
         @assignment.section_due_dates.build(section: s)
       end
     end
+    @section_due_dates = @assignment.section_due_dates
+                                    .sort_by { |s| [SectionDueDate.due_date_for(s.section, @assignment), s.section.name] }
   end
 
   # Called when editing assignments form is submitted (PUT).
@@ -271,6 +270,8 @@ class AssignmentsController < ApplicationController
 
     # build section_due_dates for each section
     Section.all.each { |s| @assignment.section_due_dates.build(section: s)}
+    @section_due_dates = @assignment.section_due_dates
+                                    .sort_by { |s| s.section.name }
 
     # set default value if web submits are allowed
     @assignment.allow_web_submits =

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -202,7 +202,9 @@ class AssignmentsController < ApplicationController
                                    .where.not(id: @assignment.id)
                                    .order(:id)
     @sections = Section.all
-    @section_due_dates = SectionDueDate.joins(:section).where(assignment: @assignment).order(:due_date, "sections.name")
+    @section_due_dates = SectionDueDate.joins(:section)
+                                       .where(assignment: @assignment)
+                                       .order(:due_date, "sections.name")
 
     unless @past_date.nil? || @past_date.empty?
       flash.now[:notice] = t('past_due_date_notice') + @past_date.join(', ')

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -202,6 +202,7 @@ class AssignmentsController < ApplicationController
                                    .where.not(id: @assignment.id)
                                    .order(:id)
     @sections = Section.all
+    @section_due_dates = SectionDueDate.joins(:section).where(assignment: @assignment).order(:due_date, "sections.name")
 
     unless @past_date.nil? || @past_date.empty?
       flash.now[:notice] = t('past_due_date_notice') + @past_date.join(', ')

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -53,7 +53,17 @@ class GradersController < ApplicationController
 
   def populate
     @assignment = Assignment.find(params[:assignment_id])
-    @sections = Section.all
+    @sections = Section.joins(:section_due_dates)
+                       .where("section_due_dates.assignment_id = ?", @assignment.id)
+                       .order("section_due_dates.due_date", :name)
+    @all_sections = Section.order(:name)
+    unless @sections.count == @all_sections.count
+      @all_sections.each do |section|
+        unless @sections.include? section
+          @sections.push(section)
+        end
+      end
+    end
 
     assign_to_criteria = @assignment.assign_graders_to_criteria
     if assign_to_criteria

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -53,17 +53,7 @@ class GradersController < ApplicationController
 
   def populate
     @assignment = Assignment.find(params[:assignment_id])
-    @sections = Section.joins(:section_due_dates)
-                       .where("section_due_dates.assignment_id = ?", @assignment.id)
-                       .order("section_due_dates.due_date", :name)
-    @all_sections = Section.order(:name)
-    unless @sections.count == @all_sections.count
-      @all_sections.each do |section|
-        unless @sections.include? section
-          @sections.push(section)
-        end
-      end
-    end
+    @sections = Section.order(:name)
 
     assign_to_criteria = @assignment.assign_graders_to_criteria
     if assign_to_criteria


### PR DESCRIPTION
Fix for #1219.
On both Assignment>Edit and Assignment>Graders, the sections are now sorted by due date and then by name.