### PR TITLE
Added autocapitalize: 'off' to username field on login page

### DIFF
--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -22,7 +22,7 @@
                          tabindex: 1,
                          placeholder: t(:login),
                          autocorrect: 'off',
-                         autocapitalize='off',
+                         autocapitalize: 'off',
                          autofocus: user_login == '',
                          value: user_login %>
       <%= password_field_tag 'user_password',

--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -22,6 +22,7 @@
                          tabindex: 1,
                          placeholder: t(:login),
                          autocorrect: 'off',
+                         autocapitalize='off',
                          autofocus: user_login == '',
                          value: user_login %>
       <%= password_field_tag 'user_password',


### PR DESCRIPTION
Something I noticed particularly with the switch to utorid as the login, is that the username is case sensitive. On phones, the first letter of your username will get capitalized which results in failing to log in until you manually fix it. This is just a minor ux improvement.