### PR TITLE
Fix for #2448 - Sections don't appear in Marks Spreadsheet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,3 +368,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   ya2yaml
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   ya2yaml
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -162,7 +162,7 @@ class GradeEntryFormsController < ApplicationController
       s = student.attributes
       student_grade_entry = @grade_entry_form.grade_entry_students
                                              .find_by_user_id(student.id)
-      s[:section] = student.section.name
+      s[:section] = student.section.try(:name)
       unless student_grade_entry.nil?
         # Populate grades
         @grade_entry_form.grade_entry_items.each do |grade_entry_item|

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -162,6 +162,7 @@ class GradeEntryFormsController < ApplicationController
       s = student.attributes
       student_grade_entry = @grade_entry_form.grade_entry_students
                                              .find_by_user_id(student.id)
+      s[:section] = student.section.name
       unless student_grade_entry.nil?
         # Populate grades
         @grade_entry_form.grade_entry_items.each do |grade_entry_item|

--- a/app/views/grade_entry_forms/_react_grades_table.js.jsx.erb
+++ b/app/views/grade_entry_forms/_react_grades_table.js.jsx.erb
@@ -194,6 +194,7 @@
         r['user_name'] = row.user_name
         r['first_name'] = row.first_name
         r['last_name'] = row.last_name
+        r['section'] = row.section
 
         this.state.grade_columns.map(function(column){
           var column_id = column.id;

--- a/app/views/summaries/_summaries_table.js.jsx.erb
+++ b/app/views/summaries/_summaries_table.js.jsx.erb
@@ -178,6 +178,7 @@
         s['repository'] = <a href={summary.repo_url}>{summary.repo_name}</a>;
         s['marking_state'] = this.renderMarkingState(summary.state);
         s['final_grade'] = summary.final_grade;
+        s['section'] = summary.section
         s['state'] = summary.state;
         <% for criterion in @criteria %>
           var key = 'criterion_' + '<%= criterion.id %>';


### PR DESCRIPTION
Fix for #2448. Added the student's section name to the mark spreadsheets. Also adds the group's section name to the summaries spreadsheet.