### PR TITLE
Fix missing function in GitRevision

### DIFF
--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -773,6 +773,10 @@ module Repository
       end
     end
 
+    def changed_filenames_at_path(path)
+      []
+    end
+
     def last_modified_date()
       return self.timestamp
     end


### PR DESCRIPTION
Instead of removing the check, which could be relevant for a SvnRevision, I just added a function in GitRevision that always returns an empty array, making the check false.