### PR TITLE
Added uniqueness pair for peer review table, removed timestamps

### DIFF
--- a/db/migrate/20160610202949_add_unique_constraint_to_peer_reviews.rb
+++ b/db/migrate/20160610202949_add_unique_constraint_to_peer_reviews.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToPeerReviews < ActiveRecord::Migration
+  def change
+    add_index :peer_reviews, [:result_id, :reviewer_id], unique: true
+  end
+end

--- a/db/migrate/20160610203549_remove_timestamps_from_peer_reviews.rb
+++ b/db/migrate/20160610203549_remove_timestamps_from_peer_reviews.rb
@@ -1,6 +1,0 @@
-class RemoveTimestampsFromPeerReviews < ActiveRecord::Migration
-  def change
-    remove_column :peer_reviews, :created_at, :string
-    remove_column :peer_reviews, :updated_at, :string
-  end
-end

--- a/db/migrate/20160610203549_remove_timestamps_from_peer_reviews.rb
+++ b/db/migrate/20160610203549_remove_timestamps_from_peer_reviews.rb
@@ -1,0 +1,6 @@
+class RemoveTimestampsFromPeerReviews < ActiveRecord::Migration
+  def change
+    remove_column :peer_reviews, :created_at, :string
+    remove_column :peer_reviews, :updated_at, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160518004516) do
+ActiveRecord::Schema.define(version: 20160610202949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 20160518004516) do
     t.datetime "updated_at",  null: false
   end
 
+  add_index "peer_reviews", ["result_id", "reviewer_id"], name: "index_peer_reviews_on_result_id_and_reviewer_id", unique: true, using: :btree
   add_index "peer_reviews", ["result_id"], name: "index_peer_reviews_on_result_id", using: :btree
   add_index "peer_reviews", ["reviewer_id"], name: "index_peer_reviews_on_reviewer_id", using: :btree
 


### PR DESCRIPTION
For removal of timestamps, they made it very annoying to add/remove any new rows manually, and I don't believe we use them at all (or may never use it). If you want to keep it I'll drop the remove timestamp changeset.