### PR TITLE
Fixed issue of not being able to sort Graders in an assignment

### DIFF
--- a/app/assets/javascripts/ReactComponents/table.js
+++ b/app/assets/javascripts/ReactComponents/table.js
@@ -53,7 +53,6 @@ if (typeof React !== 'undefined') {
 var Table = React.createClass({displayName: 'Table',
   propTypes: {
     data: React.PropTypes.array,
-    sort: React.PropTypes.array,
     search_placeholder: React.PropTypes.string,
     columns: React.PropTypes.array,
     filters: React.PropTypes.array, // Optional: pass null
@@ -167,7 +166,6 @@ var Table = React.createClass({displayName: 'Table',
 
     var rows = this.state.sorted_rows.slice();
     sort_by_column(rows,
-                   this.props.sort,
                    sort_column,
                    sort_direction,
                    compare_func);

--- a/app/assets/javascripts/ReactComponents/table.js
+++ b/app/assets/javascripts/ReactComponents/table.js
@@ -599,7 +599,7 @@ function search_item(search_text, item) {
   }
 }
 
-function sort_by_column(data, sort, column, direction, compare) {
+function sort_by_column(data, column, direction, compare) {
   // determine sort behaviour
   function makeComparable(a)
   {

--- a/app/assets/javascripts/ReactComponents/table.js
+++ b/app/assets/javascripts/ReactComponents/table.js
@@ -603,13 +603,6 @@ function sort_by_column(data, sort, column, direction, compare) {
   // determine sort behaviour
   function makeComparable(a)
   {
-    if (sort && sort.hasOwnProperty(a.id)) {
-      var sort_data = sort[a.id];
-      if (sort_data.hasOwnProperty(column)) {
-        return sort_data[column];
-      }
-    }
-    a = a[column];
     if (typeof a === 'string') {
       return a.toLowerCase().replace(' ', '');
     } else if (a.hasOwnProperty('props')) {
@@ -640,7 +633,7 @@ function sort_by_column(data, sort, column, direction, compare) {
 
   // sort row by column id
   data.sort(function(a, b) {
-    var c = compare(makeComparable(a), makeComparable(b));
+    var c = compare(makeComparable(a[column]), makeComparable(b[column]));
 
     if (c === 0) {
       return a.pos - b.pos;

--- a/app/assets/javascripts/ReactComponents/table.js
+++ b/app/assets/javascripts/ReactComponents/table.js
@@ -53,6 +53,7 @@ if (typeof React !== 'undefined') {
 var Table = React.createClass({displayName: 'Table',
   propTypes: {
     data: React.PropTypes.array,
+    sort: React.PropTypes.array,
     search_placeholder: React.PropTypes.string,
     columns: React.PropTypes.array,
     filters: React.PropTypes.array, // Optional: pass null
@@ -166,6 +167,7 @@ var Table = React.createClass({displayName: 'Table',
 
     var rows = this.state.sorted_rows.slice();
     sort_by_column(rows,
+                   this.props.sort,
                    sort_column,
                    sort_direction,
                    compare_func);
@@ -597,10 +599,17 @@ function search_item(search_text, item) {
   }
 }
 
-function sort_by_column(data, column, direction, compare) {
+function sort_by_column(data, sort, column, direction, compare) {
   // determine sort behaviour
   function makeComparable(a)
   {
+    if (sort && sort.hasOwnProperty(a.id)) {
+      var sort_data = sort[a.id];
+      if (sort_data.hasOwnProperty(column)) {
+        return sort_data[column];
+      }
+    }
+    a = a[column];
     if (typeof a === 'string') {
       return a.toLowerCase().replace(' ', '');
     } else if (a.hasOwnProperty('props')) {
@@ -631,7 +640,7 @@ function sort_by_column(data, column, direction, compare) {
 
   // sort row by column id
   data.sort(function(a, b) {
-    var c = compare(makeComparable(a[column]), makeComparable(b[column]));
+    var c = compare(makeComparable(a), makeComparable(b));
 
     if (c === 0) {
       return a.pos - b.pos;

--- a/app/assets/javascripts/ReactComponents/table_sorts.js
+++ b/app/assets/javascripts/ReactComponents/table_sorts.js
@@ -63,3 +63,10 @@ function compare_values(a, b) {
   }
   return 0;
 }
+
+function compare_graders(a, b) {
+  var nameA = a[0].props.children[1];
+  var nameB = b[0].props.children[1];
+
+  return compare_values(nameA, nameB);
+}

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -550,8 +550,14 @@
       <%= raw @section_column  %>
       {
         id: 'graders',
-        content:<input type='checkbox'
-        onChange={this.graderCheckboxAllClicked}> <%= j raw t('graders.graders') %></input>,
+        content: (
+            <input
+              type='checkbox'
+              onChange={this.graderCheckboxAllClicked}
+            >
+              <%= j raw t('graders.graders') %>
+            </input>
+        ),
         sortable: true,
         searchable: false
       },
@@ -572,6 +578,7 @@
       filters.unshift({name: all, text: all, func: null});
 
       // Massage the data so it will fit into the table.
+      var sort_data = {};
       var groups_data = this.props.groups.map(function(group) {
         var g = {};
         g['id'] = group.id;
@@ -581,13 +588,17 @@
         g['name'] = group.name;
         g['section'] = group.section;
         var graders = [];
+        var graders_name = [];
         for (var i = 0; i < group.graders.length; i++) {
           graders.push(<div key={group.graders[i].membership_id}>
             <input id={group.graders[i].membership_id}
               type='checkbox'
               checked={this.props.selected_graders_in_groups.indexOf(group.graders[i].membership_id) !== -1 ? true : false}
               onChange={this.graderCheckboxClicked} />{group.graders[i].user_name}</div>);
+          graders_name.push(group.graders[i].user_name)
         }
+
+        sort_data[group.id] = {graders: graders_name.join('')};
 
         g['graders'] = graders;
         return g;
@@ -595,7 +606,7 @@
 
       return (
         <div className='tab-pane ui-tabs ui-widget ui-widget-content ui-corner-all' id='groups-tabs'>
-          <Table data={groups_data} columns={columns} ref="myTable"
+          <Table data={groups_data} sort={sort_data} columns={columns} ref="myTable"
                filters={filters} filter_type={filters.length > 3}
                search_placeholder={'<%= j raw t('groups.search_groups') %>'} />
         </div>

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -552,12 +552,12 @@
         id: 'graders',
         compare: 'compare_graders',
         content: (
-            <input
-              type='checkbox'
-              onChange={this.graderCheckboxAllClicked}
-            >
-              <%= j raw t('graders.graders') %>
-            </input>
+          <input
+            type='checkbox'
+            onChange={this.graderCheckboxAllClicked}
+          >
+            <%= j raw t('graders.graders') %>
+          </input>
         ),
         sortable: true,
         searchable: false

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -579,7 +579,6 @@
       filters.unshift({name: all, text: all, func: null});
 
       // Massage the data so it will fit into the table.
-      var sort_data = {};
       var groups_data = this.props.groups.map(function(group) {
         var g = {};
         g['id'] = group.id;
@@ -589,17 +588,13 @@
         g['name'] = group.name;
         g['section'] = group.section;
         var graders = [];
-        var graders_name = [];
         for (var i = 0; i < group.graders.length; i++) {
           graders.push(<div key={group.graders[i].membership_id}>
             <input id={group.graders[i].membership_id}
               type='checkbox'
               checked={this.props.selected_graders_in_groups.indexOf(group.graders[i].membership_id) !== -1 ? true : false}
               onChange={this.graderCheckboxClicked} />{group.graders[i].user_name}</div>);
-          graders_name.push(group.graders[i].user_name)
         }
-
-        sort_data[group.id] = {graders: graders_name.join('')};
 
         g['graders'] = graders;
         return g;
@@ -607,7 +602,7 @@
 
       return (
         <div className='tab-pane ui-tabs ui-widget ui-widget-content ui-corner-all' id='groups-tabs'>
-          <Table data={groups_data} sort={sort_data} columns={columns} ref="myTable"
+          <Table data={groups_data} columns={columns} ref="myTable"
                filters={filters} filter_type={filters.length > 3}
                search_placeholder={'<%= j raw t('groups.search_groups') %>'} />
         </div>

--- a/app/views/graders/_graders_manager.js.jsx.erb
+++ b/app/views/graders/_graders_manager.js.jsx.erb
@@ -550,6 +550,7 @@
       <%= raw @section_column  %>
       {
         id: 'graders',
+        compare: 'compare_graders',
         content: (
             <input
               type='checkbox'


### PR DESCRIPTION
## Ready for Review
This pull request fixed the issue of not being able to sort Graders for an assignment. The original issue was that _graders_manager.js.jsx.erb was calling table.js, which was trying to sort the checkboxes of each grader instead of the graders' names. 

### Additions and Modifications
- Added sort_data in _graders_manager.js.jsx.erb: sort_data contains the names of each grader for each row
- sort_data is passed in as a props named "sort" to table.js
- method sort_by_column in table.js sorts the graders' names if the data exists

### Screenshots
<img width="638" alt="screen shot 2017-10-02 at 12 28 46 am" src="https://user-images.githubusercontent.com/24910741/31064279-aea0fc7a-a708-11e7-829a-4e5e41771365.png">
<img width="627" alt="screen shot 2017-10-02 at 12 28 40 am" src="https://user-images.githubusercontent.com/24910741/31064280-aea60224-a708-11e7-91ef-ca18e48f2641.png">
