### PR TITLE
Git required files hook

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -292,21 +292,22 @@ class AssignmentsController < ApplicationController
                                    .order(:id)
 
     begin
+      new_required_files = false
       @assignment.transaction do
-        @assignment, @new_files_required = process_assignment_form(@assignment)
+        @assignment, new_required_files = process_assignment_form(@assignment)
+        @assignment.save!
       end
+      if new_required_files && !MarkusConfigurator.markus_config_repository_hooks.empty?
+        # update list of required files in all repos only if there is a hook that will use that list
+        UpdateRepoRequiredFilesJob.perform_later(current_user)
+      end
+      flash_message(:success, I18n.t('assignment.update_success'))
+      redirect_to action: 'edit', id: params[:id]
     rescue SubmissionRule::InvalidRuleType => e
       @assignment.errors.add(:base, t('assignment.error', message: e.message))
       flash_message(:error, t('assignment.error', message: e.message))
       render :edit, id: @assignment.id
-      return
-    end
-
-    if @assignment.save
-      # TODO trigger repo .required.json update in a job only if HOOKS setting exists
-      flash_message(:success, I18n.t('assignment.update_success'))
-      redirect_to action: 'edit', id: params[:id]
-    else
+    rescue
       render :edit, id: @assignment.id
     end
   end
@@ -923,10 +924,10 @@ class AssignmentsController < ApplicationController
   def process_assignment_form(assignment)
     num_files_before = assignment.assignment_files.length
     assignment.assign_attributes(assignment_params)
-    new_files_required = assignment.only_required_files_changed? ||
+    new_required_files = assignment.only_required_files_changed? ||
                          assignment.assignment_files.any? { |file| file.changed? }
-    assignment.save
-    new_files_required = new_files_required ||
+    assignment.save!
+    new_required_files = new_required_files ||
                          num_files_before != assignment.assignment_files.length
 
     # if there are no section due dates, destroy the objects that were created
@@ -1010,7 +1011,7 @@ class AssignmentsController < ApplicationController
       assignment.group_max = 1
     end
 
-    return assignment, new_files_required
+    return assignment, new_required_files
   end
 
   def assignment_params

--- a/app/jobs/update_repo_required_files_job.rb
+++ b/app/jobs/update_repo_required_files_job.rb
@@ -1,0 +1,32 @@
+class UpdateRepoRequiredFilesJob < ActiveJob::Base
+
+  queue_as MarkusConfigurator.markus_job_update_repo_required_files_queue_name
+
+  def update_group_repo(group, current_user, required_files)
+    repo = group.repo
+    t = repo.get_transaction(current_user.user_name)
+    t.replace('.required.json', required_files, 'application/json', repo.get_latest_revision.revision_identifier)
+    repo.commit(t)
+  end
+
+  def perform(current_user)
+    failed_groups = []
+    required_files = Assignment.get_required_files.to_json
+    Group.all.each do |group|
+      begin
+        update_group_repo(group, current_user, required_files)
+      rescue
+        # in the event of a concurrent repo modification, retry later
+        # TODO add a repo.update api maybe and retry here?
+        failed_groups.push(group)
+      end
+    end
+    failed_groups.each do |group|
+      begin
+        update_group_repo(group, current_user, required_files)
+      rescue
+        # give up
+      end
+    end
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -113,7 +113,7 @@ class Assignment < ActiveRecord::Base
                          numericality: { only_integer: true,
                                          greater_than_or_equal_to: 0 }
   end
-  with_options if: ->{ !:non_regenerating_tokens && :enable_student_tests && !unlimited_tokens} do |assignment|
+  with_options if: ->{ !:non_regenerating_tokens && :enable_student_tests && !:unlimited_tokens} do |assignment|
     assignment.validates :token_period,
                          presence: true,
                          numericality: { greater_than: 0 }
@@ -1101,8 +1101,8 @@ class Assignment < ActiveRecord::Base
   # That creates a problem since authentication in svn/git is at the repository level, while Markus handles it at
   # the assignment level, allowing the same Group repo to have different students according to the assignment.
   # The two extremes to implement it are using the union of all students (permissive) or the intersection (restrictive).
-  # Instead, we are going to take a last-deadline approach instead, where we assume that the valid students at any point
-  # in time are the ones valid for the last assignment due.
+  # Instead, we are going to take a last-deadline approach, where we assume that the valid students at any point in time
+  # are the ones valid for the last assignment due.
   # (Basically, it's nice for a group to share a repo among assignments, but at a certain point during the course
   # we may want to add or [more frequently] remove some students from it)
   def self.get_repo_auth_records
@@ -1116,6 +1116,22 @@ class Assignment < ActiveRecord::Base
       repo = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
       repo.__set_all_permissions
     end
+  end
+
+  def self.get_required_files
+    assignments = Assignment.includes(:assignment_files)
+                            .where(scanned_exam: false, is_hidden: false)
+    required = {}
+    assignments.each do |assignment|
+      files = assignment.assignment_files.map(&:filename)
+      if assignment.only_required_files.nil?
+        required_only = false
+      else
+        required_only = assignment.only_required_files
+      end
+      required[assignment.repository_folder] = {required: files, required_only: required_only}
+    end
+    required
   end
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -248,6 +248,10 @@ Markus::Application.configure do
   JOB_COLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_collect'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   JOB_UNCOLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_uncollect'
+  # The name of the queue where jobs to update repos with the list of required files wait to be executed.
+  JOB_UPDATE_REPO_REQUIRED_FILES_QUEUE_NAME = 'CSC108_job_req_files'
+  JOB_GENERATE_QUEUE_NAME = 'CSC108_job_generate'
+  JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108_job_split_pdf'
 
   ###################################################################
   # Automated Testing Engine settings

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -277,6 +277,10 @@ Markus::Application.configure do
   JOB_COLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_collect'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   JOB_UNCOLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_uncollect'
+  # The name of the queue where jobs to update repos with the list of required files wait to be executed.
+  JOB_UPDATE_REPO_REQUIRED_FILES_QUEUE_NAME = 'CSC108_job_req_files'
+  JOB_GENERATE_QUEUE_NAME = 'CSC108_job_generate'
+  JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108_job_split_pdf'
 
   ###################################################################
   # Automated Testing Engine settings

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -244,6 +244,10 @@ Markus::Application.configure do
   JOB_COLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_collect'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   JOB_UNCOLLECT_SUBMISSIONS_QUEUE_NAME = 'CSC108_job_uncollect'
+  # The name of the queue where jobs to update repos with the list of required files wait to be executed.
+  JOB_UPDATE_REPO_REQUIRED_FILES_QUEUE_NAME = 'CSC108_job_req_files'
+  JOB_GENERATE_QUEUE_NAME = 'CSC108_job_generate'
+  JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108_job_split_pdf'
 
   ###################################################################
   # Automated Testing Engine settings

--- a/lib/markus_configurator.rb
+++ b/lib/markus_configurator.rb
@@ -380,6 +380,15 @@ module MarkusConfigurator
       return 'job_uncollect'
     end
   end
+
+  def markus_job_update_repo_required_files_queue_name
+    if defined? JOB_UPDATE_REPO_REQUIRED_FILES_QUEUE_NAME
+      return JOB_UPDATE_REPO_REQUIRED_FILES_QUEUE_NAME
+    else
+      return 'job_req_files'
+    end
+  end
+
   def markus_job_generate_queue_name
     if defined? JOB_GENERATE_QUEUE_NAME
       return JOB_GENERATE_QUEUE_NAME
@@ -387,6 +396,7 @@ module MarkusConfigurator
       return 'job_generate'
     end
   end
+
   def markus_job_split_pdf_queue_name
     if defined? JOB_SPLIT_PDF_QUEUE_NAME
       return JOB_SPLIT_PDF_QUEUE_NAME
@@ -394,4 +404,5 @@ module MarkusConfigurator
       return 'job_split_pdf'
     end
   end
+
 end

--- a/lib/repo/git_hooks/update.d/01-block_forced_push_master.py
+++ b/lib/repo/git_hooks/update.d/01-block_forced_push_master.py
@@ -8,11 +8,11 @@ if __name__ == '__main__':
     ref_name = sys.argv[1]
     old_commit = sys.argv[2]
     new_commit = sys.argv[3]
+    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
     if ref_name == 'refs/heads/master':
-        # no need to check if old_commit or new_commit are 0, master can't be deleted or created
+        # check if there are commits reachable from old_commit but not from new_commit, i.e. the old tree was replaced
         rev_list = subprocess.run(['git', 'rev-list', old_commit, '^{}'.format(new_commit)], stdout=subprocess.PIPE,
                                   universal_newlines=True)
         if rev_list.stdout:
-            # there are commits reachable from old_commit but not from new_commit, i.e. the old tree was replaced
-            print('[MARKUS] Forced push is not allowed on master!')
+            print('[MARKUS] Error: forced push is not allowed on master!')
             exit(1)

--- a/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
+++ b/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
@@ -20,8 +20,8 @@ if __name__ == '__main__':
             print('[MARKUS] Error: creating/deleting top level files and directories is not allowed on master!')
             exit(1)
         # check 2: modified top level files
-        changes = subprocess.run(['git', 'diff', '--name-only', old_commit, new_commit], stdout=subprocess.PIPE,
-                                 universal_newlines=True)
+        changes = subprocess.run(['git', 'diff', '--name-only', '--no-renames', old_commit, new_commit],
+                                 stdout=subprocess.PIPE, universal_newlines=True)
         if any(os.sep not in change for change in changes.stdout.splitlines()):
             print('[MARKUS] Error: modifying top level files is not allowed on master!')
             exit(1)

--- a/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
+++ b/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
@@ -9,13 +9,19 @@ if __name__ == '__main__':
     ref_name = sys.argv[1]
     old_commit = sys.argv[2]
     new_commit = sys.argv[3]
-    if ref_name == 'refs/heads/master':
-        # no need to check if old_commit or new_commit are 0, master can't be deleted or created
+    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
+    if ref_name == 'refs/heads/master' and os.environ.get('REMOTE_USER') is not None:  # push not coming from MarkUs
+        # check 1: created/deleted top level files/directories
         old_ls = subprocess.run(['git', 'ls-tree', '--name-only', old_commit], stdout=subprocess.PIPE,
                                 universal_newlines=True)
         new_ls = subprocess.run(['git', 'ls-tree', '--name-only', new_commit], stdout=subprocess.PIPE,
                                 universal_newlines=True)
-        if old_ls.stdout != new_ls.stdout:  # there are changes to the top level files/directories
-            if os.environ.get('REMOTE_USER'):  # the push is not coming from MarkUs
-                print('[MARKUS] Modifying top level files and directories is not allowed on master!')
-                exit(1)
+        if old_ls.stdout != new_ls.stdout:
+            print('[MARKUS] Error: creating/deleting top level files and directories is not allowed on master!')
+            exit(1)
+        # check 2: modified top level files
+        changes = subprocess.run(['git', 'diff', '--name-only', old_commit, new_commit], stdout=subprocess.PIPE,
+                                 universal_newlines=True)
+        if any(os.sep not in change for change in changes.stdout.splitlines()):
+            print('[MARKUS] Error: modifying top level files is not allowed on master!')
+            exit(1)

--- a/lib/repo/git_hooks/update.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/update.d/03-check_required_files_master.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+import subprocess
+
+if __name__ == '__main__':
+
+    ref_name = sys.argv[1]
+    old_commit = sys.argv[2]
+    new_commit = sys.argv[3]
+    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
+    if ref_name == 'refs/heads/master' and os.environ.get('REMOTE_USER') is not None:  # push not coming from MarkUs
+        requirements = subprocess.run(['git', 'show', '{}:{}'.format(old_commit, '.required.json')],
+                                      stdout=subprocess.PIPE, universal_newlines=True)
+        # TODO {'A1': {'required': [], 'required_only': true}}
+        req = json.loads(requirements.stdout)
+        changes = subprocess.run(['git', 'diff', '--name-status', '--no-renames', old_commit, new_commit],
+                                 stdout=subprocess.PIPE, universal_newlines=True)
+        for change in changes.stdout.splitlines():
+            status, path = change.split(maxsplit=1)
+            assignment, file_path = path.split(os.sep, maxsplit=1)  # never a top level file/dir
+            # TODO Think about an assignment that is hidden after being enabled for a while, it goes through for now
+            req_a = req.get(assignment)
+            # check if the assignment forbids adding non-required files
+            # (everything else is allowed, which is safe against policy changes to the assignment after students
+            # already pushed: A required, D required and non-required, M required and non-required)
+            # warn about..
+            if req_a is not None and status == 'A' and req_a['required_only'] and file_path not in req_a['required']:
+                print('[MARKUS] Error: {} is required by {} and cannot be deleted!'.format(file_path, assignment))
+                exit(1)
+                # TODO for each assignment in the changes, warn about missing files
+                # print('[MARKUS] Warning: some required files are missing.')

--- a/lib/repo/git_hooks/update.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/update.d/03-check_required_files_master.py
@@ -20,6 +20,7 @@ if __name__ == '__main__':
         # check if the assignment forbids adding non-required files; everything else is allowed, which is safe against
         # changes to the assignment after students already pushed some work:
         # A required is ok
+        # A non-required is rejected
         # D required is warned
         # D non-required is ok
         # M required is ok

--- a/lib/repo/git_hooks/update.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/update.d/03-check_required_files_master.py
@@ -14,21 +14,46 @@ if __name__ == '__main__':
     if ref_name == 'refs/heads/master' and os.environ.get('REMOTE_USER') is not None:  # push not coming from MarkUs
         requirements = subprocess.run(['git', 'show', '{}:{}'.format(old_commit, '.required.json')],
                                       stdout=subprocess.PIPE, universal_newlines=True)
-        # TODO {'A1': {'required': [], 'required_only': true}}
-        req = json.loads(requirements.stdout)
+        required_files = json.loads(requirements.stdout)
         changes = subprocess.run(['git', 'diff', '--name-status', '--no-renames', old_commit, new_commit],
                                  stdout=subprocess.PIPE, universal_newlines=True)
+        # check if the assignment forbids adding non-required files; everything else is allowed, which is safe against
+        # changes to the assignment after students already pushed some work:
+        # A required is ok
+        # D required is warned
+        # D non-required is ok
+        # M required is ok
+        # M non-required is warned
         for change in changes.stdout.splitlines():
             status, path = change.split(maxsplit=1)
-            assignment, file_path = path.split(os.sep, maxsplit=1)  # never a top level file/dir
-            # TODO Think about an assignment that is hidden after being enabled for a while, it goes through for now
-            req_a = req.get(assignment)
-            # check if the assignment forbids adding non-required files
-            # (everything else is allowed, which is safe against policy changes to the assignment after students
-            # already pushed: A required, D required and non-required, M required and non-required)
-            # warn about..
-            if req_a is not None and status == 'A' and req_a['required_only'] and file_path not in req_a['required']:
-                print('[MARKUS] Error: {} is required by {} and cannot be deleted!'.format(file_path, assignment))
-                exit(1)
-                # TODO for each assignment in the changes, warn about missing files
-                # print('[MARKUS] Warning: some required files are missing.')
+            assignment, file_path = path.split(os.sep, maxsplit=1)  # it can never be a top level file/dir
+            req = required_files.get(assignment)
+            if req is None:
+                # this can happen only if an assignment becomes hidden after being visible for a while
+                # (the top level hook prevents the creation of an arbitrary assignment directory)
+                print("[MARKUS] Warning: assignment '{}' is currently hidden".format(assignment))
+                continue
+            if status == 'A':
+                if file_path not in req['required']:
+                    msg = "you are adding '{}' to assignment '{}', but it only requires '{}'".format(
+                        file_path, assignment, ', '.join(req['required']))
+                    if req['required_only']:
+                        print('[MARKUS] Error: {}!'.format(msg))
+                        exit(1)
+                    else:
+                        print('[MARKUS] Warning: {}.'.format(msg))
+            elif status == 'D' and file_path in req['required']:
+                print("[MARKUS] Warning: you are deleting '{}' from assignment '{}', but it requires it.".format(
+                    file_path, assignment))
+            elif status == 'M' and file_path not in req['required']:
+                print("[MARKUS] Warning: you are modifying '{}' in assignment '{}', but it only requires '{}'.".format(
+                    file_path, assignment, ', '.join(req['required'])))
+        # warn about missing files
+        new_ls = subprocess.run(['git', 'ls-tree', '-r', '--name-only', new_commit], stdout=subprocess.PIPE,
+                                universal_newlines=True)
+        files = new_ls.stdout.splitlines()
+        for assignment in required_files.keys():
+            for file_path in required_files[assignment]['required']:
+                if file_path not in files:
+                    print("[MARKUS] Warning: required file '{}' is missing in assignment '{}'.".format(
+                        file_path, assignment))

--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -83,14 +83,15 @@ module Repository
       bare_config['gc.reflogExpire'] = 'never' # never garbage collect the reflog
       repo = Rugged::Repository.clone_at(bare_path, connect_string)
 
-      # Do an initial commit with a README.md file.
-      readme_path = File.join(connect_string, 'README.md')
-      File.open(readme_path, 'w') do |readme|
-        readme.write('Initial commit.')
+      # Do an initial commit with the .required_files.json
+      required = Assignment.get_required_files
+      required_path = File.join(connect_string, '.required.json')
+      File.open(required_path, 'w') do |req|
+        req.write(required.to_json)
       end
-      oid = Rugged::Blob.from_workdir(repo, 'README.md')
-      repo.index.add(path: 'README.md', oid: oid, mode: 0100644)
-      GitRepository.do_commit_and_push(repo, 'Markus', 'Initial readme commit.')
+      oid = Rugged::Blob.from_workdir(repo, '.required.json')
+      repo.index.add(path: '.required.json', oid: oid, mode: 0100644)
+      GitRepository.do_commit_and_push(repo, 'Markus', 'Initial commit.')
 
       # Set up hooks
       MarkusConfigurator.markus_config_repository_hooks.each do |hook_symbol, hook_script|


### PR DESCRIPTION
This adds the necessary infrastructure to have a git hook check for required files.

Push rejected when:
- Adding a non-required file

Warning issued when:
- Deleting a required file
- Modifying a non-required file
- Working on a hidden assignment
- Missing required files