### PR TITLE
Fix user authentication issues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
       #  1 means no such user
       #  2 means bad password
       #  3 is used for other error exits
-      pipe = IO.popen(MarkusConfigurator.markus_config_validate_file, 'w+')
+      pipe = IO.popen("'#{MarkusConfigurator.markus_config_validate_file}'", 'w+') # quotes to avoid choking on spaces
       pipe.puts("#{login}\n#{password}") # write to stdin of markus_config_validate
       pipe.close
       m_logger = MarkusLogger.instance

--- a/lib/session_handler.rb
+++ b/lib/session_handler.rb
@@ -166,7 +166,7 @@ module SessionHandler
           return true
         end
         # Otherwise, expire only if the session timed out.
-        session[:timeout] < Time.now
+        return session[:timeout] < Time.now
       end
       # Expire session if remote user does not match the session's uid.
       # We cannot have switched roles at this point.


### PR DESCRIPTION
* Fix switch role when using remote user authentication, by preventing a wrong session expiry
* Fix login validation when the path to the validation script has spaces