### PR TITLE
rails5: update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'spring'
-  gem 'debugger', :platforms => :mri_19
   gem 'quiet_assets'
   gem 'bullet'
 end
@@ -111,13 +110,14 @@ group :test do
   gem 'time-warp'
   gem 'database_cleaner'
   gem 'shoulda-callback-matchers', '~> 1.1.1'
+  gem 'rails-controller-testing'
 end
 
 # Gems needed (wanted) for both development and test can be
 # listed here
 group :development, :test do
   gem 'byebug', :platforms => [:mri_20, :mri_21, :mri_22, :mri_23]
-  gem "rspec-rails", '~> 3.0'
+  gem "rspec-rails", '~> 3.5'
 end
 
 # Gems needed (wanted) for development, test and production_test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    columnize (0.9.0)
     combine_pdf (0.2.34)
       ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.0.5)
@@ -96,12 +95,6 @@ GEM
     daemons (1.2.5)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.8)
     descriptive_statistics (2.4.0)
     diff-lcs (1.3)
     docile (1.1.5)
@@ -190,6 +183,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.10)
       sprockets-rails
+    rails-controller-testing (0.0.3)
+      rails (>= 4.2)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.8)
@@ -362,7 +357,6 @@ DEPENDENCIES
   coffee-script
   combine_pdf
   database_cleaner
-  debugger
   descriptive_statistics (~> 2.4.0)
   dynamic_form
   exception_notification
@@ -388,6 +382,7 @@ DEPENDENCIES
   quiet_assets
   railroady
   rails (~> 4.2.0)
+  rails-controller-testing
   rails-deprecated_sanitizer
   rails-html-sanitizer
   rails-observers (~> 0.1.1)
@@ -398,7 +393,7 @@ DEPENDENCIES
   responders (~> 2.0)
   resque
   rmagick
-  rspec-rails (~> 3.0)
+  rspec-rails (~> 3.5)
   rubocop
   rubocop-git
   rubyzip


### PR DESCRIPTION
See
http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#extraction-of-some-helper-methods-to-rails-controller-testing

and

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#removed-support-for-debugger