### PR TITLE
Add a new 'partial' test result status

### DIFF
--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -330,13 +330,22 @@ fieldset {
     }
 
     tbody {
-      .test-result-success {
+      .test-result-pass {
         background-color: #caffc9 !important;
       }
 
-      .test-result-failure {
+      .test-result-partial {
+        background-color: #ffffc9 !important;
+      }
+
+      .test-result-fail {
         background-color: #ffcac9 !important;
       }
+
+      .test-result-error {
+        background-color: #ff7a77 !important;
+      }
+
       tr {
         transition: background-color $time-quick;
 

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -486,7 +486,8 @@ module AutomatedTestsClientHelper
         test_actual = test['actual'].nil? ? '' : test['actual']
         test_expected = test['expected'].nil? ? '' : test['expected']
         test_status = test['status']
-        if test_status.nil? or not test_status.in?(%w(pass fail error))
+        if test_status.nil? or not test_status.in?(%w(pass partial fail error))
+          test_actual = I18n.t('automated_tests.test_result.bad_status', {status: test_status})
           test_status = 'error'
           marks_earned = 0
         end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -26,7 +26,7 @@ class TestResult < ActiveRecord::Base
   validates_presence_of :marks_earned
 
   validates_inclusion_of :completion_status,
-                         in: %w(pass fail error),
+                         in: %w(pass partial fail error),
                          message: "%{value} is not a valid status"
   validates_numericality_of :marks_earned,
                             only_integer: true,

--- a/app/views/automated_tests/_test_script_result.html.erb
+++ b/app/views/automated_tests/_test_script_result.html.erb
@@ -31,8 +31,7 @@
       </thead>
       <tbody>
         <% test_script_result.test_results.each do |test| %>
-          <tr class="<%= test.completion_status == 'pass' ?
-          'test-result-success' : 'test-result-failure' %>">
+          <tr class="<%= "test-result-#{test.completion_status}" %>">
             <td><%= test.name %></td>
             <% if false %><td><%= test.input %></td><% end %>
             <% if show_output %><td><%= test.actual_output %></td><% end %>
@@ -40,9 +39,7 @@
             <td><%= test.expected_output %></td>
             <td><%= test.marks_earned %></td>
             <% end %>
-            <td><%= test.completion_status == 'pass' ?
-                    t('automated_tests.test_results_table.passed') :
-                    t('automated_tests.test_results_table.failed') %>
+            <td><%= t("automated_tests.test_results_table.#{test.completion_status}") %>
             </td>
           </tr>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1630,8 +1630,10 @@ en:
         expected: "Expected"
         marks_earned: "Marks Earned"
         status: "Status"
-        passed: "Passed"
-        failed: "Failed"
+        pass: "Passed"
+        partial: "Partially Passed"
+        fail: "Failed"
+        error: "Error"
       error:
         not_enabled: "Tests are not enabled for this assignment"
         no_test_server_user: "There is no test server user for %{hostname}"
@@ -1648,6 +1650,7 @@ en:
         bad_server: "Server '%{hostname}' error: %{error}"
         bad_results: "The test results are malformed: %{xml}"
         no_tests: "The test results are empty"
+        bad_status: "Unrecognized test status '%{status}'"
 
 #Missing Activerecord Translations for english
     datetime:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1860,8 +1860,10 @@ es:
         expected:     "Esperado"
         marks_earned: "Notas Obtenidas"
         status:       "Estado"
-        passed:       "Pasó"
-        failed:       "Falló"
+        pass:         "Pasó"
+        partial:      "UPDATE ME"
+        fail:         "Falló"
+        error:        "UPDATE ME"
       error:
         not_enabled:          "UPDATE ME"
         no_test_server_user:  "UPDATE ME"
@@ -1879,6 +1881,7 @@ es:
         bad_server: "UPDATE ME"
         bad_results: "UPDATE ME"
         no_tests: "UPDATE ME"
+        bad_status: "UPDATE ME '%{status}'"
 
 #Missing Activerecord Translations for english
     datetime:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1474,8 +1474,10 @@ fr:
         expected: "Attendu"
         marks_earned: "Marques Gagnés"
         status: "Statut"
-        passed: "Passé"
-        failed: "Échoué"
+        pass: "Passé"
+        partial: "UPDATE ME"
+        fail: "Échoué"
+        error: "UPDATE ME"
       error:
         not_enabled: "UPDATE ME"
         no_test_server_user: "UPDATE ME"
@@ -1492,6 +1494,7 @@ fr:
         bad_server: "UPDATE ME"
         bad_results: "UPDATE ME"
         no_tests: "UPDATE ME"
+        bad_status: "UPDATE ME '%{status}'"
 
 #Missing Activerecord Translations for french
     datetime:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1435,8 +1435,10 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         expected: "Esperado"
         marks_earned: "Marcas Ganhou"
         status: "Estado"
-        passed: "Passou"
-        failed: "Fracassado"
+        pass: "Passou"
+        partial: "UPDATE ME"
+        fail: "Fracassado"
+        error: "UPDATE ME"
       error:
         not_enabled: "UPDATE ME"
         no_test_server_user: "UPDATE ME"
@@ -1453,6 +1455,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         bad_server: "UPDATE ME"
         bad_results: "UPDATE ME"
         no_tests: "UPDATE ME"
+        bad_status: "UPDATE ME '%{status}'"
 
 #Missing Activerecord Translations for english
     datetime:


### PR DESCRIPTION
This pull request adds a new test result status for tests partially passed, using yellow as the row color.
(it's still up to the test server passing the adequate number of points)

![image](https://user-images.githubusercontent.com/6097798/30764320-55b94998-9fb8-11e7-89f0-e300e053a8ef.png)

The color for hard errors is now a darker red, and a better message is printed in case an unrecognizable status is received.
