### PR TITLE
svn: try installing svn from two different mirrors

### DIFF
--- a/script/install-svn.sh
+++ b/script/install-svn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 SVN_BASE=subversion-1.9.7
-MIRROR_PRIMARY=http://www-us.apache.org/dist
-MIRROR_SECONDARY=http://www-eu.apache.org/dist
+MIRROR_PRIMARY=http://www-us.apache.org/dist/subversion
+MIRROR_SECONDARY=http://www-eu.apache.org/dist/subversion
 
 echo "- - - Detecting Ruby version - - -"
 source /etc/profile.d/rvm.sh

--- a/script/install-svn.sh
+++ b/script/install-svn.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 SVN_BASE=subversion-1.9.7
+MIRROR_PRIMARY=http://www-us.apache.org/dist
+MIRROR_SECONDARY=http://www-eu.apache.org/dist
 
 echo "- - - Detecting Ruby version - - -"
 source /etc/profile.d/rvm.sh
@@ -12,7 +14,11 @@ echo "- - - Installing subversion dependencies - - -"
 sudo apt-get install -y libaprutil1-dev swig
 
 echo "- - - Downloading subversion and sqlite source - - -"
-wget http://apache.parentingamerica.com/subversion/${SVN_BASE}.tar.gz
+if not wget --tries 5 ${MIRROR_PRIMARY}/${SVN_BASE}.tar.gz; then
+  if not wget --tries 5 ${MIRROR_SECONDARY}/${SVN_BASE}.tar.gz; then
+    exit 1
+  fi
+fi
 tar xzf ${SVN_BASE}.tar.gz
 wget https://www.sqlite.org/sqlite-amalgamation-3071501.zip
 unzip sqlite-amalgamation-3071501.zip

--- a/script/install-svn.sh
+++ b/script/install-svn.sh
@@ -14,8 +14,8 @@ echo "- - - Installing subversion dependencies - - -"
 sudo apt-get install -y libaprutil1-dev swig
 
 echo "- - - Downloading subversion and sqlite source - - -"
-if not wget --tries 5 ${MIRROR_PRIMARY}/${SVN_BASE}.tar.gz; then
-  if not wget --tries 5 ${MIRROR_SECONDARY}/${SVN_BASE}.tar.gz; then
+if ! wget --tries 5 ${MIRROR_PRIMARY}/${SVN_BASE}.tar.gz; then
+  if ! wget --tries 5 ${MIRROR_SECONDARY}/${SVN_BASE}.tar.gz; then
     exit 1
   fi
 fi


### PR DESCRIPTION
The mirror that was previously being used to get SVN for travis-ci is either down permanently or is unreliable.  
This will try to get SVN from two (hopefully more reliable) mirrors before giving up. 