### PR TITLE
Change logout to POST request

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,10 +23,9 @@
                     remote: true %>
       <% end %>
 
-      <%= button_to(t(:log_out),
+      <%= link_to(t(:log_out),
+                  logout_main_index_path,
                   id: 'logout_link',
-                  controller: 'main',
-                  action: 'logout',
                   method: :post) unless
                   MarkusConfigurator.markus_config_logout_redirect == 'NONE' %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,10 +23,11 @@
                     remote: true %>
       <% end %>
 
-      <%= link_to(t(:log_out),
+      <%= button_to(t(:log_out),
                   id: 'logout_link',
                   controller: 'main',
-                  action: 'logout') unless
+                  action: 'logout',
+                  method: :post) unless
                   MarkusConfigurator.markus_config_logout_redirect == 'NONE' %>
 
       <% if MarkusConfigurator.markus_config_remote_user_auth &&

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -409,7 +409,7 @@ Markus::Application.routes.draw do
 
     resources :main do
       collection do
-        get 'logout'
+        post 'logout'
         get 'about'
         post 'login_as'
         get 'role_switch'

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -1369,7 +1369,7 @@ context 'main' do
 
   context 'collection' do
     it 'routes GET logout properly' do
-      expect(get: path + '/logout').to route_to(
+      expect(post: path + '/logout').to route_to(
         controller: ctrl,
         action: 'logout',
         locale: 'en')
@@ -1427,7 +1427,7 @@ context 'main' do
   end
 
   it 'routes GET logout properly' do
-    expect(get: path + '/logout').to route_to(
+    expect(post: path + '/logout').to route_to(
       controller: ctrl,
       action: 'logout',
       locale: 'en')


### PR DESCRIPTION
Change logout to a POST request (from a GET request), following regular conventions and allows for CSRF protection. Fixes second half of issue #3237.