### PR TITLE
Updates to TA's grade distribution graphs

### DIFF
--- a/app/assets/stylesheets/graders.scss
+++ b/app/assets/stylesheets/graders.scss
@@ -27,6 +27,7 @@
 
 .grader-summary-graph {
   display: inline-block;
+  width: 400px;
 }
 
 .grader-summary-content {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -86,11 +86,7 @@
 
   .grader_distribution {
     margin-bottom: 0;
-  }
-
-  #grader-right {
-    height: 380px;
-    overflow: scroll;
+    display: block;
   }
 
   ::-webkit-scrollbar {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -53,6 +53,11 @@
     width: 250px;
   }
 
+  .ta_grade_distribution {
+    display: inline-block;
+    width: 700px;
+  }
+
   .title {
     color: $dark-blue;
     font-weight: 300;

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -545,6 +545,7 @@ class AssignmentsController < ApplicationController
   def view_summary
     @assignment = Assignment.find(params[:id])
     @current_ta = @assignment.tas.first
+    @tas = @assignment.tas unless @assignment.nil?
   end
 
   def download_assignment_list

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -162,6 +162,7 @@ class MainController < ApplicationController
 
     @current_assignment = Assignment.get_current_assignment
     @current_ta = @current_assignment.tas.first unless @current_assignment.nil?
+    @tas = @current_assignment.tas unless @current_assignment.nil?
 
     render :index, layout: 'content'
   end

--- a/app/views/assignments/_assignment_summary.html.erb
+++ b/app/views/assignments/_assignment_summary.html.erb
@@ -22,7 +22,7 @@
     </div>
     <br>
     <div id='assignment_<%= assignment.id %>_ta_graph' class='ta_grade_distribution'>
-      <%= render partial: 'graders/ta_grade_distribution_graph', locals: { assignment: assignment, ta: ta } %>
+      <%= render partial: 'graders/ta_grade_distribution_graph', locals: { assignment: assignment, tas: tas } %>
     </div>
     <div class='right'>
       <%= render partial: 'assignments/grader_summary', locals: { assignment: assignment } %>

--- a/app/views/assignments/_assignment_summary.html.erb
+++ b/app/views/assignments/_assignment_summary.html.erb
@@ -21,7 +21,7 @@
        </p>
     </div>
     <br>
-    <div id='assignment_<%= assignment.id %>_ta_graph' class='left'>
+    <div id='assignment_<%= assignment.id %>_ta_graph' class='ta_grade_distribution'>
       <%= render partial: 'graders/ta_grade_distribution_graph', locals: { assignment: assignment, ta: ta } %>
     </div>
     <div class='right'>

--- a/app/views/assignments/_grader_summary.html.erb
+++ b/app/views/assignments/_grader_summary.html.erb
@@ -8,20 +8,6 @@
                                              action: 'grader_summary',
                                              assignment_id: assignment.id }
   %>):</p>
-  <div id="grader-right">
-    <ul>
-      <% assignment.tas.each do |ta| %>
-        <li>
-          <%= link_to "#{ta.first_name} #{ta.last_name}",
-                      { controller: 'tas', action: 'refresh_graph', id: ta.id,
-                        assignment: assignment.id },
-                      remote: true %>
-          (<%= t('browse_submissions.how_many_marked_short',
-                 num_marked: assignment.get_num_marked(ta.id),
-                 num_assigned: assignment.get_num_assigned(ta.id)) %>)
-        </li>
-      <% end %>
-    </ul>
-  </div>
+
 <% end %>
 

--- a/app/views/assignments/_grader_summary.html.erb
+++ b/app/views/assignments/_grader_summary.html.erb
@@ -7,7 +7,7 @@
     (<%= link_to t('graders.all_graders'), { controller: 'graders',
                                              action: 'grader_summary',
                                              assignment_id: assignment.id }
-  %>):</p>
+  %>)</p>
 
 <% end %>
 

--- a/app/views/assignments/view_summary.js.erb
+++ b/app/views/assignments/view_summary.js.erb
@@ -1,6 +1,6 @@
 document.getElementById('assignment_summaries').innerHTML =
   "<%= escape_javascript(render partial: 'assignment_summary',
-                                locals: { assignment: @assignment, ta: @tas}).html_safe %>";
+                                locals: { assignment: @assignment, tas: @tas}).html_safe %>";
 
 $('#assignment_<%= @assignment.id %>_graph').html(
   "<%= escape_javascript(render partial: 'grade_distribution_graph',
@@ -8,7 +8,7 @@ $('#assignment_<%= @assignment.id %>_graph').html(
 
 $('#assignment_<%= @assignment.id %>_ta_graph').html(
   "<%= escape_javascript(render partial: 'graders/ta_grade_distribution_graph',
-                                locals: { assignment: @assignment, ta: @tas }) %>");
+                                locals: { assignment: @assignment, tas: @tas }) %>");
 
 $('a[data-id]').removeClass('link_disabled');
 

--- a/app/views/assignments/view_summary.js.erb
+++ b/app/views/assignments/view_summary.js.erb
@@ -1,6 +1,6 @@
 document.getElementById('assignment_summaries').innerHTML =
   "<%= escape_javascript(render partial: 'assignment_summary',
-                                locals: { assignment: @assignment, ta: @current_ta}).html_safe %>";
+                                locals: { assignment: @assignment, ta: @tas}).html_safe %>";
 
 $('#assignment_<%= @assignment.id %>_graph').html(
   "<%= escape_javascript(render partial: 'grade_distribution_graph',
@@ -8,7 +8,7 @@ $('#assignment_<%= @assignment.id %>_graph').html(
 
 $('#assignment_<%= @assignment.id %>_ta_graph').html(
   "<%= escape_javascript(render partial: 'graders/ta_grade_distribution_graph',
-                                locals: { assignment: @assignment, ta: @current_ta }) %>");
+                                locals: { assignment: @assignment, ta: @tas }) %>");
 
 $('a[data-id]').removeClass('link_disabled');
 

--- a/app/views/graders/_ta_grade_distribution_graph.html.erb
+++ b/app/views/graders/_ta_grade_distribution_graph.html.erb
@@ -1,10 +1,15 @@
 <% unless ta.nil? %>
 
-    <canvas id='a<%= assignment.id %>_tas' width='400' height='350'></canvas>
+    <% if ta.nil? || ta.first.nil? %>
+        <% @ta_id = 0 %>
+    <% else %>
+        <% @ta_id = ta.first.id %>
+
+    <canvas id='a<%= assignment.id %>_ta_<%= @ta_id %>' width='400' height='350'></canvas>
     <script>
         //<![CDATA[
         // Set up graph
-        var ctx = document.getElementById('a<%= assignment.id %>_tas').getContext('2d');
+        var ctx = document.getElementById('a<%= assignment.id %>_ta_<%= @ta_id %>').getContext('2d');
         // Set up data
 
         var colours = ['rgba(255, 99, 132, 0.5)', 'rgba(54, 162, 235, 0.5)', 'rgba(255, 206, 86, 0.5)',
@@ -54,4 +59,5 @@
         });
         //]]>
     </script>
+<% end %>
 <% end %>

--- a/app/views/graders/_ta_grade_distribution_graph.html.erb
+++ b/app/views/graders/_ta_grade_distribution_graph.html.erb
@@ -1,46 +1,57 @@
 <% unless ta.nil? %>
-  <h3><%= ta.first_name + ' ' + ta.last_name%></h3>
-  <div>
-    (<%= t('browse_submissions.how_many_marked',
-           num_marked: assignment.get_num_marked(ta.id),
-           num_assigned: assignment.get_num_assigned(ta.id)) %>)
-  </div>
-  <canvas id='a<%= assignment.id %>_ta_<%= ta.id %>' width='400' height='350'></canvas>
-  <script>
-    //<![CDATA[
-    // Set up graph
-    var ctx = document.getElementById('a<%= assignment.id %>_ta_<%= ta.id %>').getContext('2d');
 
-    // Set up data
-    var data = {
-      // Set up labels [0, 5, ..., 95]
-      labels: Array.apply(null, Array(20)).map(function (_, i) { return i * 5; }),
-      datasets: [{
-        data: <%= ta.grade_distribution_array(assignment, 20) %>
-      }]
-    };
+    <canvas id='a<%= assignment.id %>_tas' width='400' height='350'></canvas>
+    <script>
+        //<![CDATA[
+        // Set up graph
+        var ctx = document.getElementById('a<%= assignment.id %>_tas').getContext('2d');
+        // Set up data
 
-    var options = {
-      tooltips: {
-        callbacks: {
-          title: function (tooltipItems) {
-            var baseNum = parseInt(tooltipItems[0].xLabel);
-            if (baseNum === 0) {
-              return '0-5';
-            } else {
-              return (baseNum + 1) + '-' + (baseNum + 5);
+        var colours = ['rgba(255, 99, 132, 0.5)', 'rgba(54, 162, 235, 0.5)', 'rgba(255, 206, 86, 0.5)',
+            'rgba(75, 192, 192, 0.5)', 'rgba(153, 102, 255, 0.5)', 'rgba(255, 159, 64, 0.5)'];
+
+        var data = {
+            // Set up labels [0, 5, ..., 95]
+            labels: Array.apply(null, Array(20)).map(function (_, i) {
+                return i * 5;
+            }),
+            datasets: [
+                <% ta.each_with_index do |ta, index| %>
+                  {
+                      label: "<%= ta.first_name + ' ' + ta.last_name + t('browse_submissions.how_many_marked',
+                          num_marked: assignment.get_num_marked(ta.id),
+                          num_assigned: assignment.get_num_assigned(ta.id)) %>",
+                      backgroundColor: colours[<%= index %>],
+                      data: <%= ta.grade_distribution_array(assignment, 20) %>
+                  },
+                <% end %>
+            ]
+        };
+
+        var options = {
+            tooltips: {
+                callbacks: {
+                    title: function (tooltipItems) {
+                        var baseNum = parseInt(tooltipItems[0].xLabel);
+                        if (baseNum === 0) {
+                            return '0-5';
+                        } else {
+                            return (baseNum + 1) + '-' + (baseNum + 5);
+                        }
+                    }
+                }
+            },
+            legend: {
+                display: true
             }
-          }
-        }
-      }
-    };
+        };
 
-    // Draw it
-    new Chart(ctx, {
-      type: 'bar',
-      data: data,
-      options: options
-    });
-    //]]>
-  </script>
+        // Draw it
+        new Chart(ctx, {
+            type: 'bar',
+            data: data,
+            options: options
+        });
+        //]]>
+    </script>
 <% end %>

--- a/app/views/graders/_ta_grade_distribution_graph.html.erb
+++ b/app/views/graders/_ta_grade_distribution_graph.html.erb
@@ -1,63 +1,59 @@
-<% unless ta.nil? %>
+<% unless tas.nil? %>
 
-    <% if ta.nil? || ta.first.nil? %>
-        <% @ta_id = 0 %>
-    <% else %>
-        <% @ta_id = ta.first.id %>
+  <% if tas.nil? || tas.first.nil? %>
+    <% ta_id = 0 %>
+  <% else %>
+    <% ta_id = tas.first.id %>
+  <% end %>
 
-    <canvas id='a<%= assignment.id %>_ta_<%= @ta_id %>' width='400' height='350'></canvas>
+    <canvas id='<%= "a#{assignment.id}_ta_#{ta_id}" %>' width='400' height='350'></canvas>
     <script>
-        //<![CDATA[
-        // Set up graph
-        var ctx = document.getElementById('a<%= assignment.id %>_ta_<%= @ta_id %>').getContext('2d');
-        // Set up data
+      // Set up graph
+      var ctx = document.getElementById('<%= "a#{assignment.id}_ta_#{ta_id}" %>').getContext('2d');
+      // Set up data
 
-        var colours = ['rgba(255, 99, 132, 0.5)', 'rgba(54, 162, 235, 0.5)', 'rgba(255, 206, 86, 0.5)',
-            'rgba(75, 192, 192, 0.5)', 'rgba(153, 102, 255, 0.5)', 'rgba(255, 159, 64, 0.5)'];
+      var colours = ['rgba(255, 99, 132, 0.5)', 'rgba(54, 162, 235, 0.5)', 'rgba(255, 206, 86, 0.5)',
+        'rgba(75, 192, 192, 0.5)', 'rgba(153, 102, 255, 0.5)', 'rgba(255, 159, 64, 0.5)'];
 
-        var data = {
-            // Set up labels [0, 5, ..., 95]
-            labels: Array.apply(null, Array(20)).map(function (_, i) {
-                return i * 5;
-            }),
-            datasets: [
-                <% ta.each_with_index do |ta, index| %>
-                  {
-                      label: "<%= ta.first_name + ' ' + ta.last_name + t('browse_submissions.how_many_marked',
-                          num_marked: assignment.get_num_marked(ta.id),
-                          num_assigned: assignment.get_num_assigned(ta.id)) %>",
-                      backgroundColor: colours[<%= index %>],
-                      data: <%= ta.grade_distribution_array(assignment, 20) %>
-                  },
-                <% end %>
-            ]
-        };
-
-        var options = {
-            tooltips: {
-                callbacks: {
-                    title: function (tooltipItems) {
-                        var baseNum = parseInt(tooltipItems[0].xLabel);
-                        if (baseNum === 0) {
-                            return '0-5';
-                        } else {
-                            return (baseNum + 1) + '-' + (baseNum + 5);
-                        }
-                    }
-                }
+      var data = {
+        // Set up labels [0, 5, ..., 95]
+        labels: Array.apply(null, Array(20)).map(function (_, i) { return i * 5; }),
+        datasets: [
+          <% tas.each_with_index do |ta, index| %>
+            {
+              label: "<%= ta.first_name + ' ' + ta.last_name + ' ' + t('browse_submissions.how_many_marked',
+                num_marked: assignment.get_num_marked(ta.id),
+                num_assigned: assignment.get_num_assigned(ta.id)) %>",
+              backgroundColor: colours[<%= index %>],
+              data: <%= ta.grade_distribution_array(assignment, 20) %>
             },
-            legend: {
-                display: true
-            }
-        };
+          <% end %>
+        ]
+      };
 
-        // Draw it
-        new Chart(ctx, {
-            type: 'bar',
-            data: data,
-            options: options
-        });
-        //]]>
+      var options = {
+        tooltips: {
+          callbacks: {
+            title: function (tooltipItems) {
+              var baseNum = parseInt(tooltipItems[0].xLabel);
+              if (baseNum === 0) {
+                return '0-5';
+              } else {
+                return (baseNum + 1) + '-' + (baseNum + 5);
+              }
+            }
+          }
+        },
+        legend: {
+          display: true
+        }
+      };
+
+      // Draw it
+      new Chart(ctx, {
+        type: 'bar',
+        data: data,
+        options: options
+      });
     </script>
-<% end %>
 <% end %>

--- a/app/views/graders/grader_summary.html.erb
+++ b/app/views/graders/grader_summary.html.erb
@@ -17,7 +17,7 @@
         <div class='grader-summary-graph'>
           <div id='assignment_<%= @assignment.id %>_ta_<% ta.id %>_graph'>
             <%= render partial: 'graders/ta_grade_distribution_graph',
-                       locals: { assignment: @assignment, ta: [ta] } %>
+                       locals: { assignment: @assignment, tas: [ta] } %>
           </div>
         </div>
       <% end %>

--- a/app/views/graders/grader_summary.html.erb
+++ b/app/views/graders/grader_summary.html.erb
@@ -17,7 +17,7 @@
         <div class='grader-summary-graph'>
           <div id='assignment_<%= @assignment.id %>_ta_<% ta.id %>_graph'>
             <%= render partial: 'graders/ta_grade_distribution_graph',
-                       locals: { assignment: @assignment, ta: ta } %>
+                       locals: { assignment: @assignment, ta: [ta] } %>
           </div>
         </div>
       <% end %>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div id='assignment_summaries'>
-      <%= render partial: 'assignments/assignment_summary', locals: { assignment: @current_assignment, ta: @current_ta } %>
+      <%= render partial: 'assignments/assignment_summary', locals: { assignment: @current_assignment, ta: @tas } %>
     </div>
     <div style="clear:both;"></div>
   </div>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div id='assignment_summaries'>
-      <%= render partial: 'assignments/assignment_summary', locals: { assignment: @current_assignment, ta: @tas } %>
+      <%= render partial: 'assignments/assignment_summary', locals: { assignment: @current_assignment, tas: @tas } %>
     </div>
     <div style="clear:both;"></div>
   </div>

--- a/app/views/tas/refresh_graph.js.erb
+++ b/app/views/tas/refresh_graph.js.erb
@@ -1,4 +1,4 @@
 $('#assignment_<%= @assignment.id %>_ta_graph').html(
     "<%= escape_javascript(render partial: 'graders/ta_grade_distribution_graph',
                                   locals: { assignment: @assignment,
-                                  ta: @current_ta }) %>");
+                                  ta: [@current_ta] }) %>");

--- a/app/views/tas/refresh_graph.js.erb
+++ b/app/views/tas/refresh_graph.js.erb
@@ -1,4 +1,4 @@
 $('#assignment_<%= @assignment.id %>_ta_graph').html(
     "<%= escape_javascript(render partial: 'graders/ta_grade_distribution_graph',
                                   locals: { assignment: @assignment,
-                                  ta: [@current_ta] }) %>");
+                                  tas: [@current_ta] }) %>");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,7 +542,7 @@ en:
       tags_search:          "Search for Tags:"
       tags_list:            "Filter by Tag:"
       search_submissions:   "Search Submissions"
-      how_many_marked:      "%{num_marked}/%{num_assigned} assignments have been marked"
+      how_many_marked:      "%{num_marked}/%{num_assigned} completed"
       how_many_marked_short: "%{num_marked}/%{num_assigned} marked"
       average_annotations:  "%{average_annotations} annotations per marked submission"
 


### PR DESCRIPTION
## Ready for Review

This pull request adds all TAs' datasets into the ta grade distribution graph (which currently only displays a TA's dataset at a time). It also adds other visual features to the graph.

### Additions and Modifications:
* Changed dataset source to all TAs to show all TAs' grade distributions
* Increased graph size, added legends, and displays different colours for each TA's dataset
* Updated view summary, grader summary, and refresh graph to draw ta grade distribution graphs
* Fixed issue to allow different canvases to be drawn for each TA's grader summary graph
* Moved Grader Distribution below graph and removed the TAs' links under Grader Distribution

### Screenshots
#### Ta grade distribution graph displays all TAs' grade distributions:
<img width="722" alt="screen shot 2017-02-19 at 3 09 46 pm" src="https://cloud.githubusercontent.com/assets/24910741/23106021/85539b2e-f6b5-11e6-904b-ab7c7a2e67c1.png">

#### Moved Grader Distribution below graph and removed TAs' links
<img width="239" alt="screen shot 2017-02-19 at 3 10 03 pm" src="https://cloud.githubusercontent.com/assets/24910741/23106026/a2ee8aa4-f6b5-11e6-86bd-b169da319fe0.png">
