### PR TITLE
Fix rubric criteria max_mark rounding

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -225,7 +225,7 @@ class RubricCriterion < Criterion
     # (this was being done in a weird way, leaving the original in case there are problems)
     # factor = 10.0 ** 3
     # self.max_mark = (max_mark * factor).round.to_f / factor
-    self.max_mark = self.max_mark.round(3)
+    self.max_mark = self.max_mark.round(1)
   end
 
   def all_assigned_groups

--- a/test/unit/rubric_criteria_test.rb
+++ b/test/unit/rubric_criteria_test.rb
@@ -32,13 +32,13 @@ class RubricCriterionTest < ActiveSupport::TestCase
     assert !assignment_id_dne.save
   end
 
-  should 'round weights that have more than 3 significant digits' do
+  should 'round weights that have more than 1 significant digits' do
     RubricCriterion.make
     assert RubricCriterion.count > 0
     criterion = RubricCriterion.first
     criterion.max_mark = 0.5555555555
     criterion.save
-    assert_equal 0.556, criterion.max_mark
+    assert_equal 0.6, criterion.max_mark
   end
 
   should 'find a mark for a specific rubric and result' do


### PR DESCRIPTION
max_mark has scale 1 in the db, so the rounding to 3 decimal digits and its test are wrong