### PR TITLE
view: only display Run Tests button in Test Results tab for admins 

### DIFF
--- a/app/views/automated_tests/_test_script_results.html.erb
+++ b/app/views/automated_tests/_test_script_results.html.erb
@@ -10,7 +10,7 @@
       <%= t('automated_tests.no_results') %>
     <% end %>
     <%# This run tests button is only for instructors before releasing the marks %>
-    <% if !current_user.student? && local_assigns[:submission] && !submission.current_result.released_to_students %>
+    <% if current_user.admin? && local_assigns[:submission] && !submission.current_result.released_to_students %>
       <%= link_to t('automated_tests.run_tests'),
                   run_tests_assignment_submission_result_path(grouping_id: submission.grouping.id),
                   class: 'button run_tests right' %>


### PR DESCRIPTION
The previous behaviour was that TAs could see this button even though they are not allowed to run tests. 
This hides the button for all users except admins. 