### PR TITLE
Feature: Normal view and compact view (flex boxes) for Markers

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -321,3 +321,17 @@ function update_total_mark(total_mark) {
   document.getElementById('current_mark_div').innerHTML       = total_mark;
   document.getElementById('current_total_mark_div').innerHTML = total_mark;
 }
+
+function compact_view_toggle() {
+  var toggle_elements = [
+    $('#menus'),
+    $('.top_bar'),
+    $('.title_bar'),
+    $('#footer_wrapper')
+  ];
+  $.each(toggle_elements, function(idx, element){
+    element.toggle();
+  });
+  $('#content').toggleClass('expanded_view');
+  fix_panes();
+}

--- a/app/assets/javascripts/panes.js
+++ b/app/assets/javascripts/panes.js
@@ -16,7 +16,8 @@ function resize_col() {
   if (offset >= limit && offset <= (1 - limit)) {
     $drag.draggable('option', 'revert', false);
     left.style.width = offset * panes_width + 'px';
-    right.style.width = (1 - offset) * panes_width - 5 + 'px';
+    var drag_width = $drag.width() + 2 * parseInt($drag.css('margin-left'));
+    right.style.width = (1 - offset) * panes_width - drag_width + 'px';
   } else {
     // Just in case we somehow go past the limit
     $drag.draggable('option', 'revert', true);
@@ -39,21 +40,25 @@ function make_draggable() {
       // Calculate offset and resize
       offset = (ui.offset.left - panes_offset.left) / panes_width;
       resize_col();
+      $drag.css('height', ($drag.parent().height() -
+        2 * parseInt($drag.css('margin-top'))) + 'px');
     }
   });
 }
 
 /* Calculates the bounds for the drag bar */
 function calculate_bounds() {
-  bounds = [panes_offset.left + limit * panes_width,
+  var drag_width = $drag.width() + 2 * parseInt($drag.css('margin-left'));
+  bounds = [panes_offset.left + limit * panes_width + drag_width,
             panes_offset.top,
-            panes_offset.left + panes_width - (limit * panes_width) - 5,
+            panes_offset.left + panes_width -
+              (limit * panes_width) - drag_width,
             panes_offset.top + $panes.height()];
 }
 
 /* On page load: get DOM elements, calculate some stuff,
    and initialize the drag bar/columns.  */
-$(document).ready(function() {
+$(window).load(function() {
   left   = document.getElementById('left-pane');
   right  = document.getElementById('right-pane');
   $panes = $('#panes');
@@ -70,14 +75,17 @@ $(document).ready(function() {
 
   // Initialize the drag bar and resize the columns
   make_draggable();
+  $drag.css('height', ($drag.parent().height() -
+                       2 * parseInt($drag.css('margin-top'))) + 'px');
   $drag.css('left', (panes_offset.left + offset * panes_width) + 'px');
   resize_col();
+  $("*[role='tab']").on('click', fix_panes);
 });
 
 /* Handle window resizing */
 // NOTE: Don't manually override window.onresize. This will conflict with
 // other such uses, as we do in menu.js (TODO: change that one, too).
-window.addEventListener('resize', function(event) {
+function fix_panes(){
   panes_width = $panes.width();
   panes_offset = $panes.offset();
   resize_col();
@@ -88,5 +96,8 @@ window.addEventListener('resize', function(event) {
   make_draggable();
 
   // Make sure the drag bar stays in the right place
+  $drag.css('height', ($drag.parent().height() -
+    2 * parseInt($drag.css('margin-top'))) + 'px');
   $drag.css('left', (panes_offset.left + offset * panes_width) + 'px');
-});
+}
+window.addEventListener('resize', fix_panes);

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -56,11 +56,8 @@
 /* Top toolbars: student selector/file selector/download buttons */
 
 #student_selector {
-  background: #ececec;
-  border: 1px solid #ddd;
-  border-radius: $radius;
   display: table;
-  margin: 0 0 10px 0;
+  margin: 0;
   padding: 2px 10px;
   width: 100%;
 
@@ -91,6 +88,7 @@
   .right {
     text-align: right;
     width: 20%;
+    float: none;
   }
 }
 
@@ -988,21 +986,32 @@ ul.annotation_text_list {
 
 /* Resizable column panes */
 
+.flex-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 #panes-content {
-  height: 100%;
-  margin-top: 1em;
+  display: flex;
+  flex-grow: 1;
+  margin-top: 0.5em;
   width: 100%;
 
   #panes {
-    height: 100%;
+    display: flex;
     width: 100%;
   }
 
   #left-pane,
   #drag,
   #right-pane {
-    display: inline-block;
-    height: 100%;
     margin: 0;
     padding: 0;
     vertical-align: top;
@@ -1021,7 +1030,7 @@ ul.annotation_text_list {
 
   #left-pane {
     width: 70%;
-    padding-right: 0.5em;
+    margin-right: 3px;
 
     @include breakpoint(small) {
       margin-bottom: 1em;
@@ -1031,7 +1040,7 @@ ul.annotation_text_list {
 
   #right-pane {
     width: 29.5%;
-    padding-left: 0.5em;
+    margin-left: 3px;
 
     @include breakpoint(small) {
       padding-left: 0;
@@ -1041,10 +1050,11 @@ ul.annotation_text_list {
   #drag {
     background: #ccc;
     cursor: col-resize;
-    height: 700px;
+    height: 50%;
     overflow: hidden;
     position: absolute;
-    width: 5px;
+    margin: 5px 1px;
+    width: 4px;
 
     @include breakpoint(small) {
       display: none;

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -30,3 +30,76 @@
 .test_points {
   font-size: large;
 }
+
+.wrapper_flex {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.top_bar {
+  background-color: #e8f4f2;
+}
+
+.title_bar {
+  margin-bottom: 0 !important;
+}
+
+.results_title_bar {
+  display: flex;
+  flex-direction: row;
+  height: 34px;
+  padding: 0 3.5em;
+  border-bottom: 2px solid #89b1dd;
+}
+
+.flex_vertical_center {
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+.logo {
+  display: flex;
+  flex-grow: 1;
+}
+
+.title_text {
+  display: flex;
+  flex-grow: 5;
+}
+
+.download_text {
+  display: flex;
+  flex-grow: 1;
+}
+
+#content {
+  z-index: auto !important;
+}
+
+.expanded_view {
+  z-index: auto !important;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding: 0.5em !important;
+}
+
+.wrapLeft {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+#results-logo-img {
+  display: block;
+  margin: 0 auto;
+  background: transparent url(markus_logo_small.png) no-repeat center center / 90px 30px;
+  height: 30px;
+  width: 90px;
+
+  @include hidpi {
+    background-image: url(markus_logo_small@2x.png);
+  }
+}

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -158,7 +158,9 @@ class ResultsController < ApplicationController
 
     # Respond to AJAX request.
     respond_to do |format|
-      format.html
+      format.html do
+        render layout: 'result_content'
+      end
       format.json do
         @request_type = params[:type]
 

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <%= render partial: 'layouts/head' %>
+  <title><%= t(:markus) %> - <%= controller.action_name.titleize %></title>
+  <%# React stuff (compressed version + JSX transformer) %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/react.min.js',
+                             'https://cdnjs.cloudflare.com/ajax/libs/react/0.11.0/JSXTransformer.js' %>
+  <%= javascript_include_tag 'application' %>
+  <% # UI LIBRARIES %>
+  <%= javascript_include_tag 'menu',
+                             'layouts',
+                             'help-system' %>
+  <%= yield :head %>
+</head>
+<body>
+<div id='<%= controller.action_name == "login" ? "loggedOut" : "loggedIn" %>'>
+  <div id='mobile_menu'>
+    <a id='menu_icon'></a>
+  </div>
+  <div id='wrapper' class='wrapper_flex'>
+    <nav id='menus'>
+      <div id='menus_child'>
+        <%= render partial: 'layouts/header' %>
+        <%= render partial: 'layouts/menu' %>
+        <%= render partial: 'layouts/sub_menu' %>
+        <%= render partial: 'layouts/sub_sub_menu' %>
+        <%= render partial: 'layouts/footer' %>
+      </div>
+      <%= render partial: 'layouts/about' %>
+      <%= render partial: 'layouts/role_switch' %>
+      <%= render partial: 'layouts/redirect' %>
+    </nav>
+
+    <div class='top_bar' style="display: none">
+      <div id='working' style='display:none;'>
+        <span><%= t(:working) %></span>
+        <span id='ellipsis'></span>
+      </div>
+      <div class='results_title_bar'>
+        <div class='logo_img flex_vertical_center'>
+          <a href='<%= root_url %>' id='results-logo-img'></a>
+        </div>
+        <h3 class='title_text flex_vertical_center'>
+        <%= t('results.title',
+              { assignment_name: @assignment.short_identifier,
+                group_name: @current_user.student? ? t('assignment.review') : @grouping.get_group_name }) %>
+        </h3>
+        <div class='download_text flex_vertical_center'>
+          <a onclick="compact_view_toggle()" style="margin: 0px 15px">Normal View</a>
+          <% unless @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) %>
+            <%= link_to t(:download),
+                        'javascript:void(0);',
+                        onclick:'modal_download.open();' %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <section id='content'>
+      <%= render partial: 'layouts/noscript'%>
+      <%= content_for?(:content) ? yield(:content) : yield %>
+    </section>
+
+    <div id='footer_wrapper'><%= render partial: 'layouts/footer' %></div>
+  </div>
+
+</div>
+
+<%= render partial: 'layouts/redirect', formats: [:js], handlers: [:erb] %>
+
+<script>
+  $(document).ready(function($) {
+    setInterval(function() {
+      $.get('<%= check_timeout_main_index_path %>');
+    }, 120000);
+  });
+</script>
+</body>
+</html>

--- a/app/views/results/_result_summary.html.erb
+++ b/app/views/results/_result_summary.html.erb
@@ -1,4 +1,4 @@
-<div id='result_summary'>
+<div id='result_summary' class='flex-col'>
   <%= render partial: 'results/student/student_panes',
              locals: { extra_marks_points: @extra_marks_points,
                        extra_marks_percentage: @extra_marks_percentage,

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -172,6 +172,7 @@
   </h1>
 
   <div class='heading_buttons'>
+    <a onclick="compact_view_toggle()" style="margin: 0px 15px">Compact View</a>
     <% unless @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) %>
       <%= link_to t(:download),
                   'javascript:void(0);',

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -40,7 +40,7 @@
           <div id='codeviewer' class='flex-col'></div>
         </div>
 
-        <div id='annotations_summary' class='flex-cold'>
+        <div id='annotations_summary' class='flex-col'>
           <div id='annotations_summary_head'>
             <h3><%= t('marker.overall_comments') %></h3>
 

--- a/app/views/results/marker/_marker_panes.html.erb
+++ b/app/views/results/marker/_marker_panes.html.erb
@@ -1,7 +1,7 @@
 <div id='panes-content'>
   <div id='panes'>
     <div id='left-pane'>
-      <div class='tab-pane' id='code_pane'>
+      <div class='tab-pane flex-pane' id='code_pane'>
         <ul id='code_and_annotations_tabs' class='subsection_tabs'>
            <li><a href='#code_holder'><%= t('marker.source_code') %></a></li>
            <li><a href='#annotations_summary'><%= t('marker.annot_summary') %></a></li>
@@ -16,7 +16,7 @@
            <% end %>
         </ul>
 
-        <div id='code_holder'>
+        <div id='code_holder' class='flex-col'>
           <%# For image/PDF annotations %>
           <div id='sel_box'></div>
 
@@ -37,10 +37,10 @@
               <% end %>
           </div>
 
-          <div id='codeviewer'></div>
+          <div id='codeviewer' class='flex-col'></div>
         </div>
 
-        <div id='annotations_summary'>
+        <div id='annotations_summary' class='flex-cold'>
           <div id='annotations_summary_head'>
             <h3><%= t('marker.overall_comments') %></h3>
 
@@ -115,7 +115,7 @@
     <div id='drag'></div>
 
     <div id='right-pane'>
-      <div class='tab-pane' id='mark_pane'>
+      <div class='tab-pane flex-pane' id='mark_pane'>
         <ul id='mark_tabs' class='subsection_tabs'>
           <li><a href='#mark_viewer'><%= t('marker.marks.marks') %></a></li>
           <li><a href='#summary_viewer'><%= t('marker.marks.summary') %></a></li>
@@ -124,7 +124,7 @@
           <% end %>
         </ul>
 
-        <div id='mark_viewer'>
+        <div id='mark_viewer' class='flex-col'>
           <div class='mark_tools'>
             <button class='inline-button' id='expand_all'>
               <%= t('marker.marks.expand_all') %>
@@ -151,7 +151,7 @@
           </div>
         </div> <%# Criterion Viewer %>
 
-        <div id='summary_viewer' class='marks_summary_pane'>
+        <div id='summary_viewer' class='marks_summary_pane flex-col'>
           <%= render partial: 'results/marker/marker_summary',
                      locals: { mark_criteria: mark_criteria,
                                marks_map: marks_map,
@@ -165,7 +165,7 @@
 
         <!-- Tag insertion pane. -->
         <% unless @result.is_a_review? %>
-          <div id='tag_viewer'>
+          <div id='tag_viewer' class='flex-col'>
             <%= render partial: 'results/marker/tag_summary',
                        locals: { assignment: assignment,
                                  old_result: @old_result,

--- a/app/views/results/student/_student_panes.html.erb
+++ b/app/views/results/student/_student_panes.html.erb
@@ -1,7 +1,7 @@
 <div id='panes-content'>
   <div id='panes'>
     <div id='left-pane'>
-      <div class='tab-pane' id='code_pane'>
+      <div class='tab-pane flex-pane' id='code_pane'>
         <ul>
           <li><a href='#code_holder'><%= t('marker.source_code') %></a></li>
           <li><a href='#annotations_summary'><%= t('marker.annot_summary') %></a></li>
@@ -16,7 +16,7 @@
           <% end %>
         </ul>
 
-        <div id='code_holder'>
+        <div id='code_holder' class='flex-col'>
           <%# For image/PDF annotations %>
           <div id='sel_box'></div>
 
@@ -27,10 +27,10 @@
                                  can_download: true } %>
           </div>
 
-          <div id='codeviewer'></div>
+          <div id='codeviewer' class='flex-col'></div>
         </div>
 
-        <div id='annotations_summary'>
+        <div id='annotations_summary' class='flex-col'>
           <div id='annotations_summary_head'>
             <h3><%= t('marker.overall_comments') %></h3>
 
@@ -107,13 +107,13 @@
     <div id='drag'></div>
 
     <div id='right-pane'>
-      <div class='tab-pane' id='mark_pane'>
+      <div class='tab-pane flex-pane' id='mark_pane'>
         <ul>
           <li><a href='#mark_viewer'><%= t('marker.marks.marks') %></a></li>
           <li><a href='#summary_viewer'><%= t('marker.marks.summary') %></a></li>
         </ul>
 
-        <div id='mark_viewer'>
+        <div id='mark_viewer' class='flex-col'>
           <div id='mark_criteria_pane'>
             <ul id='mark_criteria_pane_list'>
               <%# Also need to render the mark per criteria (if exist) %>
@@ -128,7 +128,7 @@
           </div>
         </div>
 
-        <div id='summary_viewer' class='marks_summary_pane tabbedArea'>
+        <div id='summary_viewer' class='marks_summary_pane tabbedArea flex-col'>
           <%= render partial: 'results/student/student_summary',
                      locals: { mark_criteria: @mark_criteria,
                                marks_map: marks_map,


### PR DESCRIPTION
## Ready for Review

The changes in this pull request add UI features and improvements. The layout for the results page (grader/student, released/unreleased), now take advantage of flex boxes with the goal of having a clean UI that utilizes most of the available browser space efficiently. More notably, a "compact view" feature has been added to the results edit page so that graders may have even more browser space while annotating and assignment marks.

### Additions and Modifications:
- Content panes now take advantage of flex boxes - (no more fixed heights or uneven panes)
- Pane adjustment bar (draggable bar) improved (less buggy, works with flex boxes, no more fixed height assumptions)
- Goal of the modifications were to extend the existing css/markup, with little modification to the existing
- Ensured other views, that utilize the affected files in this PR, were unaffected 
- Tested on Chrome (need to test on Safari)

### Screenshots

#### New results page (normal mode):
- Notice: Toggle compact view button, smaller margins, flush draggable bar, even panes, cleaner feel
![normal_view](https://cloud.githubusercontent.com/assets/7610411/25058025/76245914-2143-11e7-997f-30a4f6d4c362.PNG)

#### New results page (compact mode):
- Notice: Toggle normal view button, main menu hidden, footer hidden, minimal margins, effective use of space, no html body scroll bar on any resolutions.
![compact](https://cloud.githubusercontent.com/assets/7610411/25058068/d2a0164c-2143-11e7-9892-447129962945.PNG)


