### PR TITLE
Use push date instead of commit date with get_all_revisions

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -55,8 +55,10 @@ class SubmissionsController < ApplicationController
       assignment_revisions << revision
       # store the displayed revision
       if @revision.nil?
-        if (params[:revision_identifier] && params[:revision_identifier] == revision.revision_identifier.to_s) ||
-             (params[:revision_timestamp] && Time.parse(params[:revision_timestamp]).in_time_zone >= revision.timestamp)
+        if (params[:revision_identifier] &&
+             params[:revision_identifier] == revision.revision_identifier.to_s) ||
+           (params[:revision_timestamp] &&
+             Time.parse(params[:revision_timestamp]).in_time_zone >= revision.server_timestamp)
           @revision = revision
         end
       end
@@ -65,7 +67,7 @@ class SubmissionsController < ApplicationController
     @revision = assignment_revisions[0] if @revision.nil? # latest relevant revision
     @revisions_history = assignment_revisions.map { |revision| { id: revision.revision_identifier,
                                                                  id_ui: revision.revision_identifier_ui,
-                                                                 date: revision.timestamp } }
+                                                                 date: revision.timestamp} }
 
     respond_to do |format|
       format.html

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -523,7 +523,7 @@ class Grouping < ActiveRecord::Base
       # but in git, the latter returns commit times instead of push times, and would be less efficient because it has to
       # walk through the entire history
     end
-    revision.timestamp
+    revision.server_timestamp
   end
 
   # Returns a list of missing assignment_files yet to be submitted

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -58,7 +58,7 @@ class Submission < ActiveRecord::Base
     new_submission.grouping = grouping
     new_submission.submission_version = 1
     new_submission.submission_version_used = true
-    new_submission.revision_timestamp = revision.timestamp
+    new_submission.revision_timestamp = revision.server_timestamp
     new_submission.revision_identifier = revision.revision_identifier
     new_submission.transaction do
       begin

--- a/app/views/submissions/_repo_files_table.js.jsx.erb
+++ b/app/views/submissions/_repo_files_table.js.jsx.erb
@@ -52,7 +52,7 @@
           @grouping.assignment,
           id: @grouping.id,
           path: @path,
-          revision_timestamp: @revision.timestamp,
+          revision_timestamp: @revision.server_timestamp,
           revision_identifier: @revision.revision_identifier) %>',
         method: 'POST',
         dataType: 'json',

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -57,7 +57,7 @@
 
   <div class='global_actions'>
     <h2><%= raw(t('browse_submissions.viewing_revision', identifier_ui: @revision.revision_identifier_ui)) %>
-        (<span id='current_revision_timestamp_display'> <%= l(@revision.timestamp, format: :long_date) %> </span>)
+        (<span id='current_revision_timestamp_display'><%= l(@revision.timestamp, format: :long_date) %></span>)
         <br>
         <%= t('browse_submissions.currently_collected') %>
         <% if @grouping.is_collected %>

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -56,20 +56,32 @@
   </div>
 
   <div class='global_actions'>
-    <h2><%= raw(t('browse_submissions.viewing_revision', identifier_ui: @revision.revision_identifier_ui)) %>
-        (<span id='current_revision_timestamp_display'><%= l(@revision.timestamp, format: :long_date) %></span>)
-        <br>
-        <%= t('browse_submissions.currently_collected') %>
-        <% if @grouping.is_collected %>
-           <% if @collected_revision %>
-               <%= "#{@collected_revision.revision_identifier_ui}" +
-                   " (#{l(@collected_revision.timestamp, format: :long_date)})" %>
-           <% else %>
-               <%= t('browse_submissions.no_rev_before_deadline') %>
-           <% end %>
+    <h2>
+      <%= t('browse_submissions.viewing_revision') %>
+      <%= @revision.revision_identifier_ui %>
+      <% if @revision.timestamp != @revision.server_timestamp %>
+        (<%= "#{t('browse_submissions.client_time')} #{l(@revision.timestamp, format: :long_date)},
+              #{t('browse_submissions.server_time')} #{l(@revision.server_timestamp, format: :long_date)}" %>)
+      <% else %>
+        (<%= l(@revision.timestamp, format: :long_date) %>)
+      <% end %>
+      <br>
+      <%= t('browse_submissions.currently_collected') %>
+      <% if @grouping.is_collected %>
+        <% if @collected_revision %>
+          <%= @collected_revision.revision_identifier_ui %>
+          <% if @collected_revision.timestamp != @collected_revision.server_timestamp %>
+            (<%= "#{t('browse_submissions.client_time')} #{l(@collected_revision.timestamp, format: :long_date)},
+                  #{t('browse_submissions.server_time')} #{l(@collected_revision.server_timestamp, format: :long_date)}" %>)
+          <% else %>
+            (<%= l(@collected_revision.timestamp, format: :long_date) %>)
+          <% end %>
         <% else %>
-           <%= t('none') %>
+          <%= t('browse_submissions.no_rev_before_deadline') %>
         <% end %>
+      <% else %>
+        <%= t('none') %>
+      <% end %>
     </h2>
 
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,9 +484,11 @@ en:
       find_different_revision: "Find a different revision"
       find_by_revision_timestamp: "Find by Submission Date"
       find_by_revision_number:    "Find by Revision Identifier"
-      viewing_revision:           "Viewing Revision: <span id=\"current_revision_number_display\">%{identifier_ui}</span>"
+      viewing_revision:           "Viewing Revision:"
       currently_collected:  "Collected Revision:"
       no_rev_before_deadline: 	"No revision submitted before deadline"
+      client_time:          "commit:"
+      server_time:          "push:"
       current_path:         "Current Path:"
       all_files:            "all files"
       root:                 "[root]"
@@ -1447,7 +1449,7 @@ en:
         long_ordinal: "%A %d %B %Y %H:%M:%S %Z"
         only_second: "%S"
         #MarkUs LONG_DATE_TIME_FORMAT
-        long_date: "%A, %B %d, %Y, %l:%M %p"
+        long_date: "%A, %B %d, %Y, %l:%M:%S %p"
         #MarkUs SHORT_DATE_TIME_FORMAT
         short_date:       "%B %d, %Y"
         #MarkUs ANT_LOG_DATE_TIME_FORMAT

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -647,9 +647,11 @@ es:
       find_different_revision:              "Encontrar una revisión diferente"
       find_by_revision_timestamp:           "Encontrar basado en la fecha y hora de modificación de la revisión"
       find_by_revision_number:              "Encontrar basado en el número de revisión"
-      viewing_revision:                     "Mirando Revisión: <span id=\"current_revision_number_display\">%{identifier_ui}</span>"
+      viewing_revision:                     "Mirando Revisión:"
       currently_collected:                  "Versión recolectada:"
       no_rev_before_deadline: 	            "Ninguna revisión fue enviada antes de la fecha límite"
+      client_time:                          "UPDATE ME:"
+      server_time:                          "UPDATE ME:"
       current_path:                         "Ruta al Directorio:"
       all_files:                            "todos los archivos"
       root:                                 "[root]"
@@ -1670,7 +1672,7 @@ es:
         long_ordinal: "%A %d %B %Y %H:%M:%S %Z"
         only_second:  "%S"
         #MarkUs LONG_DATE_TIME_FORMAT
-        long_date:    "%A, %B %d, %Y, %l:%M %p"
+        long_date:    "%A, %B %d, %Y, %l:%M:%S %p"
         #MarkUs SHORT_DATE_TIME_FORMAT
         short_date:   "%B %d, %Y"
         #MarkUs ANT_LOG_DATE_TIME_FORMAT

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -466,9 +466,11 @@ fr:
       find_different_revision: "Trouver une autre révision"
       find_by_revision_timestamp: "Par date de révision"
       find_by_revision_number:    "Par numéro de révision"
-      viewing_revision:           "Révision : <span id=\"current_revision_number_display\">%{identifier_ui}</span>"
+      viewing_revision:           "Révision:"
       currently_collected:  "Version recueillies:"
       no_rev_before_deadline:   "Aucune révision soumise avant la date limite"
+      client_time:          "UPDATE ME:"
+      server_time:          "UPDATE ME:"
       current_path:         "Chemin actuel : "
       all_files:   "tous les fichiers"
       root:                 "[racine]"
@@ -1287,7 +1289,7 @@ fr:
         long_ordinal: "%A %d %B %Y %H:%M:%S %Z"
         only_second: "%S"
         #MarkUs LONG_DATE_TIME_FORMAT
-        long_date: "%A %d %B %Y %H:%M"
+        long_date: "%A %d %B %Y %H:%M:%S"
         #MarkUs SHORT_DATE_TIME_FORMAT
         short_date: "%d %B %Y"
         #MarkUs ANT_LOG_DATE_TIME_FORMAT

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -442,9 +442,11 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
       find_different_revision: "Encontrar uma revisão diferente"
       find_by_revision_timestamp: "Encontrar revisão por Timestamp"
       find_by_revision_number:    "Encontrar revisão por número"
-      viewing_revision:           "Vendo revisão: <span id=\"current_revision_number_display\">%{identifier_ui}</span>"
+      viewing_revision:           "Vendo revisão:"
       currently_collected:  "Versão coletada:"
       no_rev_before_deadline: 	"Nenhuma revisão apresentado antes do prazo"
+      client_time:          "UPDATE ME:"
+      server_time:          "UPDATE ME:"
       current_path:         "Caminho atual:"
       all_files:   "todos os arquivos"
       root:                 "[root]"
@@ -1275,7 +1277,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
         long_ordinal: "%A %d %B %Y %H:%M:%S %Z"
         only_second: "%S"
         #MarkUs LONG_DATE_TIME_FORMAT
-        long_date: "%A, %d de %B de %Y %H:%M"
+        long_date: "%A, %d de %B de %Y %H:%M:%S"
         #MarkUs SHORT_DATE_TIME_FORMAT
         short_date: "%d de %B de %Y"
         #MarkUs ANT_LOG_DATE_TIME_FORMAT

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -151,6 +151,7 @@ module Repository
       # revisions
       timestamp = Time.now
       new_rev.timestamp = timestamp
+      new_rev.server_timestamp = timestamp
       @revision_history.push(@current_revision)
       @current_revision = new_rev
       @current_revision.__increment_revision_number() # increment revision number
@@ -399,6 +400,7 @@ module Repository
       new_revision.comment = original.comment
       new_revision.files_content = {}
       new_revision.timestamp = original.timestamp
+      new_revision.server_timestamp = original.server_timestamp
       # copy files objects
       original.files.each do |object|
         if object.instance_of?(RevisionFile)

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -246,7 +246,7 @@ module Repository
 
   class AbstractRevision
     attr_reader :revision_identifier, :revision_identifier_ui, :timestamp, :user_id, :comment
-    attr_writer :timestamp
+    attr_accessor :server_timestamp
 
     def initialize(revision_identifier)
       @revision_identifier = revision_identifier

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -979,6 +979,7 @@ module Repository
       rescue Svn::Error::FsNoSuchRevision
         raise RevisionDoesNotExist
       end
+      @server_timestamp = @timestamp
       super(revision_number)
     end
 


### PR DESCRIPTION
With git, the repo browser was displaying revision commit times to avoid the overhead of getting push times. Push times were used for collection purposes only, and displayed in the submission list page.

That is confusing for instructors because they may think Markus has some clock problem, so this pull request now displays push times too for the current and collected revisions in git.

The long dates now include seconds, because it can be a needed level of detail to waive submissions exceeding the deadline, and gives more confidence to the instructor on the precision of results.

![image](https://user-images.githubusercontent.com/6097798/38587045-11b903ea-3cee-11e8-9054-ae4a39eb126d.png)

Technically, now revisions support two dates, timestamp and server_timestamp, indicating the client and server clocks. SVN just sets them to the same value, while GIT uses them to store the commit and push dates.