### PR TITLE
fixed result_spec according to callback function we added

### DIFF
--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -199,15 +199,17 @@ describe Result do
                   context 'when marks are created for this incomplete result' do
                     let!(:incomp_result) { results[2] }
                     let!(:prev_subtotal) { incomp_result.get_subtotal }
-                    let!(:flex_criteria_first) { create(:flexible_criterion, assignment: assignment) }
-                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment) }
+                    let!(:flex_criteria_first) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: 3) }
+                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: 10) }
                     before do
-                      create(:flexible_mark, result: incomp_result, mark: 1, markable: flex_criteria_first)
-                      create(:flexible_mark, result: incomp_result, mark: 2, markable: flex_criteria_second)
+                      mark_1 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
+                      mark_2 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
+                      mark_1.update_attributes(markable: flex_criteria_first)
+                      mark_2.update_attributes(markable: flex_criteria_second)
                     end
 
                     it 'gets a subtotal' do
-                      expect(incomp_result.get_subtotal).to eq(prev_subtotal + 3)
+                      expect(incomp_result.get_subtotal).to eq(prev_subtotal)
                     end
 
                     it 'considers the result valid' do

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -204,8 +204,8 @@ describe Result do
                     before do
                       mark_1 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
                       mark_2 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
-                      mark_1.update_attributes(markable: flex_criteria_first)
-                      mark_2.update_attributes(markable: flex_criteria_second)
+                      mark_1.update_attributes(markable: flex_criteria_first, mark: 1)
+                      mark_2.update_attributes(markable: flex_criteria_second, mark: 2)
                     end
 
                     it 'gets a subtotal' do

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -199,17 +199,18 @@ describe Result do
                   context 'when marks are created for this incomplete result' do
                     let!(:incomp_result) { results[2] }
                     let!(:prev_subtotal) { incomp_result.get_subtotal }
-                    let!(:flex_criteria_first) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: 3) }
-                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: 10) }
+                    let!(:flex_criteria_first) { create(:flexible_criterion, assignment: assignment, id: incomp_result.id) }
+                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: incomp_result.id + 1) }
                     before do
-                      mark_1 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
-                      mark_2 = create(:flexible_mark, result_id: incomp_result.id, result: incomp_result)
+                      #byebug
+                      mark_1 = create(:flexible_mark, result: incomp_result)
+                      mark_2 = create(:flexible_mark, result: incomp_result)
                       mark_1.update_attributes(markable: flex_criteria_first, mark: 1)
                       mark_2.update_attributes(markable: flex_criteria_second, mark: 2)
                     end
 
                     it 'gets a subtotal' do
-                      expect(incomp_result.get_subtotal).to eq(prev_subtotal)
+                      expect(incomp_result.get_subtotal).to eq(prev_subtotal + 3)
                     end
 
                     it 'considers the result valid' do

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -199,14 +199,37 @@ describe Result do
                   context 'when marks are created for this incomplete result' do
                     let!(:incomp_result) { results[2] }
                     let!(:prev_subtotal) { incomp_result.get_subtotal }
-                    let!(:flex_criteria_first) { create(:flexible_criterion, assignment: assignment, id: incomp_result.id) }
-                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment, id: incomp_result.id + 1) }
+                    let!(:flex_criteria_first) { create(:flexible_criterion, assignment: assignment) }
+                    let!(:flex_criteria_second) { create(:flexible_criterion, max_mark: 2.0, assignment: assignment) }
+
+                    # When we create flex_criteria_first and flex_criteria_second, it goes through callback function
+                    # called replace_marks, which creates marks or deletes marks depending on whether criterion is
+                    # peer_visible or ta_visible. We have to undo the process.
                     before do
-                      #byebug
-                      mark_1 = create(:flexible_mark, result: incomp_result)
-                      mark_2 = create(:flexible_mark, result: incomp_result)
-                      mark_1.update_attributes(markable: flex_criteria_first, mark: 1)
-                      mark_2.update_attributes(markable: flex_criteria_second, mark: 2)
+                      results = Result.joins(submission: :grouping)
+                                  .where(groupings: {assignment_id: flex_criteria_first.assignment_id})
+                      results.each do |r|
+                        unless r.is_a_review? # filter results that are not peer reviews
+                          flex_criteria_first.marks.where(result_id: r.id).destroy_all # create mark object for TA review result
+                          r.update_total_mark
+                        else
+                          flex_criteria_first.marks.create(result_id: r.id) # create mark object for peer review result
+                          r.update_total_mark
+                        end
+                      end
+                      results = Result.joins(submission: :grouping)
+                                  .where(groupings: {assignment_id: flex_criteria_second.assignment_id})
+                      results.each do |r|
+                        unless r.is_a_review? # filter results that are not peer reviews
+                          flex_criteria_second.marks.where(result_id: r.id).destroy_all # create mark object for TA review result
+                          r.update_total_mark
+                        else
+                          flex_criteria_second.marks.create(result_id: r.id) # create mark object for peer review result
+                          r.update_total_mark
+                        end
+                      end
+                      flex_criteria_first.marks.create!(result: incomp_result, mark: 1)
+                      flex_criteria_second.marks.create!(result: incomp_result, mark: 2)
                     end
 
                     it 'gets a subtotal' do


### PR DESCRIPTION
result_spec was having few error cases because of the callback function 'replace_marks' added to criterion model. It should be tested with callback function added in criterion.rb