### PR TITLE
Fixed issue #2901

### DIFF
--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -90,7 +90,10 @@ class CriteriaController < ApplicationController
 
     ActiveRecord::Base.transaction do
       params[:criterion].each_with_index do |type_id, index|
-        type, id = type_id.split(' ')
+
+        type = type_id.match(/^[a-zA-Z]+/).to_s
+        id   = type_id.match(/\d+/).to_s
+
         type.constantize.update(id, position: index + 1) unless id.blank?
       end
     end


### PR DESCRIPTION
# Fix to issue #2901 
## Before 
Variable ```id``` was not being assigned to anything becuase the ```type_id``` string doesn't contain a space that seperates ```type``` and ```id```.
 
```
File : /Markus/app/controllers/criteria_controller.rb

line 93 : type, id = type_id.split(' ')
```

## After 
In this case, ```type``` and ```id``` are parsed separately from the string using regex. This implementation doesn't rely on the string to have space in between ```type``` and ```id```.

```
File : /Markus/app/controllers/criteria_controller.rb

line 94 : type = type_id.match(/^[a-zA-Z]+/).to_s
line 95 : id   = type_id.match(/\d+/).to_s
```

