### PR TITLE
Guard student tests execution with assignment due date check

### DIFF
--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -196,7 +196,7 @@ module AutomatedTestsClientHelper
   # Verify the user has the permission to run the tests - admins
   # always have the permission, while student has to
   # belong to the group, and have at least one token.
-  def self.check_user_permission(user, grouping, assignment)
+  def self.check_user_permission(user, grouping)
 
     # admins are always ok
     if user.admin?
@@ -217,7 +217,7 @@ module AutomatedTestsClientHelper
       raise I18n.t('automated_tests.error.bad_group')
     end
     # deadline has not passed
-    if assignment.submission_rule.can_collect_now?
+    if grouping.assignment.submission_rule.can_collect_now?
       raise I18n.t('automated_tests.error.after_due_date')
     end
     token = grouping.prepare_tokens_to_use
@@ -265,7 +265,7 @@ module AutomatedTestsClientHelper
     end
     test_server_user = get_test_server_user
     test_scripts = get_test_scripts(assignment, current_user)
-    check_user_permission(current_user, grouping, assignment)
+    check_user_permission(current_user, grouping)
 
     # if current_user is an instructor, then a submission exists and we use that repo revision
     # if current_user is a student, then we use the latest repo revision

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -196,7 +196,7 @@ module AutomatedTestsClientHelper
   # Verify the user has the permission to run the tests - admins
   # always have the permission, while student has to
   # belong to the group, and have at least one token.
-  def self.check_user_permission(user, grouping)
+  def self.check_user_permission(user, grouping, assignment)
 
     # admins are always ok
     if user.admin?
@@ -215,6 +215,10 @@ module AutomatedTestsClientHelper
     # student belongs to the grouping
     unless user.accepted_groupings.include?(grouping)
       raise I18n.t('automated_tests.error.bad_group')
+    end
+    # deadline has not passed
+    if assignment.submission_rule.can_collect_now?
+      raise I18n.t('automated_tests.error.after_due_date')
     end
     token = grouping.prepare_tokens_to_use
     # no other enqueued tests
@@ -261,7 +265,7 @@ module AutomatedTestsClientHelper
     end
     test_server_user = get_test_server_user
     test_scripts = get_test_scripts(assignment, current_user)
-    check_user_permission(current_user, grouping)
+    check_user_permission(current_user, grouping, assignment)
 
     # if current_user is an instructor, then a submission exists and we use that repo revision
     # if current_user is a student, then we use the latest repo revision

--- a/app/views/automated_tests/student_interface.html.erb
+++ b/app/views/automated_tests/student_interface.html.erb
@@ -45,7 +45,7 @@
         <% if @assignment.unlimited_tokens || @token.remaining > 0 %>
           <h3><%= t('automated_tests.run_tests') %></h3>
           <% if @grouping.assignment.submission_rule.can_collect_now? %>
-            <p><%= t('automated_tests.due_date_is_passed') %></p>
+            <p><%= t('automated_tests.error.after_due_date') %></p>
           <% else %>
             <p><%= raw t('automated_tests.need_one_file') %></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1624,7 +1624,7 @@ en:
       script_name: "Script Name"
       test_parameters: "Test Script Options"
       revision_used_for_test: "<span class='prop_label'>Revision used:</span> %{revision}"
-      due_date_is_passed: "You cannot run test as the due date for this assignment is passed"
+      due_date_is_passed: "You cannot run tests as the due date for this assignment is passed"
       information: "Information"
       run_tests: "Run tests"
       test_run: "Test Run"
@@ -1707,6 +1707,7 @@ en:
         no_tokens: "You do not have tokens to run the tests"
         no_test_files: "There are no test scripts to run the tests"
         already_enqueued: "You have a test already enqueued for execution, please wait for the results"
+        after_due_date: "The due date for this assignment has passed"
       test_result:
         all_tests: "All tests"
         unknown_test: "Unknown test"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1624,7 +1624,6 @@ en:
       script_name: "Script Name"
       test_parameters: "Test Script Options"
       revision_used_for_test: "<span class='prop_label'>Revision used:</span> %{revision}"
-      due_date_is_passed: "You cannot run tests as the due date for this assignment is passed"
       information: "Information"
       run_tests: "Run tests"
       test_run: "Test Run"
@@ -1707,7 +1706,7 @@ en:
         no_tokens: "You do not have tokens to run the tests"
         no_test_files: "There are no test scripts to run the tests"
         already_enqueued: "You have a test already enqueued for execution, please wait for the results"
-        after_due_date: "The due date for this assignment has passed"
+        after_due_date: "You cannot run tests as the due date for this assignment has passed"
       test_result:
         all_tests: "All tests"
         unknown_test: "Unknown test"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1977,6 +1977,7 @@ es:
         no_tokens:            "No se encontraron fichas para este estudiante y para este proyecto"
         no_test_files:        "No hay un script para lanzar la prueba"
         already_enqueued:     "UPDATE ME"
+        after_due_date:       "UPDATE ME"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1886,8 +1886,6 @@ es:
       script_name:                        "Nombre del script"
       test_parameters:                    "Opciones del script de la prueba"
       revision_used_for_test:             "<span class='prop_label'>Revisión usada:</span> %{revision}"
-      due_date_is_passed:                 "Usted no puede lanzar las prueba debido a que el último plazo de entrega para
-                                           este proyecto ha pasado"
       information:                        "Información"
       run_tests:                          "Lanzar pruebas"
       test_run:                           "Lanzar prueba"
@@ -1977,7 +1975,8 @@ es:
         no_tokens:            "No se encontraron fichas para este estudiante y para este proyecto"
         no_test_files:        "No hay un script para lanzar la prueba"
         already_enqueued:     "UPDATE ME"
-        after_due_date:       "UPDATE ME"
+        after_due_date:       "Usted no puede lanzar las prueba debido a que el último plazo de entrega para este
+                               proyecto ha pasado"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1473,7 +1473,6 @@ fr:
       script_name: "UPDATE ME"
       test_parameters: "UPDATE ME"
       revision_used_for_test: "<span class=\"prop_label\">Révision utilisée:</span> %{revision}"
-      due_date_is_passed: "Vous ne pouvez pas exécuter de test après la date de retour."
       information: "Information"
       run_tests: "Exécuter les tests."
       test_run: "L'exécution du test"
@@ -1565,7 +1564,7 @@ fr:
         no_tokens: "Aucun jeton trouvé pour cet(te) étudiant(e) et pour ce projet"
         no_test_files: "UPDATE ME"
         already_enqueued: "UPDATE ME"
-        after_due_date: "UPDATE ME"
+        after_due_date: "Vous ne pouvez pas exécuter de test après la date de retour"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1565,6 +1565,7 @@ fr:
         no_tokens: "Aucun jeton trouvé pour cet(te) étudiant(e) et pour ce projet"
         no_test_files: "UPDATE ME"
         already_enqueued: "UPDATE ME"
+        after_due_date: "UPDATE ME"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1497,6 +1497,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         no_tokens: "Nenhum token foi encontrado para esse estudante e para esse projeto"
         no_test_files: "UPDATE ME"
         already_enqueued: "UPDATE ME"
+        after_due_date: "UPDATE ME"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1446,7 +1446,6 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
       need_group_for_test: "Você precisa possuir um grupo para executar os testes"
       test: "Teste"
       revision_used_for_test: "<span class=\"prop_label\">Revisão utilizada:</span> %{revision}"
-      due_date_is_passed: "Você não pode executar o teste pois a sua entrega está fora do prazo "
       information: "Informação"
       run_tests: "Executar testes"
       test_run: "Execução de Teste"
@@ -1497,7 +1496,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         no_tokens: "Nenhum token foi encontrado para esse estudante e para esse projeto"
         no_test_files: "UPDATE ME"
         already_enqueued: "UPDATE ME"
-        after_due_date: "UPDATE ME"
+        after_due_date: "Você não pode executar o teste pois a sua entrega está fora do prazo"
       test_result:
         all_tests: "UPDATE ME"
         unknown_test: "UPDATE ME"


### PR DESCRIPTION
This adds a check to prevent student running tests after the due date.
An equal check existed to show the button in the user interface, but not to prevent the actual test function from running.