### PR TITLE
Add support for required files in subdirs

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -389,7 +389,7 @@ class SubmissionsController < ApplicationController
             txn.remove(File.join(assignment_folder, filename),
                        file_revisions[filename])
             log_messages.push("Student '#{current_user.user_name}'" +
-                              " deleted file '#{filename}' for assignment" +
+                              " deleted file '#{@path}/#{filename}' for assignment" +
                               " '#{@assignment.short_identifier}'.")
           end
         end
@@ -414,7 +414,7 @@ class SubmissionsController < ApplicationController
             txn.replace(File.join(assignment_folder, filename), file_object.read,
                         file_object.content_type, revision.revision_identifier)
             log_messages.push("Student '#{current_user.user_name}'" +
-                              " replaced content of file '#{filename}'" +
+                              " replaced content of file '#{@path}/#{filename}'" +
                               ' for assignment' +
                               " '#{@assignment.short_identifier}'.")
           else
@@ -427,7 +427,7 @@ class SubmissionsController < ApplicationController
                     file_object.read, file_object.content_type)
             log_messages.push("Student '#{current_user.user_name}'" +
                               ' submitted file' +
-                              " '#{filename}'" +
+                              " '#{@path}/#{filename}'" +
                               ' for assignment ' +
                               "'#{@assignment.short_identifier}'.")
           end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -338,7 +338,7 @@ class SubmissionsController < ApplicationController
     @file_manager_errors = Hash.new
     required_files = AssignmentFile.where(
                            assignment_id: @assignment).pluck(:filename)
-    students_filenames = []
+    filenames = []
     @path = params[:path] || '/'
     @grouping = current_user.accepted_grouping_for(assignment_id)
     unless @grouping.is_valid?
@@ -364,7 +364,8 @@ class SubmissionsController < ApplicationController
     end
     @grouping.group.access_repo do |repo|
 
-      assignment_folder = File.join(@assignment.repository_folder, @path)
+      assignment_path = Pathname.new(@assignment.repository_folder)
+      current_path = assignment_path.join(@path[1..-1]) # remove trailing '/' or join won't join
 
       # Get the revision numbers for the files that we've seen - these
       # values will be the "expected revision numbers" that we'll provide
@@ -383,13 +384,13 @@ class SubmissionsController < ApplicationController
 
       log_messages = []
       begin
-
         if new_files.empty?
           # delete files marked for deletion
           delete_files.each do |filename|
-            file_path_full = File.join(assignment_folder, filename)
-            file_path_relative = File.join(@path, filename)[1..-1] # remove trailing '/' to match required files
-            txn.remove(file_path_full, file_revisions[filename])
+            file_path = current_path.join(filename)
+            file_path_relative = file_path.relative_path_from(assignment_path).to_s
+            file_path = file_path.to_s
+            txn.remove(file_path, file_revisions[filename])
             log_messages.push("Student '#{current_user.user_name}' deleted file '#{file_path_relative}' "\
                               "for assignment '#{@assignment.short_identifier}'.")
           end
@@ -405,35 +406,36 @@ class SubmissionsController < ApplicationController
             raise I18n.t('student.submission.invalid_file_name')
           end
           filename = sanitize_file_name(filename)
-          file_path_full = File.join(assignment_folder, filename)
-          file_path_relative = File.join(@path, filename)[1..-1] # remove trailing '/' to match required files
+          file_path = current_path.join(filename)
+          file_path_relative = file_path.relative_path_from(assignment_path).to_s
+          file_path = file_path.to_s
           # Sometimes the file pointer of file_object is at the end of the file.
           # In order to avoid empty uploaded files, rewind it to be safe.
           file_object.rewind
 
           # Branch on whether the file is new or a replacement
-          if revision.path_exists?(file_path_full)
-            txn.replace(file_path_full, file_object.read, file_object.content_type, revision.revision_identifier)
+          if revision.path_exists?(file_path)
+            txn.replace(file_path, file_object.read, file_object.content_type, revision.revision_identifier)
             log_messages.push("Student '#{current_user.user_name}' replaced file '#{file_path_relative}' "\
                               "for assignment '#{@assignment.short_identifier}'.")
           else
-            students_filenames << file_path_relative
-            txn.add(file_path_full, file_object.read, file_object.content_type)
+            filenames << file_path_relative
+            txn.add(file_path, file_object.read, file_object.content_type)
             log_messages.push("Student '#{current_user.user_name}' submitted file '#{file_path_relative}' "\
                               "for assignment '#{@assignment.short_identifier}'.")
           end
         end
 
         # check if only required files are allowed for a submission
-        unless students_filenames.empty? ||
+        unless filenames.empty? ||
                required_files.empty? ||
                !@assignment.only_required_files
-          if !(students_filenames - required_files).empty?
+          if !(filenames - required_files).empty?
             @file_manager_errors[:size_conflict] = I18n.t('assignment.upload_file_requirement')
             render :file_manager
             return
           else
-            required_files = required_files - students_filenames
+            required_files = required_files - filenames
           end
         end
         # finish transaction

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -137,11 +137,7 @@ module AutomatedTestsClientHelper
       end
       submission.submission_files.each do |file|
         dir = file.path.partition(File::SEPARATOR)[2] # cut the top-level assignment dir
-        if dir == ''
-          file_path = file.filename
-        else
-          file_path = File.join(dir, file.filename)
-        end
+        file_path = if dir == '' then file.filename else File.join(dir, file.filename) end
         unless required_files.nil? || required_files.include?(file_path) # TODO use &. with ruby > 2.3
           # do not export non-required files, if only required files are allowed
           # (a non-required file may end up in a repo if a hook to prevent it does not exist or is not enforced)

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -136,7 +136,13 @@ module AutomatedTestsClientHelper
         required_files = assignment.assignment_files.map(&:filename).to_set
       end
       submission.submission_files.each do |file|
-        unless required_files.nil? || required_files.include?(file.filename) # TODO use &. with ruby > 2.3
+        dir = file.path.partition(File::SEPARATOR)[2] # cut the top-level assignment dir
+        if dir == ''
+          file_path = file.filename
+        else
+          file_path = File.join(dir, file.filename)
+        end
+        unless required_files.nil? || required_files.include?(file_path) # TODO use &. with ruby > 2.3
           # do not export non-required files, if only required files are allowed
           # (a non-required file may end up in a repo if a hook to prevent it does not exist or is not enforced)
           next

--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -6,6 +6,9 @@ class AssignmentFile < ApplicationRecord
 
   validates_presence_of :filename
   validates_uniqueness_of :filename, scope: :assignment_id
+  before_validation do
+    self.filename = Pathname.new(self.filename).cleanpath.to_s
+  end
   validates_format_of :filename,
           with: /\A[\-\._a-zA-Z0-9][\/\-\._a-zA-Z0-9]*\z/,
           message: I18n.t('validation_messages.format_of_assignment_file')

--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -4,13 +4,18 @@ class AssignmentFile < ApplicationRecord
   has_many :criteria_assignment_files_joins, dependent: :destroy
   has_many :template_divisions
 
+  before_validation :clean_filename
   validates_presence_of :filename
   validates_uniqueness_of :filename, scope: :assignment_id
-  before_validation do
-    self.filename = Pathname.new(self.filename).cleanpath.to_s
-  end
   validates_format_of :filename,
           with: /\A[\-\._a-zA-Z0-9][\/\-\._a-zA-Z0-9]*\z/,
           message: I18n.t('validation_messages.format_of_assignment_file')
 
+  private
+
+  def clean_filename
+    if self.filename
+      self.filename = Pathname.new(self.filename).cleanpath.to_s
+    end
+  end
 end

--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -7,7 +7,7 @@ class AssignmentFile < ApplicationRecord
   validates_presence_of :filename
   validates_uniqueness_of :filename, scope: :assignment_id
   validates_format_of :filename,
-          with: /\A[0-9a-zA-Z\.\-_\(\)]+\z/,
+          with: /\A[\-\._a-zA-Z0-9][\/\-\._a-zA-Z0-9]*\z/,
           message: I18n.t('validation_messages.format_of_assignment_file')
 
 end

--- a/app/views/assignments/_boot.js.erb
+++ b/app/views/assignments/_boot.js.erb
@@ -41,7 +41,7 @@
       }
     });
 
-    var filename_re = /^[-_\.a-zA-Z0-9]+$/;
+    var filename_re = /^[\-\._a-zA-Z0-9][\/\-\._a-zA-Z0-9]*$/;
     $('.assignment_file').each(function() {
       if (!filename_re.exec(this.value)) {
         invalid = true;

--- a/app/views/submissions/_react_file_manager_boot_table.js.jsx.erb
+++ b/app/views/submissions/_react_file_manager_boot_table.js.jsx.erb
@@ -157,7 +157,8 @@
         method: 'POST',
         data: {
           delete_files: delete_file,
-          file_revisions: file_revisions
+          file_revisions: file_revisions,
+          path: '<%= @path %>'
         },
         success: function(data) {
           this.props.resetTable();

--- a/app/views/submissions/file_manager.html.erb
+++ b/app/views/submissions/file_manager.html.erb
@@ -146,6 +146,7 @@
   <%= form_tag update_files_assignment_submissions_path(@assignment.id),
                { multipart: true, id: 'file_form' } do %>
     <%= file_field_tag :new_files, name: 'new_files[]', multiple: true %>
+    <%= hidden_field_tag :path, @path %>
 
     <section class='dialog-actions'>
       <%= submit_tag t(:submit),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "must be alphanumeric, '.', '-', '(', ')', or '_' only"
+      format_of_assignment_file: "must include alphanumeric, '.', '-', '_' or '/' characters only"
 
     # app/views/main/index.html.erb
     switch_role:         "Switch Role"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -81,7 +81,7 @@ es:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "debe incluir sólo caracteres alfanuméricos, '.', '-', '(', ')', o '_'"
+      format_of_assignment_file: "debe incluir sólo caracteres alfanuméricos, '.', '-', '_' o '/'"
 
     # app/views/main/index.html.erb
     switch_role:                   "Cambio de rol"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -74,7 +74,7 @@ fr:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "doit être un caractère alphanumérique, « . », « - », « ( », « ) » ou « _ » uniquement."
+      format_of_assignment_file: "doit être un caractère alphanumérique, « . », « - », « _ » ou « / » uniquement."
 
     # app/views/main/index.html.erb
     switch_role:         "Changer d'utilisateur"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -74,7 +74,7 @@ pt:
 
     # app/models/assignment_file.rb
     validation_messages:
-      format_of_assignment_file: "apenas letras, números, '.', '-', '(', ')', ou '_'"
+      format_of_assignment_file: "apenas letras, números, '.', '-', '_' ou '/'"
 
     # app/views/main/index.html.erb
     switch_role:         "Trocar de papel"

--- a/lib/repo/git_hooks/client/pre-commit.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/client/pre-commit.d/03-check_required_files_master.py
@@ -7,17 +7,18 @@ import subprocess
 
 
 if __name__ == '__main__':
+
     branch = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stdout=subprocess.PIPE,
                             universal_newlines=True)
     # Only check master branch
     if branch.stdout.strip() != 'master':
         exit(0)
 
-    requirements = subprocess.run(['git', 'show', 'HEAD:.required.json'],
-                                    stdout=subprocess.PIPE, universal_newlines=True)
+    requirements = subprocess.run(['git', 'show', 'HEAD:.required.json'], stdout=subprocess.PIPE,
+                                  universal_newlines=True)
     required_files = json.loads(requirements.stdout)
-    changes = subprocess.run(['git', 'diff-index', '--name-status', '--no-renames', 'HEAD'],
-                                stdout=subprocess.PIPE, universal_newlines=True)
+    changes = subprocess.run(['git', 'diff-index', '--name-status', '--no-renames', 'HEAD'], stdout=subprocess.PIPE,
+                             universal_newlines=True)
     staged_dirs = []
 
     # Check if the assignment forbids adding non-required files.
@@ -49,19 +50,18 @@ if __name__ == '__main__':
                     print('[MarkUs] Warning: {}.'.format(msg))
         elif status == 'D' and file_path in req['required']:
             print("[MarkUs] Warning: you are deleting required file '{}' from assignment '{}'.".format(
-                file_path, assignment))
+                  file_path, assignment))
         elif status == 'M' and file_path not in req['required'] and req['required_only']:
             print("[MarkUs] Warning: you are modifying non-required '{}' in assignment '{}', but it only requires '{}'.".format(
-                file_path, assignment, ', '.join(req['required'])))
+                  file_path, assignment, ', '.join(req['required'])))
 
     # warn about missing files
-    new_ls = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
-                            universal_newlines=True)
-    files = [path.split('/') for path in new_ls.stdout.splitlines()]
+    new_ls = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE, universal_newlines=True)
+    files = {tuple(path.split('/', maxsplit=1)) for path in new_ls.stdout.splitlines()}
     for assignment in staged_dirs:
         if assignment not in required_files:
             continue
         for file_path in required_files[assignment]['required']:
-            if [assignment, file_path] not in files:
+            if (assignment, file_path) not in files:
                 print("[MarkUs] Warning: required file '{}' is missing in assignment '{}'.".format(
-                    file_path, assignment))
+                      file_path, assignment))

--- a/lib/repo/git_hooks/update.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/update.d/03-check_required_files_master.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         # M non-required is warned
         for change in changes.stdout.splitlines():
             status, path = change.split(maxsplit=1)
-            assignment, file_path = path.split(os.sep, maxsplit=1)  # it can never be a top level file/dir
+            assignment, file_path = path.split('/', maxsplit=1)  # it can never be a top level file/dir
             req = required_files.get(assignment)
             if req is None:
                 # this can happen only if an assignment becomes hidden after being visible for a while
@@ -37,7 +37,7 @@ if __name__ == '__main__':
             if status == 'A':
                 if file_path not in req['required']:
                     msg = "you are adding '{}' to assignment '{}', but it only requires '{}'".format(
-                        file_path, assignment, ', '.join(req['required']))
+                          file_path, assignment, ', '.join(req['required']))
                     if req['required_only']:
                         print('[MARKUS] Error: {}!'.format(msg))
                         exit(1)
@@ -45,16 +45,16 @@ if __name__ == '__main__':
                         print('[MARKUS] Warning: {}.'.format(msg))
             elif status == 'D' and file_path in req['required']:
                 print("[MARKUS] Warning: you are deleting '{}' from assignment '{}', but it requires it.".format(
-                    file_path, assignment))
+                      file_path, assignment))
             elif status == 'M' and file_path not in req['required']:
                 print("[MARKUS] Warning: you are modifying '{}' in assignment '{}', but it only requires '{}'.".format(
-                    file_path, assignment, ', '.join(req['required'])))
+                      file_path, assignment, ', '.join(req['required'])))
         # warn about missing files
         new_ls = subprocess.run(['git', 'ls-tree', '-r', '--name-only', new_commit], stdout=subprocess.PIPE,
                                 universal_newlines=True)
-        files = [path.split('/') for path in new_ls.stdout.splitlines()]
+        files = {tuple(path.split('/', maxsplit=1)) for path in new_ls.stdout.splitlines()}
         for assignment in required_files.keys():
             for file_path in required_files[assignment]['required']:
-                if [assignment, file_path] not in files:
+                if (assignment, file_path) not in files:
                     print("[MARKUS] Warning: required file '{}' is missing in assignment '{}'.".format(
-                        file_path, assignment))
+                          file_path, assignment))


### PR DESCRIPTION
This pull request adds support for specifying required files in subdirs, using the already existing interface (closes #3290):
1. In the assignment properties, you can specify a usual 'file.xxx' or a new 'subdir/file.xxx'.
2. Required files in subdirs are then enforced by:
  a. Git hooks
  b. File browser
  c. Autotest repo exporter
3. As a side effect, you can now add and delete files in subdirs through the file browser.