### PR TITLE
Students can no longer auto-generate groups on exams

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -102,7 +102,7 @@ class AssignmentsController < ApplicationController
       @pending_grouping = @student.pending_groupings_for(@assignment.id)
     end
     if @grouping.nil?
-      if @assignment.group_max == 1
+      if @assignment.group_max == 1 && !@assignment.scanned_exam
         begin
           # fix for issue #627
           # currently create_group_for_working_alone_student only returns false
@@ -118,6 +118,9 @@ class AssignmentsController < ApplicationController
         end
         redirect_to action: 'student_interface', id: @assignment.id
       else
+        if @assignment.scanned_exam
+          flash_now(:notice, t('assignments.scanned_exam.under_review'))
+        end
         render :student_interface
       end
     else

--- a/config/locales/views/assignments/en.yml
+++ b/config/locales/views/assignments/en.yml
@@ -2,3 +2,5 @@ en:
   assignments:
     due_date:
       final_due_date_passed: "The deadline, including late or grace periods, has passed."
+    scanned_exam:
+      under_review: "This exam is still under review"

--- a/config/locales/views/assignments/es.yml
+++ b/config/locales/views/assignments/es.yml
@@ -2,3 +2,5 @@ es:
   assignments:
     due_date:
       final_due_date_passed: "El plazo de aplazamiento de gracia para este proyecto ha pasado"
+    scanned_exam:
+      under_review: "Este examen todavía está en revisión"

--- a/config/locales/views/assignments/fr.yml
+++ b/config/locales/views/assignments/fr.yml
@@ -2,3 +2,5 @@ fr:
   assignments:
     due_date:
       final_due_date_passed: "La période de grâce pour ce projet est terminée"
+    scanned_exam:
+      under_review: "Cet examen est marqué"

--- a/config/locales/views/assignments/pt.yml
+++ b/config/locales/views/assignments/pt.yml
@@ -2,3 +2,5 @@ pt:
   assignments:
     due_date:
       final_due_date_passed: "O período de tolerância para este projeto já passou"
+    scanned_exam:
+      under_review: "Este exame está sendo marcado"


### PR DESCRIPTION
An automated flash message will tell them that the exam is still under review.