### PR TITLE
Increase ui validation for max timeout to 1 hour

### DIFF
--- a/app/views/automated_tests/_test_script_upload.html.erb
+++ b/app/views/automated_tests/_test_script_upload.html.erb
@@ -60,7 +60,7 @@
         <div>
           <%= f.label :timeout, raw(t('automated_tests.script_option.timeout')),
                       title: t('automated_tests.script_option.timeout_help') %>
-          <%= f.number_field :timeout, value: (saved ? f.object.timeout : 30), min: 1, max: 600, step: 1 %>
+          <%= f.number_field :timeout, value: (saved ? f.object.timeout : 30), min: 1, max: 3600, step: 1 %>
         </div>
 
         <div class="desc">


### PR DESCRIPTION
A course requested the limit to be more than the current 10 minutes, but I'm not really happy to go to more than 1 hour (it could already allow for a deliberate denial of service and require the sysadmin support).