### PR TITLE
Removed refresh_graph from grade spreadsheets

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -87,15 +87,6 @@ class GradeEntryFormsController < ApplicationController
     @date = params[:date]
   end
 
-  # Refreshes the grade distribution graph
-  def refresh_graph
-    @grade_entry_form = GradeEntryForm.find(params[:id])
-    @grade_entry_form.grade_distribution_array
-    respond_to do |format|
-      format.js
-    end
-  end
-
   # Update a grade in the table
   def update_grade
     grade_entry_form = GradeEntryForm.find(params[:id])

--- a/app/views/grade_entry_forms/_grade_entry_form_summary.html.erb
+++ b/app/views/grade_entry_forms/_grade_entry_form_summary.html.erb
@@ -18,11 +18,6 @@
 
       <div class='right'>
         <%= render partial: 'grade_entry_forms/grade_entry_form_info_summary', locals: { grade_entry_form: @grade_entry_form } %>
-        <p>
-          <%= link_to I18n.t(:refresh_graph),
-                      refresh_graph_grade_entry_form_path(id: @grade_entry_form.id),
-                      remote: true %>
-        </p>
       </div>
 
       <br>

--- a/app/views/grade_entry_forms/refresh_graph.js.erb
+++ b/app/views/grade_entry_forms/refresh_graph.js.erb
@@ -1,3 +1,0 @@
-$('#grade_entry_form_<%= @grade_entry_form.id %>_graph').html(
-    "<%= escape_javascript(render partial: 'grade_entry_forms/grade_distribution_graph',
-                                locals: { grade_entry_form: @grade_entry_form }) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,7 +293,6 @@ Markus::Application.routes.draw do
         get 'populate_grades_table'
         get 'get_mark_columns'
         get 'view_summary'
-        get 'refresh_graph'
         get 'grades'
         get 'csv_download'
         post 'csv_upload'


### PR DESCRIPTION
## Ready for Review
This pull request removes the refresh_graph link from grade spreadsheets.

### Additions and Modifications:
- Removed refresh_graph route from grade spreadsheets

### Screenshots:
**Removed refresh_graph route from grade spreadsheets**
![screen shot 2017-06-17 at 11 10 14 pm](https://user-images.githubusercontent.com/24910741/27254024-26d63034-53b2-11e7-918f-27cbe055fd29.png)
