### PR TITLE
Feature: annotation context menu - "Common Annotations", "Copy", and "Download File" menu items added

### DIFF
--- a/app/assets/javascripts/Results/context_menu.js
+++ b/app/assets/javascripts/Results/context_menu.js
@@ -48,19 +48,16 @@ var annotation_context_menu = {
 
           if (annot_id !== null && annot_id.length !== 0 &&
               sub_file_id !== null && sub_file_id.length !== 0) {
-            var query_str_params = [
-              ['id=' + annot_id],
-              ['submission_file_id=' + sub_file_id],
-              ['result_id=' + result_id],
-              ['assignment_id=' + assignment_id]
-            ];
             $.ajax({
-              url: annot_path + '?' + query_str_params.join('&'),
-              method: 'POST',
-              data: { _method: 'delete' },
+              url: annot_path,
+              method: 'DELETE',
+              data: { _method: 'delete',
+                      id: annot_id,
+                      submission_file_id: sub_file_id,
+                      result_id: result_id,
+                      assignment_id: assignment_id },
               dataType: 'script'
             });
-
           }
           return;
         },
@@ -92,7 +89,7 @@ var annotation_context_menu = {
     function download_func(include_annot) {
       var sub_file_id = $('#select_file_id').val();
       if (sub_file_id !== null && sub_file_id.length !== 0) {
-        window.open(file_dl_path + '?utf8=?&include_annotations=' +
+        window.open(file_dl_path + '?utf8=✓&include_annotations=' +
                     include_annot + '&select_file_id=' + sub_file_id);
       }
     }

--- a/app/assets/javascripts/Results/context_menu.js
+++ b/app/assets/javascripts/Results/context_menu.js
@@ -1,0 +1,172 @@
+/*
+  This file contains the Javascript code necessary for the functionality
+  of the annotation context menu. For the annotation context menu to
+  function properly, these dependencies are necessary:
+
+  Context-Menu and library related:
+    * jquery.ui-contextmenu.min.js (..\app\assets\javascripts\)
+      * Depends on jQuery and jQuery-ui
+    * context_menu.css (..\app\assets\stylesheets\)
+
+  Context-Menu button functionality:
+    * _annotations.js.erb (..\app\views\results\common\)
+
+   */
+var annotation_context_menu = {
+  setup: function(annot_path, result_id, assignment_id, file_dl_path) {
+    var menu_items = {
+      new_annotation: {
+        title: 'New Annotation',
+        cmd: 'new_annotation',
+        action: make_new_annotation,
+        disabled: true
+      },
+      common_annotations: {
+        title: 'Common Annotations <kbd>></kbd>',
+        cmd: 'common_annotations',
+        disabled: true
+      },
+      delete_annotation: {
+        title: 'Delete Annotation',
+        cmd: "delete_annotation",
+        action: function(event, ui) {
+          var clicked_element = $(ui.target);
+          var annot_id = '';
+          var sub_file_id = $('#select_file_id').val();
+          if (annotation_type === ANNOTATION_TYPES.CODE) {
+            $.each(clicked_element[0].attributes, function(index, attr) {
+              if (attr.nodeName.toLowerCase()
+                      .indexOf('data-annotationid') != -1) {
+                annot_id = attr.value;
+                // Continue iteration in case of multiple annotations
+              }
+            });
+          } else {
+            annot_id = clicked_element.attr('id')
+                                      .replace('annotation_holder_', '');
+          }
+
+          if (annot_id !== null && annot_id.length !== 0 &&
+              sub_file_id !== null && sub_file_id.length !== 0) {
+            var query_str_params = [
+              ['id=' + annot_id],
+              ['submission_file_id=' + sub_file_id],
+              ['result_id=' + result_id],
+              ['assignment_id=' + assignment_id]
+            ];
+            $.ajax({
+              url: annot_path + '?' + query_str_params.join('&'),
+              method: 'POST',
+              data: { _method: 'delete' },
+              dataType: 'script'
+            });
+
+          }
+          return;
+        },
+        disabled: true
+      },
+      separator: {
+        title: '----'
+      },
+      copy: {
+        title: 'Copy',
+        cmd: 'copy',
+        action: function(){ document.execCommand('copy'); },
+        disabled: true
+      },
+      download: {
+        title: 'Download File',
+        cmd: 'download',
+        action: function() { download_func('false'); },
+        disabled: false
+      },
+      download_annotated: {
+        title: 'Download Annotated File',
+        cmd: 'download_annotated',
+        action: function() { download_func('true'); },
+        disabled: false
+      }
+    };
+
+    function download_func(include_annot) {
+      var sub_file_id = $('#select_file_id').val();
+      if (sub_file_id !== null && sub_file_id.length !== 0) {
+        window.open(file_dl_path + '?utf8=?&include_annotations=' +
+                    include_annot + '&select_file_id=' + sub_file_id);
+      }
+    }
+
+    $(document).contextmenu({
+      delegate: '#codeviewer, #sel_box',
+      autoFocus: false,
+      preventContextMenuForPopup: true,
+      preventSelect: false,
+      taphold: true,
+      ignoreParentSelect: false,
+      show: {
+        effect: 'slidedown',
+        duration: 'fast'
+      },
+      menu: [
+        menu_items.new_annotation,
+        menu_items.common_annotations,
+        menu_items.delete_annotation,
+        menu_items.separator,
+        menu_items.copy,
+        menu_items.download,
+        menu_items.download_annotated
+      ],
+      beforeOpen: function (event, ui) {
+        ui.menu.zIndex($(event.target).zIndex() + 1);
+
+        // Enable annotation menu items only if a selection has been made
+        var selection_exists = (function() {
+          if (annotation_type === ANNOTATION_TYPES.CODE) {
+            return window.getSelection().toString() !== '';
+          } else if (annotation_type === ANNOTATION_TYPES.PDF) {
+            return !!get_pdf_box_attrs();
+          } else {
+            return !!get_selection_box_coordinates();
+          }
+        })();
+        $(document).contextmenu('enableEntry', 'new_annotation',
+                                selection_exists);
+        $(document).contextmenu('enableEntry', 'common_annotations',
+                                selection_exists);
+        $(document).contextmenu('enableEntry', 'copy',
+                                selection_exists);
+
+        var has_common_annot = $(document).contextmenu('getMenu')
+                                          .find('.has_common_annotations')
+                                          .length > 0;
+        $(document).contextmenu('showEntry', 'common_annotations',
+                                has_common_annot);
+
+        // Enable "delete" menu item if an annotation was clicked.
+        var annotation_selected = (function() {
+          var clicked_element = $(ui.target);
+          if (annotation_type === ANNOTATION_TYPES.CODE) {
+            return clicked_element.hasClass('source-code-glowing-1');
+          } else {
+            return clicked_element.hasClass('annotation_holder');
+          }
+        })();
+        $(document).contextmenu('enableEntry', 'delete_annotation',
+                                annotation_selected);
+      }
+    });
+  },
+  set_common_annotations: function(common_annotations_menu_children) {
+    if (common_annotations_menu_children.length > 0) {
+      $(document).contextmenu("setEntry", "common_annotations", {
+        title: 'Common Annotations <kbd>></kbd>',
+        cmd: 'common_annotations',
+        addClass: 'has_common_annotations',
+        action: function(event, ui){ return false; },
+        children: common_annotations_menu_children,
+        disabled: true
+      });
+    }
+  }
+};

--- a/app/assets/javascripts/Results/context_menu.js
+++ b/app/assets/javascripts/Results/context_menu.js
@@ -51,8 +51,7 @@ var annotation_context_menu = {
             $.ajax({
               url: annot_path,
               method: 'DELETE',
-              data: { _method: 'delete',
-                      id: annot_id,
+              data: { id: annot_id,
                       submission_file_id: sub_file_id,
                       result_id: result_id,
                       assignment_id: assignment_id },

--- a/app/assets/stylesheets/context_menu.css
+++ b/app/assets/stylesheets/context_menu.css
@@ -19,13 +19,6 @@
   padding: 0;
   width: 100%;
 }
-.ui-menu .ui-menu-divider {
-  margin: 5px -2px 5px -2px;
-  height: 0;
-  font-size: 0;
-  line-height: 0;
-  border-width: 1px 0 0 0;
-}
 .ui-menu .ui-menu-item a {
   text-decoration: none;
   display: block;
@@ -72,20 +65,21 @@
 }
 
 .ui-menu .ui-widget-content {
-    border: 1px solid #aaaaaa;
-    color: #222222;
+  border: 1px solid #aaaaaa;
+  color: #222222;
 }
 
 .ui-menu .ui-menu-divider {
-    margin: 5px -2px 5px -2px;
-    height: 0;
-    font-size: 0;
-    line-height: 0;
-    border-width: 1px 0 0 0;
+  margin: 5px -2px 5px -2px;
+  height: 0;
+  font-size: 0;
+  line-height: 0;
+  border-color: lightgrey;
+  border-width: 1px 0 0 0;
 }
 
 .ui-menu kbd {
-    padding-left: 1em;
-    float: right;
+  padding-left: 1em;
+  float: right;
 }
 

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -1,171 +1,17 @@
 <script>
-  /*
-    This file contains the Javascript code necessary for the functionality
-    of the annotation context menu. For the annotation context menu to
-    function properly, these dependencies are necessary:
-
-    Context-Menu and library related:
-      * jquery.ui-contextmenu.min.js (..\app\assets\javascripts\)
-        * Depends on jQuery and jQuery-ui
-      * context_menu.css (..\app\assets\stylesheets\)
-
-    Context-Menu button functionality:
-      * _annotations.js.erb (..\app\views\results\common\)
-
-     */
   (function() {
     var released_to_students = <%= result.released_to_students %>;
     if (released_to_students) return;
-    var menu_items = {
-      new_annotation: {
-        title: 'New Annotation',
-        cmd: 'new_annotation',
-        action: make_new_annotation,
-        disabled: true
-      },
-      common_annotations: {
-        title: 'Common Annotations <kbd>></kbd>',
-        cmd: 'common_annotations',
-        disabled: true
-      },
-      delete_annotation: {
-        title: 'Delete Annotation',
-        cmd: "delete_annotation",
-        action: function(event, ui) {
-          var clicked_element = $(ui.target);
-          var annot_id = '';
-          var sub_file_id = $('#select_file_id').val();
-          if (annotation_type === ANNOTATION_TYPES.CODE) {
-            $.each(clicked_element[0].attributes, function(index, attr) {
-              if (attr.nodeName.toLowerCase()
-                      .indexOf('data-annotationid') != -1) {
-                annot_id = attr.value;
-                // Continue iteration in case of multiple annotations
-              }
-            });
-          } else {
-            annot_id = clicked_element.attr('id')
-                                      .replace('annotation_holder_', '');
-          }
 
-          if (annot_id !== null && annot_id.length !== 0 &&
-              sub_file_id !== null && sub_file_id.length !== 0) {
-            var query_str_params = [
-              ['id=' + annot_id],
-              ['submission_file_id=' + sub_file_id],
-              ['result_id=<%= result.id %>'],
-              ['assignment_id=<%= result.submission.grouping.assignment.id %>']
-            ];
-            $.ajax({
-              url: '<%= annotations_path %>?' + query_str_params.join('&'),
-              method: 'POST',
-              data: { _method: 'delete' },
-              dataType: 'script'
-            });
-
-          }
-          return;
-        },
-        disabled: true
-      },
-      separator: {
-        title: '----'
-      },
-      copy: {
-        title: 'Copy',
-        cmd: 'copy',
-        action: function(){ document.execCommand('copy'); },
-        disabled: true
-      },
-      download: {
-        title: 'Download File',
-        cmd: 'download',
-        action: function() { download_func('false'); },
-        disabled: false
-      },
-      download_annotated: {
-        title: 'Download Annotated File',
-        cmd: 'download_annotated',
-        action: function() { download_func('true'); },
-        disabled: false
-      }
-    }
-    function download_func(include_annot) {
-      var sub_file_id = $('#select_file_id').val()
-      if (sub_file_id !== null && sub_file_id.length !== 0) {
-      window.open('<%= download_assignment_submission_result_path(
-              result.submission.grouping.assignment.id,
-              result.submission.grouping.current_submission_used.id,
-              result.submission.grouping
-                    .current_submission_used.get_latest_result.id) %>' +
-      '?utf8=✓&include_annotations=' + include_annot +
-      '&select_file_id=' + sub_file_id);
-      }
-    }
-
-    $(document).contextmenu({
-      delegate: '#codeviewer, #sel_box',
-      autoFocus: false,
-      preventContextMenuForPopup: true,
-      preventSelect: false,
-      taphold: true,
-      ignoreParentSelect: false,
-      show: {
-        effect: 'slidedown',
-        duration: 'fast'
-      },
-      menu: [
-        menu_items.new_annotation,
-        menu_items.common_annotations,
-        menu_items.delete_annotation,
-        menu_items.separator,
-        menu_items.copy,
-        menu_items.download,
-        menu_items.download_annotated
-      ],
-      beforeOpen: function (event, ui) {
-        ui.menu.zIndex($(event.target).zIndex() + 1);
-
-        // Enable annotation menu items only if a selection has been made
-        var selection_exists = (function() {
-          if (annotation_type === ANNOTATION_TYPES.CODE) {
-            return window.getSelection().toString() !== '';
-          } else if (annotation_type === ANNOTATION_TYPES.PDF) {
-            return !!get_pdf_box_attrs();
-          } else {
-            return !!get_selection_box_coordinates();
-          }
-        })();
-        $(document).contextmenu('enableEntry', 'new_annotation',
-                                selection_exists);
-        $(document).contextmenu('enableEntry', 'common_annotations',
-                                selection_exists);
-        $(document).contextmenu('enableEntry', 'copy',
-                                selection_exists);
-
-        var has_common_annot = $(document).contextmenu('getMenu')
-                                          .find('.has_common_annotations')
-                                          .length > 0;
-        $(document).contextmenu('showEntry', 'common_annotations',
-                                has_common_annot);
-
-        // Enable "delete" menu item if an annotation was clicked.
-        var annotation_selected = (function() {
-          var clicked_element = $(ui.target);
-          if (annotation_type === ANNOTATION_TYPES.CODE) {
-            return clicked_element.hasClass('source-code-glowing-1');
-          } else {
-            return clicked_element.hasClass('annotation_holder');
-          }
-        })();
-        $(document).contextmenu('enableEntry', 'delete_annotation',
-                                annotation_selected);
-      }
-    });
-  })();
-
-  (function() {
-   var common_annotations = [
+    var annot_path = '<%= annotations_path %>';
+    var result_id = '<%= result.id %>';
+    var assignment_id = '<%= result.submission.grouping.assignment.id %>';
+    var file_dl_path = '<%= download_assignment_submission_result_path(
+      result.submission.grouping.assignment.id,
+      result.submission.grouping.current_submission_used.id,
+      result.submission.grouping
+            .current_submission_used.get_latest_result.id) %>';
+    var common_annotations = [
     <% annotation_categories.each do |annotation_category| %>
       {
         title: '<%= truncate(annotation_category.annotation_category_name, length: 40) %> <kbd>></kbd>',
@@ -193,15 +39,8 @@
     <% end %>
     ];
 
-    if (common_annotations.length > 0) {
-      $(document).contextmenu("setEntry", "common_annotations", {
-        title: 'Common Annotations <kbd>></kbd>',
-        cmd: 'common_annotations',
-        addClass: 'has_common_annotations',
-        action: function(event, ui){ return false; },
-        children: common_annotations,
-        disabled: true
-      });
-    }
+    annotation_context_menu.setup(annot_path, result_id,
+                                  assignment_id, file_dl_path);
+    annotation_context_menu.set_common_annotations(common_annotations);
   })();
 </script>

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -67,6 +67,15 @@
           return;
         },
         disabled: true
+      },
+      separator: {
+        title: '----'
+      },
+      copy: {
+        title: 'Copy',
+        cmd: 'copy',
+        action: function(){ document.execCommand('copy'); },
+        disabled: true
       }
     }
 
@@ -84,7 +93,9 @@
       menu: [
         menu_items.new_annotation,
         menu_items.common_annotations,
-        menu_items.delete_annotation
+        menu_items.delete_annotation,
+        menu_items.separator,
+        menu_items.copy,
       ],
       beforeOpen: function (event, ui) {
         ui.menu.zIndex($(event.target).zIndex() + 1);
@@ -102,6 +113,8 @@
         $(document).contextmenu('enableEntry', 'new_annotation',
                                 selection_exists);
         $(document).contextmenu('enableEntry', 'common_annotations',
+                                selection_exists);
+        $(document).contextmenu('enableEntry', 'copy',
                                 selection_exists);
 
         var has_common_annot = $(document).contextmenu('getMenu')

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -26,34 +26,6 @@
       common_annotations: {
         title: 'Common Annotations <kbd>></kbd>',
         cmd: 'common_annotations',
-        action: function(event, ui){ return false; },
-        children: [
-        <% annotation_categories.each do |annotation_category| %>
-          {
-            title: '<%= truncate(annotation_category.annotation_category_name, length: 40) %>',
-            cmd: 'annotation_category_<%= annotation_category.id %>',
-            action: function(event, ui){ return false; },
-            children: [
-            <% if annotation_category.annotation_texts.empty? %>
-              {
-                title: '<%= t('marker.annotation.no_annotation_in_this_category') %>',
-                action: function(event, ui){ return false; }
-              }
-            <% end %>
-
-            <% annotation_category.annotation_texts.each do |annotation_text| %>
-              {
-                title: '<%= truncate(annotation_text.content, length: 70) %>',
-                cmd: 'annotation_text_<%= annotation_text.id %>',
-                action: function(){
-                  add_existing_annotation(<%= annotation_text.id %>, <%= result.id %>);
-                }
-              },
-            <% end %>
-            ]
-          },
-        <% end %>
-        ],
         disabled: true
       },
       delete_annotation: {
@@ -131,8 +103,12 @@
                                 selection_exists);
         $(document).contextmenu('enableEntry', 'common_annotations',
                                 selection_exists);
+
+        var has_common_annot = $(document).contextmenu('getMenu')
+                                          .find('.has_common_annotations')
+                                          .length > 0;
         $(document).contextmenu('showEntry', 'common_annotations',
-                                menu_items.common_annotations.children.length > 0);
+                                has_common_annot);
 
         // Enable "delete" menu item if an annotation was clicked.
         var annotation_selected = (function() {
@@ -147,5 +123,46 @@
                                 annotation_selected);
       }
     });
+  })();
+
+  (function() {
+   var common_annotations = [
+    <% annotation_categories.each do |annotation_category| %>
+      {
+        title: '<%= truncate(annotation_category.annotation_category_name, length: 40) %> <kbd>></kbd>',
+        cmd: 'annotation_category_<%= annotation_category.id %>',
+        action: function(event, ui){ return false; },
+        children: [
+        <% if annotation_category.annotation_texts.empty? %>
+          {
+            title: '<%= t('marker.annotation.no_annotation_in_this_category') %>',
+            action: function(event, ui){ return false; }
+          }
+        <% end %>
+
+        <% annotation_category.annotation_texts.each do |annotation_text| %>
+          {
+            title: '<%= truncate(annotation_text.content, length: 70) %>',
+            cmd: 'annotation_text_<%= annotation_text.id %>',
+            action: function(){
+              add_existing_annotation(<%= annotation_text.id %>, <%= result.id %>);
+            }
+          },
+        <% end %>
+        ]
+      },
+    <% end %>
+    ];
+
+    if (common_annotations.length > 0) {
+      $(document).contextmenu("setEntry", "common_annotations", {
+        title: 'Common Annotations <kbd>></kbd>',
+        cmd: 'common_annotations',
+        addClass: 'has_common_annotations',
+        action: function(event, ui){ return false; },
+        children: common_annotations,
+        disabled: true
+      });
+    }
   })();
 </script>

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -76,6 +76,30 @@
         cmd: 'copy',
         action: function(){ document.execCommand('copy'); },
         disabled: true
+      },
+      download: {
+        title: 'Download File',
+        cmd: 'download',
+        action: function() { download_func('false'); },
+        disabled: false
+      },
+      download_annotated: {
+        title: 'Download Annotated File',
+        cmd: 'download_annotated',
+        action: function() { download_func('true'); },
+        disabled: false
+      }
+    }
+    function download_func(include_annot) {
+      var sub_file_id = $('#select_file_id').val()
+      if (sub_file_id !== null && sub_file_id.length !== 0) {
+      window.open('<%= download_assignment_submission_result_path(
+              result.submission.grouping.assignment.id,
+              result.submission.grouping.current_submission_used.id,
+              result.submission.grouping
+                    .current_submission_used.get_latest_result.id) %>' +
+      '?utf8=✓&include_annotations=' + include_annot +
+      '&select_file_id=' + sub_file_id);
       }
     }
 
@@ -96,6 +120,8 @@
         menu_items.delete_annotation,
         menu_items.separator,
         menu_items.copy,
+        menu_items.download,
+        menu_items.download_annotated
       ],
       beforeOpen: function (event, ui) {
         ui.menu.zIndex($(event.target).zIndex() + 1);

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -21,7 +21,8 @@
         <% if annotation_category.annotation_texts.empty? %>
           {
             title: '<%= t('marker.annotation.no_annotation_in_this_category') %>',
-            action: function(event, ui){ return false; }
+            action: function(event, ui){ return false; },
+            disabled: true
           }
         <% end %>
 

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -23,6 +23,40 @@
         action: make_new_annotation,
         disabled: true
       },
+      common_annotations: {
+        title: 'Common Annotations',
+        cmd: 'common_annotations',
+        action: function(event, ui){ return false; },
+        children: [
+        <% @assignment.annotation_categories.each do |annotation_category| %>
+          {
+            title: '<%= truncate(annotation_category.annotation_category_name, length: 40) %>',
+            cmd: 'annotation_category_<%= annotation_category.id %>',
+            action: function(event, ui){ return false; },
+            children: [
+            <% if annotation_category.annotation_texts.empty? %>
+              {
+                title: '<%= t('marker.annotation.no_annotation_in_this_category') %>',
+                action: function(event, ui){ return false; }
+              }
+            <% end %>
+
+            <% annotation_category.annotation_texts.each do |annotation_text| %>
+              {
+                title: '<%= truncate(annotation_text.content, length: 70) %>',
+                cmd: 'annotation_text_<%= annotation_text.id %>',
+                action: function(){
+                  add_existing_annotation(<%= annotation_text.id %>, <%= @result.id %>);
+                }
+              },
+            <% end %>
+            ]
+          },
+        <% end %>
+        ],
+        disabled: false
+        //show: false
+      },
       delete_annotation: {
         title: 'Delete Annotation',
         cmd: "delete_annotation",
@@ -78,6 +112,7 @@
       },
       menu: [
         menu_items.new_annotation,
+        menu_items.common_annotations,
         menu_items.delete_annotation
       ],
       beforeOpen: function (event, ui) {
@@ -95,6 +130,10 @@
         })();
         $(document).contextmenu('enableEntry', 'new_annotation',
                                 selection_exists);
+        $(document).contextmenu('enableEntry', 'common_annotations',
+                                selection_exists);
+        //$(document).contextmenu('showEntry', 'common_annotations',
+        //                        annotation_selected);
 
         // Enable "delete" menu item if an annotation was clicked.
         var annotation_selected = (function() {

--- a/app/views/results/common/_context_menu.js.erb
+++ b/app/views/results/common/_context_menu.js.erb
@@ -14,7 +14,7 @@
 
      */
   (function() {
-    var released_to_students = <%= @result.released_to_students %>;
+    var released_to_students = <%= result.released_to_students %>;
     if (released_to_students) return;
     var menu_items = {
       new_annotation: {
@@ -24,11 +24,11 @@
         disabled: true
       },
       common_annotations: {
-        title: 'Common Annotations',
+        title: 'Common Annotations <kbd>></kbd>',
         cmd: 'common_annotations',
         action: function(event, ui){ return false; },
         children: [
-        <% @assignment.annotation_categories.each do |annotation_category| %>
+        <% annotation_categories.each do |annotation_category| %>
           {
             title: '<%= truncate(annotation_category.annotation_category_name, length: 40) %>',
             cmd: 'annotation_category_<%= annotation_category.id %>',
@@ -46,7 +46,7 @@
                 title: '<%= truncate(annotation_text.content, length: 70) %>',
                 cmd: 'annotation_text_<%= annotation_text.id %>',
                 action: function(){
-                  add_existing_annotation(<%= annotation_text.id %>, <%= @result.id %>);
+                  add_existing_annotation(<%= annotation_text.id %>, <%= result.id %>);
                 }
               },
             <% end %>
@@ -54,8 +54,7 @@
           },
         <% end %>
         ],
-        disabled: false
-        //show: false
+        disabled: true
       },
       delete_annotation: {
         title: 'Delete Annotation',
@@ -82,8 +81,8 @@
             var query_str_params = [
               ['id=' + annot_id],
               ['submission_file_id=' + sub_file_id],
-              ['result_id=<%= @result.id %>'],
-              ['assignment_id=<%= @result.submission.grouping.assignment.id %>']
+              ['result_id=<%= result.id %>'],
+              ['assignment_id=<%= result.submission.grouping.assignment.id %>']
             ];
             $.ajax({
               url: '<%= annotations_path %>?' + query_str_params.join('&'),
@@ -132,8 +131,8 @@
                                 selection_exists);
         $(document).contextmenu('enableEntry', 'common_annotations',
                                 selection_exists);
-        //$(document).contextmenu('showEntry', 'common_annotations',
-        //                        annotation_selected);
+        $(document).contextmenu('showEntry', 'common_annotations',
+                                menu_items.common_annotations.children.length > 0);
 
         // Enable "delete" menu item if an annotation was clicked.
         var annotation_selected = (function() {

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -7,7 +7,8 @@
   <%= javascript_include_tag 'Results/file_selector',
                              'panes',
                              'pdfjs',
-                             'testresults_config'%>
+                             'testresults_config',
+                             'Results/context_menu' %>
 
   <%= javascript_tag do -%>
     PDFJS.workerSrc = "<%= @host %>/assets/pdfjs_lib/pdf.worker.js";

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -92,7 +92,11 @@
            locals: { first_file: @first_file } %>
 
 <%= render partial: 'results/common/context_menu',
-         formats: [:js] %>
+           formats: [:js],
+           locals: {
+             result: @result,
+             annotation_categories: @assignment.annotation_categories.includes(:annotation_texts)
+           } %>
 
 <!-- Dialogs -->
 <aside class='dialog' id='notes_dialog'></aside>


### PR DESCRIPTION
## Ready for Review

This pull request adds additional menu items to the annotation context menu (which currently, as of this PR only has "New Annotation" and "Delete Annotation").

### Additions and Modifications:
 - Added "Common Annotations" menu item: all of the "pre-canned" annotations can now be accessed through the context menu
 - Added "Copy" menu item: behaves in the same manner as the original "Copy" item in the default browser context menu
 - Added "Download File" and "Download Annotated File" menu items: when right-clicking and going to either of these 2 download menu items, the file currently being viewed is downloaded. Behaves the same as clicking the "Download" file link at the top right - and then selecting the file you're currently viewing.
 - Moved the bulk of the context menu javascript source code to `context_menu.js` in dir `app/assets/javascript/Results/`

### Relevant remaining TODOs for future PR:
 - Add "Edit" annotation menu item
 - Add internationalization/localization support for the annotation context menu (currently all texts are ENG hard-coded)
 - Add support for using "Delete" or "Edit" when clicking on layered annotations (currently just accessing the most recently added annotation)
 - Move on to adding hotkey support

### Screenshots

#### Common Annotations (pre-canned annotations) automagically set in the context menu:
![common_annotations](https://cloud.githubusercontent.com/assets/7610411/22817650/8ccc14e8-ef36-11e6-8d29-f57971432903.PNG)

#### Copy is back!:
![copy](https://cloud.githubusercontent.com/assets/7610411/22817683/b8b338f2-ef36-11e6-9aab-7d4f97508c35.PNG)

#### Download current files with ease:
![download](https://cloud.githubusercontent.com/assets/7610411/22817689/c7c01de2-ef36-11e6-852d-0d76db179ca4.PNG)

