### PR TITLE
fix error that occurs when exam template's name doesn't match its assignment's short_identifier

### DIFF
--- a/app/jobs/generate_job.rb
+++ b/app/jobs/generate_job.rb
@@ -28,7 +28,7 @@ class GenerateJob < ActiveJob::Base
         m_logger.log("Now generating: #{exam_num}")
         pdf = Prawn::Document.new(margin: 20)
         exam_template.num_pages.times do |page_num|
-          qrcode_content = "#{exam_template.assignment.short_identifier}-#{exam_num}-#{page_num + 1}"
+          qrcode_content = "#{exam_template.name}-#{exam_num}-#{page_num + 1}"
           qrcode = RQRCode::QRCode.new qrcode_content, level: :l, size: 2
           alignment = page_num % 2 == 0 ? :right : :left
           pdf.render_qr_code(qrcode, align: alignment, dot: 3.2, stroke: false)

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -47,12 +47,13 @@ class SplitPDFJob < ActiveJob::Base
           new_page.save File.join(error_dir, "#{filename}-#{i}.pdf")
           num_pages_qr_scan_error += 1
         else
-          if m[:short_id] == exam_template.name # if QR code contains corresponding exam template
+          if m[:short_id] == exam_template.assignment.short_identifier # if QR code contains corresponding exam template
             partial_exams[m[:exam_num]] << [m[:page_num].to_i, page]
             m_logger.log("#{m[:short_id]}: exam number #{m[:exam_num]}, page #{m[:page_num]}")
           else # if QR code doesn't contain corresponding exam template
             new_page.save File.join(error_dir, "#{filename}-#{i}.pdf")
             m_logger.log('QR code does not contain corresponding exam template.')
+            num_pages_qr_scan_error += 1
           end
         end
         progress.increment

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -79,7 +79,7 @@ class SplitPDFJob < ActiveJob::Base
             group_name: group_name_for(exam_template, m[:exam_num].to_i),
             repo_name: group_name_for(exam_template, m[:exam_num].to_i)
           )
-          if m[:short_id] == exam_template.assignment.short_identifier # if QR code contains corresponding exam template
+          if m[:short_id] == exam_template.name # if QR code contains corresponding exam template
             partial_exams[m[:exam_num]] << [m[:page_num].to_i, page, i + 1]
             m_logger.log("#{m[:short_id]}: exam number #{m[:exam_num]}, page #{m[:page_num]}")
           else # if QR code doesn't contain corresponding exam template


### PR DESCRIPTION
I was testing by adding new exam template called `midterm1` under an assignment called `csc236-midterm1` and I noticed that even though correctly generated file was uploaded in `split_pdf`, pages were created in `error` directory because of the mistake made in my previous PR. Since QR code content is made with `#{exam_template.assignment.short_identifier}-#{exam_num}-#{page_num + 1}`, it should be compared to `exam_template.assignment.short_identifier`, not `exam_template.name`