### PR TITLE
Fix seq_num in test script upload

### DIFF
--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -45,6 +45,7 @@ module AutomatedTestsClientHelper
         # Edit existing test script file
         if params[('new_update_script_' + testscripts[file_num][:script_name]).to_sym].nil?
           updated_script_files[file_num] = file.clone
+          updated_script_files[file_num][:seq_num] = file_num
         else
           new_update_script = params[('new_update_script_' + testscripts[file_num][:script_name]).to_sym]
           new_script_name = new_update_script.original_filename

--- a/app/models/test_script.rb
+++ b/app/models/test_script.rb
@@ -83,18 +83,7 @@ class TestScript < ActiveRecord::Base
       record.errors.add attr, ' ' + name + ' ' + I18n.t("automated_tests.filename_exists")
     end
   end
-  
-  # validates the uniqueness of seq_num for the same assignment
-  validates_each :seq_num do |record, attr, value|
-    # FIXME: create a loop to loop through all dup_file
-    # dup_files = TestScript.find_all_by_assignment_id_and_seq_num(record.assignment_id, value)
-    dup_file = TestScript.find_by_assignment_id_and_seq_num(record.assignment_id, value)
-    if dup_file && dup_file.id != record.id
-      # FIXME: fix the error message: this is not filename
-      record.errors.add attr, ' ' + value.to_s + ' ' + I18n.t("automated_tests.filename_exists")
-    end
-  end
-  
+
   validates_numericality_of :seq_num
   validates_numericality_of :max_marks, only_integer: true, greater_than_or_equal_to: 0
 


### PR DESCRIPTION
(Currently, seq_num doesn't have much sense because it just reflects the file order, but it could in the future if we let the instructor edit it, so I'm not throwing it away)

A problem with seq_num can happen when you delete an existing file, because the other files' seq_nums don't get updated and the ui could later create a new seq_num that is the same of an existing one. Fix this by:
- Removing the uniqueness validation altogether: if two seq_nums are the same, we just don't care which one is executed first.
- Compacting the seq_nums when a new file is being added, filling the holes left by previous deletes; this is consistent with the current policy of seq_num == file order.