### PR TITLE
Fix creation of pdf annotations for pre-created annotations

### DIFF
--- a/lib/session_handler.rb
+++ b/lib/session_handler.rb
@@ -91,8 +91,12 @@ module SessionHandler
   end
 
   def authorize_for_ta_admin_and_reviewer(aid, result_id)
-    assignment = Assignment.find(aid)
     result = Result.find(result_id)
+    if aid == 'undefined'
+      assignment = result.submission.assignment
+    else
+      assignment = Assignment.find(aid)
+    end
     unless authorized?(Admin) || authorized?(Ta) ||
         (authorized?(Student) && assignment.has_peer_review_assignment? &&
             current_user.is_reviewer_for?(assignment.pr_assignment, result))


### PR DESCRIPTION
(The route for "add_existing_annotation" doesn't require an assignment id, which is perhaps a little odd, but oh well.)