### PR TITLE
'name' attribute of exam template's uniqueness is now scoped to assignment

### DIFF
--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -9,7 +9,8 @@ class ExamTemplate < ActiveRecord::Base
   after_initialize :set_defaults_for_name, unless: :persisted? # will only work if the object is new
   belongs_to :assignment
   validates :assignment, :filename, :num_pages, :name, presence: true
-  validates :name, uniqueness: true
+  validates_uniqueness_of :name,
+                          scope: :assignment
   validates :num_pages, numericality: { greater_than_or_equal_to: 0,
                                         only_integer: true }
 


### PR DESCRIPTION
When I tried to add 'midterm1.pdf' as an exam template for two different assignments, it wouldn't allow it because of name validation. I modified it so that it would allow exam templates with identical names for different assignments.