### PR TITLE
Harmonize Markus and markus-autotesting defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@
 
 # Ignore redis dump file
 .dump.rdb
+
+# Yarn-related files
 /public/packs
+/public/packs-test
 /public/javascripts
 /node_modules

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -112,7 +112,7 @@ class AutomatedTestsController < ApplicationController
       assn_short_id = Assignment.find(params[:assignment_id]).short_identifier
 
       # the given file should be in this directory
-      should_be_in = File.join(MarkusConfigurator.autotest_client_dir, assn_short_id)
+      should_be_in = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assn_short_id)
       should_be_in = File.expand_path(should_be_in)
       filename = File.expand_path(File.join(should_be_in, filename))
 

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -1,13 +1,12 @@
 module AutomatedTestsClientHelper
 
+  ASSIGNMENTS_DIR = File.join(MarkusConfigurator.autotest_client_dir, 'assignments')
+  STUDENTS_DIR = File.join(MarkusConfigurator.autotest_client_dir, 'students')
+
   def create_test_repo(assignment)
-    # Create the automated test repository
-    unless File.exist?(MarkusConfigurator.autotest_client_dir)
-      FileUtils.mkdir(MarkusConfigurator.autotest_client_dir)
-    end
-    test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+    test_dir = File.join(ASSIGNMENTS_DIR, assignment.short_identifier)
     unless File.exist?(test_dir)
-      FileUtils.mkdir(test_dir)
+      FileUtils.mkdir_p(test_dir)
     end
   end
 
@@ -51,7 +50,7 @@ module AutomatedTestsClientHelper
         raise I18n.t('automated_tests.duplicate_filename') + new_file_name
       end
       updated_form_file[:file_name] = new_file_name
-      new_file_path = File.join(MarkusConfigurator.autotest_client_dir, assignment.repository_folder, new_file_name)
+      new_file_path = File.join(ASSIGNMENTS_DIR, assignment.short_identifier, new_file_name)
       files.push({path: new_file_path, upload: new_file})
     # 5) Possibly replace existing test file
     else
@@ -60,10 +59,10 @@ module AutomatedTestsClientHelper
       upd_file = params[("#{upd_name}_#{old_file_name}").to_sym]
       upd_file_name = upd_file.original_filename
       updated_form_file[:file_name] = upd_file_name
-      mod_file_path = File.join(MarkusConfigurator.autotest_client_dir, assignment.repository_folder, upd_file_name)
+      mod_file_path = File.join(ASSIGNMENTS_DIR, assignment.short_identifier, upd_file_name)
       f = {path: mod_file_path, upload: upd_file}
       unless upd_file_name == old_file_name
-        old_file_path = File.join(MarkusConfigurator.autotest_client_dir, assignment.repository_folder, old_file_name)
+        old_file_path = File.join(ASSIGNMENTS_DIR, assignment.short_identifier, old_file_name)
         f[:delete] = old_file_path
       end
       files.push(f)
@@ -119,12 +118,12 @@ module AutomatedTestsClientHelper
   def self.export_group_repo(group, repo_dir, assignment, submission = nil)
 
     # Create the automated test repository
-    unless File.exists?(MarkusConfigurator.autotest_client_dir)
-      FileUtils.mkdir(MarkusConfigurator.autotest_client_dir)
+    unless File.exist?(STUDENTS_DIR)
+      FileUtils.mkdir_p(STUDENTS_DIR)
     end
     # Delete student's assignment repository if it already exists
     # TODO clean up in client worker, or try to optimize if revision is the same?
-    if File.exists?(repo_dir)
+    if File.exist?(repo_dir)
       FileUtils.rm_rf(repo_dir)
     end
     # Export the correct repo revision
@@ -204,7 +203,7 @@ module AutomatedTestsClientHelper
   def self.get_test_scripts(assignment, user)
 
     # No test directory or test files
-    test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+    test_dir = File.join(ASSIGNMENTS_DIR, assignment.short_identifier)
     unless File.exist?(test_dir)
       raise I18n.t('automated_tests.error.no_test_files')
     end
@@ -242,7 +241,7 @@ module AutomatedTestsClientHelper
     # if current_user is an instructor, then a submission exists and we use that repo revision
     # if current_user is a student, then we use the latest repo revision
     group = grouping.group
-    repo_dir = File.join(MarkusConfigurator.autotest_client_dir, group.repo_name)
+    repo_dir = File.join(STUDENTS_DIR, group.repo_name)
     submission = submission_id.nil? ? nil : Submission.find(submission_id)
     export_group_repo(group, repo_dir, assignment, submission)
     AutotestRunJob.perform_later(host_with_port, test_scripts, current_user.api_key, test_server_user.api_key,

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -61,7 +61,7 @@ class AutotestRunJob < ApplicationJob
     results_path = MarkusConfigurator.autotest_server_results_dir
     file_username = MarkusConfigurator.autotest_server_files_username
     test_username = tests_config[:user]
-    if test_server_host == 'localhost' || file_username == test_username
+    if file_username == test_username
       test_username = nil
     end
     server_queue = "queue:#{tests_config[:queue]}"
@@ -71,7 +71,7 @@ class AutotestRunJob < ApplicationJob
                                group.repo_name, submission_id]}
 
     begin
-      if test_server_host == 'localhost'
+      if test_server_host == 'localhost' && file_username.nil?
         # tests executed locally with no authentication:
         # create a temp folder, copying the student's submission and all test files
         FileUtils.mkdir_p(files_path, {mode: 0700}) # create base files dir if not already existing

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -65,10 +65,10 @@ class AutotestRunJob < ApplicationJob
       tests_username = nil
     end
     server_queue = "queue:#{tests_config[:queue]}"
-    resque_params = {:class => 'AutomatedTestsServer',
-                     :args => [markus_address, user_api_key, server_api_key, tests_username, test_scripts,
-                               'files_path_placeholder', tests_config[:dir], results_path, assignment.id, group.id,
-                               group.repo_name, submission_id]}
+    resque_params = { class: 'AutomatedTestsServer',
+                      args: [markus_address, user_api_key, server_api_key, tests_username, test_scripts,
+                             'files_path_placeholder', tests_config[:dir], results_path, assignment.id, group.id,
+                             group.repo_name, submission_id] }
 
     begin
       if files_username.nil?
@@ -84,7 +84,7 @@ class AutotestRunJob < ApplicationJob
       else
         # tests executed locally or remotely with authentication:
         # copy the student's submission and all test files through ssh/scp in a temp folder
-        Net::SSH::start(test_server_host, files_username, auth_methods: ['publickey']) do |ssh|
+        Net::SSH.start(test_server_host, files_username, auth_methods: ['publickey']) do |ssh|
           ssh.exec!("mkdir -m 700 -p '#{files_path}'") # create base tests dir if not already existing
           files_path = ssh.exec!("mktemp -d --tmpdir='#{files_path}'").strip # create temp subfolder
           # copy all files using passwordless scp (natively, the net-scp gem has poor performance)

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -35,7 +35,7 @@ class AutotestRunJob < ApplicationJob
     group = grouping.group
 
     # create empty test results for no submission files
-    repo_dir = File.join(MarkusConfigurator.autotest_client_dir, group.repo_name)
+    repo_dir = File.join(AutomatedTestsClientHelper::STUDENTS_DIR, group.repo_name)
     unless repo_files_available?(assignment, repo_dir)
       submission = submission_id.nil? ? nil : Submission.find(submission_id)
       requested_by = User.find_by(api_key: user_api_key)
@@ -47,7 +47,7 @@ class AutotestRunJob < ApplicationJob
     end
 
     submission_path = File.join(repo_dir, assignment.repository_folder)
-    assignment_tests_path = File.join(MarkusConfigurator.autotest_client_dir, assignment.repository_folder)
+    assignment_tests_path = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
     markus_address = Rails.application.config.action_controller.relative_url_root.nil? ?
       host_with_port :
       host_with_port + Rails.application.config.action_controller.relative_url_root
@@ -59,19 +59,19 @@ class AutotestRunJob < ApplicationJob
     tests_config = get_concurrent_tests_config
     files_path = MarkusConfigurator.autotest_server_files_dir
     results_path = MarkusConfigurator.autotest_server_results_dir
-    file_username = MarkusConfigurator.autotest_server_files_username
-    test_username = tests_config[:user]
-    if file_username == test_username
-      test_username = nil
+    files_username = MarkusConfigurator.autotest_server_files_username
+    tests_username = tests_config[:user]
+    if files_username == tests_username
+      tests_username = nil
     end
     server_queue = "queue:#{tests_config[:queue]}"
     resque_params = {:class => 'AutomatedTestsServer',
-                     :args => [markus_address, user_api_key, server_api_key, test_username, test_scripts,
+                     :args => [markus_address, user_api_key, server_api_key, tests_username, test_scripts,
                                'files_path_placeholder', tests_config[:dir], results_path, assignment.id, group.id,
                                group.repo_name, submission_id]}
 
     begin
-      if test_server_host == 'localhost' && file_username.nil?
+      if files_username.nil?
         # tests executed locally with no authentication:
         # create a temp folder, copying the student's submission and all test files
         FileUtils.mkdir_p(files_path, {mode: 0700}) # create base files dir if not already existing
@@ -84,13 +84,13 @@ class AutotestRunJob < ApplicationJob
       else
         # tests executed locally or remotely with authentication:
         # copy the student's submission and all test files through ssh/scp in a temp folder
-        Net::SSH::start(test_server_host, file_username, auth_methods: ['publickey']) do |ssh|
+        Net::SSH::start(test_server_host, files_username, auth_methods: ['publickey']) do |ssh|
           ssh.exec!("mkdir -m 700 -p '#{files_path}'") # create base tests dir if not already existing
           files_path = ssh.exec!("mktemp -d --tmpdir='#{files_path}'").strip # create temp subfolder
           # copy all files using passwordless scp (natively, the net-scp gem has poor performance)
           scp_command = "scp -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -rq "\
                              "'#{submission_path}'/. '#{assignment_tests_path}'/. "\
-                             "#{file_username}@#{test_server_host}:'#{files_path}'"
+                             "#{files_username}@#{test_server_host}:'#{files_path}'"
           Open3.capture3(scp_command)
           # enqueue remotely directly with redis-cli, resque does not allow for multiple redis servers
           resque_params[:args][5] = files_path

--- a/app/models/test_file.rb
+++ b/app/models/test_file.rb
@@ -94,7 +94,7 @@ class TestFile < ApplicationRecord
     # Execute if the full file path exists (indicating a new File object)
     if @file_path
       name =  self.filename
-      test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+      test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
 
       # Folders for test, lib and parse files:
       # Test Files Folder
@@ -121,7 +121,7 @@ class TestFile < ApplicationRecord
 
   def delete_file
     # Test Framework repository to delete from
-    test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+    test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
     if self.filetype == 'test'
       test_dir = File.join(test_dir, 'test')
     elsif self.filetype == 'lib'

--- a/app/models/test_script.rb
+++ b/app/models/test_script.rb
@@ -137,7 +137,7 @@ class TestScript < ApplicationRecord
     # Execute if the full file path exists (indicating a new File object)
     if @file_path
       name = self.file_name
-      test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+      test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
 
       # Create the file path
       path = File.join(test_dir, name)
@@ -149,7 +149,7 @@ class TestScript < ApplicationRecord
 
   def delete_file
     # Automated tests repository to delete from
-    test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+    test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
 
     # Delete file if it exists
     path = File.join(test_dir, self.file_name)

--- a/app/models/test_support_file.rb
+++ b/app/models/test_support_file.rb
@@ -86,7 +86,7 @@ class TestSupportFile < ApplicationRecord
     # Execute if the full file path exists (indicating a new File object)
     if @file_path
       name = self.file_name
-      test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+      test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
 
       # Create the file path
       path = File.join(test_dir, name)
@@ -98,7 +98,7 @@ class TestSupportFile < ApplicationRecord
 
   def delete_file
     # Automated tests repository to delete from
-    test_dir = File.join(MarkusConfigurator.autotest_client_dir, assignment.short_identifier)
+    test_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, assignment.short_identifier)
 
     # Delete file if it exists
     path = File.join(test_dir, self.file_name)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -272,11 +272,11 @@ Markus::Application.configure do
   AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/dev/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
-  AUTOTEST_SERVER_FILES_USERNAME = 'localhost'
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/dev/autotest/files"
-  AUTOTEST_SERVER_RESULTS_DIR = "#{::Rails.root.to_s}/data/dev/autotest/results"
+  AUTOTEST_SERVER_FILES_USERNAME = nil
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/dev/autotest/server"
+  AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
   AUTOTEST_SERVER_TESTS = [
-    {user: 'localhost', dir: "#{::Rails.root.to_s}/data/dev/autotest/tests", queue: 'autotest'}]
+    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
 
   ###################################################################
   # Exam Plugin settings

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -269,21 +269,20 @@ Markus::Application.configure do
   AUTOTEST_ON = true
   AUTOTEST_STUDENT_TESTS_ON = true
   AUTOTEST_STUDENT_TESTS_BUFFER_TIME = 1.hour
-  AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/dev/autotest"
+  AUTOTEST_CLIENT_DIR = "#{::Rails.root}/data/dev/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
   AUTOTEST_SERVER_FILES_USERNAME = nil
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/dev/autotest/server"
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root}/data/dev/autotest/server"
   AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
-  AUTOTEST_SERVER_TESTS = [
-    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
+  AUTOTEST_SERVER_TESTS = [{ user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester' }]
 
   ###################################################################
   # Exam Plugin settings
   ###################################################################
   # Global flag to enable/disable all exam plugin features.
   EXPERIMENTAL_EXAM_PLUGIN_ON = true
-  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/dev/exam_templates"
+  EXAM_TEMPLATE_DIR = "#{::Rails.root}/data/dev/exam_templates"
 
   ###################################################################
   # END OF MarkUs SPECIFIC CONFIGURATION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -301,18 +301,18 @@ Markus::Application.configure do
   AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/prod/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
-  AUTOTEST_SERVER_FILES_USERNAME = 'localhost'
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/prod/autotest/files"
-  AUTOTEST_SERVER_RESULTS_DIR = "#{::Rails.root.to_s}/data/prod/autotest/results"
+  AUTOTEST_SERVER_FILES_USERNAME = nil
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/prod/autotest/server"
+  AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
   AUTOTEST_SERVER_TESTS = [
-    {user: 'localhost', dir: "#{::Rails.root.to_s}/data/prod/autotest/tests", queue: 'autotest'}]
+    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
 
   ###################################################################
   # Exam Plugin settings
   ###################################################################
   # Global flag to enable/disable all exam plugin features.
   EXPERIMENTAL_EXAM_PLUGIN_ON = false
-  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/dev/exam_templates"
+  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/prod/exam_templates"
 
   ###################################################################
   # END OF MarkUs SPECIFIC CONFIGURATION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -298,21 +298,20 @@ Markus::Application.configure do
   AUTOTEST_ON = true
   AUTOTEST_STUDENT_TESTS_ON = true
   AUTOTEST_STUDENT_TESTS_BUFFER_TIME = 1.hour
-  AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/prod/autotest"
+  AUTOTEST_CLIENT_DIR = "#{::Rails.root}/data/prod/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
   AUTOTEST_SERVER_FILES_USERNAME = nil
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/prod/autotest/server"
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root}/data/prod/autotest/server"
   AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
-  AUTOTEST_SERVER_TESTS = [
-    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
+  AUTOTEST_SERVER_TESTS = [{ user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester' }]
 
   ###################################################################
   # Exam Plugin settings
   ###################################################################
   # Global flag to enable/disable all exam plugin features.
   EXPERIMENTAL_EXAM_PLUGIN_ON = false
-  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/prod/exam_templates"
+  EXAM_TEMPLATE_DIR = "#{::Rails.root}/data/prod/exam_templates"
 
   ###################################################################
   # END OF MarkUs SPECIFIC CONFIGURATION

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -268,18 +268,18 @@ Markus::Application.configure do
   AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/test/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
-  AUTOTEST_SERVER_FILES_USERNAME = 'localhost'
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/test/autotest/files"
-  AUTOTEST_SERVER_RESULTS_DIR = "#{::Rails.root.to_s}/data/test/autotest/results"
+  AUTOTEST_SERVER_FILES_USERNAME = nil
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/test/autotest/server"
+  AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
   AUTOTEST_SERVER_TESTS = [
-    {user: 'localhost', dir: "#{::Rails.root.to_s}/data/test/autotest/tests", queue: 'autotest'}]
+    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
 
   ###################################################################
   # Exam Plugin settings
   ###################################################################
   # Global flag to enable/disable all exam plugin features.
   EXPERIMENTAL_EXAM_PLUGIN_ON = true
-  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/dev/exam_templates"
+  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/test/exam_templates"
 
   ###################################################################
   # END OF MarkUs SPECIFIC CONFIGURATION

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -265,21 +265,20 @@ Markus::Application.configure do
   AUTOTEST_ON = true
   AUTOTEST_STUDENT_TESTS_ON = true
   AUTOTEST_STUDENT_TESTS_BUFFER_TIME = 1.hour
-  AUTOTEST_CLIENT_DIR = "#{::Rails.root.to_s}/data/test/autotest"
+  AUTOTEST_CLIENT_DIR = "#{::Rails.root}/data/test/autotest"
   AUTOTEST_RUN_QUEUE = 'CSC108_autotest_run'
   AUTOTEST_SERVER_HOST = 'localhost'
   AUTOTEST_SERVER_FILES_USERNAME = nil
-  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root.to_s}/data/test/autotest/server"
+  AUTOTEST_SERVER_FILES_DIR = "#{::Rails.root}/data/test/autotest/server"
   AUTOTEST_SERVER_RESULTS_DIR = "#{AUTOTEST_SERVER_FILES_DIR}/results"
-  AUTOTEST_SERVER_TESTS = [
-    {user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester'}]
+  AUTOTEST_SERVER_TESTS = [{ user: nil, dir: "#{AUTOTEST_SERVER_FILES_DIR}/tester", queue: 'tester' }]
 
   ###################################################################
   # Exam Plugin settings
   ###################################################################
   # Global flag to enable/disable all exam plugin features.
   EXPERIMENTAL_EXAM_PLUGIN_ON = true
-  EXAM_TEMPLATE_DIR = "#{::Rails.root.to_s}/data/test/exam_templates"
+  EXAM_TEMPLATE_DIR = "#{::Rails.root}/data/test/exam_templates"
 
   ###################################################################
   # END OF MarkUs SPECIFIC CONFIGURATION

--- a/lib/markus_configurator.rb
+++ b/lib/markus_configurator.rb
@@ -304,7 +304,7 @@ module MarkusConfigurator
     if autotest_on? && (defined? AUTOTEST_SERVER_TESTS)
       AUTOTEST_SERVER_TESTS
     else
-      [{user: nil, dir: File.join(autotest_server_files_dir, 'tester'), queue: 'tester'}]
+      [{ user: nil, dir: File.join(autotest_server_files_dir, 'tester'), queue: 'tester' }]
     end
   end
 

--- a/lib/markus_configurator.rb
+++ b/lib/markus_configurator.rb
@@ -280,7 +280,7 @@ module MarkusConfigurator
     if autotest_on? && (defined? AUTOTEST_SERVER_FILES_USERNAME)
       AUTOTEST_SERVER_FILES_USERNAME
     else
-      'localhost'
+      nil
     end
   end
 
@@ -288,7 +288,7 @@ module MarkusConfigurator
     if autotest_on? && (defined? AUTOTEST_SERVER_FILES_DIR)
       AUTOTEST_SERVER_FILES_DIR
     else
-      File.join(::Rails.root.to_s, 'autotest', 'files')
+      File.join(::Rails.root.to_s, 'autotest', 'server')
     end
   end
 
@@ -296,7 +296,7 @@ module MarkusConfigurator
     if autotest_on? && (defined? AUTOTEST_SERVER_RESULTS_DIR)
       AUTOTEST_SERVER_RESULTS_DIR
     else
-      File.join(::Rails.root.to_s, 'autotest', 'results')
+      File.join(autotest_server_files_dir, 'results')
     end
   end
 
@@ -304,7 +304,7 @@ module MarkusConfigurator
     if autotest_on? && (defined? AUTOTEST_SERVER_TESTS)
       AUTOTEST_SERVER_TESTS
     else
-      [{user: 'localhost', dir: File.join(::Rails.root.to_s, 'autotest', 'tests'), queue: 'autotest'}]
+      [{user: nil, dir: File.join(autotest_server_files_dir, 'tester'), queue: 'tester'}]
     end
   end
 

--- a/lib/tasks/autotest.rake
+++ b/lib/tasks/autotest.rake
@@ -41,13 +41,13 @@ class AutotestSetup
   def clear_old_files
     # remove existing files to create room for new ones
     # remove test scripts
-    autotest_dir = File.join(MarkusConfigurator.autotest_client_dir, @assg_short_id)
+    autotest_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, @assg_short_id)
     FileUtils.remove_dir(autotest_dir, force: true)
   end
 
   def move_test_script_files
     # create new directories to put new autotest files into
-    test_file_destination = File.join(MarkusConfigurator.autotest_client_dir, @assg_short_id)
+    test_file_destination = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, @assg_short_id)
     FileUtils.makedirs test_file_destination
 
     # copy test script files into the destination directory
@@ -159,7 +159,7 @@ class AutotestSetup
     criteria = @assignment.get_criteria
 
     # get the test files stored in db/data/autotest_files
-    test_file_dir = File.join(MarkusConfigurator.autotest_client_dir, @assg_short_id)
+    test_file_dir = File.join(AutomatedTestsClientHelper::ASSIGNMENTS_DIR, @assg_short_id)
     test_files = Dir.glob(File.join(test_file_dir, '*')).select { |f| File.file?(f) }
 
     test_files.zip(criteria) do |test_file, criterion|


### PR DESCRIPTION
This is the Markus side of harmonizing a default installation of Markus+markus-autotesting.
(see MarkUsProject/markus-autotesting#76)

There are settings changes, minor logic changes about when to do the scp transfer, and subdirs to contain assignment files vs student files (to avoid name clashes).