### PR TITLE
Fix Issue-2558: fix required field check for filename

### DIFF
--- a/app/views/assignments/_boot.js.erb
+++ b/app/views/assignments/_boot.js.erb
@@ -48,7 +48,7 @@
     var input_id = 'assignment_assignment_files_attributes_' + new_id +
                    '_filename';
     var assignment_file = '<p id="' + input_id + '_holder">' +
-      '<label for="' + input_id + '"><%= t(:filename) %></label>' +
+      '<label class="required" for="' + input_id + '"><%= t(:filename) %></label>' +
       '<input type="text" name="assignment[assignment_files_attributes][' +
       new_id + '][filename]" id="' + input_id + '"class="assignment_file" />' +
       '<a onclick="remove_assignment_file(\''+input_id+'\'); return false;">' +

--- a/app/views/assignments/_boot.js.erb
+++ b/app/views/assignments/_boot.js.erb
@@ -49,7 +49,7 @@
                    '_filename';
     var assignment_file = '<p id="' + input_id + '_holder">' +
       '<label class="required" for="' + input_id + '"><%= t(:filename) %></label>' +
-      '<input type="text" name="assignment[assignment_files_attributes][' +
+      '<input type="text" required="required" name="assignment[assignment_files_attributes][' +
       new_id + '][filename]" id="' + input_id + '"class="assignment_file" />' +
       '<a onclick="remove_assignment_file(\''+input_id+'\'); return false;">' +
       '<%= t(:remove) %></a></p>';
@@ -123,8 +123,9 @@
 
     // Handle required fields
     check_required_fields();
-    jQuery('input[required]').change(check_required_fields)
-                             .keyup(check_required_fields);
+    jQuery(document).on("change", jQuery('input[required]'), check_required_fields)
+                    .on("keyup", jQuery('input[required]'), check_required_fields)
+                    .on("click", jQuery('#assignment_file_add_link'), check_required_fields);
 
     // Handle date/time pickers
     jQuery('.section_due_date_input').each(function() {


### PR DESCRIPTION
The issue opened by David was:
Instructor reports: "I had a typo in one of 10 required files (“q10,sql” with a comma instead of a period). MarkUs flagged every one of the required files as invalid, with a red star."

When create a new assignment.
Old:
1. After a new row for adding required filename, there is no required field symbol.
2. The input of required filename can be blank (submit button is not disabled), even if the input is a required input.

New:
1. All required filename are required fields and have red star symbol to remind user to input or remove the row.
2. If any required field is empty, submit button is disabled.  