### PR TITLE
Isolate layout changes for controller methods

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -34,7 +34,6 @@ class SubmissionsController < ApplicationController
                        :populate_peer_submissions_table]
   before_filter :authorize_for_user, only: [:download, :downloads, :get_file]
 
-  layout 'assignment_content', only: [:file_manager]
 
   def repo_browser
     @grouping = Grouping.find(params[:id])
@@ -119,6 +118,7 @@ class SubmissionsController < ApplicationController
     if @assignment.allow_web_submits && @assignment.vcs_submit
       flash_message(:notice, t('student.submission.version_control_warning'))
     end
+    render layout: 'assignment_content'
   end
 
   def populate_file_manager_react

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -39,7 +39,7 @@
         <span class='prop_label'><%= raw(t('deadline_max_penalty')) %></span>
         <% @enum_penalty.each { |p| acc += p.hours } %>
       <% end %>
-      <%= I18n.l(@assignment.due_date + acc.hours, format: :long_date ) %>
+      <%= I18n.l(@assignment.due_date + acc.hours, format: :long ) %>
     </div>
 
     <div class='sub_block'>

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -39,7 +39,7 @@
         <span class='prop_label'><%= raw(t('deadline_max_penalty')) %></span>
         <% @enum_penalty.each { |p| acc += p.hours } %>
       <% end %>
-      <%= I18n.l(@assignment.due_date + acc.hours, format: :long ) %>
+      <%= I18n.l(@assignment.due_date + acc.hours) %>
     </div>
 
     <div class='sub_block'>

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -33,8 +33,6 @@ describe SubmissionsController do
               assignment_id: @assignment.id,
               new_files: [file_1, file_2]
 
-      # must not respond with redirect_to (see comment in
-      # app/controllers/submission_controller.rb#update_files)
       is_expected.to respond_with(:redirect)
 
       # update_files action assert assign to various instance variables.
@@ -74,6 +72,11 @@ describe SubmissionsController do
       expect(assigns :revision).to_not be_nil
       expect(assigns :files).to_not be_nil
       expect(assigns :missing_assignment_files).to_not be_nil
+    end
+
+    it 'should render with the assignment content layout' do
+      get_as @student, :file_manager, assignment_id: @assignment.id
+      expect(response).to render_template('layouts/assignment_content')
     end
 
     # TODO figure out how to test this test into the one above
@@ -162,8 +165,6 @@ describe SubmissionsController do
                                 old_file_2.from_revision })
       end
 
-      # must not respond with redirect_to (see comment in
-      # app/controllers/submission_controller.rb#update_files)
       is_expected.to respond_with(:redirect)
 
       expect(assigns :assignment).to_not be_nil
@@ -245,6 +246,17 @@ describe SubmissionsController do
       is_expected.to respond_with(:success)
     end
 
+    it 'should render with the content layout' do
+      get_as @ta_membership.user,
+             :repo_browser,
+             assignment_id: @assignment.id,
+             id: Grouping.last.id,
+             revision_identifier:
+               Grouping.last.group.repo.get_latest_revision.revision_identifier,
+             path: '/'
+      expect(response).to render_template('layouts/content')
+    end
+
     it 'should be able to download the svn checkout commands' do
       get_as @ta_membership.user,
              :download_repo_checkout_commands,
@@ -288,6 +300,15 @@ describe SubmissionsController do
              id: Grouping.last.id,
              path: '/'
       is_expected.to respond_with(:success)
+    end
+
+    it 'should render with the content layout' do
+      get_as @admin,
+             :repo_browser,
+             assignment_id: @assignment.id,
+             id: Grouping.last.id,
+             path: '/'
+      expect(response).to render_template(layout: 'layouts/content')
     end
 
     it 'should be able to download the svn checkout commands' do


### PR DESCRIPTION
It turns out that setting 

    layout 'some_layout', only: [:some_method]

at the top of a controller disables existing layouts for all methods that are not `some_method`. 
This fixes this problem for the submission controller in response to changes made in by pull request #3337.

This also updates a date format in the `read` partial view to be consistent with the changes made in pull request #3340 . The incorrect formatting had previously caused rendering errors when viewing the student interface for an assignment with a grace period submission rule.  