### PR TITLE
Fix pane dragging issues

### DIFF
--- a/app/assets/javascripts/panes.js
+++ b/app/assets/javascripts/panes.js
@@ -75,8 +75,11 @@ jQuery(document).ready(function() {
 });
 
 /* Handle window resizing */
-window.onresize = function(event) {
+// NOTE: Don't manually override window.onresize. This will conflict with
+// other such uses, as we do in menu.js (TODO: change that one, too).
+window.addEventListener('resize', function(event) {
   panes_width = $panes.width();
+  panes_offset = $panes.offset();
   resize_col();
 
   // Update bounds
@@ -85,6 +88,6 @@ window.onresize = function(event) {
   make_draggable();
 
   // Make sure the drag bar stays in the right place
-  $drag.css('left', offset * panes_width + 'px');
+  $drag.css('left', (panes_offset.left + offset * panes_width) + 'px');
   $drag.css('margin-left', '0');
-};
+});

--- a/app/assets/javascripts/panes.js
+++ b/app/assets/javascripts/panes.js
@@ -1,6 +1,6 @@
 /* Constants: change them to customize the columns */
 // Initial width percentage of left pane (e.g. 0.4 for 40%/60%)
-var offset = 0.65;
+var offset = 0.70;
 
 // Limit from left/right that you can drag to. Must be smaller than offset
 var limit = 0.25;
@@ -39,7 +39,6 @@ function make_draggable() {
       // Calculate offset and resize
       offset = (ui.offset.left - panes_offset.left) / panes_width;
       resize_col();
-      $drag.css('margin-left', '0');
     }
   });
 }
@@ -71,6 +70,7 @@ jQuery(document).ready(function() {
 
   // Initialize the drag bar and resize the columns
   make_draggable();
+  $drag.css('left', (panes_offset.left + offset * panes_width) + 'px');
   resize_col();
 });
 
@@ -89,5 +89,4 @@ window.addEventListener('resize', function(event) {
 
   // Make sure the drag bar stays in the right place
   $drag.css('left', (panes_offset.left + offset * panes_width) + 'px');
-  $drag.css('margin-left', '0');
 });

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -1020,7 +1020,7 @@ ul.annotation_text_list {
   }
 
   #left-pane {
-    width: 60% !important;
+    width: 60%;
     padding-right: 0.5em;
 
     @include breakpoint(small) {
@@ -1030,7 +1030,7 @@ ul.annotation_text_list {
   }
 
   #right-pane {
-    width: 39.5% !important;
+    width: 39.5%;
     padding-left: 0.5em;
 
     @include breakpoint(small) {

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -1020,7 +1020,7 @@ ul.annotation_text_list {
   }
 
   #left-pane {
-    width: 60%;
+    width: 70%;
     padding-right: 0.5em;
 
     @include breakpoint(small) {
@@ -1030,7 +1030,7 @@ ul.annotation_text_list {
   }
 
   #right-pane {
-    width: 39.5%;
+    width: 29.5%;
     padding-left: 0.5em;
 
     @include breakpoint(small) {
@@ -1042,7 +1042,6 @@ ul.annotation_text_list {
     background: #ccc;
     cursor: col-resize;
     height: 700px;
-    margin-left: -5px;
     overflow: hidden;
     position: absolute;
     width: 5px;


### PR DESCRIPTION
The initial problem was introduced by @christinem in adding an `!important` term to css rules. The commit message said this was to fix a window resizing problem, although I can't remember exactly what that was.

Possibly related: I also fixed the problem of the divider not appearing in the correct location when the window is resized. Tested this out on Chrome and Microsoft Edge (yup). @arkon you may be interested in this as well.