### PR TITLE
keeping track of which pages have QR code with wrong exam template in SplitPDFLog

### DIFF
--- a/app/views/exam_templates/_split_pdf_log.html.erb
+++ b/app/views/exam_templates/_split_pdf_log.html.erb
@@ -9,5 +9,8 @@
   <p><strong><%= SplitPdfLog.human_attribute_name('num_groups_in_incomplete') %></strong>: <%= split_pdf_log.num_groups_in_incomplete %></p>
   <p><strong><%= SplitPdfLog.human_attribute_name('original_num_pages') %></strong>: <%= split_pdf_log.original_num_pages %></p>
   <p><strong><%= SplitPdfLog.human_attribute_name('num_pages_qr_scan_error') %></strong>: <%= split_pdf_log.num_pages_qr_scan_error %></p>
+  <% unless split_pdf_log.error_description.blank? %>
+    <p><strong><%= SplitPdfLog.human_attribute_name('error_description') %></strong>: <%= split_pdf_log.error_description %></p>
+  <% end %>
 </div>
 <hr>


### PR DESCRIPTION
<img width="1280" alt="screen shot 2017-07-07 at 3 56 20 pm" src="https://user-images.githubusercontent.com/14116152/27974693-0ae26250-632d-11e7-8b62-0d11f05ae16b.png">
