### PR TITLE
Fixed a syntax error to resolve the issue #2833

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -113,7 +113,7 @@ class TagsController < ApplicationController
 
   # Export a YAML formatted string.
   def export_tags_yaml
-    tags = Tag.all(order: 'name')
+    tags = Tag.all.order(:name)
 
     # The final list of all tags.
     final = ActiveSupport::OrderedHash.new


### PR DESCRIPTION
# Resolved issue #2833 
An error message was being thrown when attempted to download assignment tags in a file with .yaml format. 

This was happening due to the bad syntax for getting all the tags ordered by name in file ``` tags_controller.rb```.