### PR TITLE
db migration: adding name field to exam_template & enabling instructors to change name

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -72,10 +72,7 @@ class ExamTemplatesController < ApplicationController
   def exam_template_params
     params.require(:exam_template)
        .permit(
-         :assignment,
-         :id,
-         :filename,
-         :num_pages,
+         :name,
          template_divisions_attributes: [:id, :start, :end, :label, :_destroy]
        )
   end

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -7,7 +7,8 @@ require 'rmagick'
 
 class ExamTemplate < ActiveRecord::Base
   belongs_to :assignment
-  validates :assignment, :filename, :num_pages, presence: true
+  validates :assignment, :filename, :num_pages, :name, presence: true
+  validates :name, uniqueness: true
   validates :num_pages, numericality: { greater_than_or_equal_to: 0,
                                         only_integer: true }
 

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -6,6 +6,7 @@ require 'zxing'
 require 'rmagick'
 
 class ExamTemplate < ActiveRecord::Base
+  after_initialize :set_defaults_for_name, unless: :persisted? # will only work if the object is new
   belongs_to :assignment
   validates :assignment, :filename, :num_pages, :name, presence: true
   validates :name, uniqueness: true
@@ -224,5 +225,12 @@ class ExamTemplate < ActiveRecord::Base
 
   def group_name_for(exam_num)
     "#{assignment.short_identifier}_paper_#{exam_num}"
+  end
+
+  def set_defaults_for_name
+    # Attribute 'name' of exam template is by default set to filename without extension
+    extension = File.extname self.filename
+    basename = File.basename self.filename, extension
+    self.name ||= basename
   end
 end

--- a/app/views/exam_templates/_form.html.erb
+++ b/app/views/exam_templates/_form.html.erb
@@ -5,6 +5,7 @@
       <h4>
         <%= link_to t('exam_templates.download'), download_assignment_exam_template_path(id: exam_template.id) %>
       </h4>
+      <h4><%= ExamTemplate.human_attribute_name('name') %>: <%= exam_template.name %></h4>
       <h4><%= ExamTemplate.human_attribute_name('num_pages') %>: <%= exam_template.num_pages %></h4>
       <h4><%= ExamTemplate.human_attribute_name('filename') %>: <%= exam_template.filename %></h4>
     </div>

--- a/app/views/exam_templates/_form.html.erb
+++ b/app/views/exam_templates/_form.html.erb
@@ -14,7 +14,7 @@
       <legend><%= t('exam_templates.update.general') %></legend>
       <p><%= raw t('assignment.required_fields') %> <span class='required_field'>*</span></p>
       <p>
-        <%= f.label 'Exam Template Name' %>
+        <%= f.label ExamTemplate.human_attribute_name('name') %>
         <%= f.text_field :name %>
       </p>
       <%= f.label t('exam_templates.update.instruction') %>

--- a/app/views/exam_templates/_form.html.erb
+++ b/app/views/exam_templates/_form.html.erb
@@ -13,6 +13,10 @@
     <fieldset>
       <legend><%= t('exam_templates.update.general') %></legend>
       <p><%= raw t('assignment.required_fields') %> <span class='required_field'>*</span></p>
+      <p>
+        <%= f.label 'Exam Template Name' %>
+        <%= f.text_field :name %>
+      </p>
       <%= f.label t('exam_templates.update.instruction') %>
       <%= f.file_field :new_template %>
     </fieldset>

--- a/config/locales/models/exam_templates/en.yml
+++ b/config/locales/models/exam_templates/en.yml
@@ -8,3 +8,4 @@ en:
         filename: "Name of file"
         num_pages: "Number of pages"
         template_divisions: "Template Divisions"
+        name: "Name"

--- a/config/locales/models/exam_templates/es.yml
+++ b/config/locales/models/exam_templates/es.yml
@@ -8,3 +8,4 @@ es:
         filename: "Nombre del archivo"
         num_pages: "número de páginas"
         template_divisions: "Divisiones de plantillas"
+        name: "nombre"

--- a/config/locales/models/exam_templates/fr.yml
+++ b/config/locales/models/exam_templates/fr.yml
@@ -8,3 +8,4 @@ fr:
         filename: "Nom du fichier"
         num_pages: "Nombre de pages"
         template_divisions: "Divisions de modèles"
+        name: "prénom"

--- a/config/locales/models/exam_templates/pt.yml
+++ b/config/locales/models/exam_templates/pt.yml
@@ -8,3 +8,4 @@ pt:
         filename: "Nome do arquivo"
         num_pages: "número de páginas"
         template_divisions: "Divisões de modelos"
+        name: "nome"

--- a/db/migrate/20170605141017_add_name_to_exam_templates.rb
+++ b/db/migrate/20170605141017_add_name_to_exam_templates.rb
@@ -1,0 +1,5 @@
+class AddNameToExamTemplates < ActiveRecord::Migration
+  def change
+    add_column :exam_templates, :name, :string, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170219132130) do
+ActiveRecord::Schema.define(version: 20170605141017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 20170219132130) do
     t.integer  "num_pages",     null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.string   "name",          null: false
   end
 
   add_index "exam_templates", ["assignment_id"], name: "index_exam_templates_on_assignment_id", using: :btree
@@ -528,10 +529,10 @@ ActiveRecord::Schema.define(version: 20170219132130) do
     t.integer  "grouping_id"
     t.integer  "test_script_id"
     t.integer  "marks_earned"
+    t.integer  "repo_revision"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "submission_id"
-    t.integer  "repo_revision"
     t.integer  "requested_by_id"
   end
 


### PR DESCRIPTION
by default, name is set to the filename without file extension. We enable instructors to change name.