### PR TITLE
Annotation text search

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -81,11 +81,11 @@ class AnnotationCategoriesController < ApplicationController
 
   def find_annotation_text
     string = params[:string]
-    @annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
-    if @annotation_texts.size == 1
-      render json: "#{@annotation_texts.first.content}".html_safe
+    annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
+    if annotation_texts.size == 1
+      render json: "#{annotation_texts.first.content}".html_safe
     else
-      render json: "".html_safe
+      render json: ''.html_safe
     end
   end
 

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -79,6 +79,16 @@ class AnnotationCategoriesController < ApplicationController
     @annotation_text.destroy
   end
 
+  def find_annotation_text
+    string = params[:string]
+    @annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
+    if @annotation_texts.size == 1
+      render json: "#{@annotation_texts.first.content}".html_safe
+    else
+      render json: "".html_safe
+    end
+  end
+
   # This method handles the drag/drop Annotations sorting
   def update_positions
     unless request.post?

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -135,4 +135,14 @@ class AnnotationsController < ApplicationController
     @submission = @submission_file.submission
     @annotations = @submission.annotations
   end
+
+  def find_annotation_text
+    string = params[:string]
+    @annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
+    if @annotation_texts.size == 1
+      render html: "#{@annotation_texts.first.content}".html_safe
+    else
+      render html: "".html_safe
+    end
+  end
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -135,5 +135,4 @@ class AnnotationsController < ApplicationController
     @submission = @submission_file.submission
     @annotations = @submission.annotations
   end
-
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -136,13 +136,4 @@ class AnnotationsController < ApplicationController
     @annotations = @submission.annotations
   end
 
-  def find_annotation_text
-    string = params[:string]
-    @annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
-    if @annotation_texts.size == 1
-      render html: "#{@annotation_texts.first.content}".html_safe
-    else
-      render html: "".html_safe
-    end
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,5 +73,4 @@ class ApplicationController < ActionController::Base
   def get_file_encodings
     @encodings = [%w(Unicode UTF-8), %w(ISO-8859-1 ISO-8859-1)]
   end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,7 +238,6 @@ Markus::Application.routes.draw do
           get 'add_annotation_text'
           post 'add_annotation_text'
           put 'update_annotation'
-          get 'find_annotation_text'
         end
 
         collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,7 @@ Markus::Application.routes.draw do
         post 'add_existing_annotation'
         patch 'update_annotation'
         delete '/' => 'annotations#destroy'
+        get 'find_annotation_text'
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,7 @@ Markus::Application.routes.draw do
           get 'add_annotation_text'
           post 'delete_annotation_text'
           post 'update_annotation'
+          get 'find_annotation_text'
         end
       end
     end
@@ -335,7 +336,6 @@ Markus::Application.routes.draw do
         post 'add_existing_annotation'
         patch 'update_annotation'
         delete '/' => 'annotations#destroy'
-        get 'find_annotation_text'
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,7 @@ Markus::Application.routes.draw do
           get 'add_annotation_text'
           post 'add_annotation_text'
           put 'update_annotation'
+          get 'find_annotation_text'
         end
 
         collection do

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -164,4 +164,40 @@ describe AnnotationCategoriesController do
       expect(filename).to eq "#{assignment.short_identifier}_annotations.csv"
     end
   end
+
+  context 'When searching for an annotation text' do
+    before(:each) do
+      @annotation_text_one = create(:annotation_text,
+                                    annotation_category: annotation_category,
+                                    content: "This is an annotation text.")
+
+    end
+
+    it 'should render an annotation context, where first part of its content matches given string' do
+      string = "This is an"
+
+      get :find_annotation_text, assignment_id: assignment.id,
+          string: string
+      expect(response.body).to eq("This is an annotation text.")
+    end
+
+    it 'should render an empty string if string does not match first part of any annotation text' do
+      string = "Hello"
+
+      get :find_annotation_text, assignment_id: assignment.id,
+          string: string
+      expect(response.body).to eq("")
+    end
+
+    it 'should render an empty string if string matches first part of more than one annotation text' do
+      annotation_text_two = create(:annotation_text,
+                                   annotation_category: annotation_category,
+                                   content: "This is another annotation text.")
+      string = "This is an"
+
+      get :find_annotation_text, assignment_id: assignment.id,
+          string: string
+      expect(response.body).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
Beginning work for #2561, this adds a function which searches for an annotation text that matches the first part of a string, and renders the text if exactly one match is found, renders an empty string otherwise.