### PR TITLE
Fix updating repo permissions file for every ta in a csv list

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'repo', 'repository
 class Admin < User
   SESSION_TIMEOUT = USER_ADMIN_SESSION_TIMEOUT
 
-  after_create  :grant_repository_permissions
-  after_destroy :revoke_repository_permissions
-  after_update  :maintain_repository_permissions
+  after_create  :grant_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
+  after_destroy :revoke_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
+  after_update  :maintain_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
 
 end

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -8,9 +8,9 @@ class Ta < User
   CSV_UPLOAD_ORDER = USER_TA_CSV_UPLOAD_ORDER
   SESSION_TIMEOUT = USER_TA_SESSION_TIMEOUT
 
-  after_create  :grant_repository_permissions
-  after_destroy :revoke_repository_permissions
-  after_update  :maintain_repository_permissions
+  after_create  :grant_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
+  after_destroy :revoke_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
+  after_update  :maintain_repository_permissions, if: Proc.new { |admin| admin.batch_processing.blank? }
 
   has_many :criterion_ta_associations, dependent: :delete_all
 


### PR DESCRIPTION
It all boils down to the after_create callback, which is totally right if we save a single new ta.
We may not want to do that in a batch transaction, but I can't just disable the callback and reenable it, it would potentially do it for all other concurrent requests.
What I've added instead is a normal ruby attribute which is checked by the callback, and can be set on a per-model-instance basis.

@david-yz-liu if this feels like a hack we can discuss tomorrow.