### PR TITLE
adding optional name field in ajax form for creating exam template 

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -17,12 +17,15 @@ class ExamTemplatesController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     new_uploaded_io = params[:create_template][:file_io]
     name_input = params[:create_template][:name]
-    filename = name_input.nil ? new_uploaded_io.original_filename : name_input
+    filename = new_uploaded_io.original_filename
     # error checking when new_uploaded_io is not pdf, nil, or when filename is not given
     if filename.nil? || new_uploaded_io.nil? || new_uploaded_io.content_type != 'application/pdf'
       flash_message(:error, t('exam_templates.create.failure'))
     else
-      new_template = ExamTemplate.new_with_file(new_uploaded_io.read, assignment_id: assignment.id, filename: filename)
+      new_template = ExamTemplate.new_with_file(new_uploaded_io.read,
+                                                assignment_id: assignment.id,
+                                                filename: filename,
+                                                name_input: name_input)
       # sending flash message if saved
       if new_template.save
         flash_message(:success, t('exam_templates.create.success'))

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -16,7 +16,8 @@ class ExamTemplatesController < ApplicationController
   def create
     assignment = Assignment.find(params[:assignment_id])
     new_uploaded_io = params[:create_template][:file_io]
-    filename = new_uploaded_io.original_filename
+    name_input = params[:create_template][:name]
+    filename = name_input.nil ? new_uploaded_io.original_filename : name_input
     # error checking when new_uploaded_io is not pdf, nil, or when filename is not given
     if filename.nil? || new_uploaded_io.nil? || new_uploaded_io.content_type != 'application/pdf'
       flash_message(:error, t('exam_templates.create.failure'))

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -42,6 +42,7 @@ class ExamTemplate < ActiveRecord::Base
     assignment = Assignment.find(attributes[:assignment_id])
     assignment_name = assignment.short_identifier
     filename = attributes[:filename]
+    name_input = attributes[:name_input]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name
@@ -52,11 +53,20 @@ class ExamTemplate < ActiveRecord::Base
     end
     pdf = CombinePDF.parse blob
     num_pages = pdf.pages.length
-    new_template = ExamTemplate.new(
-      filename: filename,
-      num_pages: num_pages,
-      assignment: assignment
-    )
+    unless name_input == ''
+      new_template = ExamTemplate.new(
+        name: name_input,
+        filename: filename,
+        num_pages: num_pages,
+        assignment: assignment
+      )
+    else
+      new_template = ExamTemplate.new(
+        filename: filename,
+        num_pages: num_pages,
+        assignment: assignment
+      )
+    end
     return new_template
   end
 

--- a/app/views/exam_templates/_create_new_template.html.erb
+++ b/app/views/exam_templates/_create_new_template.html.erb
@@ -5,6 +5,10 @@
                url: assignment_exam_templates_path(@assignment),
                html: { multipart: true, size: 1 } do |f| %>
     <div>
+      <p class="alignleft"><%= f.label ExamTemplate.human_attribute_name('name') + ' (optional)' %></p>
+      <p class="clear-alignment">
+        <%= f.text_field :name %>
+      </p>
       <p class="alignleft"><%= t('exam_templates.create.upload') %> <span class='required_field'>*</span></p>
       <p class="clear-alignment">
         <%= f.file_field :file_io %>

--- a/app/views/exam_templates/_create_new_template.html.erb
+++ b/app/views/exam_templates/_create_new_template.html.erb
@@ -5,7 +5,7 @@
                url: assignment_exam_templates_path(@assignment),
                html: { multipart: true, size: 1 } do |f| %>
     <div>
-      <p class="alignleft"><%= f.label ExamTemplate.human_attribute_name('name') + ' (optional)' %></p>
+      <p class="alignleft"><%= f.label ExamTemplate.human_attribute_name('name') + ' (' + t(:optional) + ')' %></p>
       <p class="clear-alignment">
         <%= f.text_field :name %>
       </p>

--- a/config/locales/defaults/form/en.yml
+++ b/config/locales/defaults/form/en.yml
@@ -1,0 +1,2 @@
+en:
+  optional: "Optional"

--- a/config/locales/defaults/form/es.yml
+++ b/config/locales/defaults/form/es.yml
@@ -1,0 +1,2 @@
+es:
+  optional: "Opcional"

--- a/config/locales/defaults/form/fr.yml
+++ b/config/locales/defaults/form/fr.yml
@@ -1,0 +1,2 @@
+fr:
+  optional: "optionnel"

--- a/config/locales/defaults/form/pt.yml
+++ b/config/locales/defaults/form/pt.yml
@@ -1,0 +1,2 @@
+pt:
+  optional: "opcional"


### PR DESCRIPTION
It will be set to filename without extension by default. But we also allow instructor to specify the name of exam template by adding name field.