### PR TITLE
autotest: converts newlines in all uploaded test scripts to LF

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -22,13 +22,13 @@ class AutomatedTestsController < ApplicationController
           files.each do |file|
             File.open(file[:path], 'wb') do |f|
               content = file[:upload].read
-              # remove carriage return or other non-newline whitespace from
-              # the end of a shebang
-              if content.start_with? '#!'
-                line_end = content.index "\n"
-                unless line_end.nil?
-                  shebang = content[0...line_end].strip
-                  content[0...line_end] = shebang
+              # remove carriage return or other non-LF whitespace from the end of lines
+              if content.start_with?('#!')
+                newline_chars = content[/\r?\n|\r{1,2}/] # captures line endings: "\n" "\r\n" "\r\r" "\r"
+                if !newline_chars.nil? && newline_chars != "\n"
+                  filename = File.basename file[:path]
+                  flash_message(:notice, t('automated_tests.convert_newline_notice', file: filename))
+                  content = content.encode(content.encoding, universal_newline: true)
                 end
               end
               f.write(content)

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -22,7 +22,16 @@ class AutomatedTestsController < ApplicationController
           files.each do |file|
             File.open(file[:path], 'wb') do |f|
               content = file[:upload].read
-              f.write(content.encode(content.encoding, universal_newline: true))
+              # remove carriage return or other non-newline whitespace from
+              # the end of a shebang
+              if content.start_with? '#!'
+                line_end = content.index "\n"
+                unless line_end.nil?
+                  shebang = content[0...line_end].strip
+                  content[0...line_end] = shebang
+                end
+              end
+              f.write(content)
             end
             if file.has_key?(:delete) && File.exist?(file[:delete])
               File.delete(file[:delete])

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -20,7 +20,10 @@ class AutomatedTestsController < ApplicationController
         if @assignment.save
           # write the uploaded files
           files.each do |file|
-            File.open(file[:path], 'wb') { |f| f.write(file[:upload].read) }
+            File.open(file[:path], 'wb') do |f|
+              content = file[:upload].read
+              f.write(content.encode(content.encoding, universal_newline: true))
+            end
             if file.has_key?(:delete) && File.exist?(file[:delete])
               File.delete(file[:delete])
             end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1503,6 +1503,7 @@ en:
       add_test_support_file_link: "Add Test Support File"
       add_test_script_file_alert: "You must enable tests for this assignment to add a test script file."
       add_test_support_file_alert: "You must enable tests for this assignment to add a test support file."
+      convert_newline_notice: "Newline characters in %{file} converted to \\n"
       new_test_script_file: "New Test Script File"
       new_test_support_file: "New Test Support File"
       assignment_test_script_files: "Test Script Files"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1752,6 +1752,7 @@ es:
                                            archivo con un script de la prueba."
       add_test_support_file_alert:        "Usted debe habilitar las pruebas para este proyecto para añadir un archivo
                                            de soporte de prueba."
+      convert_newline_notice:             "UPDATE ME"
       new_test_script_file:               "Nuevo archivo del script de la prueba"
       new_test_support_file:              "Nuevo Archivo de Soporte de Prueba"
       assignment_test_script_files:       "Archivos del Script de la Prueba"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1357,6 +1357,7 @@ fr:
       add_test_support_file_link: "UPDATE ME"
       add_test_script_file_alert: "UPDATE ME"
       add_test_support_file_alert: "UPDATE ME"
+      convert_newline_notice: "Les caractères de retour dans le fichier %{file} ont été modifié à \\n"
       new_test_script_file: "UPDATE ME"
       new_test_support_file: "UPDATE ME"
       assignment_test_script_files: "UPDATE ME"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1342,6 +1342,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
       add_test_file_alert: "Você deve habilitar os testes para esse projeto para inserir um arquivo de teste."
       add_lib_file_alert: "Você deve habilitar testes para esse projeto para inserir um arquivo de biblioteca."
       add_parser_file_alert: "Você deve habilitar testes para esse projeto para inserir um arquivo interpretador (Parser)."
+      convert_newline_notice: "UPDATE ME"
       assignment_test_files: "Arquivos testes associados"
       assignment_lib_files: "Arquivos de bibliotecas associadas"
       assignment_parser_files: "Arquivos de interpretador associados"


### PR DESCRIPTION
When test scripts and test script files and test support files are uploaded, their newline characters are converted to LF only (ie. no CRLF)