### PR TITLE
Forbid tas from creating/updating users through the apis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'redis-rails'
 gem 'activejob-status', git: 'https://github.com/inkstak/activejob-status.git'
 gem 'net-ssh'
 gem 'pluck_to_hash'
+gem 'pundit'
 
 gem 'actionpack-action_caching'
 gem 'actionpack-page_caching', '~>1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
     prawn-qrcode (0.3.0)
       prawn (>= 1)
       rqrcode (>= 0.4.1)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.8)
@@ -391,6 +393,7 @@ DEPENDENCIES
   pluck_to_hash
   prawn
   prawn-qrcode
+  pundit
   quiet_assets
   railroady
   rails (~> 4.2.0)

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -4,8 +4,15 @@ module Api
   # This is the parent class of all API controllers. Shared functionality of
   # all API controllers should go here.
   class MainApiController < ActionController::Base
+    include Pundit
 
     before_filter :check_format, :authenticate
+
+    rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+    def current_user
+      @current_user
+    end
 
     # Unless overridden by a subclass, all routes are 404's by default
     def index
@@ -163,5 +170,12 @@ module Api
       end
       false
     end
+
+    def user_not_authorized
+      render 'shared/http_status',
+             locals: { code: '403', message: HttpStatusHelper::ERROR_CODE['message']['403'] },
+             status: 403
+    end
+
   end
 end # end Api module

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -6,13 +6,11 @@ module Api
   class MainApiController < ActionController::Base
     include Pundit
 
+    attr_reader :current_user
+
     before_filter :check_format, :authenticate
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-
-    def current_user
-      @current_user
-    end
 
     # Unless overridden by a subclass, all routes are 404's by default
     def index
@@ -176,6 +174,5 @@ module Api
              locals: { code: '403', message: HttpStatusHelper::ERROR_CODE['message']['403'] },
              status: 403
     end
-
   end
 end # end Api module

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -25,6 +25,7 @@ module Api
     # Requires: user_name, type, first_name, last_name
     # Optional: section_name, grace_credits
     def create
+      authorize User
       if has_missing_params?([:user_name, :type, :first_name, :last_name])
         # incomplete/invalid HTTP params
         render 'shared/http_status', locals: {code: '422', message:
@@ -109,6 +110,7 @@ module Api
     # Requires: id
     # Optional: first_name, last_name, user_name, section_name, grace_credits
     def update
+      authorize User
       # If no user is found, render an error.
       user = User.find_by_id(params[:id])
       if user.nil?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,7 +11,7 @@ class ApplicationPolicy
   end
 
   def show?
-    scope.where(:id => record.id).exists?
+    scope.where(id: record.id).exists?
   end
 
   def create?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,11 @@
+class UserPolicy < ApplicationPolicy
+
+  def create?
+    self.user.admin?
+  end
+
+  def update?
+    self.user.admin?
+  end
+
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,11 +1,9 @@
 class UserPolicy < ApplicationPolicy
-
   def create?
-    self.user.admin?
+    user.admin?
   end
 
   def update?
-    self.user.admin?
+    user.admin?
   end
-
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe UserPolicy do
-
   let(:admin) { Admin.new(user_name: 'admin', type: User::ADMIN) }
   let(:ta) { Ta.new(user_name: 'ta', type: User::TA) }
   let(:student) { Student.new(user_name: 'student', type: User::STUDENT) }
@@ -31,5 +30,4 @@ describe UserPolicy do
       expect(subject).not_to permit(student, User)
     end
   end
-
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe UserPolicy do
+
+  let(:admin) { Admin.new(user_name: 'admin', type: User::ADMIN) }
+  let(:ta) { Ta.new(user_name: 'ta', type: User::TA) }
+  let(:student) { Student.new(user_name: 'student', type: User::STUDENT) }
+
+  subject { described_class }
+
+  permissions :create? do
+    it 'allows admins to create users' do
+      expect(subject).to permit(admin, User)
+    end
+    it 'forbids tas to create users' do
+      expect(subject).not_to permit(ta, User)
+    end
+    it 'forbids students to create users' do
+      expect(subject).not_to permit(student, User)
+    end
+  end
+
+  permissions :update? do
+    it 'allows admins to update users' do
+      expect(subject).to permit(admin, User)
+    end
+    it 'forbids tas to update users' do
+      expect(subject).not_to permit(ta, User)
+    end
+    it 'forbids students to update users' do
+      expect(subject).not_to permit(student, User)
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+require 'pundit/rspec'
 # Loads lib repo stuff.
 require 'repo/repository'
 require 'repo/git_repository'


### PR DESCRIPTION
This adds the gem pundit to manage authorization policies, and applies it to the creation of users through the apis.

The two main candidate gems for this purpose (based on usage and development status) were cancancan and pundit:
1. cancancan is the most used, easier to set up and more actively maintained, it centralizes all authorization policies in one single function, which can easily become a mess and take a toll on performance;
2. pundit is the second most used, a bit more verbose to set up, development has stagnated for the past year (although developers promise to get back on track https://github.com/varvet/pundit/issues/484), it uses regular ruby classes for creating policies in an object oriented way and break them down into more manageable chunks.

Fixes #2774.