### PR TITLE
create extra directory for each exam template under assignment (for split_pdf)

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -96,7 +96,7 @@ class ExamTemplatesController < ApplicationController
   def download_generate
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find(params[:id])
-    send_file(exam_template.base_path + '/' + params[:file_name],
+    send_file(File.join(exam_template.base_path, params[:file_name]),
               filename: params[:file_name],
               type: "application/pdf")
   end

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -40,8 +40,7 @@ class ExamTemplatesController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find_by(id: params[:id]) # look up a specific exam template based on the params[:id]
     filename = exam_template.filename
-    assignment_name = assignment.short_identifier
-    send_file("#{EXAM_TEMPLATE_DIR}/#{assignment_name}/#{filename}",
+    send_file(exam_template.base_path + '/' + filename,
               filename: "#{filename}",
               type: "application/pdf")
   end

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -16,7 +16,7 @@ class ExamTemplatesController < ApplicationController
   def create
     assignment = Assignment.find(params[:assignment_id])
     new_uploaded_io = params[:create_template][:file_io]
-    name_input = params[:create_template][:name]
+    name = params[:create_template][:name]
     # error checking when new_uploaded_io is not pdf, nil, or when filename is not given
     if new_uploaded_io.nil? || new_uploaded_io.content_type != 'application/pdf'
       flash_message(:error, t('exam_templates.create.failure'))
@@ -25,7 +25,7 @@ class ExamTemplatesController < ApplicationController
       new_template = ExamTemplate.new_with_file(new_uploaded_io.read,
                                                 assignment_id: assignment.id,
                                                 filename: filename,
-                                                name_input: name_input)
+                                                name: name)
       # sending flash message if saved
       if new_template.save
         flash_message(:success, t('exam_templates.create.success'))
@@ -40,7 +40,7 @@ class ExamTemplatesController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find_by(id: params[:id]) # look up a specific exam template based on the params[:id]
     filename = exam_template.filename
-    send_file(exam_template.base_path + '/' + filename,
+    send_file(File.join(exam_template.base_path, filename),
               filename: "#{filename}",
               type: "application/pdf")
   end

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -22,10 +22,8 @@ class SplitPDFJob < ActiveJob::Base
     m_logger = MarkusLogger.instance
     begin
       # Create directory for files whose QR code couldn't be parsed
-      error_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
-                            exam_template.assignment.short_identifier, 'error')
-      raw_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
-                          exam_template.assignment.short_identifier, 'raw')
+      error_dir = File.join(exam_template.base_path, 'error')
+      raw_dir = File.join(exam_template.base_path, 'raw')
       complete_dir = File.join(exam_template.base_path, 'complete')
       incomplete_dir = File.join(exam_template.base_path, 'incomplete')
       FileUtils.mkdir_p error_dir unless Dir.exists? error_dir
@@ -121,8 +119,7 @@ class SplitPDFJob < ActiveJob::Base
     return unless Admin.exists?
     complete_dir = File.join(exam_template.base_path, 'complete')
     incomplete_dir = File.join(exam_template.base_path, 'incomplete')
-    error_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
-                          exam_template.assignment.short_identifier, 'error')
+    error_dir = File.join(exam_template.base_path, 'error')
 
     groupings = []
     partial_exams.each do |exam_num, pages|
@@ -145,7 +142,7 @@ class SplitPDFJob < ActiveJob::Base
       else
         destination = File.join incomplete_dir, "#{exam_num}"
       end
-      FileUtils.mkdir_p destination unless Dir.exists? destination
+      FileUtils.mkdir_p destination
       pages.each do |page_num, page, raw_page_num|
         new_pdf = CombinePDF.new
         new_pdf << page

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -26,8 +26,8 @@ class SplitPDFJob < ActiveJob::Base
       raw_dir = File.join(exam_template.base_path, 'raw')
       complete_dir = File.join(exam_template.base_path, 'complete')
       incomplete_dir = File.join(exam_template.base_path, 'incomplete')
-      FileUtils.mkdir error_dir unless Dir.exists? error_dir
-      FileUtils.mkdir raw_dir unless Dir.exists? raw_dir
+      FileUtils.mkdir_p error_dir unless Dir.exists? error_dir
+      FileUtils.mkdir_p raw_dir unless Dir.exists? raw_dir
 
       basename = File.basename path, '.pdf'
       filename = original_filename.nil? ? basename : File.basename(original_filename)

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -22,8 +22,10 @@ class SplitPDFJob < ActiveJob::Base
     m_logger = MarkusLogger.instance
     begin
       # Create directory for files whose QR code couldn't be parsed
-      error_dir = File.join(exam_template.base_path, 'error')
-      raw_dir = File.join(exam_template.base_path, 'raw')
+      error_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
+                            exam_template.assignment.short_identifier, 'error')
+      raw_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
+                          exam_template.assignment.short_identifier, 'raw')
       complete_dir = File.join(exam_template.base_path, 'complete')
       incomplete_dir = File.join(exam_template.base_path, 'incomplete')
       FileUtils.mkdir_p error_dir unless Dir.exists? error_dir
@@ -119,7 +121,8 @@ class SplitPDFJob < ActiveJob::Base
     return unless Admin.exists?
     complete_dir = File.join(exam_template.base_path, 'complete')
     incomplete_dir = File.join(exam_template.base_path, 'incomplete')
-    error_dir = File.join(exam_template.base_path, 'error')
+    error_dir = File.join(MarkusConfigurator.markus_exam_template_dir,
+                          exam_template.assignment.short_identifier, 'error')
 
     groupings = []
     partial_exams.each do |exam_num, pages|

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -23,7 +23,7 @@ class ExamTemplate < ActiveRecord::Base
   def self.create_with_file(blob, attributes={})
     return unless attributes.has_key? :assignment_id
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
-    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename], '.pdf') : attributes[:name]
+    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename].tr(' ', '_'), '.pdf') : attributes[:name]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,
@@ -48,7 +48,7 @@ class ExamTemplate < ActiveRecord::Base
     assignment_name = assignment.short_identifier
     filename = attributes[:filename].tr(' ', '_')
     name_input = attributes[:name]
-    exam_template_name = name_input.nil? ? File.basename(attributes[:filename], '.pdf') : name_input
+    exam_template_name = name_input == '' ? File.basename(attributes[:filename].tr(' ', '_'), '.pdf') : name_input
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,
@@ -81,7 +81,7 @@ class ExamTemplate < ActiveRecord::Base
   def replace_with_file(blob, attributes={})
     return unless attributes.has_key? :assignment_id
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
-    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename], '.pdf') : attributes[:name]
+    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename].tr(' ', '_'), '.pdf') : attributes[:name]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -25,9 +25,10 @@ class ExamTemplate < ActiveRecord::Base
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
-      assignment_name
+      assignment_name,
+      self.name
     )
-    FileUtils.mkdir template_path unless Dir.exists? template_path
+    FileUtils.mkdir_p template_path unless Dir.exists? template_path
 
     File.open(File.join(template_path, attributes[:filename]), 'wb') do |f|
       f.write blob
@@ -48,9 +49,10 @@ class ExamTemplate < ActiveRecord::Base
     name_input = attributes[:name_input]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
-      assignment_name
+      assignment_name,
+      self.name
     )
-    FileUtils.mkdir template_path unless Dir.exists? template_path
+    FileUtils.mkdir_p template_path unless Dir.exists? template_path
     File.open(File.join(template_path, filename), 'wb') do |f|
       f.write blob
     end
@@ -79,7 +81,8 @@ class ExamTemplate < ActiveRecord::Base
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
-      assignment_name
+      assignment_name,
+      self.name
     )
 
     File.open(File.join(template_path, attributes[:old_filename].tr(' ', '_')), 'wb') do |f|
@@ -189,7 +192,7 @@ class ExamTemplate < ActiveRecord::Base
 
   def base_path
     File.join MarkusConfigurator.markus_exam_template_dir,
-              assignment.short_identifier
+              assignment.short_identifier, name
   end
 
   private

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -23,10 +23,11 @@ class ExamTemplate < ActiveRecord::Base
   def self.create_with_file(blob, attributes={})
     return unless attributes.has_key? :assignment_id
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
+    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename], '.pdf') : attributes[:name]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,
-      self.name
+      exam_template_name
     )
     FileUtils.mkdir_p template_path unless Dir.exists? template_path
 
@@ -46,11 +47,12 @@ class ExamTemplate < ActiveRecord::Base
     assignment = Assignment.find(attributes[:assignment_id])
     assignment_name = assignment.short_identifier
     filename = attributes[:filename].tr(' ', '_')
-    name_input = attributes[:name_input]
+    name_input = attributes[:name]
+    exam_template_name = name_input.nil? ? File.basename(attributes[:filename], '.pdf') : name_input
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,
-      self.name
+      exam_template_name
     )
     FileUtils.mkdir_p template_path unless Dir.exists? template_path
     File.open(File.join(template_path, filename), 'wb') do |f|
@@ -79,12 +81,12 @@ class ExamTemplate < ActiveRecord::Base
   def replace_with_file(blob, attributes={})
     return unless attributes.has_key? :assignment_id
     assignment_name = Assignment.find(attributes[:assignment_id]).short_identifier
+    exam_template_name = attributes[:name].nil? ? File.basename(attributes[:filename], '.pdf') : attributes[:name]
     template_path = File.join(
       MarkusConfigurator.markus_exam_template_dir,
       assignment_name,
-      self.name
+      exam_template_name
     )
-
     File.open(File.join(template_path, attributes[:old_filename].tr(' ', '_')), 'wb') do |f|
       f.write blob
     end
@@ -192,7 +194,7 @@ class ExamTemplate < ActiveRecord::Base
 
   def base_path
     File.join MarkusConfigurator.markus_exam_template_dir,
-              assignment.short_identifier, name
+              assignment.short_identifier, self.name
   end
 
   private


### PR DESCRIPTION
So far we have a directory for each assignment where we store pages in `complete`, `incomplete`, `error`, `raw` directory. When we have multiple exam templates in an assignment and we split generated PDF for each exam template, the pages go into `error` directory because `incomplete/exam_num.pdf` or `complete/exam_num.pdf` already exists in the corresponding directory. We should have a directory layer for each exam template underneath assignment directory.
<img width="294" alt="screen shot 2017-07-19 at 2 28 02 pm" src="https://user-images.githubusercontent.com/14116152/28383156-8613e93e-6c8e-11e7-9f1c-f8168b0239a8.png">
