### PR TITLE
exam template db migration: add name field

### DIFF
--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -7,7 +7,8 @@ require 'rmagick'
 
 class ExamTemplate < ActiveRecord::Base
   belongs_to :assignment
-  validates :assignment, :filename, :num_pages, presence: true
+  validates :assignment, :filename, :num_pages, :name, presence: true
+  validates :name, uniqueness: true
   validates :num_pages, numericality: { greater_than_or_equal_to: 0,
                                         only_integer: true }
 

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -6,6 +6,8 @@ require 'zxing'
 require 'rmagick'
 
 class ExamTemplate < ActiveRecord::Base
+  after_initialize :set_defaults, unless: :persisted? # The set_defaults will only work if the object is new
+
   belongs_to :assignment
   validates :assignment, :filename, :num_pages, :name, presence: true
   validates :name, uniqueness: true
@@ -199,5 +201,12 @@ class ExamTemplate < ActiveRecord::Base
 
   def group_name_for(exam_num)
     "#{assignment.short_identifier}_paper_#{exam_num}"
+  end
+
+  def set_defaults
+    # Attribute 'name' of exam template is by default set to filename without extension
+    extension = File.extname self.filename
+    basename = File.basename self.filename, extension
+    self.name ||= basename
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define(version: 20170219132130) do
   create_table "exam_templates", force: :cascade do |t|
     t.integer  "assignment_id"
     t.string   "filename",      null: false
+    t.string   "name",          null: false
     t.integer  "num_pages",     null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false


### PR DESCRIPTION
by default, name is set to the filename without file extension.