### PR TITLE
js: always activate the selected rubric criterion mark

### DIFF
--- a/app/assets/javascripts/Grader/marking.js
+++ b/app/assets/javascripts/Grader/marking.js
@@ -417,6 +417,8 @@ function select_mark(mark_id, mark) {
     var rubric_div = document.getElementById('mark_' + mark_id + '_' + mark);
     rubric_div.addClass('rubric_criterion_level_selected');
     rubric_div.removeClass('rubric_criterion_level');
+    $('.active-rubric').removeClass('active-rubric');
+    rubric_div.addClass('active-rubric');
   }
 }
 


### PR DESCRIPTION
Pressing enter/return when a criterion mark is "active" will select the active criterion mark. 
However, selecting a criterion mark by clicking on it did not also mark it as "active".
This meant that it was possible to click on a criterion mark and then hit enter, which would select the previous mark since it was still marked as "active", effectively reverting the action taken by clicking.

This update ensures that clicking on a criterion mark (or selecting it in any way) also has the effect of marking the selected criterion mark as "active". 

Fixes #3332 