### PR TITLE
Ensure late penalties are applied after remark request

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -287,9 +287,9 @@ class Submission < ActiveRecord::Base
     original_result.extra_marks.each do |extra_mark|
       remark.extra_marks.create(result: remark,
                                 created_at: Time.zone.now,
-                                markable_id: extra_mark.markable_id,
-                                mark: extra_mark.mark,
-                                markable_type: extra_mark.markable_type)
+                                description: extra_mark.description,
+                                extra_mark: extra_mark.extra_mark,
+                                unit: extra_mark.unit)
     end
 
     remark_assignment.get_criteria(:ta).each do |criterion|

--- a/spec/factories/extra_marks.rb
+++ b/spec/factories/extra_marks.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :extra_mark do
+    association :result
+    description Faker::Lorem.sentence
+    unit 'percentage'
+    extra_mark -10.0
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -27,12 +27,34 @@ describe Submission do
   end
 
   context 'handle remark requests' do
+    let(:submission) do
+      submission = create(:submission)
+      submission.update(remark_request_timestamp: Time.zone.now)
+      submission
+    end
+    let(:extra_mark) { create(:extra_mark, result: submission.results.first) }
+
     it 'should have proper remarking status' do
-      @submission = create(:submission)
-      @submission.update(remark_request_timestamp: Time.zone.now)
-      @submission.make_remark_result
-      expect(@submission.has_remark?).to be true
-      expect(@submission.remark_submitted?).to be true
+      submission.make_remark_result
+      expect(submission.has_remark?).to be true
+      expect(submission.remark_submitted?).to be true
+    end
+
+    it 'should create another extra mark if there was one originally' do
+      extra_mark
+      submission.make_remark_result
+      marks = ExtraMark.joins("LEFT OUTER JOIN results ON results.id=extra_marks.id")
+                .where("results.submission_id=?", submission.id)
+      expect(marks.count).to eq(2)
+    end
+
+    it 'should copy extra marks from the original result to the remark request' do
+      extra_mark
+      submission.make_remark_result
+      marks = ExtraMark.joins("LEFT OUTER JOIN results ON results.id=extra_marks.id")
+                .where("results.submission_id=?", submission.id)
+      attributes = marks.pluck('description', 'extra_mark', 'unit')
+      expect(attributes[0]).to eq(attributes[1])
     end
   end
 


### PR DESCRIPTION
Makes sure that when a new result object is created after a remark request, any marking penalties are also applied to this new result object by default. 

Fixes #2136