### PR TITLE
Move file selector

### DIFF
--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -217,8 +217,8 @@
 
 #annotation_categories {
   display: table-cell;
-  vertical-align: top;
   float: left;
+  padding-top: 7px;
 }
 
 .file_selector,

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -71,32 +71,6 @@
   }
 }
 
-.file_selector,
-.download_file {
-  background: $light-grey;
-  border: 1px solid #ddd;
-  border-radius: $radius;
-  display: inline-block;
-  padding: 0.5em;
-}
-
-.file_selector {
-  margin-right: 1em;
-
-  @include breakpoint(mobile) {
-    margin-bottom: 1em;
-  }
-
-  select {
-    background: $white;
-  }
-
-  #next_button,
-  #back_button {
-    min-width: 0;
-  }
-}
-
 .nested-submenu > .nested-folder {
     top: 0;
     left: 100%;
@@ -235,14 +209,51 @@
 #new_annotation_button {
   display: table-cell;
   font-weight: 300;
-  margin: 0 0.25em 0 0;
+  margin: 0 2.0em 0 0;
   min-width: 0;
   vertical-align: top;
+  float: left;
 }
 
 #annotation_categories {
   display: table-cell;
   vertical-align: top;
+  float: left;
+}
+
+.file_selector,
+.download_file {
+  background: $light-grey;
+  border-radius: $radius;
+  display: table-cell;
+  vertical-align: top;
+  float: left;
+  line-height: 16.25px;
+}
+
+#file_selector_seperator {
+  float: left;
+  display: table-cell;
+  vertical-align: top;
+  border-left: solid;
+  min-width: 0;
+}
+
+.file_selector {
+  margin-right: 1em;
+
+  @include breakpoint(mobile) {
+    margin-bottom: 1em;
+  }
+
+  select {
+    background: $white;
+  }
+
+  #next_button,
+  #back_button {
+    min-width: 0;
+  }
 }
 
 li.annotation_category {

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -197,7 +197,7 @@
 
 /* Annotations menus */
 
-#annotation_menu, #file_selector_menu {
+#annotation_menu, #file_selector_menu, #feedback_file_selector_menu {
   background: #b7d3ec;
   border-radius: $radius $radius 0 0;
   display: table;

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -231,14 +231,6 @@
   line-height: 16.25px;
 }
 
-#file_selector_seperator {
-  float: left;
-  display: table-cell;
-  vertical-align: top;
-  border-left: solid;
-  min-width: 0;
-}
-
 .file_selector {
   margin-right: 1em;
 

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -197,7 +197,7 @@
 
 /* Annotations menus */
 
-#annotation_menu {
+#annotation_menu, #file_selector_menu {
   background: #b7d3ec;
   border-radius: $radius $radius 0 0;
   display: table;

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -43,16 +43,16 @@ module ResultsHelper
     outermost_dir = Hash.new
     files.each do |file|
       innermost_dir = outermost_dir
-      innermost_dir["files"] = Array.new
+      innermost_dir[:files] = Array.new
       folders = file.path.split('/')
       folders.each do |folder_name|
         if !innermost_dir.key?(folder_name)
           innermost_dir[folder_name] = Hash.new
-          innermost_dir[folder_name]["files"] = Array.new
+          innermost_dir[folder_name][:files] = Array.new
         end
         innermost_dir = innermost_dir[folder_name]
       end
-      innermost_dir["files"].push(file)
+      innermost_dir[:files].push(file)
     end
     outermost_dir
   end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -37,4 +37,23 @@ module ResultsHelper
   def can_show_feedback_files_tab?(submission)
     not submission.feedback_files.empty?
   end
+
+  def create_nested_files_hash_table(files)
+    # arrange the files list into a nested hashtable for displaying in a recursive menu
+    outermost_dir = Hash.new
+    files.each do |file|
+      innermost_dir = outermost_dir
+      innermost_dir["files"] = Array.new
+      folders = file.path.split('/')
+      folders.each do |folder_name|
+        if !innermost_dir.key?(folder_name)
+          innermost_dir[folder_name] = Hash.new
+          innermost_dir[folder_name]["files"] = Array.new
+        end
+        innermost_dir = innermost_dir[folder_name]
+      end
+      innermost_dir["files"].push(file)
+    end
+    outermost_dir
+  end
 end

--- a/app/views/results/_result_summary.html.erb
+++ b/app/views/results/_result_summary.html.erb
@@ -7,5 +7,7 @@
                        marks_map: @marks_map,
                        assignment: @assignment,
                        submission: @submission,
-                       old_result: @old_result } %>
+                       old_result: @old_result,
+                       files: @files,
+                       feedback_files: @feedback_files} %>
 </div>

--- a/app/views/results/common/_file_selector_dropdown.html.erb
+++ b/app/views/results/common/_file_selector_dropdown.html.erb
@@ -1,0 +1,72 @@
+<%= form_tag(download_assignment_submission_result_path(
+                 @assignment.id, @grouping.current_submission_used.id,
+                 @grouping.current_submission_used.get_latest_result.id)) do %>
+    <%= hidden_field_tag :include_annotations,
+                         true,
+                         id: 'download_include_annotations' %>
+    <div class='file_selector'>
+      <!-- so jQuery knows which file to autoload when the page loads -->
+      <script>
+        var first_file_id;
+        var first_file_path;
+        <% if files.empty? %>
+        first_file_id = null;
+        first_file_path = null;
+        <% else %>
+        first_file_id = <%= files[0].id %>;
+        first_file_path = '<%= files[0].path %>/<%= files[0].filename %>';
+        <% end %>
+      </script>
+
+
+      <!-- arrange the files list into a nested hashtable for displaying in a recursive menu -->
+      <% outermost_dir = Hash.new %>
+      <% files.each do |file| %>
+          <% innermost_dir = outermost_dir %>
+          <% innermost_dir["files"] = Array.new %>
+          <% folders = file.path.split('/') %>
+          <% folders.each do |folder_name| %>
+              <% if !innermost_dir.key?(folder_name) %>
+                  <% innermost_dir[folder_name] = Hash.new %>
+                  <% innermost_dir[folder_name]["files"] = Array.new %>
+              <% end %>
+              <% innermost_dir = innermost_dir[folder_name] %>
+          <% end %>
+          <% innermost_dir["files"].push(file) %>
+      <% end %>
+
+      <% def show_folder_recursive(dir) %>
+          <% dir.each do |name, contents|  %>
+              <% if name != "files" %>
+                  <li class="nested-submenu">
+                    <a onmouseenter='open_submenu(this)'>
+                      <b><%= name %></b>
+                    </a>
+                    <ul class="nested-folder" style="display: none;"><% show_folder_recursive(contents) %></ul>
+                  </li>
+              <% end %>
+          <% end %>
+          <% if dir["files"] != nil %>
+              <% dir["files"].each do |file| %>
+                  <li><a onclick='open_file(<%= file.id %>, "<%= file.path %>/<%= file.filename %>")'
+                         onmouseover='close_submenu_recursive(
+                             this.parentNode.parentNode, null)'>
+                    <%= file.filename %>
+                  </a></li>
+              <% end %>
+          <% end %>
+      <% end %>
+
+      <div class="dropdown" id="select_file_id">
+        <a id="file_selector_dropdown_text">Files</a>
+        <span class="caret"></span>
+        <ul class="nested-folder">
+          <% outermost_dir.each do |key, value| %>
+              <% if key != "files" %>
+                  <% show_folder_recursive(outermost_dir[key]) %>
+              <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+<% end %>

--- a/app/views/results/common/_file_selector_dropdown.html.erb
+++ b/app/views/results/common/_file_selector_dropdown.html.erb
@@ -20,7 +20,7 @@
 
       <% def show_folder_recursive(dir) %>
           <% dir.each do |name, contents|  %>
-              <% if name != "files" %>
+              <% if name != :files %>
                   <li class="nested-submenu">
                     <a onmouseenter='open_submenu(this)'>
                       <b><%= name %></b>
@@ -29,8 +29,8 @@
                   </li>
               <% end %>
           <% end %>
-          <% if dir["files"] != nil %>
-              <% dir["files"].each do |file| %>
+          <% if dir[:files] != nil %>
+              <% dir[:files].each do |file| %>
                   <li><a onclick='open_file(<%= file.id %>, "<%= file.path %>/<%= file.filename %>")'
                          onmouseover='close_submenu_recursive(
                              this.parentNode.parentNode, null)'>
@@ -46,7 +46,7 @@
         <span class="caret"></span>
         <ul class="nested-folder">
           <% outermost_dir.each do |key, value| %>
-              <% if key != "files" %>
+              <% if key != :files %>
                   <% show_folder_recursive(outermost_dir[key]) %>
               <% end %>
           <% end %>

--- a/app/views/results/common/_file_selector_dropdown.html.erb
+++ b/app/views/results/common/_file_selector_dropdown.html.erb
@@ -18,23 +18,6 @@
         <% end %>
       </script>
 
-
-      <!-- arrange the files list into a nested hashtable for displaying in a recursive menu -->
-      <% outermost_dir = Hash.new %>
-      <% files.each do |file| %>
-          <% innermost_dir = outermost_dir %>
-          <% innermost_dir["files"] = Array.new %>
-          <% folders = file.path.split('/') %>
-          <% folders.each do |folder_name| %>
-              <% if !innermost_dir.key?(folder_name) %>
-                  <% innermost_dir[folder_name] = Hash.new %>
-                  <% innermost_dir[folder_name]["files"] = Array.new %>
-              <% end %>
-              <% innermost_dir = innermost_dir[folder_name] %>
-          <% end %>
-          <% innermost_dir["files"].push(file) %>
-      <% end %>
-
       <% def show_folder_recursive(dir) %>
           <% dir.each do |name, contents|  %>
               <% if name != "files" %>
@@ -58,6 +41,7 @@
       <% end %>
 
       <div class="dropdown" id="select_file_id">
+        <% outermost_dir = create_nested_files_hash_table(files) %>
         <a id="file_selector_dropdown_text">Files</a>
         <span class="caret"></span>
         <ul class="nested-folder">

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -169,19 +169,6 @@
 
   <%= render partial: 'results/common/errors' %>
 
-  <div id='file_selector'>
-    <%= render partial: 'results/common/file_selector',
-               locals: { files: @files,
-                         can_download: true } %>
-    <% if can_show_feedback_files_tab?(@submission) %>
-      <div id='feedback_files_controls'>
-        <%= render partial: 'results/common/feedback_file_selector',
-                   locals: { feedback_files: @feedback_files,
-                             submission_id: @submission.id } %>
-      </div>
-    <% end %>
-  </div>
-
   <% if !@result.released_to_students %>
     <%= render partial: 'results/marker/marker_panes',
                locals: { extra_marks_points: @extra_marks_points,
@@ -194,7 +181,9 @@
                          mark_criteria:@mark_criteria,
                          submission: @submission,
                          old_result: @old_result,
-                         test_results: @test_results } %>
+                         test_results: @test_results,
+                         files: @files,
+                         feedback_files: @feedback_files} %>
   <% else %>
     <%= render partial: 'results/result_summary',
                formats: [:html],

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -26,13 +26,13 @@
           <div id='annotation_menu'>
 
             <%= render partial: 'results/common/file_selector_dropdown',
-                       locals: { files: @files,
+                       locals: { files: files,
                                  can_download: true } %>
-            <% if can_show_feedback_files_tab?(@submission) %>
+            <% if can_show_feedback_files_tab?(submission) %>
                 <div id='feedback_files_controls'>
                   <%= render partial: 'results/common/feedback_file_selector',
-                             locals: { feedback_files: @feedback_files,
-                                       submission_id: @submission.id } %>
+                             locals: { feedback_files: feedback_files,
+                                       submission_id: submission.id } %>
                 </div>
             <% end %>
 

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -28,13 +28,6 @@
             <%= render partial: 'results/common/file_selector_dropdown',
                        locals: { files: files,
                                  can_download: true } %>
-            <% if can_show_feedback_files_tab?(submission) %>
-                <div id='feedback_files_controls'>
-                  <%= render partial: 'results/common/feedback_file_selector',
-                             locals: { feedback_files: feedback_files,
-                                       submission_id: submission.id } %>
-                </div>
-            <% end %>
 
             <button id='new_annotation_button' onclick='make_new_annotation(); return false;'>
               <%= t('marker.new_annot')%>
@@ -91,6 +84,15 @@
 
         <% if can_show_feedback_files_tab?(submission) %>
           <div id='feedback_file_tab' style='display:none;'>
+
+            <div id='feedback_file_selector_menu'>
+              <div id='feedback_files_controls'>
+                <%= render partial: 'results/common/feedback_file_selector',
+                           locals: { feedback_files: feedback_files,
+                                     submission_id: submission.id } %>
+              </div>
+            </div>
+
             <div id='feedback_file_content'>
             </div>
           </div>

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -24,6 +24,18 @@
           <div id='sel_box'></div>
 
           <div id='annotation_menu'>
+
+            <%= render partial: 'results/common/file_selector_dropdown',
+                       locals: { files: @files,
+                                 can_download: true } %>
+            <% if can_show_feedback_files_tab?(@submission) %>
+                <div id='feedback_files_controls'>
+                  <%= render partial: 'results/common/feedback_file_selector',
+                             locals: { feedback_files: @feedback_files,
+                                       submission_id: @submission.id } %>
+                </div>
+            <% end %>
+
             <button id='new_annotation_button' onclick='make_new_annotation(); return false;'>
               <%= t('marker.new_annot')%>
             </button>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -22,13 +22,6 @@
             <%= render partial: 'results/common/file_selector_dropdown',
                        locals: { files: files,
                                  can_download: true } %>
-            <% if can_show_feedback_files_tab?(submission) %>
-                <div id='feedback_files_controls'>
-                  <%= render partial: 'results/common/feedback_file_selector',
-                             locals: { feedback_files: feedback_files,
-                                       submission_id: submission.id } %>
-                </div>
-            <% end %>
           </div>
 
           <div id='codeviewer'></div>
@@ -48,8 +41,17 @@
           <ul id='annotation_summary_list'></ul>
         </div>
 
-         <% if can_show_feedback_files_tab?(submission) %>
+        <% if can_show_feedback_files_tab?(submission) %>
           <div id='feedback_file_tab' style='display:none;'>
+
+            <div id='feedback_file_selector_menu'>
+              <div id='feedback_files_controls'>
+                <%= render partial: 'results/common/feedback_file_selector',
+                           locals: { feedback_files: feedback_files,
+                                     submission_id: submission.id } %>
+              </div>
+            </div>
+
             <div id='feedback_file_content'>
             </div>
           </div>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -17,6 +17,20 @@
           <%# For image/PDF annotations %>
           <div id='sel_box'></div>
 
+          <div id='file_selector_menu'>
+
+            <%= render partial: 'results/common/file_selector_dropdown',
+                       locals: { files: files,
+                                 can_download: true } %>
+            <% if can_show_feedback_files_tab?(submission) %>
+                <div id='feedback_files_controls'>
+                  <%= render partial: 'results/common/feedback_file_selector',
+                             locals: { feedback_files: feedback_files,
+                                       submission_id: submission.id } %>
+                </div>
+            <% end %>
+          </div>
+
           <div id='codeviewer'></div>
         </div>
 

--- a/app/views/results/view_marks.html.erb
+++ b/app/views/results/view_marks.html.erb
@@ -49,18 +49,6 @@
 <div class='wrapLeft'>
   <%= render partial: 'results/common/errors' %>
 
-  <%= render partial: 'results/common/file_selector',
-             locals: { files: @files,
-                       can_download: true,
-                       test_result_files: @test_result_files } %>
-    <% if can_show_feedback_files_tab?(@submission) %>
-      <div id='feedback_files_controls'>
-        <%= render partial: 'results/common/feedback_file_selector',
-                   locals: { feedback_files: @feedback_files,
-                             submission_id: @submission.id } %>
-      </div>
-    <% end %>
-
   <%= render partial: 'results/student/student_panes',
              locals: { extra_marks_points: @extra_marks_points,
                        extra_marks_percentage: @extra_marks_percentage,
@@ -69,5 +57,7 @@
                        marks_map: @marks_map,
                        assignment: @assignment,
                        submission: @submission,
-                       old_result: @old_result } %>
+                       old_result: @old_result,
+                       files: @files,
+                       feedback_files: @feedback_files} %>
 </div>


### PR DESCRIPTION
This PR moved the file selector into the annotations menu. It currently removes the "download files" functionality, as I removed the original file selector bar. It will be added back in the next pull request.