### PR TITLE
New Result Mark Creation

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -10,6 +10,7 @@ class Result < ActiveRecord::Base
   has_many :marks
   has_many :extra_marks
 
+  after_create :create_marks
   validates_presence_of :marking_state
   validates_inclusion_of :marking_state, in: MARKING_STATES.values
 
@@ -119,5 +120,17 @@ class Result < ActiveRecord::Base
       return false
     end
     true
+  end
+
+  def create_marks
+    @assignment = self.submission.assignment
+    @marks_map = Hash.new
+    @assignment.get_criteria.each do |criterion|
+      mark = criterion.marks.find_or_create_by(result_id: self.id)
+      @marks_map[criterion.id] = mark
+
+      mark.save(validate: false)
+      self.update_total_mark
+    end
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -123,14 +123,10 @@ class Result < ActiveRecord::Base
   end
 
   def create_marks
-    @assignment = self.submission.assignment
-    @marks_map = Hash.new
-    @assignment.get_criteria.each do |criterion|
-      mark = criterion.marks.find_or_create_by(result_id: self.id)
-      @marks_map[criterion.id] = mark
-
-      mark.save(validate: false)
-      self.update_total_mark
+    assignment = self.submission.assignment
+    assignment.get_criteria.each do |criterion|
+      mark = criterion.marks.create(result_id: id)
     end
+    self.update_total_mark
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1030,10 +1030,9 @@ describe Assignment do
           result = s.get_latest_result
           result.total_mark = total_mark
           result.marking_state = Result::MARKING_STATES[:complete]
-          @assignment.rubric_criteria.each do |cri|
-            result.marks.create!(markable_id: cri.id,
-                                 markable_type: RubricCriterion,
-                                 mark: (total_mark * 4.0 / 20).round)
+          result.marks.each do |m|
+            m.mark = (total_mark * 4.0 / 20).round
+            m.save!
           end
           result.save!
         end
@@ -1077,9 +1076,6 @@ describe Assignment do
           3.times { create(:accepted_student_membership, grouping: grouping) }
           submission = create(:version_used_submission, grouping: grouping)
           r = submission.get_latest_result
-          criteria.each do |criterion|
-            create(:mark, result: r, markable: criterion)
-          end
           r.reload
           r.update_attributes(marking_state: Result::MARKING_STATES[:complete])
         end
@@ -1140,9 +1136,6 @@ describe Assignment do
           3.times { create(:accepted_student_membership, grouping: grouping) }
           submission = create(:version_used_submission, grouping: grouping)
           r = submission.get_latest_result
-          criteria.each do |criterion|
-            create(:mark, result: r, markable: criterion)
-          end
           r.reload
           r.update_attributes(marking_state: Result::MARKING_STATES[:complete])
         end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1031,7 +1031,7 @@ describe Assignment do
           result.total_mark = total_mark
           result.marking_state = Result::MARKING_STATES[:complete]
           result.marks.each do |m|
-            m.update!(:mark => (total_mark * 4.0 / 20).round)
+            m.update!(mark: (total_mark * 4.0 / 20).round)
           end
           result.save!
         end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1031,8 +1031,7 @@ describe Assignment do
           result.total_mark = total_mark
           result.marking_state = Result::MARKING_STATES[:complete]
           result.marks.each do |m|
-            m.mark = (total_mark * 4.0 / 20).round
-            m.save!
+            m.update!(:mark => (total_mark * 4.0 / 20).round)
           end
           result.save!
         end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Result do
   describe '.student_marks_by_assignment' do
     let(:assignment) { create(:assignment) }
+    let!(:criteria) { Array.new(2) { create(:rubric_criterion, assignment: assignment) } }
 
     shared_examples 'empty' do
       it 'returns an empty array' do
@@ -62,13 +63,27 @@ describe Result do
                 create(:submission, grouping: groupings.first)
               end
 
+              context 'when a new result is created' do
+                let!(:new_result) { submission.results.first }
+
+                it 'has same amount of marks as criteria associated with the result' do
+                  expect(new_result.marks.length).to eq(criteria.length)
+                end
+
+                it 'has a mark associated with each criterion' do
+                  criteria.each do |criterion|
+                    expect(criterion.marks.length).to be >= 1
+                  end
+                end
+              end
+
               context 'when no results are found' do
                 it_returns 'empty'
               end
 
               context 'when results are found' do
                 let!(:results) do
-                  create(:complete_result, submission: submission)
+                  create(:partial_result, submission: submission)
                 end
 
                 it_returns 'empty'
@@ -79,6 +94,20 @@ describe Result do
               let!(:submissions) do
                 Array.new(3) do |i|
                   create(:version_used_submission, grouping: groupings[i])
+                end
+              end
+
+              context 'when a new result is created' do
+                let!(:new_result) { submissions.first.results.first }
+
+                it 'has same amount of marks as criteria associated with the result' do
+                  expect(new_result.marks.length).to eq(criteria.length)
+                end
+
+                it 'has a mark associated with each criterion' do
+                 criteria.each do |criterion|
+                    expect(criterion.marks.length).to be >= 1
+                 end
                 end
               end
 
@@ -99,9 +128,21 @@ describe Result do
                 let(:marks) { [3, 0, 9] }
                 let!(:results) do
                   Array.new(3) do |i|
-                    create(:complete_result,
-                           total_mark: marks[i],
-                           submission: submissions[i])
+                    create(:result,
+                           # total_mark: marks[i],
+                           submission: submissions[i],
+                           marking_state: Result::MARKING_STATES[:partial])
+                  end
+                end
+                before do
+                  results.each_with_index do |result, i|
+                    result.marks.each do |m|
+                      m.mark = 0.0
+                      m.save
+                    end
+                    result.total_mark = marks[i]
+                    result.marking_state = Result::MARKING_STATES[:complete]
+                    result.save
                   end
                 end
 
@@ -129,9 +170,18 @@ describe Result do
                 context 'when remarked results are found' do
                   let!(:remarked_result) do
                     # Create a new result for the second submission.
-                    create(:complete_result,
-                           total_mark: 5,
-                           submission: submissions.second)
+                    create(:result,
+                           submission: submissions.second,
+                           marking_state: Result::MARKING_STATES[:partial])
+                  end
+                  before do
+                    remarked_result.marks.each do |m|
+                      m.mark = 0.0
+                      m.save
+                    end
+                    remarked_result.total_mark = 5
+                    remarked_result.marking_state = Result::MARKING_STATES[:complete]
+                    remarked_result.save
                   end
 
                   it 'returns student marks without old results' do

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -129,7 +129,6 @@ describe Result do
                 let!(:results) do
                   Array.new(3) do |i|
                     create(:result,
-                           # total_mark: marks[i],
                            submission: submissions[i],
                            marking_state: Result::MARKING_STATES[:partial])
                   end
@@ -137,8 +136,7 @@ describe Result do
                 before do
                   results.each_with_index do |result, i|
                     result.marks.each do |m|
-                      m.mark = 0.0
-                      m.save
+                      m.update(:mark => 0.0)
                     end
                     result.total_mark = marks[i]
                     result.marking_state = Result::MARKING_STATES[:complete]

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -136,7 +136,7 @@ describe Result do
                 before do
                   results.each_with_index do |result, i|
                     result.marks.each do |m|
-                      m.update(:mark => 0.0)
+                      m.update(mark: 0.0)
                     end
                     result.total_mark = marks[i]
                     result.marking_state = Result::MARKING_STATES[:complete]


### PR DESCRIPTION
This pull request fixes the error where marks were not created when a result is initially created, which prevented us from assigning marks automatically through the API.