### PR TITLE
Issue 2561: Annotation Text Search fix

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -80,10 +80,12 @@ class AnnotationCategoriesController < ApplicationController
   end
 
   def find_annotation_text
+    @assignment = Assignment.find(params[:assignment_id])
     string = params[:string]
     annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
-    if annotation_texts.size == 1
-      render json: "#{annotation_texts.first.content}".html_safe
+    texts_for_current_assignment = annotation_texts.find_all{|a| a.annotations.first.result.submission.grouping.assignment == @assignment}
+    if texts_for_current_assignment.size == 1
+      render json: "#{texts_for_current_assignment.first.content}".html_safe
     else
       render json: ''.html_safe
     end

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -82,10 +82,11 @@ class AnnotationCategoriesController < ApplicationController
   def find_annotation_text
     @assignment = Assignment.find(params[:assignment_id])
     string = params[:string]
-    annotation_texts = AnnotationText.where("content LIKE ?", "#{string}%")
-    texts_for_current_assignment = annotation_texts.find_all{|a| a.annotations.first.result.submission.grouping.assignment == @assignment}
-    if texts_for_current_assignment.size == 1
-      render json: "#{texts_for_current_assignment.first.content}".html_safe
+    texts_for_current_assignment = AnnotationText.joins(annotations: {result: {submission: {grouping: :assignment}}}).
+        where(assignments: {id: @assignment.id})
+    annotation_texts = texts_for_current_assignment.where("content LIKE ?", "#{string}%")
+    if annotation_texts.size == 1
+      render json: "#{annotation_texts.first.content}".html_safe
     else
       render json: ''.html_safe
     end


### PR DESCRIPTION
This fixes a comment in #2561, where annotation texts from all assignments were being returned, instead of only the ones from the current assignment.