### PR TITLE
No longer pass in groupings to 'download all submissions'

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -591,25 +591,11 @@ class SubmissionsController < ApplicationController
     ## delete the old file if it exists
     File.delete(zip_path) if File.exist?(zip_path)
 
-    grouping_ids = params[:groupings]
-
-    ## if there is no grouping, render a message
-    if grouping_ids.blank?
-      render text: t('student.submission.no_groupings_available')
-      return
-    end
-
-    groupings = Grouping.where(id: grouping_ids)
-      .includes(:group,
-                current_submission_used: {
-                  submission_files: {
-                    submission: { grouping: :group }
-                  }
-                })
+    groupings = Grouping.get_groupings_for_assignment(assignment,
+                                                      current_user)
 
     ## build the zip file
     Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
-
       groupings.each do |grouping|
         ## retrieve the submitted files
         submission = grouping.current_submission_used
@@ -621,7 +607,6 @@ class SubmissionsController < ApplicationController
         zip_file.mkdir(sub_folder) unless zip_file.find_entry(sub_folder)
 
         files.each do |file|
-
           ## retrieve the file and print an error on redirect back if there is
           begin
             file_content = file.retrieve_file
@@ -649,21 +634,9 @@ class SubmissionsController < ApplicationController
   # Check the status of collection for all groupings
   ##
   def check_collect_status
-    grouping_ids = params[:groupings]
-
-    ## if there is no grouping, render a message
-    if grouping_ids.blank?
-      render text: t('student.submission.no_groupings_available')
-      return
-    end
-
-    groupings = Grouping.where(id: grouping_ids)
-                        .includes(:group,
-                                  current_submission_used: {
-                                    submission_files: {
-                                      submission: { grouping: :group }
-                                    }
-                                  })
+    assignment = Assignment.find(params[:assignment_id])
+    groupings = Grouping.get_groupings_for_assignment(assignment,
+                                                      current_user)
 
     ## check collection is completed for all groupings
     all_groupings_collected = groupings.all?(&:is_collected?)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -661,7 +661,8 @@ class Grouping < ActiveRecord::Base
                                                     current_submission_used:
                                                       [:submission_files,
                                                        :submitted_remark,
-                                                       :results],
+                                                       :results,
+                                                       grouping: :group],
                                                     accepted_student_memberships:
                                                       [:grace_period_deductions,
                                                        :user]])
@@ -669,17 +670,18 @@ class Grouping < ActiveRecord::Base
                 .select { |m| m.grouping.is_valid? }
                 .map &:grouping
     else
-      Grouping.joins(:memberships)
+      assignment.groupings.joins(:memberships)
               .includes(:assignment,
                         :group,
                         :grace_period_deductions,
+                        :tags,
                         { current_submission_used: [:results,
                                                     :submission_files,
-                                                    :submitted_remark] },
+                                                    :submitted_remark,
+                                                    grouping: :group] },
                         { accepted_student_memberships: :user },
-                        { inviter: :section },
-                        :tags)
-              .where(assignment_id: assignment.id)
+                        { inviter: :section }
+                        )
               .where(memberships: { membership_status:
                                    [StudentMembership::STATUSES[:inviter],
                                     StudentMembership::STATUSES[:pending],

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -42,8 +42,7 @@
 <% @heading_buttons.push(
   {
     link_text: t('browse_submissions.download_groupings_files'),
-    link_path: download_groupings_files_assignment_submissions_path(
-               groupings: @groupings),
+    link_path: download_groupings_files_assignment_submissions_path,
     html_options: { id: 'download_all_submissions_link' }
   }) %>
 
@@ -65,14 +64,13 @@
 <% end %>
 <script>
   jQuery(document).ready(function() {
-    var downloadGroupingsFiles = function(){
-      window.location.href = "<%= download_groupings_files_assignment_submissions_path(
-          groupings: @groupings); %>";
+    var downloadGroupingsFiles = function() {
+      window.location.href = "<%= download_groupings_files_assignment_submissions_path %>";
     };
 
     jQuery('#download_all_submissions_link').on('click', function () {
       jQuery.ajax({
-        url: '<%= check_collect_status_assignment_submissions_path(groupings: @groupings) %>',
+        url: '<%= check_collect_status_assignment_submissions_path %>',
         type: 'GET',
         success: function (data) {
           if (data.collect_status !== true) {


### PR DESCRIPTION
Had an issue last term where the request to download all submissions would give an error because it was too large. (The actual grouping objects were being sent, not just their ids.)

Since the link says "download all submissions," I've modified the controller to download all of the submissions for the groupings that appear in the submissions table.