### PR TITLE
Error fix when bin/markus is run: 'optional: true'=>'required: false'

### DIFF
--- a/app/models/split_page.rb
+++ b/app/models/split_page.rb
@@ -1,6 +1,6 @@
 class SplitPage < ActiveRecord::Base
   belongs_to :split_pdf_log
-  belongs_to :group, optional: true
+  belongs_to :group, required: false
   validates :split_pdf_log, :filename, :raw_page_number, presence: true
   validates :raw_page_number, :exam_page_number,
             numericality: { greater_than_or_equal_to: 1,


### PR DESCRIPTION
There should be an error `ArgumentError: Unknown key: :optional.` everytime we run `bin/markus`. So I changed `optional: true` to `required: false`.