### PR TITLE
Add gemfile group for testing a production-like deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,13 @@ end
 # listed here
 group :development, :test do
   gem 'byebug', :platforms => [:mri_20, :mri_21]
+end
+
+# Gems needed (wanted) for development, test and production_test
+# can be listed here
+# production_test is for testing a production-like deployment,
+# but using a seeded database
+group :development, :test, :production_test do
   gem 'faker' # required for database seeding
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,6 @@ DEPENDENCIES
   git
   gitolite
   gitolite-rugged
-  hike
   i18n
   jbuilder (~> 2.0)
   jquery-rails

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -4,6 +4,7 @@ namespace :db do
   task :rubric => :environment do
     puts 'Add Rubric To Assignments'
     require 'faker'
+    I18n.reload!
 
     def pos_rand(range)
       rand(range) + 1


### PR DESCRIPTION
 * Add production_test gemfile group, to cover gems that are not strictly
   needed in production, but still required to test a production-like
   deployment; an example is 'faker', to seed the database with test data
 * Fix rubric rake task to avoid stympy/faker#278 when run in a production
   environment