### PR TITLE
Fix failing test in submissions_controller_spec.rb

### DIFF
--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -569,7 +569,9 @@ module Repository
       result = Hash.new(nil)
       @files.each do |object|
         alt_path = ""
-        if object.path != '/'
+        if object.path == '.'
+          alt_path = '/'
+        elsif object.path != '/'
           alt_path = '/' + object.path
         end
         git_path = object.path + '/'


### PR DESCRIPTION
The memory repository version of `files_at_path_helper` didn't handle a the root directory, with path value `.`