### PR TITLE
Fixed Issue #2925: Marks Spreadsheet Cell Colours

### DIFF
--- a/app/views/grade_entry_forms/update_grade.js.erb
+++ b/app/views/grade_entry_forms/update_grade.js.erb
@@ -4,7 +4,10 @@
     .css('background-color', '')
     .addClass('updated')
     .delay(600)
-    .queue(function () {$(this).removeClass('updated')});
+    .queue(function () {
+        $(this).removeClass('updated');
+        $(this).dequeue();
+    });
 
   <%
     # This code calls the javascript function 'update_cell(cell, value)' in


### PR DESCRIPTION
## Ready for Review
This pull request fixes issue #2925 and updates the code so that when a valid input is typed into a marks spreadsheet cell the cell flashes green. Previously the cell would remain green after the second valid input attempt.

### Additions and Modifications
- Added dequeue() to remove the removeClass function from the queue after it has been called