### PR TITLE
Fix for criterion overwrite

### DIFF
--- a/app/views/criteria/_criterion.html.erb
+++ b/app/views/criteria/_criterion.html.erb
@@ -1,4 +1,4 @@
-<li id='criterion_<%= criterion.class %> <%= criterion.id %>'>
+<li id='criterion_<%= criterion.class %><%= criterion.id %>'>
   <span class='left'>
     <%= link_to truncate(criterion.name,
                          length: 30,
@@ -6,13 +6,13 @@
                 edit_assignment_criterion_url(assignment_id: @assignment.id,
                                               id: criterion.id,
                                               criterion_type: criterion.class.to_s),
-                id: "criterion_title_#{criterion.id}",
+                id: "criterion_title_#{criterion.class}#{criterion.id}",
                 remote: true %>
   </span>
-  <span class='center' id='criterion_max_mark_<%= criterion.id %>'>
+  <span class='center' id='criterion_max_mark_<%= criterion.class %><%= criterion.id %>'>
     <%= criterion.max_mark %>
   </span>
-  <span class='right' id='visibility_indicator_<%= criterion.id %>'>
+  <span class='right' id='visibility_indicator_<%= criterion.class %><%= criterion.id %>'>
     <% if criterion.ta_visible && criterion.peer_visible %>
       <%= image_tag 'icons/user_suit.png' %><%= image_tag 'icons/group.png' %>
     <% elsif criterion.ta_visible %>

--- a/app/views/criteria/update.js.erb
+++ b/app/views/criteria/update.js.erb
@@ -1,7 +1,7 @@
 // Update criterion information in the pane that contains the list of criteria
-document.getElementById('criterion_title_<%= @criterion.id %>').innerHTML = '<%= @criterion.name %>';
-document.getElementById('criterion_max_mark_<%= @criterion.id %>').innerHTML = '<%= @criterion.max_mark %>';
-document.getElementById('visibility_indicator_<%= @criterion.id %>').innerHTML =
+document.getElementById('criterion_title_<%= @criterion.class %><%= @criterion.id %>').innerHTML = '<%= @criterion.name %>';
+document.getElementById('criterion_max_mark_<%= @criterion.class %><%= @criterion.id %>').innerHTML = '<%= @criterion.max_mark %>';
+document.getElementById('visibility_indicator_<%= @criterion.class %><%= @criterion.id %>').innerHTML =
   <% if @criterion.ta_visible && @criterion.peer_visible %>
     '<%= image_tag 'icons/user_suit.png' %><%= image_tag 'icons/group.png' %>'
   <% elsif @criterion.ta_visible %>


### PR DESCRIPTION
Changed element IDs to include the criterion’s class, resolving the
problem where multiple criteria of different classes could have the
same element ID.