### PR TITLE
Restore proper text for student tests that regenerate

### DIFF
--- a/app/views/automated_tests/student_interface.html.erb
+++ b/app/views/automated_tests/student_interface.html.erb
@@ -17,24 +17,20 @@
           <div class='sub_block'>
             <%= raw t('automated_tests.token.unlimited_tokens') %>
           </div>
-        <% elsif !@assignment.non_regenerating_tokens %>
+        <% else %>
+          <% unless @assignment.non_regenerating_tokens %>
           <div class='sub_block'>
-            <%= raw t('automated_tests.token.tokens_per_period',
-                      tokens: @assignment.tokens_per_period,
+            <%= raw t('automated_tests.token.tokens_per_period', tokens: @assignment.tokens_per_period,
                       regeneration_period: @assignment.token_period) %>
           </div>
-        <% else %>
-          <div class='sub_block'>
-            <%= raw t('automated_tests.token.tokens_regenerate') %>
-          </div>
+          <% end %>
           <div class='sub_block'>
             <% if DateTime.now < @assignment.token_start_date %>
               <%= raw t('automated_tests.token.tokens_not_given_yet') %>
             <% elsif @token.remaining == 0 %>
               <%= raw t('automated_tests.token.tokens_no_more_available') %>
             <% else %>
-              <%= raw t('automated_tests.token.tokens_available',
-                        tokens: @token.remaining) %>
+              <%= raw t('automated_tests.token.tokens_available', tokens: @token.remaining) %>
             <% end %>
           </div>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1615,7 +1615,6 @@ en:
       token:
         tokens_form: "Tokens available per group"
         tokens_regenerate: "and regenerate every"
-        tokens_no_regeneration: "No regeneration"
         token_start_date: "<span class=\"prop_label\">Tokens available starting on:</span> %{date}"
         tokens_per_period: "<span class=\"prop_label\">Tokens per %{regeneration_period} hour(s):</span> %{tokens}"
         tokens_not_given_yet: "<span class=\"prop_label\">Tokens available:</span> No tokens given yet"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1846,7 +1846,6 @@ es:
       token:
         tokens_form:              "Las fichas están disponibles por grupo"
         tokens_regenerate:        "Y regenera todo/a"
-        tokens_no_regeneration:   "No regeneración"
         token_start_date:         "<span class=\"prop_label\">Las fichas disponibles empiezan en:</span> %{date}"
         tokens_per_period:        "<span class=\"prop_label\">Fichas por %{regeneration_period} hora(s):</span> %{tokens}"
         tokens_not_given_yet:     "<span class=\"prop_label\">Fichas disponibles:</span> No se han dado fichas todavía"


### PR DESCRIPTION
After the introduction of non_regenerating_tokens, the ui for student tests was not showing the same info it used to show.