### PR TITLE
Enable starter code support

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -772,7 +772,7 @@ class AssignmentsController < ApplicationController
           flash[:transaction_warning] =
               I18n.t('student.submission.no_action_detected')
           # can't use redirect_to here. See comment of this action for details.
-          set_filebrowser_vars(@grouping.group, @assignment)
+          set_filebrowser_vars(@assignment)
           render :file_manager, id: assignment_id
           return
         end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -883,11 +883,9 @@ class Assignment < ActiveRecord::Base
     groupings.includes(:current_result).map(&:current_result)
   end
 
-  # TODO: This is currently disabled until starter code is automatically added
-  # to groups.
+  # TODO Make it more robust, to accept uploads after groupings are created
   def can_upload_starter_code?
-    #groups.size == 0
-    false
+    groups.size == 0
   end
 
   # Returns true if this is a peer review, meaning it has a parent assignment,
@@ -955,8 +953,9 @@ class Assignment < ActiveRecord::Base
   # Return a repository object, if possible
   def repo
     repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, repository_name)
-    if Repository.get_class(MarkusConfigurator.markus_config_repository_type).repository_exists?(repo_loc)
-      Repository.get_class(MarkusConfigurator.markus_config_repository_type).open(repo_loc)
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    if repo_class.repository_exists?(repo_loc)
+      repo_class.open(repo_loc)
     else
       raise 'Repository not found and MarkUs not in authoritative mode!' # repository not found, and we are not repo-admin
     end
@@ -964,8 +963,9 @@ class Assignment < ActiveRecord::Base
 
   #Yields a repository object, if possible, and closes it after it is finished
   def access_repo
-    yield repo
-    repo.close()
+    repository = repo
+    yield repository
+    repository.close
   end
 
   ### /REPO ###

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -106,8 +106,9 @@ class Group < ActiveRecord::Base
   # Return a repository object, if possible
   def repo
     repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, self.repository_name)
-    if Repository.get_class(MarkusConfigurator.markus_config_repository_type).repository_exists?(repo_loc)
-      Repository.get_class(MarkusConfigurator.markus_config_repository_type).open(repo_loc)
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    if repo_class.repository_exists?(repo_loc)
+      repo_class.open(repo_loc)
     else
       raise 'Repository not found and MarkUs not in authoritative mode!' # repository not found, and we are not repo-admin
     end
@@ -115,8 +116,8 @@ class Group < ActiveRecord::Base
 
   #Yields a repository object, if possible, and closes it after it is finished
   def access_repo
-    repository = self.repo
+    repository = repo
     yield repository
-    repository.close()
+    repository.close
   end
 end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -600,12 +600,15 @@ class Grouping < ActiveRecord::Base
         end
         begin
           self.assignment.access_repo do |starter_repo|
-            txn = repo.get_transaction('Markus')
-            starter_repo.get_latest_revision.files_at_path(assignment_folder).each do |starter_file_name, starter_file|
-              starter_file_path = File.join(assignment_folder, starter_file_name)
-              txn.add(starter_file_path, starter_repo.download_as_string(starter_file))
+            starter_revision = starter_repo.get_latest_revision
+            if starter_revision.path_exists?(assignment_folder)
+              txn = repo.get_transaction('Markus')
+              starter_revision.files_at_path(assignment_folder).each do |starter_file_name, starter_file|
+                starter_file_path = File.join(assignment_folder, starter_file_name)
+                txn.add(starter_file_path, starter_repo.download_as_string(starter_file))
+              end
+              result = repo.commit(txn)
             end
-            result = repo.commit(txn)
           end
         rescue
           # repo for starter code does not exist, just continue

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -610,7 +610,7 @@ class Grouping < ActiveRecord::Base
         rescue
           # repo for starter code does not exist, just continue
         end
-        result
+        return result
       end
     end
   end

--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -581,7 +581,7 @@ module Repository
     # path should be a directory
     def make_directory(path)
       gitkeep_filename = File.join(path, '.gitkeep')
-      add_file(gitkeep_filename, '', 'markus')
+      add_file(gitkeep_filename, '', 'Markus')
     end
 
     # Helper method to check file permissions of git auth file


### PR DESCRIPTION
This is not something that can work robustly in an afternoon, so I kept the existing semantics: create the assignment (hidden probably), add all the starter files at the beginning, then unleash it and what's done is done.

This approach does not really need any background job for now, started code is copied at the time a grouping is created (together with the assignment folder). If it's part of the create all groups, it'll be already in a background job.

Next steps:
- Why does the starter code need to live in a repo? A directory under data should be more than enough.
- Allow starter code to be modified after groupings are created, and propagate the changes to all student repos.