### PR TITLE
Fixed annotations not being added to categories

### DIFF
--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -7,6 +7,7 @@ class AnnotationText < ActiveRecord::Base
   has_many :annotations, dependent: :destroy
 
   belongs_to :annotation_category, counter_cache: true
+  validates_presence_of :user
   validates_associated :annotation_category,
                        message: 'annotation_category associations failed'
 

--- a/app/views/annotations/_annotation_list.html.erb
+++ b/app/views/annotations/_annotation_list.html.erb
@@ -1,17 +1,14 @@
 <ul class='annotation_text_list'>
   <%
-    text = []
-    annotation_category.annotation_texts.each do |annotation_text|
-      if (annotation_text.user.nil? || (annotation_text.user.admin? || annotation_text.user == @current_user))
-        text << annotation_text
-      end
+    texts = annotation_category.annotation_texts.select do |annotation_text|
+      !annotation_text.user.nil? && (annotation_text.user.admin? || annotation_text.user == @current_user)
     end
   %>
-  <% if text.empty? %>
+  <% if texts.empty? %>
     <li><%= t('annotation_categories.no_annotations') %></li>
   <% end %>
 
-  <% text.each do |annotation_text| %>
+  <% texts.each do |annotation_text| %>
     <li id='annotation_text_<%= annotation_text.id %>'
         onclick='add_existing_annotation(<%= annotation_text.id %>, <%= result_id %>); return false;'
         onMouseDown='return false;'

--- a/app/views/annotations/_annotation_list.html.erb
+++ b/app/views/annotations/_annotation_list.html.erb
@@ -1,9 +1,17 @@
 <ul class='annotation_text_list'>
-  <% if annotation_category.annotation_texts.empty? %>
+  <%
+    text = []
+    annotation_category.annotation_texts.each do |annotation_text|
+      if (annotation_text.user.nil? || (annotation_text.user.admin? || annotation_text.user == @current_user))
+        text << annotation_text
+      end
+    end
+  %>
+  <% if text.empty? %>
     <li><%= t('annotation_categories.no_annotations') %></li>
   <% end %>
 
-  <% annotation_category.annotation_texts.each do |annotation_text| %>
+  <% text.each do |annotation_text| %>
     <li id='annotation_text_<%= annotation_text.id %>'
         onclick='add_existing_annotation(<%= annotation_text.id %>, <%= result_id %>); return false;'
         onMouseDown='return false;'

--- a/app/views/annotations/_annotation_modal.html.erb
+++ b/app/views/annotations/_annotation_modal.html.erb
@@ -21,7 +21,7 @@
           <%= hidden_field_tag 'new_annotation_category', value: t('annotation_categories.one_time_only') %>
         <% else %>
           <h3><%= AnnotationCategory.model_name.human %></h3>
-          <select id='new_annotation_category'>
+          <select id='new_annotation_category' name='category_id'>
             <option value=''><%= t('annotation_categories.one_time_only') %></option>
             <% annotation_categories.each do |annotation_category| %>
               <option value='<%= annotation_category.id %>'>

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -279,7 +279,7 @@
                locals: { extra_marks_points: @extra_marks_points,
                          extra_marks_percentage: @extra_marks_percentage,
                          annotation_categories:
-                           @assignment.annotation_categories.includes(:annotation_texts),
+                           @assignment.annotation_categories.includes(annotation_texts: [:user]),
                          result: @result,
                          assignment: @assignment,
                          marks_map: @marks_map,

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -25,7 +25,7 @@ namespace :db do
                                        annotation_category_name: random_words(3))
 
         (rand(10) + 3).times do
-          AnnotationText.create(annotation_category: ac, content: random_sentences(3))
+          AnnotationText.create(annotation_category: ac, content: random_sentences(3), user: Admin.first)
         end
       end
 

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -5,7 +5,7 @@ describe AnnotationCategoriesController do
     # Authenticate user is not timed out, and has administrator rights.
     allow(controller).to receive(:session_expired?).and_return(false)
     allow(controller).to receive(:logged_in?).and_return(true)
-    allow(controller).to receive(:current_user).and_return(build(:admin))
+    allow(controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
   end
 
   let(:annotation_category) { FactoryGirl.create(:annotation_category) }

--- a/spec/factories/annotation_texts.rb
+++ b/spec/factories/annotation_texts.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     content { Faker::Lorem.sentence }
     created_at { Time.now }
     updated_at { Time.now }
+    user { FactoryGirl.create(:admin) }
     association :annotation_category, factory: :annotation_category
   end
 end

--- a/test/blueprints/blueprints.rb
+++ b/test/blueprints/blueprints.rb
@@ -52,6 +52,7 @@ end
 AnnotationText.blueprint do
   annotation_category {AnnotationCategory.make}
   content {'content'}
+  user {Admin.make}
 end
 
 Assignment.blueprint do
@@ -348,7 +349,6 @@ TextAnnotation.blueprint do
   is_remark { false }
   annotation_text
       AnnotationText.make(
-          user: Admin.make,
           annotation_category: AnnotationCategory.make(
               assignment: submission_file.submission.grouping.assignment))
   annotation_number { rand(1000) + 1 }

--- a/test/blueprints/blueprints.rb
+++ b/test/blueprints/blueprints.rb
@@ -348,6 +348,7 @@ TextAnnotation.blueprint do
   is_remark { false }
   annotation_text
       AnnotationText.make(
+          user: Admin.make,
           annotation_category: AnnotationCategory.make(
               assignment: submission_file.submission.grouping.assignment))
   annotation_number { rand(1000) + 1 }

--- a/test/functional/results_controller_test.rb
+++ b/test/functional/results_controller_test.rb
@@ -884,7 +884,7 @@ class ResultsControllerTest < AuthenticatedControllerTest
             g = Grouping.make(assignment: @assignment)
             @submission = Submission.make(grouping: g)
             @file = SubmissionFile.make(submission: @submission)
-            annotation = TextAnnotation.make(submission_file_id: @file.id, user: Admin.make)
+            annotation = TextAnnotation.make(submission_file_id: @file.id)
             SubmissionFile.stubs(:find).returns(@file)
             @result = Result.make
           end

--- a/test/functional/results_controller_test.rb
+++ b/test/functional/results_controller_test.rb
@@ -884,7 +884,7 @@ class ResultsControllerTest < AuthenticatedControllerTest
             g = Grouping.make(assignment: @assignment)
             @submission = Submission.make(grouping: g)
             @file = SubmissionFile.make(submission: @submission)
-            annotation = TextAnnotation.make(submission_file_id: @file.id)
+            annotation = TextAnnotation.make(submission_file_id: @file.id, user: Admin.make)
             SubmissionFile.stubs(:find).returns(@file)
             @result = Result.make
           end


### PR DESCRIPTION
If an annotation has no user attached to it (i.e. autogenerated by rake), it will still appear to all users as it is assumed it is default.