### PR TITLE
Folder/File Name Fix

### DIFF
--- a/app/views/results/common/_file_selector.html.erb
+++ b/app/views/results/common/_file_selector.html.erb
@@ -58,7 +58,7 @@
           <li><a onclick='open_file(<%= file.id %>, "<%= file.path %>/<%= file.filename %>")'
                  onmouseover='close_submenu_recursive(
                      this.parentNode.parentNode, null)'>
-            <%=file.filename%>
+            <%= file.filename %>
           </a></li>
         <% end %>
       <% end %>

--- a/app/views/results/common/_file_selector.html.erb
+++ b/app/views/results/common/_file_selector.html.erb
@@ -58,7 +58,7 @@
           <li><a onclick='open_file(<%= file.id %>, "<%= file.path %>/<%= file.filename %>")'
                  onmouseover='close_submenu_recursive(
                      this.parentNode.parentNode, null)'>
-            <option value='<%= file.id %>'><%=file.filename%></option>
+            <%=file.filename%>
           </a></li>
         <% end %>
       <% end %>


### PR DESCRIPTION
Removed unnecessary option element, which was also preventing folder and file names from showing properly in safari in the folder/file selector.