### PR TITLE
Resolved issue #2776

### DIFF
--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -29,7 +29,7 @@ module GradeEntryFormsHelper
 
     unless grade_entry_items.nil?
       # Update the attributes hash
-      max_position = 1
+      max_position = GradeEntryItem.where(:grade_entry_form_id => 1).count
       grade_entry_items.each do |_, item|
         # Some items are being deleted so don't update those
         unless item[:_destroy]


### PR DESCRIPTION
# Resolved Issue #2776
Columns created in the spreadsheet were being viewed in the order they were created in.

## Before 
The maximum position any of the existing columns was hardcoded to 1 and because of this, other columns were being assigned the same position which led to this issue. 

## After 
Now the max position is assigned to the count of existing columns in the particular spreadsheet. Due to this change, the position of columns gets assigned the position of the last column plus 1 which resolves this issue.
 