### PR TITLE
repo: fix badly formatted repo checkout file

### DIFF
--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -133,7 +133,7 @@ module Repository
     end
 
     def self.get_checkout_command(external_repo_url, revision_hash, group_name, repo_folder=nil)
-      "git clone #{external_repo_url} \"#{group_name}\" && "\
+      "git clone \"#{external_repo_url}\" \"#{group_name}\" && "\
       "cd \"#{group_name}\" && "\
       "git reset --hard #{revision_hash} && "\
       "cd .."

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -183,7 +183,7 @@ module Repository
       unless repo_folder.nil?
         external_repo_url += "/#{repo_folder}"
       end
-      "svn checkout -r #{revision_number} #{external_repo_url} \"#{group_name}\""
+      "svn checkout -r #{revision_number} \"#{external_repo_url}\" \"#{group_name}\""
     end
 
     # Given a single object, or an array of objects of type


### PR DESCRIPTION
Add quotation marks around repo urls in repo checkout file to handle the case where a repo url contains a space.
If it does contain a space, not wrapping the url in quotation marks makes the suggested repo checkout command malformed. 

This change was made for both git and svn repo types. 

Fixes #2773
