### PR TITLE
setting default associated criteria_assignment_files_join when emplate division is created or updated

### DIFF
--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -31,7 +31,6 @@ class TemplateDivision < ActiveRecord::Base
     criterion.destroy
   end
 
-
   def set_defaults_for_associated_criteria_assignment_files_join
     if criteria_assignment_files_join.nil?
       assignment_file = AssignmentFile.find_or_initialize_by(
@@ -45,7 +44,7 @@ class TemplateDivision < ActiveRecord::Base
       if criterion.new_record?
         criterion.update(max_mark: 1.0)
       end
-      criteria_assignment_files_join_object = CriteriaAssignmentFilesJoin.create(
+      criteria_assignment_files_join_object = CriteriaAssignmentFilesJoin.new(
         assignment_file: assignment_file,
         criterion: criterion
       )

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -11,7 +11,7 @@ class TemplateDivision < ActiveRecord::Base
   validate :end_should_be_less_than_or_equal_to_num_pages
   validates :label, uniqueness: true, allow_blank: false
 
-  after_save :set_defaults_for_associated_criteria_assignment_files_join # when template division is create or updated
+  after_save :set_defaults_for_associated_criteria_assignment_files_join # when template division is created or updated
 
   def hash
     [self.start, self.end, self.label].hash
@@ -34,7 +34,7 @@ class TemplateDivision < ActiveRecord::Base
       if criterion.new_record?
         criterion.update(max_mark: 1.0)
       end
-      criteria_assignment_files_join_object = CriteriaAssignmentFilesJoin.new(
+      criteria_assignment_files_join_object = CriteriaAssignmentFilesJoin.create(
         assignment_file: assignment_file,
         criterion: criterion
       )

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -34,15 +34,17 @@ class TemplateDivision < ActiveRecord::Base
 
   def set_defaults_for_associated_criteria_assignment_files_join
     if criteria_assignment_files_join.nil?
-      assignment_file = AssignmentFile.create(
+      assignment_file = AssignmentFile.find_or_initialize_by(
         filename: "#{exam_template.name}-#{label}.pdf",
         assignment_id: exam_template.assignment.id
       )
-      criterion = FlexibleCriterion.create(
-        max_mark: 1.0,
-        name: "#{exam_template.name}-#{label}",
+      criterion = FlexibleCriterion.find_or_initialize_by(
+        name: "#{label}",
         assignment_id: exam_template.assignment.id
       )
+      if criterion.new_record?
+        criterion.update(max_mark: 1.0)
+      end
       criteria_assignment_files_join_object = CriteriaAssignmentFilesJoin.create(
         assignment_file: assignment_file,
         criterion: criterion
@@ -50,11 +52,8 @@ class TemplateDivision < ActiveRecord::Base
       self.update(criteria_assignment_files_join: criteria_assignment_files_join_object)
     else
       criteria_assignment_files_join.assignment_file.filename = "#{exam_template.name}-#{label}.pdf"
-      criteria_assignment_files_join.assignment_file.assignment_id = exam_template.assignment.id
       criteria_assignment_files_join.criterion.name = "#{exam_template.name}-#{label}"
-      criteria_assignment_files_join.criterion.assignment_id = exam_template.assignment.id
       criteria_assignment_files_join.save!
     end
   end
-
 end

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -39,7 +39,7 @@ class TemplateDivision < ActiveRecord::Base
         assignment_id: exam_template.assignment.id
       )
       criterion = FlexibleCriterion.find_or_initialize_by(
-        name: "#{label}",
+        name: label,
         assignment_id: exam_template.assignment.id
       )
       if criterion.new_record?
@@ -52,7 +52,7 @@ class TemplateDivision < ActiveRecord::Base
       self.update(criteria_assignment_files_join: criteria_assignment_files_join_object)
     else
       criteria_assignment_files_join.assignment_file.filename = "#{exam_template.name}-#{label}.pdf"
-      criteria_assignment_files_join.criterion.name = "#{exam_template.name}-#{label}"
+      criteria_assignment_files_join.criterion.name = label
       criteria_assignment_files_join.save!
     end
   end

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -21,15 +21,6 @@ class TemplateDivision < ActiveRecord::Base
     errors.add(:end, "should be less than or equal to num_pages") unless self.end <= self.exam_template.num_pages
   end
 
-  private
-  def destroy_associated_objects
-    assignment_file = criteria_assignment_files_join.assignment_file
-    criterion = criteria_assignment_files_join.criterion
-    # Note: this destroys the join record as well.
-    assignment_file.destroy
-    criterion.destroy
-  end
-
   def set_defaults_for_associated_criteria_assignment_files_join
     if criteria_assignment_files_join.nil?
       assignment_file = AssignmentFile.find_or_initialize_by(

--- a/lib/tasks/scanned_exam.rake
+++ b/lib/tasks/scanned_exam.rake
@@ -33,10 +33,10 @@ namespace :db do
     file_dir  = File.join(File.dirname(__FILE__), '/../../db/data/scanned_exams')
     f = File.open(File.join(file_dir, 'midterm1.pdf'))
     template = ExamTemplate.create_with_file(f.read, assignment_id: a.id, filename: 'midterm1.pdf')
-    template.template_divisions.create_with_associations(a.id, label: 'Q1', start: 2, end: 2)
-    template.template_divisions.create_with_associations(a.id, label: 'Q2', start: 3, end: 3)
-    template.template_divisions.create_with_associations(a.id, label: 'Q3', start: 3, end: 3)
-    template.template_divisions.create_with_associations(a.id, label: 'Q4', start: 4, end: 5)
+    template.template_divisions.create(label: 'Q1', start: 2, end: 2)
+    template.template_divisions.create(label: 'Q2', start: 3, end: 3)
+    template.template_divisions.create(label: 'Q3', start: 3, end: 3)
+    template.template_divisions.create(label: 'Q4', start: 4, end: 5)
 
     template.generate_copies 5
     template_path  = File.join(File.dirname(__FILE__), '/../../db/data/scanned_exams/midterm1_scanned_sample.pdf')


### PR DESCRIPTION
Updating nested attribute 'criteria_assginement_files_join' is necessary whenever template division is created or updated. This fixes the problem I had in #3046 where removing template division caused error.