### PR TITLE
Fixed #2903 - Change Existing Marks after Re-weighting Rubric Criterion

### DIFF
--- a/app/models/mark.rb
+++ b/app/models/mark.rb
@@ -1,10 +1,10 @@
 class Mark < ActiveRecord::Base
   # When a mark is created, or updated, we need to make sure that that
   # Result has not been released to students
-  before_save :ensure_not_released_to_students
-  before_update :ensure_not_released_to_students
+  before_save :ensure_not_released_to_students, unless: :scaled_mark?
+  before_update :ensure_not_released_to_students, unless: :scaled_mark?
 
-  after_save :update_result_mark
+  after_save :update_result_mark, :update_scaled_mark
 
   belongs_to :result
   validates_presence_of :result_id, :markable_id, :markable_type
@@ -28,6 +28,8 @@ class Mark < ActiveRecord::Base
   validates_uniqueness_of :markable_id,
                           scope: [:result_id, :markable_type]
 
+  attr_accessor :scaled_mark
+
   # Custom validator for checking the upper range of a mark
   def valid_mark
     unless mark.nil?
@@ -39,6 +41,7 @@ class Mark < ActiveRecord::Base
 
   def scale_mark(curr_max_mark, prev_max_mark)
     return if prev_max_mark == 0 || mark == 0 # no scaling occurs if prev_max_mark is 0 or mark is 0
+    self.scaled_mark = true
     if markable.is_a? RubricCriterion
       new_mark = mark * (curr_max_mark / prev_max_mark)
       update_attributes(mark: new_mark.round(2))
@@ -48,6 +51,18 @@ class Mark < ActiveRecord::Base
     else # if it is CheckboxCriterion
       update_attributes(mark: curr_max_mark)
     end
+  end
+
+  def scaled_mark
+    @scaled_mark || false
+  end
+
+  def scaled_mark?
+    return self.scaled_mark
+  end
+
+  def update_scaled_mark
+    self.scaled_mark = false
   end
 
   private


### PR DESCRIPTION
## Ready for Review
This pull request fixes issue #2903 where released marks were not being updated after re-weighting rubric criterion. The new mark attribute was not being saved to released marks due to callbacks.

### Additions and Modifications
- Added condition to callbacks so that the new mark attributes of released marks are being saved 

### Screenshots
**Before:**
![screen shot 2017-11-05 at 11 22 59 am](https://user-images.githubusercontent.com/24910741/32416719-cee18fa8-c21b-11e7-82b8-e3ebb50c0951.png)
![screen shot 2017-11-05 at 11 29 21 am](https://user-images.githubusercontent.com/24910741/32416768-9d090bb8-c21c-11e7-8e5b-ed065df98e0d.png)


**After:**
![screen shot 2017-11-05 at 11 23 15 am](https://user-images.githubusercontent.com/24910741/32416729-eeeb0a36-c21b-11e7-8f45-80cb3dd53b73.png)
![screen shot 2017-11-05 at 11 28 49 am](https://user-images.githubusercontent.com/24910741/32416769-a671dc34-c21c-11e7-9de2-19ead533f021.png)
