### PR TITLE
Fixed Issue #2109 - Show pending students in Groups

### DIFF
--- a/app/views/groups/_groups_manager.js.jsx.erb
+++ b/app/views/groups/_groups_manager.js.jsx.erb
@@ -298,11 +298,24 @@
 
         var members = [];
         for (var i = 0; i < group.members.length; i++) {
-          members.push(<div key={group.members[i][0]}>
-            <input id={group.members[i][0]}
-              type='checkbox'
-              checked={this.props.selected_students_in_groups.indexOf(group.members[i][0]) !== -1}
-              onChange={this.studentCheckboxClicked} /> {group.members[i][1]} ({group.members[i][2]})</div>);
+          var member_name = group.members[i][1];
+          var member_status = group.members[i][2];
+          var member_string;
+          if (member_status.toLowerCase() === 'pending') {
+            member_string = <b>{member_name} ({member_status})</b>
+          } else {
+            member_string = member_name + '(' + member_status + ')'
+          }
+          members.push(
+            <div key={group.members[i][0]}>
+              <input id={group.members[i][0]}
+                type='checkbox'
+                checked={this.props.selected_students_in_groups.indexOf(group.members[i][0]) !== -1}
+                onChange={this.studentCheckboxClicked}
+              />
+              {member_string}
+            </div>
+          );
         }
         g['members'] = members;
         g['valid'] = group.valid;


### PR DESCRIPTION
## Ready for Review
This pull request fixes issue #2109 and bolds pending students' names and invitation status under the Groups tab in Assignment.

### Additions and Modifications
- Added bold tags to students' names and invitation status if their status is "pending" under the Groups tab in Assignment

### Screenshots
<img width="812" alt="screen shot 2017-11-27 at 11 28 28 am" src="https://user-images.githubusercontent.com/24910741/33277308-29d75dec-d366-11e7-8994-abc4aebfb67e.png">
