### PR TITLE
Peer Review to Results Page fix

### DIFF
--- a/app/views/layouts/_sub_menu.html.erb
+++ b/app/views/layouts/_sub_menu.html.erb
@@ -222,7 +222,9 @@
             (!@result.nil? && !@result.is_a_review?) %>'>
           <%# FIXME should add the real submission %>
           <%= link_to t('results.results_name'),
-                      view_marks_assignment_submission_result_path(@assignment,
+                      view_marks_assignment_submission_result_path(@assignment.is_peer_review? ?
+                                                                       @assignment.parent_assignment :
+                                                                       @assignment,
                                                                    1,
                                                                    1) %>
         </li>


### PR DESCRIPTION
Fixes an error when switching from peer review to results page, where it redirects to the wrong assignment ID.