### PR TITLE
Adding the logging code to remove the deprecated use of VERBOSE by resque

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,3 +1,4 @@
 # To create resque workers
 require 'resque/tasks'
+Resque.logger.level = Logger::DEBUG
 task 'resque:setup' => :environment


### PR DESCRIPTION
When you start resque as 
 VVERBOSE=1 QUEUE=* bundle exec rake environment resque:work

a deprecation warning message occurs.  This add the code to the rake task file to use the newer method of logging.