### PR TITLE
Add group repo name to autotest protocol

### DIFF
--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -375,7 +375,8 @@ module AutomatedTestsClientHelper
       test_username = nil
       # enqueue locally using resque api
       Resque.enqueue_to(server_queue, AutomatedTestsServer, markus_address, user_api_key, server_api_key, test_username,
-                        test_scripts, files_path, tests_path, results_path, assignment.id, group.id, submission_id)
+                        test_scripts, files_path, tests_path, results_path, assignment.id, group.id, group.repo_name,
+                        submission_id)
     else
       # tests executed locally or remotely with authentication:
       # copy the student's submission and all necessary files through ssh in a temp folder
@@ -403,7 +404,8 @@ module AutomatedTestsClientHelper
           # enqueue remotely directly in redis, resque does not allow for multiple redis servers
           resque_params = {:class => 'AutomatedTestsServer',
                            :args => [markus_address, user_api_key, server_api_key, test_username, test_scripts,
-                                     files_path, tests_path, results_path, assignment.id, group.id, submission_id]}
+                                     files_path, tests_path, results_path, assignment.id, group.id, group.repo_name,
+                                     submission_id]}
           ssh.exec!("redis-cli rpush \"resque:queue:#{server_queue}\" '#{JSON.generate(resque_params)}'")
         end
       rescue Exception => e

--- a/lib/automated_tests/server/automated_tests_server.rb
+++ b/lib/automated_tests/server/automated_tests_server.rb
@@ -12,7 +12,7 @@ class AutomatedTestsServer
   # a) the user running MarkUs if ATE_SERVER_HOST == 'localhost'
   # b) ATE_SERVER_FILES_USERNAME otherwise
   def self.perform(markus_address, user_api_key, server_api_key, test_username, test_scripts, files_path, tests_path,
-                   results_path, assignment_id, group_id, submission_id)
+                   results_path, assignment_id, group_id, group_repo_name, submission_id)
 
     # move files to the test location (if needed)
     test_scripts_executables = get_test_scripts_chmod(test_scripts, tests_path)
@@ -27,7 +27,7 @@ class AutomatedTestsServer
     all_output = '<testrun>'
     all_errors = ''
     test_scripts.each do |script|
-      run_command = "cd '#{tests_path}'; ./'#{script}' #{markus_address} #{user_api_key} #{assignment_id} #{group_id}"
+      run_command = "cd '#{tests_path}'; ./'#{script}' #{markus_address} #{user_api_key} #{assignment_id} #{group_id} #{group_repo_name}"
       unless test_username.nil?
         run_command = "sudo -u #{test_username} -- bash -c \"#{run_command}\""
       end


### PR DESCRIPTION
A student initiated test does not have access to apis for security reasons, but it may want to commit a file back to their own repo, thus the need for the repo name.