### PR TITLE
Fixed download method for exam template controller

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -13,8 +13,12 @@ class ExamTemplatesController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find_by(id: params[:id]) # look up a specific exam template based on the params[:id]
     filename = exam_template.filename
-    basename = File.basename(filename, ".pdf")
-    send_file("#{EXAM_TEMPLATE_DIR}/#{basename}/#{filename}",
+    assignment_name = assignment.short_identifier
+    template_path = File.join(
+      EXAM_TEMPLATE_DIR,
+      assignment_name
+    )
+    send_file("#{template_path}/#{filename}",
               filename: "#{filename}",
               type: "application/pdf")
   end

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -14,11 +14,7 @@ class ExamTemplatesController < ApplicationController
     exam_template = assignment.exam_templates.find_by(id: params[:id]) # look up a specific exam template based on the params[:id]
     filename = exam_template.filename
     assignment_name = assignment.short_identifier
-    template_path = File.join(
-      EXAM_TEMPLATE_DIR,
-      assignment_name
-    )
-    send_file("#{template_path}/#{filename}",
+    send_file("#{EXAM_TEMPLATE_DIR}/#{assignment_name}/#{filename}",
               filename: "#{filename}",
               type: "application/pdf")
   end


### PR DESCRIPTION
It worked for only midterm1.pdf ( the file that got seeded ). Now it should work for other exam templates that are created under the assignment