### PR TITLE
Make timeout message more explicit

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
     email_more_info:    "E-mail: <a href=\"mailto:info@markusproject.org\">info@markusproject.org</a> or <a href=\"mailto:markus-users@cs.toronto.edu\">markus-users@cs.toronto.edu</a><br>Please visit: <a href=\"http://www.markusproject.org/\">http://www.markusproject.org/</a> for more information.<br>To submit a bug or issue please visit <a href=\"https://github.com/MarkUsProject/Markus/issues\">https://github.com/MarkUsProject/Markus/issues</a>"
 
     # app/views/main/timeout_imminent.js.erb
-    timeout_imminent:   "Your session is about to expire."
+    timeout_imminent:   "Your session is about to expire: you will be logged out shortly and changes you make to this page will not be saved afterwards. Pressing ok will NOT prevent this, instead refresh this page or navigate to a different page."
 
     # app/views/api/_key_display.html.erb
     api_key:            "Your API Key"


### PR DESCRIPTION
Related to #3303.
(@david-yz-liu this has caused troubles for a course that lost its marks, we should roll out this message at least)