### PR TITLE
remove unnecessary return statement for split_pdf_job

### DIFF
--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -104,8 +104,6 @@ class SplitPDFJob < ActiveJob::Base
         num_groups_in_incomplete: num_groups_in_incomplete,
         num_pages_qr_scan_error: num_pages_qr_scan_error
       )
-
-      return split_pdf_log
     end
      m_logger.log('Split pdf process done')
     rescue => e


### PR DESCRIPTION
We don't have to return `split_pdf_log` here. There is a tiny bug where pages gets saved into `error` directory instead of `complete` directory even though correctly generated file was uploaded (only happens with newly created scanned assignment). Not sure if it is coming from this return statement yet though!