### PR TITLE
Fixed issue with removing mark from marks spreadsheets - Issue #2754

### DIFF
--- a/app/views/grade_entry_forms/_react_grades_table.js.jsx.erb
+++ b/app/views/grade_entry_forms/_react_grades_table.js.jsx.erb
@@ -56,8 +56,9 @@
         this.props.value = this.props.default_value;
     },
     handleChange: function(event) {
+      var updated_grade = event.target.value === '' ? null : parseFloat(event.target.value);
       var params = {
-        'updated_grade':       parseFloat(event.target.value),
+        'updated_grade':       updated_grade,
         'student_id':          this.props.student_id,
         'grade_entry_item_id': this.props.grade_entry_column,
         'authenticity_token':  AUTH_TOKEN


### PR DESCRIPTION
## Ready for Review
This pull request fixes the issue where marks in the marks spreadsheet could not be removed. Whenever a mark was removed, when the page refreshes the old mark would still be in the cell.

### Additions and Modifications
- Edited the react table that handles the marks spreadsheet by adding a case where if the updated_grade is empty, it would return null (instead of NaN, which was causing the issue)

### Screenshots
![screen shot 2017-09-25 at 12 52 06 pm](https://user-images.githubusercontent.com/24910741/30820651-89343352-a1f0-11e7-8fbd-b155079c35a6.png)
![screen shot 2017-09-25 at 12 52 32 pm](https://user-images.githubusercontent.com/24910741/30820668-9bb7135a-a1f0-11e7-9c03-c3951a31e7ce.png)
![screen shot 2017-09-25 at 12 53 13 pm](https://user-images.githubusercontent.com/24910741/30820671-9eef50f0-a1f0-11e7-99ff-3febbca7966a.png)
