### PR TITLE
Git fixes

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -111,6 +111,7 @@ class SubmissionsController < ApplicationController
     repo = user_group.repo
     if revision_identifier.nil?
       @revision = repo.get_latest_revision
+      revision_identifier = @revision.revision_identifier
     else
       @revision = repo.get_revision(revision_identifier)
     end
@@ -369,11 +370,7 @@ class SubmissionsController < ApplicationController
       # values will be the "expected revision numbers" that we'll provide
       # to the transaction to ensure that we don't overwrite a file that's
       # been revised since the user last saw it.
-      file_revisions =
-          params[:file_revisions].nil? ? {} : params[:file_revisions]
-      file_revisions.merge!(file_revisions) do |_key, v1, _v2|
-        v1.to_i rescue v1
-      end
+      file_revisions = params[:file_revisions].nil? ? {} : params[:file_revisions]
 
       # The files that will be deleted
       delete_files = params[:delete_files].nil? ? [] : params[:delete_files]

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -252,7 +252,7 @@ module SubmissionsHelper
       f[:raw_name] = file_name
       f[:last_revised_date] = I18n.l(file.last_modified_date,
                                      format: :long_date)
-      f[:last_modified_revision] = file.last_modified_revision
+      f[:last_modified_revision] = revision_identifier
       f[:revision_by] = file.user_id
       f
     end
@@ -273,7 +273,7 @@ module SubmissionsHelper
                                path: File.join(path, directory_name))
       d[:last_revised_date] = I18n.l(directory.last_modified_date,
                                      format: :long_date)
-      d[:last_modified_revision] = directory.last_modified_revision
+      d[:last_modified_revision] = revision_identifier
       d[:revision_by] = directory.user_id
       d
     end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -969,22 +969,25 @@ class Assignment < ActiveRecord::Base
     true
   end
 
-  # Return a repository object, if possible
-  def repo
-    repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, repository_name)
+  def repo_loc
     repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
-    if repo_class.repository_exists?(repo_loc)
-      repo_class.open(repo_loc)
-    else
+    repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, repository_name)
+    unless repo_class.repository_exists?(repo_loc)
       raise 'Repository not found and MarkUs not in authoritative mode!' # repository not found, and we are not repo-admin
     end
+    repo_loc
+  end
+
+  # Return a repository object, if possible
+  def repo
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    repo_class.open(repo_loc)
   end
 
   #Yields a repository object, if possible, and closes it after it is finished
-  def access_repo
-    repository = repo
-    yield repository
-    repository.close
+  def access_repo(&block)
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    repo_class.access(repo_loc, &block)
   end
 
   ### /REPO ###

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -103,21 +103,24 @@ class Group < ActiveRecord::Base
     true
   end
 
-  # Return a repository object, if possible
-  def repo
-    repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, self.repository_name)
+  def repo_loc
     repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
-    if repo_class.repository_exists?(repo_loc)
-      repo_class.open(repo_loc)
-    else
+    repo_loc = File.join(MarkusConfigurator.markus_config_repository_storage, repository_name)
+    unless repo_class.repository_exists?(repo_loc)
       raise 'Repository not found and MarkUs not in authoritative mode!' # repository not found, and we are not repo-admin
     end
+    repo_loc
+  end
+
+  # Return a repository object, if possible
+  def repo
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    repo_class.open(repo_loc)
   end
 
   #Yields a repository object, if possible, and closes it after it is finished
-  def access_repo
-    repository = repo
-    yield repository
-    repository.close
+  def access_repo(&block)
+    repo_class = Repository.get_class(MarkusConfigurator.markus_config_repository_type)
+    repo_class.access(repo_loc, &block)
   end
 end

--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -121,7 +121,9 @@ module Repository
 
     # static method that should yield to a git repo and then close it
     def self.access(connect_string)
-      yield GitRepository.open(connect_string)
+      repo = GitRepository.open(connect_string)
+      yield repo
+      repo.close
     end
 
     # static method that deletes the git repo

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -352,7 +352,7 @@ module Repository
       end
       # replace content of file in question
       act_rev = get_latest_revision()
-      if (act_rev.revision_identifier != expected_revision_int)
+      if (act_rev.revision_identifier != expected_revision_int.to_i)
         raise Repository::FileOutOfSyncConflict.new(full_path)
       end
       files_list = rev.files_at_path(File.dirname(full_path))
@@ -366,7 +366,7 @@ module Repository
         raise Repostiory::FileDoesNotExistConflict.new(full_path)
       end
       act_rev = get_latest_revision()
-      if (act_rev.revision_identifier != expected_revision_int)
+      if (act_rev.revision_identifier != expected_revision_int.to_i)
         raise Repository::FileOutOfSyncConflict.new(full_path)
       end
       filename = File.basename(full_path)

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -803,7 +803,7 @@ module Repository
 
     # removes a file from a transaction and eventually from repository
     def remove_file(txn, path, expected_revision_number=0)
-      if latest_revision_number(path).to_i != expected_revision_number.to_i
+      if latest_revision_number.to_i != expected_revision_number.to_i
         raise Repository::FileOutOfSyncConflict.new(path)
       end
       if !__path_exists?(path)
@@ -816,7 +816,7 @@ module Repository
     # replaces file at provided path with file_data
     def replace_file(txn, path, file_data=nil, mime_type=nil, expected_revision_number=0)
       # Note: this check is inconsistent with the MemoryRepository
-      if latest_revision_number(path).to_i > expected_revision_number.to_i
+      if latest_revision_number.to_i > expected_revision_number.to_i
         raise Repository::FileOutOfSyncConflict.new(path)
       end
       txn = write_file(txn, path, file_data, mime_type)

--- a/test/unit/student_test.rb
+++ b/test/unit/student_test.rb
@@ -223,10 +223,10 @@ class StudentTest < ActiveSupport::TestCase
 
       # Mock the repository and expect :remove_user with the student's user_name
       mock_repo = mock('Repository::AbstractRepository')
+      Group.any_instance.stubs(:access_repo).yields(mock_repo)
       mock_repo.stubs(:remove_user).returns(true)
       mock_repo.stubs(:close).returns(true)
       mock_repo.expects(:remove_user).with(any_of(@student1.user_name, @student2.user_name)).at_least(2)
-      Group.any_instance.stubs(:repo).returns(mock_repo)
 
       Student.hide_students(@student_id_list)
     end


### PR DESCRIPTION
This fixes two problems with the student submission browser when using git: deleting a file, and deleting/replacing multiple files at once.
To do this:
1) Make the transaction really be an atomic transaction in git
2) Make all revision safety checks for delete/replace to be checks of repository changes from the time it has been opened to the transaction time (and not a check on which revision the file was last modified)

(this does not touch two other things that don't currently work for any repo type or were never meant to work: deleting a directory and deleting a file within a directory)