### PR TITLE
Added min-width on progress bar with support for up to 4 digit numbers

### DIFF
--- a/app/assets/stylesheets/common/_progress_bar.scss
+++ b/app/assets/stylesheets/common/_progress_bar.scss
@@ -13,6 +13,7 @@
 }
 
 .progress_meter > span {
+  min-width: 50px;
   display: block;
   height: 100%;
   background-color: $red;
@@ -28,5 +29,5 @@
   -ms-transition: width 1s linear,background-color 200ms linear;
   transition: width 1s linear,background-color 200ms linear;
   margin: 0;
-  padding: 0 10px;
+  padding: 0 5px;
 }


### PR DESCRIPTION
The min width may seem excessive for 5 entries, but in cases of over 100 submissions it would look more normal. 

The other way to approach this is to have the javascript dynamically set it based on the number of entries, but that would hinder performance a bit more.