### PR TITLE
Use alternative CDN provider for MathJax

### DIFF
--- a/app/views/annotation_categories/index.html.erb
+++ b/app/views/annotation_categories/index.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'boot',
              formats: [:js],
              handlers: [:erb] %>
-  <%= javascript_include_tag 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML' %>
   <%= javascript_include_tag 'MathJax/mathjax_helpers' %>
   <%= stylesheet_link_tag('clickable') %>
 <% end %>

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -20,7 +20,7 @@
 <%= javascript_include_tag 'jquery.ui-contextmenu.min' %>
 
 <!-- MathML -->
-<%= javascript_include_tag 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'%>
+<%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'%>
 <%= javascript_include_tag 'MathJax/mathjax_helpers' %>
 
 <% # EDITING MARKS FUNCTIONS AND BOOT SCRIPTS%>

--- a/app/views/results/view_marks.html.erb
+++ b/app/views/results/view_marks.html.erb
@@ -14,7 +14,7 @@
 <%= javascript_include_tag 'DropDownMenu/DropDownMenu.js'%>
 
 <!-- DISPLAYING MATHML -->
-<%= javascript_include_tag 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'%>
+<%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'%>
 <%= javascript_include_tag 'MathJax/mathjax_helpers' %>
 
 <% # VIEWING MARKS FUNCTIONS %>


### PR DESCRIPTION
[The MathJax CDN is shutting down at the end of this month.](https://www.mathjax.org/cdn-shutting-down/)