### PR TITLE
Better test output

### DIFF
--- a/app/helpers/automated_tests_server_helper.rb
+++ b/app/helpers/automated_tests_server_helper.rb
@@ -7,7 +7,8 @@ module AutomatedTestsServerHelper
   @queue = MarkusConfigurator.markus_ate_test_queue_name
   TIME_LIMIT = 600
 
-  def self.perform(markus_address, api_key, test_scripts, test_path, test_results_path, assignment_id, group_id, submission_id)
+  def self.perform(markus_address, user_api_key, server_api_key, test_scripts, test_path, test_results_path,
+                   assignment_id, group_id, submission_id)
 
     # run tests
     output = '<testrun>'
@@ -17,8 +18,8 @@ module AutomatedTestsServerHelper
       begin
         Timeout.timeout(TIME_LIMIT) do
           stdout, stderr, status = Open3.capture3(
-            {'MARKUS_ADDRESS' => "#{markus_address}", 'API_KEY' => "#{api_key}", 'ASSIGNMENT_ID' => "#{assignment_id}",
-             'GROUP_ID' => "#{group_id}"}, # needs strings as hash keys and values for env variables
+            {'MARKUS_ADDRESS' => "#{markus_address}", 'API_KEY' => "#{user_api_key}",
+             'ASSIGNMENT_ID' => "#{assignment_id}", 'GROUP_ID' => "#{group_id}"}, # needs strings as hash keys and values for env variables
             "cd '#{test_path}' && ./'#{script}'")
           errors += stderr
         end
@@ -48,7 +49,7 @@ module AutomatedTestsServerHelper
     api_url = "#{markus_address}/api/assignments/#{assignment_id}/groups/#{group_id}/test_script_results"
     # HTTParty needs strings as hash keys, or it chokes
     options = {:headers => {
-                   'Authorization' => "MarkUsAuth #{api_key}",
+                   'Authorization' => "MarkUsAuth #{server_api_key}",
                    'Accept' => 'application/json'},
                :body => {
                    'assignment_id' => assignment_id,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -305,13 +305,13 @@ class Assignment < ActiveRecord::Base
     self.save
   end
 
-  def total_test_script_marks
-    return test_scripts.sum("max_marks")
+  def total_instructor_test_script_marks
+    return test_scripts.where('run_by_instructors' => true).sum('max_marks')
   end
 
   #total marks for scripts that are run on student request
-  def total_ror_script_marks
-    return test_scripts.where("run_by_students" => true).sum("max_marks")
+  def total_student_test_script_marks
+    return test_scripts.where('run_by_students' => true).sum('max_marks')
   end
 
   def add_group(new_group_name=nil)

--- a/app/views/automated_tests/_test_script_result.html.erb
+++ b/app/views/automated_tests/_test_script_result.html.erb
@@ -12,10 +12,12 @@
       <thead>
         <tr>
           <th><%= t('automated_tests.test_results_table.test_name') %></th>
-          <th><%= t('automated_tests.test_results_table.input') %></th>
-          <th><%= t('automated_tests.test_results_table.output') %></th>
+          <% if false %><th><%= t('automated_tests.test_results_table.input') %></th><% end %>
+          <% if show_output %><th><%= t('automated_tests.test_results_table.output') %></th><% end %>
+          <% if false %>
           <th><%= t('automated_tests.test_results_table.expected') %></th>
           <th><%= t('automated_tests.test_results_table.marks_earned') %></th>
+          <% end %>
           <th><%= t('automated_tests.test_results_table.status') %></th>
         </tr>
       </thead>
@@ -24,10 +26,12 @@
           <tr class="<%= test.completion_status == 'pass' ?
           'test-result-success' : 'test-result-failure' %>">
             <td><%= test.name %></td>
-            <td><%= test.input %></td>
-            <td><%= test.actual_output %></td>
+            <% if false %><td><%= test.input %></td><% end %>
+            <% if show_output %><td><%= test.actual_output %></td><% end %>
+            <% if false %>
             <td><%= test.expected_output %></td>
             <td><%= test.marks_earned %></td>
+            <% end %>
             <td><%= test.completion_status == 'pass' ?
                     t('automated_tests.test_results_table.passed') :
                     t('automated_tests.test_results_table.failed') %>

--- a/app/views/automated_tests/student_interface.html.erb
+++ b/app/views/automated_tests/student_interface.html.erb
@@ -67,8 +67,8 @@
       <div class='block_content'>
         <div class='sub_block'>
           <%= raw t('automated_tests.marks_obtained',
-                    marking: "#{@grouping.get_total_test_script_marks * 1.0} /
-                              #{@assignment.total_ror_script_marks * 1.0}" ) %>
+                    marking: "#{@grouping.get_total_test_script_marks} /
+                              #{@assignment.total_student_test_script_marks}" ) %>
         </div>
         <div id='test_results' class='sub_block'>
           <%= render partial: 'test_script_result',

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -69,9 +69,9 @@
                   <div class="block_content">
                   <br />
                     <div class="sub_block">
-                      <%= raw (t("automated_tests.marks_obtained",
-                                    :marking => "#{@grouping.get_total_test_script_marks *
-                                    1.0} / #{@assignment.total_ror_script_marks * 1.0}" )) %>
+                      <%= raw t("automated_tests.marks_obtained",
+                                :marking => "#{@grouping.get_total_test_script_marks} /
+                                             #{@assignment.total_instructor_test_script_marks}" ) %>
                     </div>
                     <div id="test_results" class="sub_block">
                       <%= render partial: 'automated_tests/test_script_result',

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -5,15 +5,12 @@
         <ul id='code_and_annotations_tabs' class='subsection_tabs'>
            <li><a href='#code_holder'><%= t('marker.source_code') %></a></li>
            <li><a href='#annotations_summary'><%= t('marker.annot_summary') %></a></li>
-
           <% if can_show_test_results_tab?(assignment) %>
               <li><a href='#test_result_tab'><%= t('marker.test_results') %></a></li>
           <% end %>
-
           <% if can_show_feedback_files_tab?(submission) %>
               <li><a href='#feedback_file_tab'><%= t('marker.feedback_files') %></a></li>
           <% end %>
-
            <% if can_show_remark_request_tab_in_marker_pane(submission) %>
               <li><a href='#remark_request_tab'><%= t('marker.remark_request') %></a></li>
            <% end %>
@@ -75,6 +72,7 @@
                     </div>
                     <div id="test_results" class="sub_block">
                       <%= render partial: 'automated_tests/test_script_result',
+                                 locals: {show_output: true},
                                  collection: submission.test_script_results %>
                     </div>
                   </div>

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -5,6 +5,9 @@
         <ul>
           <li><a href='#code_holder'><%= t('marker.source_code') %></a></li>
           <li><a href='#annotations_summary'><%= t('marker.annot_summary') %></a></li>
+          <% if can_show_test_results_tab?(assignment) %>
+              <li><a href='#test_result_tab'><%= t('marker.test_results') %></a></li>
+          <% end %>
           <% if can_show_feedback_files_tab?(submission) %>
             <li><a href='#feedback_file_tab'><%= t('marker.feedback_files') %></a></li>
           <% end %>
@@ -40,6 +43,31 @@
 
           <ul id='annotation_summary_list'></ul>
         </div>
+
+        <% if can_show_test_results_tab?(assignment) %>
+            <div id='test_result_tab' style='display:none;'>
+              <div id='testviewer'>
+                <% unless submission.test_script_results.empty? %>
+                    <div class="block">
+                      <h2><%= t("automated_tests.test_results") %></h2>
+                      <div class="block_content">
+                        <br />
+                        <div class="sub_block">
+                          <%= raw t("automated_tests.marks_obtained",
+                                    :marking => "#{@grouping.get_total_test_script_marks} /
+                                             #{@assignment.total_instructor_test_script_marks}" ) %>
+                        </div>
+                        <div id="test_results" class="sub_block">
+                          <%= render partial: 'automated_tests/test_script_result',
+                                     locals: {show_output: !@current_user.student?},
+                                     collection: submission.test_script_results %>
+                        </div>
+                      </div>
+                    </div>
+                <% end %>
+              </div>
+            </div>
+        <% end %>
 
         <% if can_show_feedback_files_tab?(submission) %>
           <div id='feedback_file_tab' style='display:none;'>

--- a/automated-tests-files/test_runner/sample_files/uam/markus_pam_wrapper.py
+++ b/automated-tests-files/test_runner/sample_files/uam/markus_pam_wrapper.py
@@ -157,8 +157,9 @@ class MarkusPAMWrapper(PAMWrapper):
             for result in results:
                 marks = 1 if result.status == PAMResult.Status.PASS else 0
                 status = 'pass' if result.status == PAMResult.Status.PASS else 'fail'
-                self.print_result(name=result.name, input=result.description, expected='', actual=result.message,
-                                  marks=marks, status=status)
+                name = result.name if not result.description else '{name} ({desc})'.format(name=result.name,
+                                                                                           desc=result.description)
+                self.print_result(name=name, input='', expected='', actual=result.message, marks=marks, status=status)
 
 
 if __name__ == '__main__':

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1658,7 +1658,7 @@ en:
       test_files_unavailable: "There is no test script to run test"
       source_files_unavailable: "No student file is found for testing"
       dir_not_exist: "The directory %{dir} required for Ant does not exist"
-      marks_obtained: "<span class=\"prop_label\">Marks Obtained:</span> %{marking}"
+      marks_obtained: "<span class=\"prop_label\">Tests Passed:</span> %{marking}"
       download_wrong_place_or_unreadable: "The requested file is not in the expected directory or could not be read."
       download_not_in_db: "The requested file is not in the database."
       script_option:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1667,7 +1667,7 @@ en:
         description: "Description"
         update_description: "Enter Description Here"
         seq_num: "UPDATE ME: seq_num"
-        max_marks: "Maximum marks <span class='required_field'>*</span>"
+        max_marks: "Number of Tests <span class='required_field'>*</span>"
         run_by_instructors: "Runnable by Instructors"
         run_by_students: "Runnable by Students"
         halts_testing: "Halt On Failure"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1927,7 +1927,7 @@ es:
       test_files_unavailable:             "No hay un script para lanzar la prueba"
       source_files_unavailable:           "No se encontró ningún archivo para probar"
       dir_not_exist:                      "El directorio %{dir} requerido para Ant no existe"
-      marks_obtained:                     "<span class=\"prop_label\">Notas Obtenidas:</span> %{marking}"
+      marks_obtained:                     "<span class=\"prop_label\">UPDATE ME:</span> %{marking}"
       download_wrong_place_or_unreadable: "El archivo solicitado no se encuentra en el directorio esperado o no pudo ser
                                            leído."
       download_not_in_db:                 "El archivo solicitado no se encuentra en la base de datos."
@@ -1937,7 +1937,7 @@ es:
         description:                      "Descripción"
         update_description:               "Ingrese su Descripción Aquí"
         seq_num:                          "ACTUALIZAME: seq_num"
-        max_marks:                        "Notas Máximas <span class='required_field'>*</span>"
+        max_marks:                        "UPDATE ME <span class='required_field'>*</span>"
         run_by_instructors:               "Ejecutable por los Instructores"
         run_by_students:                  "Ejecutable por los Estudiantes"
         halts_testing:                    "Parar si existe un error"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1521,7 +1521,7 @@ fr:
       test_files_unavailable: "UPDATE ME"
       source_files_unavailable: "UPDATE ME"
       dir_not_exist: "Le dossier %{dir} requis par Ant n'existe pas."
-      marks_obtained: "Points obtenus :"
+      marks_obtained: "<span class=\"prop_label\">UPDATE ME:</span> %{marking}"
       download_wrong_place_or_unreadable: "UPDATE ME"
       download_not_in_db: "UPDATE ME"
       script_option:


### PR DESCRIPTION
Tweak test output to be simpler to read.
 @david-yz-liu One thing I changed from our discussion is the test description (aka the input column). There is a script description too in the assignment settings and it was making things really confusing, so I made everything simpler:
1. I left the input column as input, which could make sense in the future, and just hid it
2. If a docstring exists for the test, I just add it in parenthesis to the test name, or otherwise do nothing; the test writer decides if it's worth having it or not
3. The option to display the description is meant to display the script description, so I left it as-is, false and hidden