### PR TITLE
Fix file manager path anchors displaying as plaintext

### DIFF
--- a/app/assets/stylesheets/submissions.scss
+++ b/app/assets/stylesheets/submissions.scss
@@ -26,10 +26,6 @@
   }
 }
 
-#directory_selector {
-  font-style: italic;
-}
-
 .react_buttons {
   margin-bottom: 1em;
 

--- a/app/views/submissions/file_manager.html.erb
+++ b/app/views/submissions/file_manager.html.erb
@@ -41,22 +41,6 @@
     <p class='success'><%= flash[:submit_notice] %></p>
   <% end %>
 
-  <% if @assignment.vcs_submit %>
-    <div id='directory_selector'>
-      <p>
-        <%= I18n.t('student.submission.current_path') %>
-        <% path_memory = '/'
-           links = []
-           @path.split('/').each do |folder|
-           path_memory = File.join(path_memory, folder)
-           links.push(link_to folder, action: 'file_manager', path: path_memory)
-        end %>
-        <%= link_to '[root]', action: 'file_manager', path: '/' %>
-        <%= links.join('/')%>
-      </p>
-    </div>
-  <% end %>
-
   <% if flash[:transaction_warning] %>
     <div class='warning'><%= flash[:transaction_warning] %></div>
   <% end %>
@@ -129,6 +113,22 @@
         <% end %>
       </ul>
     </div>
+  <% end %>
+
+  <% if @assignment.vcs_submit %>
+    <p>
+      <%= t('student.submission.current_path') %>
+      <%= link_to '[root]', action: 'file_manager', path: '/' %>
+      <%
+        path_memory = '/'
+        @path.split('/').each do |folder|
+          if (folder != '')
+            path_memory = File.join(path_memory, folder) %>
+            <%= link_to(" / #{folder}", action: 'file_manager', path: path_memory).html_safe %>
+          <% end
+        end
+      %>
+    </p>
   <% end %>
 
   <div id='file_table'></div>

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -76,25 +76,22 @@
         <% end %>
     </h2>
 
-    <div id='directory_selector'>
-      <p>
-        <%= t('browse_submissions.current_path') %>
-        <% path_memory = '/'
-           links = []
-           absolute_path = @assignment.repository_folder + @path
-           absolute_path.split('/').each do |folder|
-             if(folder != @assignment.repository_folder)
-               path_memory = File.join(path_memory, folder)
-             end
-             links.push(link_to "/#{folder}",
-                        action: 'repo_browser',
-                        path: path_memory,
-                        id: @grouping.id,
-                        revision_number: @revision_number)
-           end %>
-        <%= links.join().html_safe %>
-      </p>
-    </div>
+    <p>
+      <%= t('browse_submissions.current_path') %>
+      <%
+        path_memory = '/'
+        absolute_path = @assignment.repository_folder + @path
+        absolute_path.split('/').each do |folder|
+          if (folder != @assignment.repository_folder)
+            path_memory = File.join(path_memory, folder)
+          end %>
+          <%= link_to(" / #{folder}",
+                      action: 'repo_browser',
+                      path: path_memory,
+                      id: @grouping.id,
+                      revision_number: @revision_number).html_safe %>
+      <% end %>
+    </p>
 
     <%= form_tag manually_collect_and_begin_grading_assignment_submission_path(
                    id: @grouping.id,


### PR DESCRIPTION
The "Current Path" in the file manager for students was being displayed as plain text instead of actual HTML.

**Before:**
<img width="1031" alt="screen shot 2017-02-02 at 16 48 40" src="https://cloud.githubusercontent.com/assets/4098258/22569983/92eba5a2-e967-11e6-8c16-022a40cc8ccb.png">

**After:**
<img width="177" alt="screen shot 2017-02-02 at 16 48 12" src="https://cloud.githubusercontent.com/assets/4098258/22569992/96f74d5e-e967-11e6-9edf-ae8e691923e9.png">
