### PR TITLE
fixed flash message showing in brackets and string notation

### DIFF
--- a/app/views/automated_tests/_form.html.erb
+++ b/app/views/automated_tests/_form.html.erb
@@ -17,15 +17,8 @@
 <% end %>
 
 <div class="wrapLeft">
-<% if flash[:success] %>
-  <div class="success">
-    <span><%=flash[:success]%></span>
-  </div>
-  <% elsif flash[:error] %>
-  <div class="error">
-    <span><%=flash[:error]%></span>
-  </div>
-<% end %>
+  <%= render partial: 'shared/flash_message' %>
+</div>
 
 <%= form_for @assignment,
              as: :assignment,


### PR DESCRIPTION
<img width="1265" alt="screen shot 2017-05-17 at 3 52 02 pm" src="https://cloud.githubusercontent.com/assets/14116152/26173966/b7136aea-3b1b-11e7-86d1-0cadb638eec2.png">
<img width="1272" alt="screen shot 2017-05-17 at 4 10 13 pm" src="https://cloud.githubusercontent.com/assets/14116152/26173967/b8ed3c2e-3b1b-11e7-8c45-39ed4b9d28f9.png">


