### PR TITLE
Improve interface for assignment 'Overall comments.'

### DIFF
--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -431,7 +431,7 @@ fieldset {
   border-radius: $radius;
   padding: 0;
 
-  ul {
+  > ul {
     margin: 0;
     padding: 0;
 

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -371,10 +371,6 @@ ul.annotation_text_list {
     margin: 1em 0;
     width: 100%;
   }
-
-  input#overall_comment_submit {
-    margin-bottom: 2em;
-  }
 }
 
 #annotation_summary_list {
@@ -416,8 +412,10 @@ ul.annotation_text_list {
 #annotation_preview, #overall_comment_preview, #overall_remark_comment_preview {
   margin: 1em 0 20px 0;
   border: 1px dashed $grey;
-  padding: 0px 10px;
+  padding: 0 10px;
   min-height: 43px;
+  max-height: 15em;
+  overflow-y: scroll;
 }
 
 #annotation_preview {

--- a/app/views/assignments/_list.html.erb
+++ b/app/views/assignments/_list.html.erb
@@ -52,12 +52,6 @@
                     <strong><%= t(:your_mark) %></strong>
                     <%= # show results
                         ("%.2f" % (@a_id_results[assignment.id].total_mark * 100 / assignment.max_mark)).to_s + "% (#{t('assignment_average')} " + ("%.2f" % (assignment.results_average)).to_s + "%)" %>
-                    <p>
-                      <strong><%= t('assignment.overall_comment') %></strong>
-                    </p>
-                    <p>
-                      <%= markdown(@a_id_results[assignment.id].overall_comment) %>
-                    </p>
                     <%= link_to t('results.results_name'),
                                 view_marks_assignment_submission_result_path(
                                   assignment_id: assignment.id,

--- a/app/views/results/marker/_overall_comment.html.erb
+++ b/app/views/results/marker/_overall_comment.html.erb
@@ -5,15 +5,15 @@
                  url: { action: 'update_overall_comment',
                         id: result.id },
                  html: { method: :post } do |f| %>
+      <%= f.submit t(:save_changes),
+                   disable_with: t('working'),
+                   id: 'overall_comment_submit' %>
       <%= f.text_area :overall_comment,
                       cols: 50,
                       rows: 5,
                       id: 'overall_comment_text_area' %>
       <h3 id="overall_comment_preview_title"><%= t('marker.annotation.preview') %></h3>
       <div id="overall_comment_preview" style="word-wrap: break-word;"></div>
-      <%= f.submit t(:save_changes),
-                   disable_with: t('working'),
-                   id: 'overall_comment_submit' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
- Removes it from the student dashboard (looks bad when there's a long
  comment, or is empty).
- Limit the height of the comment preview (no scrolls instead).
- Move the "Save changes" button to the top. Although eventually this
  should probably be an autosave.