### PR TITLE
Change protocol from git to https for activejob-status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'minitest'
 gem 'autoprefixer-rails'
 gem 'resque'
 gem 'redis-rails'
-gem 'activejob-status', github: 'inkstak/activejob-status'
+gem 'activejob-status', git: 'https://github.com/inkstak/activejob-status.git'
 gem 'net-ssh'
 gem 'pluck_to_hash'
 


### PR DESCRIPTION
This was changed in the Gemfile.lock only, causing errors.