### PR TITLE
Check if row array is all nil to skip line

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -373,7 +373,7 @@ class GradeEntryFormsController < ApplicationController
 
       # Parse the grades
       result = MarkusCSV.parse(grades_file.read, encoding: encoding) do |row|
-        next if CSV.generate_line(row).strip.empty?
+        next if !row.any?
         # grab names and totals from the first two rows
         if names.empty?
           names = row

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -373,7 +373,7 @@ class GradeEntryFormsController < ApplicationController
 
       # Parse the grades
       result = MarkusCSV.parse(grades_file.read, encoding: encoding) do |row|
-        next if !row.any?
+        next unless row.any?
         # grab names and totals from the first two rows
         if names.empty?
           names = row


### PR DESCRIPTION
Example of a csv with blank lines that caused an error
,Q1,Q2,Q3
,3,4,5
c8godows,2,2,2
,,,
",",,,

`CSV.generate_line(row).strip.empty?` was false for a blank line (therefore it didnt get skipped) since ",,," isnt empty so instead I checked the row array for a blank line instead.

