### PR TITLE
Fix student interface with no tests executed yet

### DIFF
--- a/app/views/automated_tests/student_interface.html.erb
+++ b/app/views/automated_tests/student_interface.html.erb
@@ -67,10 +67,9 @@
                     marking: "#{@grouping.last_student_test_marks}/#{@assignment.total_student_test_script_marks}") %>
         </div>
         <div id='test_results' class='sub_block'>
-          <% student_results = @test_script_results.where(submission_id: nil) %>
           <%= render partial: 'test_script_result',
                      locals: { current_user: @current_user, ran_by: 'student',
-                               latest_date: student_results.nil? ? nil : student_results[0].created_at },
+                               latest_date: @test_script_results.empty? ? nil : @test_script_results[0].created_at },
                      collection: @test_script_results %>
         </div>
       </div>


### PR DESCRIPTION
The student interface was crashing with the initial 0 tests, because the array was empty, not nil.
As a side change, student_results is not really needed because those test_script_results are already the student ones only.