### PR TITLE
Fix mishandling of revision "zero"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby-rc4 (0.1.5)
     rubyzip (1.2.1)
-    rugged (0.26.0)
+    rugged (0.27.0)
     sass (3.4.18)
     sass-rails (5.0.0.beta1)
       railties (>= 4.0.0, < 5.0)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -129,14 +129,7 @@ class AssignmentsController < ApplicationController
       @inviter = @grouping.inviter
 
       # Look up submission information
-      repo = @grouping.group.repo
-      @revision = repo.get_latest_revision
-      @revision_identifier = @revision.revision_identifier
-
-      @last_modified_date = @grouping.assignment_folder_last_modified_date
-      @num_submitted_files = @grouping.number_of_submitted_files
-      @num_missing_assignment_files = @grouping.missing_assignment_files.length
-      repo.close
+      set_repo_vars(@assignment, @grouping)
     end
   end
 
@@ -884,6 +877,16 @@ class AssignmentsController < ApplicationController
       end
     end
 
+  def set_repo_vars(assignment, grouping)
+    grouping.group.access_repo do |repo|
+      @revision = repo.get_revision_by_timestamp(Time.current, assignment.repository_folder)
+      @last_modified_date = @revision&.server_timestamp
+      files = @revision.files_at_path(assignment.repository_folder)
+      @num_submitted_files = files.length
+      missing_assignment_files = grouping.missing_assignment_files(@revision)
+      @num_missing_assignment_files = missing_assignment_files.length
+    end
+  end
 
     def get_files_info(files, assignment_id, revision_identifier, path)
       files.map do |file_name, file|

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -332,18 +332,18 @@ class ResultsController < ApplicationController
              layout: false
       return
     end
-    assignment = Assignment.find(params[:assignment_id])
+
     submission = Submission.find(params[:submission_id])
-    grouping = Grouping.find(submission.grouping_id)
-
-    revision_identifier = submission.revision_identifier
-    repo_folder = assignment.repository_folder
-    zip_name = "#{repo_folder}-#{grouping.group.repo_name}"
-
-    if submission.blank?
+    if submission.revision_identifier.nil?
       render text: t('student.submission.no_files_available')
       return
     end
+
+    assignment = Assignment.find(params[:assignment_id])
+    grouping = Grouping.find(submission.grouping_id)
+    revision_identifier = submission.revision_identifier
+    repo_folder = assignment.repository_folder
+    zip_name = "#{repo_folder}-#{grouping.group.repo_name}"
 
     zip_path = if params[:include_annotations] == 'true'
                  "tmp/#{assignment.short_identifier}_" +

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -65,11 +65,12 @@ class SubmissionsController < ApplicationController
         end
       end
     end
-    assignment_revisions = all_revisions if assignment_revisions.empty?
-    @revision = assignment_revisions[0] if @revision.nil? # latest relevant revision
+    # find another relevant revision to display if @revision.nil?
+    # 1) the latest assignment revision, or 2) the first repo revision
+    @revision ||= assignment_revisions[0] || all_revisions[-1]
     @revisions_history = assignment_revisions.map { |revision| { id: revision.revision_identifier,
                                                                  id_ui: revision.revision_identifier_ui,
-                                                                 date: revision.timestamp} }
+                                                                 date: revision.timestamp } }
 
     respond_to do |format|
       format.html

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -98,7 +98,7 @@ class SubmissionsController < ApplicationController
 
     # Some vars need to be set in update_files too, so do this in a
     # helper. See update_files action where this is used as well.
-    set_filebrowser_vars(@grouping, @assignment)
+    set_filebrowser_vars(@grouping)
 
     # generate flash messages
     if @assignment.submission_rule.can_collect_now?(@grouping.inviter.section)
@@ -351,7 +351,7 @@ class SubmissionsController < ApplicationController
       @path = params[:path] || '/'
       @grouping = current_user.accepted_grouping_for(assignment_id)
       unless @grouping.is_valid?
-        set_filebrowser_vars(@grouping, @assignment)
+        set_filebrowser_vars(@grouping)
         return
       end
       unless params[:new_files].nil?
@@ -445,7 +445,7 @@ class SubmissionsController < ApplicationController
           # finish transaction
           unless txn.has_jobs?
             flash_message(:warning, I18n.t('student.submission.no_action_detected'))
-            set_filebrowser_vars(@grouping, @assignment)
+            set_filebrowser_vars(@grouping)
             return
           end
           if repo.commit(txn)
@@ -463,13 +463,13 @@ class SubmissionsController < ApplicationController
             flash_message(:warning, @assignment.submission_rule.commit_after_collection_message)
           end
           # can't use redirect_to here. See comment of this action for details.
-          set_filebrowser_vars(@grouping, @assignment)
+          set_filebrowser_vars(@grouping)
 
         rescue  => e
           m_logger = MarkusLogger.instance
           m_logger.log(e.message)
           flash_message(:warning, e.message)
-          set_filebrowser_vars(@grouping, @assignment)
+          set_filebrowser_vars(@grouping)
         end
       end
     ensure
@@ -647,7 +647,7 @@ class SubmissionsController < ApplicationController
         end
       rescue Repository::RevisionDoesNotExist
         render text: t('student.submission.no_revision_available')
-        return true
+        return
       end
 
       zip_path = "tmp/#{@assignment.short_identifier}_#{@grouping.group.group_name}_"\
@@ -788,10 +788,10 @@ class SubmissionsController < ApplicationController
   private
 
   # Used in update_files and file_manager actions
-  def set_filebrowser_vars(grouping, assignment)
+  def set_filebrowser_vars(grouping)
     grouping.group.access_repo do |repo|
       @revision = repo.get_latest_revision
-      @files = @revision.files_at_path(File.join(assignment.repository_folder, @path))
+      @files = @revision.files_at_path(File.join(grouping.assignment.repository_folder, @path))
       @missing_assignment_files = grouping.missing_assignment_files(@revision)
     end
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -39,6 +39,7 @@ class SubmissionsController < ApplicationController
     @grouping = Grouping.find(params[:id])
     @path = params[:path] || File::SEPARATOR
     @collected_revision = nil
+    @revision = nil
     repo = @grouping.group.repo
     collected_submission = @grouping.current_submission_used
 
@@ -51,8 +52,7 @@ class SubmissionsController < ApplicationController
       next if !revision.path_exists?(assignment_path) || !revision.changes_at_path?(assignment_path)
       assignment_revisions << revision
       # store the collected revision
-      if @collected_revision.nil? && collected_submission &&
-          collected_submission.revision_identifier == revision.revision_identifier.to_s
+      if @collected_revision.nil? && collected_submission&.revision_identifier == revision.revision_identifier.to_s
         @collected_revision = revision
       end
       # store the displayed revision

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -633,11 +633,6 @@ class SubmissionsController < ApplicationController
   ##
   def downloads
     revision_identifier = params[:revision_identifier]
-    if revision_identifier && revision_identifier == '0'
-      render text: t('student.submission.no_revision_available')
-      return
-    end
-
     @assignment = Assignment.find(params[:assignment_id])
     @grouping = find_appropriate_grouping(@assignment.id, params)
     repo_folder = @assignment.repository_folder

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -47,14 +47,14 @@ class SubmissionsController < ApplicationController
     assignment_revisions = []
     all_revisions = repo.get_all_revisions
     all_revisions.each do |revision|
-      # store the collected revision
-      if @collected_revision.nil? && collected_submission &&
-           collected_submission.revision_identifier == revision.revision_identifier.to_s
-        @collected_revision = revision
-      end
       # store the assignment-relevant revisions
       next if !revision.path_exists?(assignment_path) || !revision.changes_at_path?(assignment_path)
       assignment_revisions << revision
+      # store the collected revision
+      if @collected_revision.nil? && collected_submission &&
+          collected_submission.revision_identifier == revision.revision_identifier.to_s
+        @collected_revision = revision
+      end
       # store the displayed revision
       if @revision.nil?
         if (params[:revision_identifier] &&

--- a/app/helpers/automated_tests_client_helper.rb
+++ b/app/helpers/automated_tests_client_helper.rb
@@ -137,7 +137,7 @@ module AutomatedTestsClientHelper
       submission.submission_files.each do |file|
         dir = file.path.partition(File::SEPARATOR)[2] # cut the top-level assignment dir
         file_path = if dir == '' then file.filename else File.join(dir, file.filename) end
-        unless required_files.nil? || required_files.include?(file_path) # TODO use &. with ruby > 2.3
+        unless required_files.nil? || required_files.include?(file_path)
           # do not export non-required files, if only required files are allowed
           # (a non-required file may end up in a repo if a hook to prevent it does not exist or is not enforced)
           next

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -106,12 +106,7 @@ module SubmissionsHelper
           g[:tags] = grouping.tags
           g[:commit_date] = grouping.last_commit_date
           g[:has_files] = grouping.has_files_in_submission?
-          g[:late_commit] =
-            if MarkusConfigurator.markus_config_repository_type == 'git'
-              false
-            else
-              grouping.past_due_date?
-            end
+          g[:late_commit] = grouping.past_due_date?
           g[:grace_credits_used] =
             if assignment.submission_rule.is_a? GracePeriodSubmissionRule
               grouping.grace_period_deduction_single

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -40,7 +40,7 @@ class AutotestRunJob < ApplicationJob
 
     # create empty test results for no submission files
     repo_dir = File.join(AutomatedTestsClientHelper::STUDENTS_DIR, group.repo_name)
-    submission = if submission_id.nil? then nil else Submission.find(submission_id) end
+    submission = submission_id.nil? ? nil : Submission.find(submission_id)
     unless repo_files_available?(assignment, submission, repo_dir)
       requested_by = User.find_by(api_key: user_api_key)
       error = OpenStruct.new(name: I18n.t('automated_tests.test_result.all_tests'),

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -20,6 +20,7 @@ class SubmissionsJob < ApplicationJob
 
     m_logger = MarkusLogger.instance
     assignment = groupings.first.assignment
+    time = assignment.submission_rule.calculate_collection_time.localtime
 
     progress.total = groupings.size
     groupings.each do |grouping|
@@ -27,7 +28,6 @@ class SubmissionsJob < ApplicationJob
         m_logger.log("Now collecting: #{assignment.short_identifier} for grouping: " +
                      "#{grouping.id}")
         if options[:revision_identifier].nil?
-          time = assignment.submission_rule.calculate_collection_time.localtime
           new_submission = Submission.create_by_timestamp(grouping, time)
         else
           new_submission = Submission.create_by_revision_identifier(grouping, options[:revision_identifier])

--- a/app/jobs/update_repo_required_files_job.rb
+++ b/app/jobs/update_repo_required_files_job.rb
@@ -3,10 +3,11 @@ class UpdateRepoRequiredFilesJob < ApplicationJob
   queue_as MarkusConfigurator.markus_job_update_repo_required_files_queue_name
 
   def update_group_repo(group, current_user, required_files)
-    repo = group.repo
-    t = repo.get_transaction(current_user.user_name)
-    t.replace('.required.json', required_files, 'application/json', repo.get_latest_revision.revision_identifier)
-    repo.commit(t)
+    group.access_repo do |repo|
+      t = repo.get_transaction(current_user.user_name)
+      t.replace('.required.json', required_files, 'application/json', repo.get_latest_revision.revision_identifier)
+      repo.commit(t)
+    end
   end
 
   def perform(current_user)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -577,13 +577,12 @@ class Assignment < ApplicationRecord
     groupings - assigned_groupings
   end
 
-  # Get a list of subversion client commands to be used for scripting
+  # Get a list of repo checkout client commands to be used for scripting
   def get_repo_checkout_commands
-    repo_commands = [] # the commands to be exported
-
+    repo_commands = []
     self.groupings.each do |grouping|
       submission = grouping.current_submission_used
-      if submission
+      if submission&.revision_identifier
         repo_commands << Repository.get_class.get_checkout_command(grouping.group.repository_external_access_url,
                                                                    submission.revision_identifier,
                                                                    grouping.group.group_name, self.repository_folder)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -582,11 +582,10 @@ class Assignment < ApplicationRecord
     repo_commands = []
     self.groupings.each do |grouping|
       submission = grouping.current_submission_used
-      if submission&.revision_identifier
-        repo_commands << Repository.get_class.get_checkout_command(grouping.group.repository_external_access_url,
-                                                                   submission.revision_identifier,
-                                                                   grouping.group.group_name, self.repository_folder)
-      end
+      next if submission&.revision_identifier.nil?
+      repo_commands << Repository.get_class.get_checkout_command(grouping.group.repository_external_access_url,
+                                                                 submission.revision_identifier,
+                                                                 grouping.group.group_name, repository_folder)
     end
     repo_commands
   end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -653,6 +653,25 @@ class Grouping < ApplicationRecord
   # the last commit
   ##
   def past_due_date?
+    # if inviter.blank? || inviter.section.blank? || assignment.section_due_dates.blank?
+    #   due_date = assignment.due_date
+    # else
+    #   due_date = assignment.section_due_dates.find_by(section_id: inviter.section.id).due_date
+    # end
+    # group.access_repo do |repo|
+    #   # we use this function because it allows to specify a path
+    #   revision = repo.get_revision_by_timestamp(Time.current, assignment.repository_folder, due_date)
+    #   # an alternative could have been:
+    #   # repo.get_latest_revision.directories_at_path('')[assignment.repository_folder].last_modified_date
+    #   # but in git, the latter returns commit times instead of push times, and would be less efficient because it has to
+    #   # walk through the entire history
+    # end
+    # revision.server_timestamp
+    #TODO modify get_revision_by_timestamp so that it can stop at a certain timestamp
+    #TODO modify get_revision_by_timestamp to return nil
+    #TODO add bogus revision "zero" to use by submission when get_revision_by_timestamp returns nil
+    #TODO use revision zero in repo browser and checkout commands
+    #TODO enable past_due_date? for git again
     timestamp = assignment_folder_last_modified_date
     if inviter.blank? || inviter.section.blank? || assignment.section_due_dates.blank?
       timestamp > assignment.due_date

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -805,15 +805,17 @@ class Grouping < ApplicationRecord
   end
 
   def create_test_script_result(file_name, requested_by, submission=nil, time=0)
-    revision_identifier = submission.nil? ?
-      self.group.repo.get_latest_revision.revision_identifier :
-      submission.revision_identifier
-    submission_id = submission.nil? ? nil : submission.id
+    revision_identifier = nil
+    if submission.nil?
+      group.access_repo { |repo| revision_identifier = repo.get_latest_revision.revision_identifier }
+    else
+      revision_identifier = submission.revision_identifier
+    end
     test_script = TestScript.find_by(assignment_id: self.assignment.id, file_name: file_name)
 
     self.test_script_results.create(
       test_script_id: test_script.id,
-      submission_id: submission_id,
+      submission_id: submission&.id,
       marks_earned: 0.0,
       marks_total: 0.0,
       repo_revision: revision_identifier,

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -619,9 +619,7 @@ class Grouping < ApplicationRecord
     missing_assignment_files = assignment.assignment_files.reject do |assignment_file|
       revision.path_exists?(File.join(assignment.repository_folder, assignment_file.filename))
     end
-    unless repo.nil?
-      repo.close
-    end
+    repo&.close
     missing_assignment_files
   end
 
@@ -802,9 +800,8 @@ class Grouping < ApplicationRecord
   end
 
   def create_test_script_result(file_name, requested_by, submission=nil, time=0)
-    revision_identifier = nil
     if submission.nil?
-      group.access_repo { |repo| revision_identifier = repo.get_latest_revision.revision_identifier }
+      revision_identifier = group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
     else
       revision_identifier = submission.revision_identifier
     end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -704,7 +704,7 @@ class Grouping < ApplicationRecord
   # Helper for populate_submissions_table.
   # Returns a formatted time string for the last commit time for this grouping.
   def last_commit_date
-    if has_submission?
+    if !current_submission_used&.revision_timestamp.nil?
       I18n.l(current_submission_used.revision_timestamp)
     else
       '-'

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -643,9 +643,6 @@ class Grouping < ApplicationRecord
     else
       true
     end
-    #TODO modify get_revision_by_timestamp so that it can stop at a certain timestamp (memory)
-    #TODO modify get_revision_by_timestamp calls to return nil (memory)
-    #TODO modify submission.revision_identifier calls to allow for nil
   end
 
   def self.get_groupings_for_assignment(assignment, user)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -37,19 +37,21 @@ class Submission < ApplicationRecord
      unless timestamp.kind_of? Time
        raise 'Expected a timestamp of type Time'
      end
-     repo = grouping.group.repo
-     path = grouping.assignment.repository_folder
-     revision = repo.get_revision_by_timestamp(timestamp, path)
-     submission = self.generate_new_submission(grouping, revision)
-     repo.close
+     submission = nil
+     grouping.group.access_repo do |repo|
+       path = grouping.assignment.repository_folder
+       revision = repo.get_revision_by_timestamp(timestamp, path)
+       submission = generate_new_submission(grouping, revision)
+     end
      submission
   end
 
   def self.create_by_revision_identifier(grouping, revision_identifier)
-    repo = grouping.group.repo
-    revision = repo.get_revision(revision_identifier)
-    submission = self.generate_new_submission(grouping, revision)
-    repo.close
+    submission = nil
+    grouping.group.access_repo do |repo|
+      revision = repo.get_revision(revision_identifier)
+      submission = generate_new_submission(grouping, revision)
+    end
     submission
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -37,20 +37,18 @@ class Submission < ApplicationRecord
      unless timestamp.kind_of? Time
        raise 'Expected a timestamp of type Time'
      end
-     submission = nil
-     grouping.group.access_repo do |repo|
+     submission = grouping.group.access_repo do |repo|
        path = grouping.assignment.repository_folder
        revision = repo.get_revision_by_timestamp(timestamp, path)
-       submission = generate_new_submission(grouping, revision)
+       generate_new_submission(grouping, revision)
      end
      submission
   end
 
   def self.create_by_revision_identifier(grouping, revision_identifier)
-    submission = nil
-    grouping.group.access_repo do |repo|
+    submission = grouping.group.access_repo do |repo|
       revision = repo.get_revision(revision_identifier)
-      submission = generate_new_submission(grouping, revision)
+      generate_new_submission(grouping, revision)
     end
     submission
   end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -128,36 +128,6 @@ class SubmissionFile < ApplicationRecord
     retrieved_file
   end
 
-  # Export this file from the svn repository into storage_path
-  # If a file of the same name as the one we are trying to export exists in
-  # the given repository, it will be overwritten by the svn exports
-  def export_file(storage_path)
-    m_logger = MarkusLogger.instance
-    m_logger.log("Exporting #{self.filename} from student repository")
-    begin
-      # Create the storage directories if they dont already exist
-      FileUtils.makedirs(storage_path)
-      # but deleted the file if it already exists
-      if File.exists?(File.join(storage_path, self.filename))
-        FileUtils.rm(File.join(storage_path, self.filename))
-      end
-      repo = submission.grouping.group.repo
-      revision_identifier = submission.revision_identifier
-      repo.export(File.join(storage_path, self.filename),
-                  File.join(self.path, self.filename),
-                  revision_identifier)
-    end
-
-    # Let's check the file exists befor claiming the file has been exported
-    # properly
-    if File.exists?(File.join(storage_path, self.filename))
-      m_logger.log("Successfully exported #{self.filename} from student repository to #{File.join(storage_path, self.filename)}")
-    else
-      m_logger.log("Failed to export #{self.filename} from student
-                      repository")
-    end
-  end
-
   private
 
   def add_annotations(file_contents)

--- a/app/models/test_script_result.rb
+++ b/app/models/test_script_result.rb
@@ -32,7 +32,6 @@ class TestScriptResult < ApplicationRecord
   validates_presence_of :test_script
   validates_presence_of :marks_earned
   validates_presence_of :marks_total
-  validates_presence_of :repo_revision
 
   validates_numericality_of :marks_earned, greater_than_or_equal_to: 0
   validates_numericality_of :marks_total, greater_than_or_equal_to: 0

--- a/app/views/assignments/student_interface.html.erb
+++ b/app/views/assignments/student_interface.html.erb
@@ -31,16 +31,17 @@
       <h2><%= t('submissions') %></h2>
 
       <div class='block_content'>
-        <% if !@grouping.nil? %>
-          <% if !@grouping.is_valid? %>
+        <% if @grouping.nil? %>
+          <p class='notice'><%= t('student.no_submission_yet') %></p>
+        <% else %>
+          <% unless @grouping.is_valid? %>
             <p class='notice'>
               <%= t('student.group_not_valid') %>
             </p>
           <% end %>
           <h3><%= t('student.overview') %></h3>
           <div class='info'>
-            <%= raw(t('student.last_revision_date',
-                      last_modified_date: l(@last_modified_date))) %>
+            <%= raw(t('student.last_revision_date', last_modified_date: l(@last_modified_date))) %>
           </div>
           <span class='info_number'>
             <%= @num_submitted_files.to_s %>
@@ -51,8 +52,6 @@
                      missing_files: @num_missing_assignment_files.to_s,
                      style_class: ('red' unless @num_missing_assignment_files == 0))) %>
           <br>
-        <% else %>
-          <p class='notice'><%= t('student.no_submission_yet') %></p>
         <% end %>
       </div>
     </div>

--- a/db/migrate/20180430184545_change_submission_revision_nullable.rb
+++ b/db/migrate/20180430184545_change_submission_revision_nullable.rb
@@ -1,0 +1,6 @@
+class ChangeSubmissionRevisionNullable < ActiveRecord::Migration
+  def change
+    change_column_null :submissions, :revision_identifier, true
+    change_column_null :submissions, :revision_timestamp, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212204015) do
+ActiveRecord::Schema.define(version: 20180430184545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -517,8 +517,8 @@ ActiveRecord::Schema.define(version: 20171212204015) do
     t.datetime "created_at"
     t.integer  "submission_version"
     t.boolean  "submission_version_used"
-    t.text     "revision_identifier",      null: false
-    t.datetime "revision_timestamp",       null: false
+    t.text     "revision_identifier"
+    t.datetime "revision_timestamp"
     t.text     "remark_request"
     t.datetime "remark_request_timestamp"
   end

--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -607,10 +607,14 @@ module Repository
 
     # Constructor; checks if +revision_hash+ is actually present in +repo+.
     def initialize(revision_hash, repo)
+      @repo = repo.get_repos
+      begin
+        @commit = @repo.lookup(revision_hash)
+      rescue Rugged::OdbError
+        raise RevisionDoesNotExist
+      end
       super(revision_hash)
       @revision_identifier_ui = @revision_identifier[0..6]
-      @repo = repo.get_repos
-      @commit = @repo.lookup(@revision_identifier)
       @author = @commit.author[:name]
       @timestamp = @commit.time.in_time_zone
       @server_timestamp = @timestamp

--- a/lib/repo/git_repository.rb
+++ b/lib/repo/git_repository.rb
@@ -194,6 +194,8 @@ module Repository
       walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_REVERSE)
       walker.push(@repos.last_commit)
       get_revision(walker.first.oid)
+    ensure
+      bare_repo.close
     end
 
     def get_all_revisions
@@ -221,6 +223,8 @@ module Repository
         revision.server_timestamp = push_info.time
         revision
       end
+    ensure
+      bare_repo.close
     end
 
     # Given a OID of a file from a Rugged::Repository lookup, return the blob

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -201,11 +201,11 @@ module Repository
     end
 
     # Return a RepositoryRevision for a given timestamp
-    def get_revision_by_timestamp(timestamp, path = nil, later_than = nil)
-      if !timestamp.kind_of?(Time)
+    def get_revision_by_timestamp(at_or_earlier_than, path = nil, later_than = nil)
+      unless at_or_earlier_than.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end
-      return get_revision_number_by_timestamp(timestamp, path)
+      get_revision_number_by_timestamp(at_or_earlier_than, path)
     end
 
     def get_all_revisions
@@ -451,9 +451,10 @@ module Repository
 
       all_timestamps_list = []
       remaining_timestamps_list = []
-      @timestamps_revisions.keys().each do |time_dump|
-        all_timestamps_list.push(Marshal.load(time_dump))
-        remaining_timestamps_list.push(Marshal.load(time_dump))
+      @timestamps_revisions.keys.each do |time_dump|
+        timestamp = Marshal.load(time_dump)
+        all_timestamps_list << timestamp
+        remaining_timestamps_list << timestamp
       end
 
       # find closest matching timestamp
@@ -462,7 +463,7 @@ module Repository
       old_diff = 0
       # find first valid revision
       all_timestamps_list.each do |best_match|
-        remaining_timestamps_list.shift()
+        remaining_timestamps_list.shift
         old_diff = wanted_timestamp - best_match
         mapping[old_diff.to_s] = best_match
         if path.nil? || (!path.nil? && @timestamps_revisions[Marshal.dump(best_match)].revision_at_path(path))

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -201,7 +201,7 @@ module Repository
     end
 
     # Return a RepositoryRevision for a given timestamp
-    def get_revision_by_timestamp(timestamp, path = nil)
+    def get_revision_by_timestamp(timestamp, path = nil, later_than = nil)
       if !timestamp.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -27,7 +27,7 @@ module Repository
 
       # variables
       @users = {}                                 # hash of users (key) with corresponding permissions (value)
-      @current_revision = MemoryRevision.new(0)   # the latest revision (we start from 0)
+      @current_revision = MemoryRevision.new(1)   # the latest revision (we start from 1)
       @revision_history = []                      # a list (array) of old revisions (i.e. < @current_revision)
       @repository_location = location
       @closed = false
@@ -145,11 +145,11 @@ module Repository
       timestamp = Time.current
       new_rev.timestamp = timestamp
       new_rev.server_timestamp = timestamp
+      new_rev.__increment_revision_number
       @revision_history.push(@current_revision)
       @current_revision = new_rev
-      @current_revision.__increment_revision_number() # increment revision number
       @@repositories[@repository_location] = self
-      return true
+      true
     end
 
     def self.__set_all_permissions

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -29,11 +29,6 @@ module Repository
       @users = {}                                 # hash of users (key) with corresponding permissions (value)
       @current_revision = MemoryRevision.new(0)   # the latest revision (we start from 0)
       @revision_history = []                      # a list (array) of old revisions (i.e. < @current_revision)
-      # mapping (hash) of timestamps and revisions
-      @timestamps_revisions = {}
-      # push first timestamp-revision mapping
-      @timestamps_revisions[Marshal.dump(
-        Marshal.load(Marshal.dump(Time.now)))] = @current_revision
       @repository_location = location
       @closed = false
       @@repositories[location] = self             # push new MemoryRepository onto repository list
@@ -146,17 +141,13 @@ module Repository
         return false
       end
 
-      # everything went fine, so push old revision to history revisions,
-      # make new_rev the latest one and create a mapping for timestamped
-      # revisions
-      timestamp = Time.now
+      # everything went fine, so push old revision to history revisions and make new_rev the latest one
+      timestamp = Time.current
       new_rev.timestamp = timestamp
       new_rev.server_timestamp = timestamp
       @revision_history.push(@current_revision)
       @current_revision = new_rev
       @current_revision.__increment_revision_number() # increment revision number
-      @timestamps_revisions[Marshal.dump(
-        Marshal.load(Marshal.dump(timestamp)))] = @current_revision
       @@repositories[@repository_location] = self
       return true
     end
@@ -205,7 +196,16 @@ module Repository
       unless at_or_earlier_than.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end
-      get_revision_number_by_timestamp(at_or_earlier_than, path)
+
+      (@revision_history + [@current_revision]).reverse_each do |revision|
+        if !later_than.nil? && revision.server_timestamp <= later_than
+          return nil
+        end
+        if revision.server_timestamp <= at_or_earlier_than && (path.nil? || revision.revision_at_path(path))
+          return revision
+        end
+      end
+      nil
     end
 
     def get_all_revisions
@@ -440,59 +440,6 @@ module Repository
         end
       end
       return false
-    end
-
-    # gets the "closest matching" revision from the revision-timestamp
-    # mapping
-    def get_revision_number_by_timestamp(wanted_timestamp, path = nil)
-      if @timestamps_revisions.empty?
-        raise "No revisions, so no timestamps."
-      end
-
-      all_timestamps_list = []
-      remaining_timestamps_list = []
-      @timestamps_revisions.keys.each do |time_dump|
-        timestamp = Marshal.load(time_dump)
-        all_timestamps_list << timestamp
-        remaining_timestamps_list << timestamp
-      end
-
-      # find closest matching timestamp
-      mapping = {}
-      first_timestamp_found = false
-      old_diff = 0
-      # find first valid revision
-      all_timestamps_list.each do |best_match|
-        remaining_timestamps_list.shift
-        old_diff = wanted_timestamp - best_match
-        mapping[old_diff.to_s] = best_match
-        if path.nil? || (!path.nil? && @timestamps_revisions[Marshal.dump(best_match)].revision_at_path(path))
-          first_timestamp_found = true
-          break
-        end
-      end
-
-      # find all other valid revision
-      remaining_timestamps_list.each do |curr_timestamp|
-        new_diff = wanted_timestamp - curr_timestamp
-        mapping[new_diff.to_s] = curr_timestamp
-        if path.nil? || (!path.nil? && @timestamps_revisions[Marshal.dump(curr_timestamp)].revision_at_path(path))
-          if(old_diff <= 0 && new_diff <= 0) ||
-            (old_diff <= 0 && new_diff > 0) ||
-            (new_diff <= 0 && old_diff > 0)
-            old_diff = [old_diff, new_diff].max
-          else
-            old_diff = [old_diff, new_diff].min
-          end
-        end
-      end
-
-      if first_timestamp_found
-        wanted_timestamp = mapping[old_diff.to_s]
-        return @timestamps_revisions[Marshal.dump(wanted_timestamp)]
-      else
-        return @current_revision
-      end
     end
 
   end # end class MemoryRepository

--- a/lib/repo/memory_repository.rb
+++ b/lib/repo/memory_repository.rb
@@ -193,17 +193,14 @@ module Repository
 
     # Return a RepositoryRevision for a given timestamp
     def get_revision_by_timestamp(at_or_earlier_than, path = nil, later_than = nil)
-      unless at_or_earlier_than.kind_of?(Time)
+      unless at_or_earlier_than.is_a?(Time)
         raise "Was expecting a timestamp of type Time"
       end
 
       (@revision_history + [@current_revision]).reverse_each do |revision|
-        if !later_than.nil? && revision.server_timestamp <= later_than
-          return nil
-        end
-        if revision.server_timestamp <= at_or_earlier_than && (path.nil? || revision.revision_at_path(path))
-          return revision
-        end
+        return nil if !later_than.nil? && revision.server_timestamp <= later_than
+        return revision if revision.server_timestamp <= at_or_earlier_than &&
+                           (path.nil? || revision.revision_at_path(path))
       end
       nil
     end

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -25,9 +25,9 @@ module Repository
   end
 
   # Exceptions for repositories
-  class ConnectionError < Exception; end
+  class ConnectionError < StandardError; end
 
-  class Conflict < Exception
+  class Conflict < StandardError
     attr_reader :path
     def initialize(path)
       super()
@@ -56,9 +56,9 @@ module Repository
     end
   end
 
-  class ExportRepositoryAlreadyExists < Exception;  end
+  class ExportRepositoryAlreadyExists < StandardError; end
 
-  class RepositoryCollision < Exception; end
+  class RepositoryCollision < StandardError; end
 
   class AbstractRepository
 
@@ -241,7 +241,7 @@ module Repository
 
 
   # Exceptions for Revisions
-  class RevisionDoesNotExist < Exception; end
+  class RevisionDoesNotExist < StandardError; end
   class RevisionOutOfSyncConflict < Conflict; end
 
   class AbstractRevision
@@ -276,16 +276,16 @@ module Repository
   end
 
   # Exceptions for Files
-  class FileOutOfDate < Exception; end
-  class FileDoesNotExist < Exception; end
+  class FileOutOfDate < StandardError; end
+  class FileDoesNotExist < StandardError; end
 
   # Exceptions for repo user management
-  class UserNotFound < Exception; end
-  class UserAlreadyExistent < Exception; end
+  class UserNotFound < StandardError; end
+  class UserAlreadyExistent < StandardError; end
   # raised when trying to modify permissions and repo is not in authoritative mode
-  class NotAuthorityError < Exception; end
+  class NotAuthorityError < StandardError; end
   # raised when configuration is wrong
-  class ConfigurationError < Exception; end
+  class ConfigurationError < StandardError; end
 
 
   #################################################

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -145,7 +145,7 @@ module Repository
     end
 
     # Return a RepositoryRevision for a given timestamp
-    def get_revision_by_timestamp(timestamp, path = nil)
+    def get_revision_by_timestamp(timestamp, path = nil, later_than = nil)
       raise NotImplementedError,  "Repository.get_revision_by_timestamp: Not yet implemented"
     end
 

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -145,7 +145,7 @@ module Repository
     end
 
     # Return a RepositoryRevision for a given timestamp
-    def get_revision_by_timestamp(timestamp, path = nil, later_than = nil)
+    def get_revision_by_timestamp(at_or_earlier_than, path = nil, later_than = nil)
       raise NotImplementedError,  "Repository.get_revision_by_timestamp: Not yet implemented"
     end
 

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -180,9 +180,6 @@ module Repository
     end
 
     def self.get_checkout_command(external_repo_url, revision_number, group_name, repo_folder=nil)
-      if revision_number.to_i == 0
-        return ''
-      end
       unless repo_folder.nil?
         external_repo_url += "/#{repo_folder}"
       end
@@ -247,23 +244,23 @@ module Repository
     # a revision at a current timestamp
     #    target_timestamp
     # should be a Ruby Time instance
-    def get_revision_by_timestamp(target_timestamp, path = nil)
+    def get_revision_by_timestamp(target_timestamp, path = nil, later_than = nil)
       if !target_timestamp.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end
       target_timestamp = target_timestamp.utc
       if !path.nil?
         # latest_revision_number will fail if the path does not exist at the given revision number or less than
-        # the revision number.  The begin and ensure statement is to ensure that there is a revision return.
+        # the revision number. The begin and ensure statement is to ensure that there is a revision return.
         # Default is set to revision 0.
-        revision_number = 0
         begin
           revision_number = latest_revision_number(path, get_revision_number_by_timestamp(target_timestamp))
-        ensure
-          return get_revision(revision_number)
+          get_revision(revision_number)
+        rescue
+          nil
         end
       else
-        return get_revision(get_revision_number_by_timestamp(target_timestamp))
+        get_revision(get_revision_number_by_timestamp(target_timestamp))
       end
 
     end

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -180,6 +180,9 @@ module Repository
     end
 
     def self.get_checkout_command(external_repo_url, revision_number, group_name, repo_folder=nil)
+      if revision_number.to_i == 0
+        return ''
+      end
       unless repo_folder.nil?
         external_repo_url += "/#{repo_folder}"
       end
@@ -966,7 +969,7 @@ module Repository
     # Constructor; Check if revision is actually present in
     # repository
     def initialize(revision_number, repo)
-      revision_number = revision_number.to_i if revision_number.is_a? String
+      revision_number = revision_number.to_i # can be passed as string or int
       @repo = repo
       @revision_identifier_ui = revision_number.to_s
       begin

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -244,23 +244,22 @@ module Repository
     # a revision at a current timestamp
     #    target_timestamp
     # should be a Ruby Time instance
-    def get_revision_by_timestamp(target_timestamp, path = nil, later_than = nil)
-      if !target_timestamp.kind_of?(Time)
+    def get_revision_by_timestamp(at_or_earlier_than, path = nil, later_than = nil)
+      unless at_or_earlier_than.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end
-      target_timestamp = target_timestamp.utc
+      at_or_earlier_than = at_or_earlier_than.utc
       if !path.nil?
         # latest_revision_number will fail if the path does not exist at the given revision number or less than
-        # the revision number. The begin and ensure statement is to ensure that there is a revision return.
-        # Default is set to revision 0.
+        # the revision number. The begin and ensure statement is to ensure that there is a nil return.
         begin
-          revision_number = latest_revision_number(path, get_revision_number_by_timestamp(target_timestamp))
+          revision_number = latest_revision_number(path, get_revision_number_by_timestamp(at_or_earlier_than))
           get_revision(revision_number)
         rescue
           nil
         end
       else
-        get_revision(get_revision_number_by_timestamp(target_timestamp))
+        get_revision(get_revision_number_by_timestamp(at_or_earlier_than))
       end
 
     end
@@ -776,24 +775,24 @@ module Repository
     #
     # This will only work for paths that have not been deleted from the repository.
     def latest_revision_number(path = nil, revision_number = nil)
-      if (!path.nil?)
+      if path.nil?
+        @repos.fs.youngest_rev
+      else
         begin
           data = Svn::Repos.get_committed_info(@repos.fs.root(revision_number || @repos.fs.youngest_rev), path)
-          return data[0]
+          data[0]
         rescue Svn::Error::FS_NOT_FOUND
           raise Repository::FileDoesNotExistConflict.new(path)
         rescue Svn::Error::FS_NO_SUCH_REVISION
-          raise "Revision " + revision_number.to_s + " does not exist."
+          raise "Revision #{revision_number} does not exist."
         end
-      else
-        return @repos.fs.youngest_rev
       end
     end
 
     # Assumes timestamp is a Time object (which is part of the Ruby
     # standard library)
-    def get_revision_number_by_timestamp(target_timestamp, path = nil)
-      if !target_timestamp.kind_of?(Time)
+    def get_revision_number_by_timestamp(target_timestamp)
+      unless target_timestamp.kind_of?(Time)
         raise "Was expecting a timestamp of type Time"
       end
       @repos.dated_revision(target_timestamp)

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -1014,13 +1014,17 @@ module Repository
     end
 
     def changes_at_path?(path)
-      !files_at_path_helper(path, true).empty?
+      !changed_filenames_at_path(path).empty?
+      # TODO: This does not take into account the creation of the empty assignment directory
     end
 
     # Return the names of changed files at this revision at 'path'
     def changed_filenames_at_path(path)
+      unless path.start_with?(File::SEPARATOR) # transform from relative to absolute
+        path = "#{File::SEPARATOR}#{path}"
+      end
       paths = @repo.__get_file_paths(@revision_identifier)
-      paths.select { |p| p.start_with? ('/' + path) }
+      paths.select { |p| p.start_with?(path) }
     end
 
     private

--- a/lib/repo/subversion_repository.rb
+++ b/lib/repo/subversion_repository.rb
@@ -245,7 +245,7 @@ module Repository
     #    target_timestamp
     # should be a Ruby Time instance
     def get_revision_by_timestamp(at_or_earlier_than, path = nil, later_than = nil)
-      unless at_or_earlier_than.kind_of?(Time)
+      unless at_or_earlier_than.is_a?(Time)
         raise "Was expecting a timestamp of type Time"
       end
       at_or_earlier_than = at_or_earlier_than.utc
@@ -792,7 +792,7 @@ module Repository
     # Assumes timestamp is a Time object (which is part of the Ruby
     # standard library)
     def get_revision_number_by_timestamp(target_timestamp)
-      unless target_timestamp.kind_of?(Time)
+      unless target_timestamp.is_a?(Time)
         raise "Was expecting a timestamp of type Time"
       end
       @repos.dated_revision(target_timestamp)

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -473,7 +473,7 @@ describe SubmissionsController do
       expect('application/zip').to eq(response.header['Content-Type'])
       is_expected.to respond_with(:success)
       zip_path = "tmp/#{@assignment.short_identifier}_" +
-                 "#{@grouping.group.group_name}_r#{@grouping.group.repo
+                 "#{@grouping.group.group_name}_#{@grouping.group.repo
                      .get_latest_revision.revision_identifier}.zip"
       Zip::File.open(zip_path) do |zip_file|
         file1_path = File.join("#{@assignment.repository_folder}-" +

--- a/spec/models/test_script_result_spec.rb
+++ b/spec/models/test_script_result_spec.rb
@@ -7,7 +7,6 @@ describe TestScriptResult do
   it { is_expected.to validate_presence_of(:test_script) }
   it { is_expected.to validate_presence_of(:marks_earned) }
   it { is_expected.to validate_presence_of(:marks_total) }
-  it { is_expected.to validate_presence_of(:repo_revision) }
   it { is_expected.to validate_numericality_of(:marks_earned) }
   it { is_expected.to validate_numericality_of(:marks_total) }
 

--- a/test/unit/grouping_test.rb
+++ b/test/unit/grouping_test.rb
@@ -45,14 +45,6 @@ class GroupingTest < ActiveSupport::TestCase
       assert_equal 0, @grouping.memberships.count
     end
 
-    should 'be able to report the last modified date of the assignment_folder' do
-      last_modified = @grouping.assignment_folder_last_modified_date
-      assert_not_nil(last_modified)
-      assert_instance_of(Time, last_modified)
-      # Assert change was made sometime during the last 60 seconds.
-      assert (Time.now-60..Time.now).cover?(last_modified)
-    end
-
     should 'display Empty Group since no students in the group' do
       assert_equal 'Empty Group', @grouping.get_all_students_in_group
     end
@@ -247,10 +239,6 @@ class GroupingTest < ActiveSupport::TestCase
 
       teardown do
         destroy_repos
-      end
-
-      should 'be able to report the number of files submitted' do
-        assert @grouping.number_of_submitted_files > 0
       end
 
       should 'report that grouping is not deleteable' do


### PR DESCRIPTION
 * svn has a fake revision zero to represent the repo at initialization
time, checkout commands that use it are just wrong, the collected
revision handles it correctly
 * git has always an inital commit with an empty file, checkout commands
are correct, the collected revision shows it incorrectly

Fixes #2758.