### PR TITLE
Feature Update: Updates for Markers' Compact View

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -195,6 +195,14 @@ $(document).ready(function() {
       mark_elem.addClass('remarked');
     }
   });
+
+  $('.error, .notice, .warning').append(
+    $('<a />', {
+      text: 'hide',
+      style: 'float: right;',
+      onclick: '$(this).parent().hide()'
+    })
+  );
 });
 
 function expand_unmarked(elem, criterion_class) {

--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -1,4 +1,10 @@
 $(document).ready(function() {
+  // Maintain compact view if toggled on
+  if (typeof(Storage) !== 'undefined' &&
+    localStorage.getItem('compact_view') === 'on') {
+    compact_view_toggle(true);
+  }
+
   // Changing the marking status
   $('#marking_state').change(function() {
     update_status(this, this.value)
@@ -8,7 +14,7 @@ $(document).ready(function() {
     var params = {
       'value': value || '',
       'authenticity_token': AUTH_TOKEN
-    }
+    };
 
     $.ajax({
       url:  element.getAttribute('data-action'),
@@ -22,7 +28,7 @@ $(document).ready(function() {
     var params = {
       'value': this.checked || '',
       'authenticity_token': AUTH_TOKEN
-    }
+    };
 
     $.ajax({
       url:  this.getAttribute('data-action'),
@@ -136,7 +142,7 @@ $(document).ready(function() {
       // Put caret in correct position
       this.selectionStart = this.selectionEnd = start + 2;
     }
-  })
+  });
 
   // Handle the expand/collapse buttons
   $('#expand_all').click(function() {
@@ -322,7 +328,7 @@ function update_total_mark(total_mark) {
   document.getElementById('current_total_mark_div').innerHTML = total_mark;
 }
 
-function compact_view_toggle() {
+function compact_view_toggle(init) {
   var toggle_elements = [
     $('#menus'),
     $('.top_bar'),
@@ -333,5 +339,12 @@ function compact_view_toggle() {
     element.toggle();
   });
   $('#content').toggleClass('expanded_view');
-  fix_panes();
+  if (!init) {
+    if (typeof(Storage) !== 'undefined') {
+      var compact_view = localStorage.getItem('compact_view');
+      if (compact_view) localStorage.removeItem('compact_view');
+      else localStorage.setItem('compact_view', 'on');
+    }
+    fix_panes();
+  }
 }

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -217,6 +217,10 @@
 }
 
 .dp-highlighter {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
   .annotation_highlighted_text {
     background-color: #f99;
     color: $dark-grey;
@@ -228,7 +232,7 @@
   }
 
   ol {
-    overflow-y: hidden;
+    flex-grow: 1;
   }
 }
 

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -69,9 +69,9 @@
   flex-grow: 5;
 }
 
-.download_text {
+.header_text_links {
   display: flex;
-  flex-grow: 1;
+  margin-left: 20px;
 }
 
 #content {

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -46,8 +46,10 @@
               { assignment_name: @assignment.short_identifier,
                 group_name: @current_user.student? ? t('assignment.review') : @grouping.get_group_name }) %>
         </h3>
-        <div class='download_text flex_vertical_center'>
-          <a onclick="compact_view_toggle()" style="margin: 0px 15px">Normal View</a>
+        <div class='header_text_links flex_vertical_center'>
+          <a onclick='compact_view_toggle()'>Normal View</a>
+        </div>
+        <div class='header_text_links flex_vertical_center'>
           <% unless @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) %>
             <%= link_to t(:download),
                         'javascript:void(0);',


### PR DESCRIPTION
## Ready for Review

This pull request contains changes that update the previously implemented "Compact View" mode for markers edit view. In summary, these changes include view mode consistency while switching submissions, scrolling issue fixes, adding the ability to "hide" notifications, and minor styling update for button positions.

### Additions and Modifications
- The current active view mode (Normal View/Compact View) is now remembered when switching between submission (this uses a js localStorage variable).
- Unexpected scrollbar positioning behaviour has now been fixed (scrollbars are located at the far end of the panes (right side for vertical and bottom of pane for horizontal scroll).
- Errors/Notificaitons/Warnings (identified by having the corresponding class in a \<p\> tag), now have "hide" link buttons on the element.
- The original positioning of the "Normal View" and "Download" buttons were stacked on top of each other. This has been changed to a side-by-side positioning for a cleaner look.

### Screenshots


#### View mode consistency uses localStorage (see compact_view variable):
![local_storage_compact_view](https://cloud.githubusercontent.com/assets/7610411/25605029/1894cf36-2ed6-11e7-9242-7ad8666e5eb5.PNG)


#### Scrollbar issues highlighted:
- Notice: The scrollbar hugs the only line of text rather than hugging the bottom of the pane:
![scroll_issue_1](https://cloud.githubusercontent.com/assets/7610411/25604966/a65ed45c-2ed5-11e7-86e7-fd82aa43a662.PNG)
- Notice: The horizontal scrollbar is not present because you have to scroll all the way down vertically first:
![scroll_issue_2](https://cloud.githubusercontent.com/assets/7610411/25604970/ae7b54ee-2ed5-11e7-9cd7-e8bc30d951a6.PNG)


#### Scrollbar issue fix result:
- Notice: Scrollbar positions are now intuitively where they belong:
![scroll_issue_sol](https://cloud.githubusercontent.com/assets/7610411/25604991/d7cad8d8-2ed5-11e7-8726-0e262fdb56dc.PNG)


#### New button position for switching back to normal view and hide button for notification:
- Notice: The changes can be seen near the top right part of the image:
![new_button_positions_and_hide_notif](https://cloud.githubusercontent.com/assets/7610411/25605058/3da6bfdc-2ed6-11e7-8a86-c5dec5e89bd8.PNG)







