### PR TITLE
Fix for issue 2615: Added line break to format date in _read.hmtl.erb

### DIFF
--- a/app/assets/stylesheets/assignments.scss
+++ b/app/assets/stylesheets/assignments.scss
@@ -177,6 +177,8 @@ input#assignment_repository_folder[readonly] {
 
 .sub_block {
   margin-bottom: 1em;
+  overflow: hidden;
+  width: 100%;
 
   .prop_label {
     display: inline-block;

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class='sub_block'>
     <span class='prop_label'><%= t('message') %>:</span>
-    <span class="prop_paragraph"><%= @assignment.message %></span>
+    <span class="prop_paragraph"><%= @assignment.message %><br></span>
   </div>
   <div class='sub_block'>
     <span class='prop_label'><%= t('due_date') %>:</span>

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -53,7 +53,8 @@
       <% end %>
     </div>
 
-    <% if !@grouping.nil? %>
+    <%#Cannot assign Grace Period without first assigning a group.%>
+    <% unless @grouping.nil? && @penalty.type == "GracePeriodSubmissionRule" %>
       <div class='sub_block'>
         <span class='prop_label'><%= t('additional_information') %>:</span>
         <% if @penalty.type == "GracePeriodSubmissionRule" %>
@@ -63,7 +64,7 @@
                           @grouping.available_grace_credits)) %>
           <% end %>
         <% elsif @penalty.type == "PenaltyDecayPeriodSubmissionRule" %>
-          <ul><br>
+          <br><ul>
           <% @enum_penalty.each do |p| %>
             <% if p == @enum_penalty.first %>
               <li><%= t('penalty_decay_message_first',
@@ -77,7 +78,7 @@
           <% end %>
           </ul>
         <% elsif @penalty.type == "PenaltyPeriodSubmissionRule" %>
-          <ul><br>
+          <br><ul>
           <% deduction = hours = 0 %>
           <% @enum_penalty.each do |p| %>
             <% deduction += p.deduction %>

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -41,15 +41,15 @@
       <% end %>
       <%= I18n.l(@assignment.due_date + acc.hours, format: :long_date ) %>
     </div>
-  
+
     <div class='sub_block'>
       <span class='prop_label'><%= t('lateness_penalty') %>:</span>
       <% if @penalty.type == "GracePeriodSubmissionRule" %>
-        <%= t('grace_period') %> 
+        <%= t('grace_period') %>
       <% elsif @penalty.type == "PenaltyDecayPeriodSubmissionRule" %>
         <%= t('penalty_decay') %>
       <% elsif @penalty.type == "PenaltyPeriodSubmissionRule" %>
-        <%= t('penalty_period') %> 
+        <%= t('penalty_period') %>
       <% end %>
     </div>
 
@@ -59,30 +59,30 @@
         <% if @penalty.type == "GracePeriodSubmissionRule" %>
           <% if !@grouping.nil? %>
               <%= raw(t('student.group_credits',
-                          available_grace_credits: 
+                          available_grace_credits:
                           @grouping.available_grace_credits)) %>
           <% end %>
         <% elsif @penalty.type == "PenaltyDecayPeriodSubmissionRule" %>
-          <ul>
+          <ul><br>
           <% @enum_penalty.each do |p| %>
             <% if p == @enum_penalty.first %>
-              <li><%= t('penalty_decay_message_first', 
-              deduction: p.deduction, interval: p.interval, 
+              <li><%= t('penalty_decay_message_first',
+              deduction: p.deduction, interval: p.interval,
               hours: p.hours) %> </li>
             <% else %>
-              <li><%= t('penalty_decay_message_other', 
-              deduction: p.deduction, interval: p.interval, 
+              <li><%= t('penalty_decay_message_other',
+              deduction: p.deduction, interval: p.interval,
               hours: p.hours) %> </li>
             <% end %>
           <% end %>
           </ul>
         <% elsif @penalty.type == "PenaltyPeriodSubmissionRule" %>
-          <ul>
+          <ul><br>
           <% deduction = hours = 0 %>
           <% @enum_penalty.each do |p| %>
-            <% deduction += p.deduction %> 
+            <% deduction += p.deduction %>
             <% hours += p.hours %>
-            <li> <%= t('penalty_period_message', hours: hours, 
+            <li><%= t('penalty_period_message', hours: hours,
             deduction: deduction) %> </li>
           <% end %>
           </ul>


### PR DESCRIPTION
#2615 issued by GitGeminiano:
Styling for assignments when no message is given #2615
How to reproduce:
Log in as an admin.
Create an assignment and do not include any message for it.
Add a student to a group for this assignment.
Log in as the recently added student.
Click on the recently created assignment.

Notice that due date is out of place (Image 1):

Image 1:
![date out of place](https://cloud.githubusercontent.com/assets/12561579/18795744/60438e72-819c-11e6-87da-a57bab209c57.PNG)

b2simms: Added a line break to ensure proper formatting.
Testing: 
-created assignment with no message and formatting was proper (Image 2).
-created assignment with message and formatting was proper (Image 3).

Image 2:
![fixed date when message blank](https://cloud.githubusercontent.com/assets/12561579/18795785/95889e60-819c-11e6-866c-2be69e0b7207.PNG)

Image 3:
![correct date](https://cloud.githubusercontent.com/assets/12561579/18795745/6045ed48-819c-11e6-80d1-f61a35292b53.PNG)
