### PR TITLE
Overall Comment/Remark MathJAX preview

### DIFF
--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -10,7 +10,7 @@ function updatePreview(source, des) {
 
     var preview = document.getElementById(des);
 
-    if(preview != null && newAnnotation != null){
+    if (preview !== null && newAnnotation !== null) {
       preview.innerHTML = marked(newAnnotation.value);
       // typeset the preview
       MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
@@ -42,8 +42,11 @@ $(document).on("keyup", "#overall_remark_comment_text_area", function () {
 });
 
 // Update when the document loads so preview is available for existing comments/annotations
-updatePreview('new_annotation_content', 'annotation_preview');
-updatePreview('overall_comment_text_area', 'overall_comment_preview');
-updatePreview('overall_remark_comment_text_area', 'overall_remark_comment_preview');
+$(document).ready(function () {
+  updatePreview('new_annotation_content', 'annotation_preview');
+  updatePreview('overall_comment_text_area', 'overall_comment_preview');
+  updatePreview('overall_remark_comment_text_area', 'overall_remark_comment_preview');
+});
+
 
 

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -1,28 +1,19 @@
 // function that reloads the DOM for
 // MathJax (http://www.mathjax.org/docs/1.1/typeset.html)
 function reloadDOM() {
-    MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+  MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
 }
 
-function hideAnnotationPreview() {
-    $('#annotation_preview').hide();
-    $('#annotation_preview_title').hide();
+function updatePreview(source, des) {
+  delay(function () {
+    var newAnnotation = document.getElementById(source).value;
 
-    // recenter dialog
-    var dialog = $('#annotation_dialog');
-    dialog.css('margin-left', -1 * dialog.width() / 2);
-}
+    var preview = document.getElementById(des);
+    preview.innerHTML = marked(newAnnotation);
 
-function updateAnnotationPreview() {
-    delay(function() {
-        var newAnnotation = document.getElementById('new_annotation_content').value;
-
-        var preview = document.getElementById('annotation_preview');
-        preview.innerHTML = marked(newAnnotation);
-
-        // typeset the preview
-        MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
-    }, 300);
+    // typeset the preview
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+  }, 300);
 }
 
 // Allow inline single dollar sign notation
@@ -30,12 +21,27 @@ MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']]}
 });
 
-var delay = (function() {
+var delay = (function () {
   var timer = 0;
-  return function(callback, ms) {
+  return function (callback, ms) {
     clearTimeout(timer);
     timer = setTimeout(callback, ms);
   };
 })();
 
-$(document).on("keyup", "#new_annotation_content", updateAnnotationPreview);
+$(document).on("keyup", "#new_annotation_content", function () {
+  updatePreview('new_annotation_content', 'annotation_preview');
+});
+$(document).on("keyup", "#overall_comment_text_area", function () {
+  updatePreview('overall_comment_text_area', 'overall_comment_preview');
+});
+$(document).on("keyup", "#overall_remark_comment_text_area", function () {
+  updatePreview('overall_remark_comment_text_area', 'overall_remark_comment_preview');
+});
+
+// Update when the document loads so preview is available for existing comments/annotations
+updatePreview('new_annotation_content', 'annotation_preview');
+updatePreview('overall_comment_text_area', 'overall_comment_preview');
+updatePreview('overall_remark_comment_text_area', 'overall_remark_comment_preview');
+
+

--- a/app/assets/javascripts/MathJax/mathjax_helpers.js
+++ b/app/assets/javascripts/MathJax/mathjax_helpers.js
@@ -6,13 +6,15 @@ function reloadDOM() {
 
 function updatePreview(source, des) {
   delay(function () {
-    var newAnnotation = document.getElementById(source).value;
+    var newAnnotation = document.getElementById(source);
 
     var preview = document.getElementById(des);
-    preview.innerHTML = marked(newAnnotation);
 
-    // typeset the preview
-    MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+    if(preview != null && newAnnotation != null){
+      preview.innerHTML = marked(newAnnotation.value);
+      // typeset the preview
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+    }
   }, 300);
 }
 

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -248,16 +248,7 @@
     width: 100%;
     padding: 10px;
   }
-
-  #annotation_preview {
-    width: 450px;
-    margin: 1em 0 20px 0;
-    border: 1px dashed $grey;
-    padding: 0px 10px;
-    min-height: 43px;
-  }
 }
-
 
 /* Annotations menus */
 
@@ -416,6 +407,18 @@ ul.annotation_text_list {
   font-size: 0.85em !important;
 }
 
+/* MathJAX previews */
+
+#annotation_preview, #overall_comment_preview, #overall_remark_comment_preview {
+  margin: 1em 0 20px 0;
+  border: 1px dashed $grey;
+  padding: 0px 10px;
+  min-height: 43px;
+}
+
+#annotation_preview {
+  width: 450px;
+}
 
 /* Remark request pane */
 

--- a/app/views/results/marker/_overall_comment.html.erb
+++ b/app/views/results/marker/_overall_comment.html.erb
@@ -9,6 +9,8 @@
                       cols: 50,
                       rows: 5,
                       id: 'overall_comment_text_area' %>
+      <h3 id="overall_comment_preview_title"><%= t('marker.annotation.preview') %></h3>
+      <div id="overall_comment_preview" style="word-wrap: break-word;"></div>
       <%= f.submit t(:save_changes),
                    disable_with: t('working'),
                    id: 'overall_comment_submit' %>

--- a/app/views/results/marker/_overall_remark_comment.html.erb
+++ b/app/views/results/marker/_overall_remark_comment.html.erb
@@ -11,6 +11,8 @@
 		    rows: 5,
 		    id: 'overall_remark_comment_text_area',
 		    onkeypress: "$('#overall_remark_comment_submit').prop('disabled',false);" %>
+        <h3 id="overall_remark_comment_preview_title"><%= t('marker.annotation.preview') %></h3>
+        <div id="overall_remark_comment_preview" style="word-wrap: break-word;"></div>
     <div>
       <%= f.submit t(:save_changes),
                    disabled: "disabled",


### PR DESCRIPTION
I also made a few small code styling changes to the `mathjax_helpers.js` file. The `updateAnnotationPreview` function has been modified to a more general `updatePreview` that works for all three fields.
