### PR TITLE
generate correct file after exam template file is changed

### DIFF
--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -86,6 +86,9 @@ class ExamTemplate < ActiveRecord::Base
       f.write blob
     end
 
+    File.rename(File.join(template_path, attributes[:old_filename].tr(' ', '_')),
+                File.join(template_path, attributes[:new_filename]))
+
     pdf = CombinePDF.parse blob
     self.update(num_pages: pdf.pages.length, filename: attributes[:new_filename])
   end


### PR DESCRIPTION
When we upload new file for `exam template` and we generate QR code, it used to still generate on old file. Now, it generates QR code on updated one instead.