### PR TITLE
Job class status

### DIFF
--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -11,7 +11,7 @@ class JobMessagesController < ApplicationController
   def get
     status = ActiveJob::Status.get(params[:job_id])
     if status.working?
-      flash_now(:success, "#{status[:progress]} out of #{status[:total]}")
+      flash_now(:success, t('poll_job.working_message', progress: status[:progress], total: status[:total]))
     else
       flash_now(:success, "#{status.status}")
       if status.completed?

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -13,7 +13,14 @@ class JobMessagesController < ApplicationController
     if status.working?
       flash_now(:success, t('poll_job.working_message', progress: status[:progress], total: status[:total]))
     else
-      flash_now(:success, "#{status.status}")
+      if status.queued?
+        status_msg = t('poll_job.queued')
+      elsif status.completed?
+        status_msg = t('poll_job.completed')
+      else
+        status_msg = t('poll_job.failed')
+      end
+      flash_now(:success, status_msg)
       if status.completed?
         session[:job_id] = nil
       end

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -4,13 +4,16 @@ class SplitPDFJob < ActiveJob::Base
   queue_as MarkusConfigurator.markus_job_split_pdf_queue_name
 
   def self.on_complete_js
-    "function() {window.location.reload.bind(window.location);}"
+    "window.location.reload.bind(window.location)"
+  end
+
+  before_enqueue do |job|
+    status.update(job_class: self.class)
   end
 
   def perform(exam_template, path, original_filename=nil, current_user=nil)
     m_logger = MarkusLogger.instance
     begin
-      status.update(job_class: self.class)
       # Create directory for files whose QR code couldn't be parsed
       error_dir = File.join(exam_template.base_path, 'error')
       raw_dir = File.join(exam_template.base_path, 'raw')

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -3,6 +3,10 @@ class SplitPDFJob < ActiveJob::Base
 
   queue_as MarkusConfigurator.markus_job_split_pdf_queue_name
 
+  def self.on_complete_js
+    puts "function() {window.location.reload.bind(window.location);}"
+  end
+
   def perform(exam_template, path, original_filename=nil, current_user=nil)
     m_logger = MarkusLogger.instance
     begin

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -4,7 +4,7 @@ class SplitPDFJob < ActiveJob::Base
   queue_as MarkusConfigurator.markus_job_split_pdf_queue_name
 
   def self.on_complete_js
-    puts "function() {window.location.reload.bind(window.location);}"
+    "function() {window.location.reload.bind(window.location);}"
   end
 
   def perform(exam_template, path, original_filename=nil, current_user=nil)

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -6,6 +6,7 @@ class SplitPDFJob < ActiveJob::Base
   def perform(exam_template, path, original_filename=nil, current_user=nil)
     m_logger = MarkusLogger.instance
     begin
+      status.update(job_class: self.class)
       # Create directory for files whose QR code couldn't be parsed
       error_dir = File.join(exam_template.base_path, 'error')
       raw_dir = File.join(exam_template.base_path, 'raw')

--- a/app/views/shared/_poll_job.js.erb
+++ b/app/views/shared/_poll_job.js.erb
@@ -1,6 +1,6 @@
 <script>
 <% if session[:job_id] %>
   <% current_job = ActiveJob::Status.get(session[:job_id]) if local_assigns[:current_job].nil? %>
-  poll_job("<%= session[:job_id] %>", undefined, <%= current_job[:job_class].on_complete_js %>);
+  poll_job("<%= session[:job_id] %>", undefined, window.location.reload.bind(window.location));
 <% end %>
 </script>

--- a/app/views/shared/_poll_job.js.erb
+++ b/app/views/shared/_poll_job.js.erb
@@ -1,6 +1,6 @@
 <script>
 <% if session[:job_id] %>
-  <% current_job = ActiveJob::Status.get(session[:job_id]) if local_assigns[:current_job].nil? %>
+  <% current_job = ActiveJob::Status.get(session[:job_id]) %>
   poll_job("<%= session[:job_id] %>", undefined, <%= current_job[:job_class].on_complete_js %>);
 <% end %>
 </script>

--- a/app/views/shared/_poll_job.js.erb
+++ b/app/views/shared/_poll_job.js.erb
@@ -1,5 +1,7 @@
 <script>
 <% if session[:job_id] %>
+  <% current_job = ActiveJob::Status.get(session[:job_id]) if local_assigns[:current_job].nil? %>
+  console.log("<%= current_job[:job_class] %>");
   poll_job("<%= session[:job_id] %>", undefined, window.location.reload.bind(window.location));
 <% end %>
 </script>

--- a/app/views/shared/_poll_job.js.erb
+++ b/app/views/shared/_poll_job.js.erb
@@ -1,7 +1,6 @@
 <script>
 <% if session[:job_id] %>
   <% current_job = ActiveJob::Status.get(session[:job_id]) if local_assigns[:current_job].nil? %>
-  console.log("<%= current_job[:job_class] %>");
-  poll_job("<%= session[:job_id] %>", undefined, window.location.reload.bind(window.location));
+  poll_job("<%= session[:job_id] %>", undefined, <%= current_job[:job_class].on_complete_js %>);
 <% end %>
 </script>

--- a/app/views/shared/_poll_job.js.erb
+++ b/app/views/shared/_poll_job.js.erb
@@ -1,6 +1,6 @@
 <script>
 <% if session[:job_id] %>
   <% current_job = ActiveJob::Status.get(session[:job_id]) if local_assigns[:current_job].nil? %>
-  poll_job("<%= session[:job_id] %>", undefined, window.location.reload.bind(window.location));
+  poll_job("<%= session[:job_id] %>", undefined, <%= current_job[:job_class].on_complete_js %>);
 <% end %>
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1637,3 +1637,6 @@ en:
 
     poll_job:
       working_message: "%{progress} out of %{total}"
+      queued: "Queued"
+      completed: "Completed"
+      failed: "Failed"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1634,3 +1634,6 @@ en:
         skip_last_comma: true
 
     server_time: "Server Time:"
+
+    poll_job:
+      working_message: "%{progress} out of %{total}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1868,3 +1868,6 @@ es:
         skip_last_comma:    true
 
     server_time: "Tiempo Servidor:"
+
+    poll_job:
+      working_message: "%{progress} fuera de %{total}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1871,3 +1871,6 @@ es:
 
     poll_job:
       working_message: "%{progress} fuera de %{total}"
+      queued: "En cola"
+      completed: "Terminado"
+      failed: "Ha fallado"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1595,3 +1595,6 @@ fr:
         full_messages:
           format: "%{attribute} %{message}"
     server_time: "Heure du serveur :"
+
+    poll_job:
+      working_message: "%{progress} hors de %{total}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1598,3 +1598,6 @@ fr:
 
     poll_job:
       working_message: "%{progress} hors de %{total}"
+      queued: "Mis en file d'attente"
+      completed: "Terminé"
+      failed: "échoué"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1445,3 +1445,6 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
 
     poll_job:
       working_message: "%{progress} fora de %{total}"
+      queued: "Enfileiradas"
+      completed: "Completado"
+      failed: "Falhou"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1442,3 +1442,6 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         skip_last_comma: true
 
     server_time: "Data servidor:"
+
+    poll_job:
+      working_message: "%{progress} fora de %{total}"


### PR DESCRIPTION
- Job class was added to split pdf job's status, and added internationalized strings for job classes.

Note:
Instead of adding the job class to the session I figured it's easier if I updated the status before the job is queued (so I also avoid the nil class error when calling it on the JS poll_job side).

Also I need to make similar changes to the generate job / other jobs, which I can do in a separate pull request.