### PR TITLE
Submission Table Fix

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -65,7 +65,7 @@ module SubmissionsHelper
             result = nil
           elsif submission.submitted_remark.nil?
             result = (results.select do |r|
-              r.submission_id == submission.id
+              r.submission_id == submission.id && !r.is_a_review?
             end).first
           else
             result = submission.remark_result

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -64,18 +64,18 @@ class Submission < ActiveRecord::Base
 
   # Returns the original result.
   def get_original_result
-    get_non_pr_results.first
+    non_pr_results.first
   end
 
   def remark_result
     if remark_request_timestamp.nil? || results.length < 2
       nil
     else
-     get_non_pr_results.last
+      non_pr_results.last
     end
   end
 
-  def get_non_pr_results
+  def non_pr_results
     results.find_all {|r| !r.is_a_review?}
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -64,15 +64,19 @@ class Submission < ActiveRecord::Base
 
   # Returns the original result.
   def get_original_result
-    results.first
+    get_non_pr_results.first
   end
 
   def remark_result
     if remark_request_timestamp.nil? || results.length < 2
       nil
     else
-      results.last
+     get_non_pr_results.last
     end
+  end
+
+  def get_non_pr_results
+    results.find_all {|r| !r.is_a_review?}
   end
 
   def remark_result_id

--- a/lib/tasks/peer_review.rake
+++ b/lib/tasks/peer_review.rake
@@ -15,7 +15,8 @@ namespace :db do
       reviewer_id = pr_grouping.id
       random_group = a1.groupings[Random.rand(a1.groupings.size)]
       if reviewer_id != random_group.id
-        reviewee_result = random_group.current_submission_used.get_latest_result
+        reviewee_result = Result.create!(submission: random_group.current_submission_used,
+                                         marking_state: Result::MARKING_STATES[:incomplete])
         PeerReview.create(reviewer: pr_grouping, result: reviewee_result)
       end
     end


### PR DESCRIPTION
Fixes issue in submissions table for admin where appropriate original and remark results were not being grabbed properly due to the new peer review results being added