### PR TITLE
Fix cancel remark request button (Cancel still sent DELETE request)

### DIFF
--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -23,7 +23,7 @@
                     id: @assignment.id,
                     submission_id: @submission.id },
                   class: 'button',
-                  onclick: "return confirm('#{t(:cancel_remark_request)}');",
+                  data: { confirm: t(:cancel_remark_request) },
                   method: :delete %>
     </p>
   </div>


### PR DESCRIPTION
The confirm dialog shown to students when they clicked on the "Cancel Remark Request" button did not work; the request was sent regardless of whether they clicked "OK" or "Cancel".