### PR TITLE
Add fields to User new/edit forms

### DIFF
--- a/app/views/layouts/_userform.html.erb
+++ b/app/views/layouts/_userform.html.erb
@@ -19,6 +19,11 @@
         <td><%= raw(f.label(:user_name, I18n.t('user.first_name'))) %>:</td>
         <td><%= raw(f.text_field :first_name) %></td>
       </tr>
+
+      <tr>
+        <td><%= raw(f.label(:email, I18n.t('user.email'))) %>:</td>
+        <td><%= raw(f.text_field :email) %></td>
+      </tr>
     </table>
 
     <%= f.hidden_field :id %>

--- a/app/views/students/_student_form.html.erb
+++ b/app/views/students/_student_form.html.erb
@@ -22,6 +22,16 @@
       </tr>
 
       <tr>
+        <td><%= raw(f.label(:email, t('user.email'))) %>:</td>
+        <td><%= raw(f.text_field :email) %></td>
+      </tr>
+
+      <tr>
+        <td><%= raw(f.label(:id_number, t('user.id_number'))) %>:</td>
+        <td><%= raw(f.text_field :id_number) %></td>
+      </tr>
+
+      <tr>
         <td><%= raw(f.label(:grace_credits, t('user.grace_credits'))) %>:</td>
         <td><%= raw(f.text_field :grace_credits) %></td>
       </tr>


### PR DESCRIPTION
Fixed #3363 issue.

Added Email and Id number fields to new/edit student forms.

The fields are added in _student_form.html.erb under app->views->students
<img width="330" alt="screen shot 2018-05-09 at 6 21 18 pm" src="https://user-images.githubusercontent.com/25095051/39842821-2703faf0-53b6-11e8-9f81-8a81b9554641.png">

Added Email field to new/edit Graders and Admins' forms:
The field is added in _userform.html.erb under app->views->layouts
<img width="293" alt="screen shot 2018-05-09 at 6 25 30 pm" src="https://user-images.githubusercontent.com/25095051/39842889-82d724e2-53b6-11e8-9629-7e0d65adecb6.png">
 