### PR TITLE
Make sure we don't delete assignment_file and criterion when we delete join table between them

### DIFF
--- a/app/models/criteria_assignment_files_join.rb
+++ b/app/models/criteria_assignment_files_join.rb
@@ -1,6 +1,6 @@
 class CriteriaAssignmentFilesJoin < ActiveRecord::Base
-  belongs_to :criterion, polymorphic: true, dependent: :destroy
-  belongs_to :assignment_file, dependent: :destroy
+  belongs_to :criterion, polymorphic: true
+  belongs_to :assignment_file
   accepts_nested_attributes_for :assignment_file, :criterion
 
   has_one :template_division


### PR DESCRIPTION
preventing stack level too deep error when we delete CriteriaAssignmentFileJoin object