### PR TITLE
Autotesting improvements

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -34,8 +34,10 @@ class AutomatedTestsController < ApplicationController
               MarkusConfigurator.markus_config_automated_tests_repository,
               @assignment.repository_folder,
               new_script.original_filename)
+          # Replace bad line endings from windows
+          contents = new_script.read.tr("\r", '')
           File.open(
-              assignment_tests_path, 'w') { |f| f.write new_script.read }
+              assignment_tests_path, 'w') { |f| f.write contents }
         end
 
         unless new_support_file.nil?
@@ -43,8 +45,10 @@ class AutomatedTestsController < ApplicationController
               MarkusConfigurator.markus_config_automated_tests_repository,
               @assignment.repository_folder,
               new_support_file.original_filename)
+          # Replace bad line endings from windows
+          contents = new_support_file.read.tr("\r", '')
           File.open(
-              assignment_tests_path, 'w') { |f| f.write new_support_file.read }
+              assignment_tests_path, 'w') { |f| f.write contents }
         end
 
         redirect_to action: 'manage',

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -75,7 +75,9 @@ module AutomatedTestsHelper
                     MarkusConfigurator.markus_config_automated_tests_repository,
                     @assignment.repository_folder,
                     new_script_name)
-          File.open(assignment_tests_path, 'w') { |f| f.write new_update_script.read }
+          # Replace bad line endings from windows
+          contents = new_update_script.read.tr("\r", '')
+          File.open(assignment_tests_path, 'w') { |f| f.write contents }
 
           # Deleting old script
           old_script_path = File.join(

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -319,7 +319,8 @@ module AutomatedTestsHelper
       # TODO: handle this error better
       raise 'error'
     else
-      process_result(result, call_on, @assignment, @grouping, @submission)
+      # Test scripts must now use calls to the MarkUs API to process results.
+      # process_result(result, call_on, @assignment, @grouping, @submission)
     end
 
   end

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -48,9 +48,6 @@ class SubmissionsJob < ActiveJob::Base
         end
 
         grouping.save
-
-        # Request a test run for the grouping
-        request_a_test_run(grouping, new_submission)
       end
       m_logger.log('Submission collection process done')
     rescue => e
@@ -64,18 +61,6 @@ class SubmissionsJob < ActiveJob::Base
     unless job_messenger.nil?
       job_messenger.update(status: :succeeded)
       PopulateCache.populate_for_job(job_messenger, job_id)
-    end
-  end
-
-  def request_a_test_run(grouping, new_submission)
-    m_logger = MarkusLogger.instance
-    if grouping.assignment.enable_test
-      m_logger.log("Now requesting test run for #{grouping.assignment.short_identifier} \
-                    on grouping: '#{grouping.id}'")
-      AutomatedTestsHelper.request_a_test_run(new_submission.grouping.id,
-                                              'collection',
-                                              @current_user,
-                                              new_submission.id)
     end
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -854,7 +854,7 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  def can_uncollect_submissions?
+  def has_a_collected_submission?
     submissions.where(submission_version_used: true).count > 0
   end
   # Returns the groupings of this assignment that have no associated section

--- a/app/views/submissions/_submissions_table.js.jsx.erb
+++ b/app/views/submissions/_submissions_table.js.jsx.erb
@@ -372,7 +372,24 @@
       });
     },
     runTests: function () {
-      return;
+      jQuery.ajax({
+        method: 'POST',
+        url: 'run_tests',
+        data: {groupings: this.props.selected_submissions},
+        success: function(data) {
+          if (data.success) {
+            this.props.onSuccess(data.success);
+            window.setInterval(this.props.refresh, 30000);
+          }
+          if (data.error) {
+            this.props.onError(data.error);
+          }
+        }.bind(this),
+        error: function(xhr, status, text) {
+          var error = text + ': ' + xhr.responseText;
+          this.props.onError(error);
+        }.bind(this)
+      })
     },
     render: function() {
       return (

--- a/app/views/submissions/_submissions_table.js.jsx.erb
+++ b/app/views/submissions/_submissions_table.js.jsx.erb
@@ -371,6 +371,9 @@
         }.bind(this)
       });
     },
+    runTests: function () {
+      return;
+    },
     render: function() {
       return (
         <div className='react-release-marks'>
@@ -378,19 +381,25 @@
             <button onClick={this.collectSubmissions}>
               <%= j raw I18n.t('collect_submissions.collect') %>
             </button>
+            <% if @assignment.has_a_collected_submission? %>
+              <button onClick={this.uncollectAllSubmissions}
+                      data-remote='true'>
+                <%= j raw I18n.t('collect_submissions.uncollect_all') %>
+              </button>
+              <button onClick={this.runTests}
+                      data-remote='true'>
+                <%= j raw t('browse_submissions.run_tests') %>
+              </button>
+            <% end %>
           <% end %>
-          <% if @assignment.can_uncollect_submissions? %>
-            <button onClick={this.uncollectAllSubmissions}
-                    data-remote="true">
-              <%=j raw I18n.t('collect_submissions.uncollect_all') %>
+          <% if @assignment.has_a_collected_submission? %>
+            <button onClick={this.releaseMarks}>
+              <%= j raw t('browse_submissions.release_marks') %>
+            </button>
+            <button onClick={this.unreleaseMarks}>
+              <%= j raw t('browse_submissions.unrelease_marks') %>
             </button>
           <% end %>
-          <button onClick={this.releaseMarks}>
-            <%= j raw I18n.t('browse_submissions.release_marks') %>
-          </button>
-          <button onClick={this.unreleaseMarks}>
-            <%= j raw I18n.t('browse_submissions.unrelease_marks') %>
-          </button>
         </div>
       );
     }

--- a/automated-tests-files/test_runner/sample_files/python_sample/py_suite_1.py
+++ b/automated-tests-files/test_runner/sample_files/python_sample/py_suite_1.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import hello
+import markusapi
 
 def printResults(name, input, exp, act, marks, status):
   return "<test>\n \
@@ -62,6 +63,11 @@ def test_3():
   return printResults(name, input, expected, actual, marks, status)
   
 if __name__ == "__main__":
-    print test_1()
-    print test_2()
-    print test_3()
+    # Note: currently this data is hard-coded, but should be passed in
+    API_KEY = 'ZTEwY2VlNmM4Nzk3NjM2N2QxYjk0YWM0MjU0M2NlMDQ='
+    ROOT_URL = 'http://localhost:3000/'
+    api = markusapi.Markus(API_KEY, ROOT_URL, protocol='http')
+    api.upload_test_script_result(6, '77',
+        '<testrun><test_script><script_name>py_suite_1.py</script_name>' +
+        test_1() + test_2() + test_3() +
+        '</test_script></testrun>')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1567,6 +1567,7 @@ en:
       test_run: "Test Run"
       tests_running: "Running tests. Please refresh this page to view results."
       need_one_file: "You need at least one file submitted in order to run tests.<br><br>If you have already submitted a file and want to run tests on it, use the \"Run Tests\" button below."
+      need_submission: "Submissions must be collected before tests are run. Not all selected groupings had tests run."
       collect_and_test: "Collect and Prepare Test"
       date_run: "Date run:"
       revision_used: "Revision used:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1410,6 +1410,7 @@ fr:
       test_run: "L'exécution du test"
       tests_running: "Tests en cours. S'il vous plaît rafraîchir la page pour afficher les résultats."
       need_one_file: "Vous devez avoir au moins un fichier envoyé pour exécuter un test. Si vous avez envoyé un fichier et vous voulez exécuter un test, veuillez cliquer sur \"Récuperer et préparer test\"."
+      need_submission: "Les soumissions doivent être recueillies avant que les tests sont exécutés. Tous les groupes sélectionnés avaient non tests exécutés."
       collect_and_test: "Récupérer et préparer test"
       date_run: "Lancement des tests le :"
       revision_used: "Révision utilisée :"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1386,6 +1386,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
       test_run: "Execução de Teste"
       need_one_file: "Você precisa de pelo menos um arquivo enviado para executar os testes.<br>
                       Se você já enviou um arquivo e que executar os testes nele, use o botao \"Coletar e preparar testes\" abaixo."
+      need_submission: "As inscrições devem ser recolhidos antes dos testes são executados. Nem todos os agrupamentos seleccionados tiveram testes executados."
       collect_and_test: "Colete e prepare os testes"
       build_xml: "build.xml"
       build_prop: "build.properties"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Markus::Application.routes.draw do
           post 'populate_file_manager'
           post 'collect_submissions'
           get 'uncollect_all_submissions'
+          post 'run_tests'
           get 'download_simple_csv_report'
           get 'download_detailed_csv_report'
           get 'download_svn_export_list'

--- a/lib/tools/markusapi.py
+++ b/lib/tools/markusapi.py
@@ -121,6 +121,17 @@ class Markus:
         path = self.get_path(assignment_id, group_id) + 'feedback_files'
         return self.submit_request(params, path, 'POST')
 
+    def upload_test_script_result(self, assignment_id, group_id, results):
+        """ (Markus, int, str, dict) -> list of str """
+        print(results)
+        params = {
+            'assignment_id': assignment_id,
+            'group_id': group_id,
+            'file_content': results
+        }
+        path = self.get_path(assignment_id, group_id) + 'test_script_results'
+        return self.submit_request(params, path, 'POST')
+
     def update_marks_single_group(self, criteria_mark_map, assignment_id, group_id):
         """ (Markus, dict, int, int) -> list of str
         Update the marks of a single group. 
@@ -193,5 +204,3 @@ class Markus:
     def decode_response(resp):
         """Converts response from submit_request into python dict."""
         return json.loads(resp[2].decode('utf-8'))
-
-


### PR DESCRIPTION
A few small updates in functionality:

1. Normalize line endings of upload scripts to `\n`
2. Decouple running of tests from submission collection; it is now possible to run tests for a selected subset of groups from the submissions table
3. Test scripts must now use the MarkUs API to communicate test results. Example is given in `py_suite_1.py`, which requires `markusapi.py` to be uploaded as a test support file.

@adisandro 