### PR TITLE
fix template division bug: validation of filename under assignment_file model

### DIFF
--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -6,7 +6,7 @@ class AssignmentFile < ActiveRecord::Base
   validates_presence_of :filename
   validates_uniqueness_of :filename, scope: :assignment_id
   validates_format_of :filename,
-          with: /\A[0-9a-zA-Z\.\-_]+\z/,
+          with: /\A[0-9a-zA-Z\.\-_\(\)]+\z/,
           message: I18n.t('validation_messages.format_of_assignment_file')
 
 end

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -24,7 +24,7 @@ class TemplateDivision < ActiveRecord::Base
   end
 
   def set_defaults_for_associated_criteria_assignment_files_join
-    filename =  "#{exam_template.name}-#{label}.pdf".delete(' ')
+    filename =  "#{exam_template.name}-#{label}.pdf".tr(' ', '_')
     if criteria_assignment_files_join.nil?
       assignment_file = AssignmentFile.find_or_initialize_by(
         filename: filename,

--- a/app/models/template_division.rb
+++ b/app/models/template_division.rb
@@ -24,9 +24,10 @@ class TemplateDivision < ActiveRecord::Base
   end
 
   def set_defaults_for_associated_criteria_assignment_files_join
+    filename =  "#{exam_template.name}-#{label}.pdf".delete(' ')
     if criteria_assignment_files_join.nil?
       assignment_file = AssignmentFile.find_or_initialize_by(
-        filename: "#{exam_template.name}-#{label}.pdf",
+        filename: filename,
         assignment_id: exam_template.assignment.id
       )
       criterion = FlexibleCriterion.find_or_initialize_by(
@@ -42,7 +43,7 @@ class TemplateDivision < ActiveRecord::Base
       )
       self.update(criteria_assignment_files_join: criteria_assignment_files_join_object)
     else
-      criteria_assignment_files_join.assignment_file.filename = "#{exam_template.name}-#{label}.pdf"
+      criteria_assignment_files_join.assignment_file.filename = filename
       criteria_assignment_files_join.criterion.name = label
       criteria_assignment_files_join.save!
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "must be alphanumeric, '.', '-' or '_' only"
+      format_of_assignment_file: "must be alphanumeric, '.', '-', '(', ')', or '_' only"
 
     # app/views/main/index.html.erb
     switch_role:         "Switch Role"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -81,7 +81,7 @@ es:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "debe incluir sólo caracteres alfanuméricos, '.', '-' o '_'"
+      format_of_assignment_file: "debe incluir sólo caracteres alfanuméricos, '.', '-', '(', ')', o '_'"
 
     # app/views/main/index.html.erb
     switch_role:                   "Cambio de rol"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -74,7 +74,7 @@ fr:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "doit être un caractère alphanumérique, « . », « - » ou « _ » uniquement."
+      format_of_assignment_file: "doit être un caractère alphanumérique, « . », « - », « ( », « ) » ou « _ » uniquement."
 
     # app/views/main/index.html.erb
     switch_role:         "Changer d'utilisateur"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -74,7 +74,7 @@ pt:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "apenas letras, números, '.', '-' ou '_'"
+      format_of_assignment_file: "apenas letras, números, '.', '-', '(', ')', ou '_'"
 
     # app/views/main/index.html.erb
     switch_role:         "Trocar de papel"


### PR DESCRIPTION
I was testing on adding template division in exam template page, with an exam template named 'midterm1 (22).pdf'. I realized that while template division gets successfully created, when I try deleting it, it doesn't successfully delete nested model 'CriteriaAssignmentFilesJoin' as well. This was because with an exam template named 'midterm1 (22).pdf', it fails validation of filename under assignment_file model for 'CriteriaAssignmentFilesJoin' (It includes blank space and parentheses)