### PR TITLE
add submission file in case new template division has been created

### DIFF
--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -141,6 +141,7 @@ class ExamTemplate < ActiveRecord::Base
         repo = group.repo
         revision = repo.get_latest_revision
         assignment_folder = self.assignment.repository_folder
+        submission_files = revision.files_at_path(assignment_folder)
         txn = repo.get_transaction(Admin.first.user_name)
         txn.add_path(assignment_folder)
         self.template_divisions.each do |template_division|
@@ -153,7 +154,7 @@ class ExamTemplate < ActiveRecord::Base
                 submission_file << pdf.pages[0]
               end
             end
-            unless revision.files_at_path(assignment_folder)["#{template_division.label}.pdf"].nil? # if submission file exists, replace it
+            unless submission_files["#{template_division.label}.pdf"].nil? # if submission file exists, replace it
               txn.replace(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf,
                           'application/pdf', revision.revision_identifier)
             else

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -153,8 +153,12 @@ class ExamTemplate < ActiveRecord::Base
                 submission_file << pdf.pages[0]
               end
             end
-            txn.replace(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf,
-                           'application/pdf', revision.revision_identifier)
+            unless revision.files_at_path(assignment_folder)["#{template_division.label}.pdf"].nil? # if submission file exists, replace it
+              txn.replace(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf,
+                          'application/pdf', revision.revision_identifier)
+            else
+              txn.add(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf, 'application/pdf')
+            end
           end
         end
         repo.commit(txn)


### PR DESCRIPTION
If instructors add new template division after having scanned exams, it updates submission files based on template divisions in `fix_error` function next time they want to scan same exams again.