### PR TITLE
Allow template divisions with same 'label' under different exam template & different assignments

### DIFF
--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -9,7 +9,9 @@ class TemplateDivision < ActiveRecord::Base
                                     only_integer: true }
   validates :end, numericality: { only_integer: true }
   validate :end_should_be_less_than_or_equal_to_num_pages
-  validates :label, uniqueness: true, allow_blank: false
+  validates_uniqueness_of :label,
+                          scope: [:exam_template],
+                          allow_blank: false
 
   after_destroy :destroy_associated_objects
 

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -10,7 +10,7 @@ class TemplateDivision < ActiveRecord::Base
   validates :end, numericality: { only_integer: true }
   validate :end_should_be_less_than_or_equal_to_num_pages
   validates_uniqueness_of :label,
-                          scope: [:exam_template],
+                          scope: :exam_template,
                           allow_blank: false
 
   after_destroy :destroy_associated_objects


### PR DESCRIPTION
Template divisions under different templates / under different assignments wouldn't get saved when they have same label. It was a problem that I have encountered while testing #3046. 