### PR TITLE
Do not require SVN installation for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - travis_wait bundle install --path=~/.bundle --jobs=3 --retry=3 --without development production console
   - yarn install
-  - ./script/install-svn.sh
+  #  - ./script/install-svn.sh  # uncomment this if we want to test interactions with svn in the future
   - cp config/database.yml.ci config/database.yml
 
 before_script:

--- a/script/install-svn.sh
+++ b/script/install-svn.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This file is currently not used but should be kept to install
+# svn on travis in case we want to test interactions with svn
+# in the future.
+
 SVN_BASE=subversion-1.9.7
 MIRROR_PRIMARY=http://www-us.apache.org/dist/subversion
 MIRROR_SECONDARY=http://www-eu.apache.org/dist/subversion

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -177,9 +177,9 @@ describe GroupsController do
           File.read(fixture_file_upload(
                       'files/wrong_csv_format.xls', 'text/csv')))
 
-        # Setup for SubversionRepository
+        # Setup for Git Repository
         allow(MarkusConfigurator)
-          .to receive(:markus_config_repository_type).and_return('svn')
+          .to receive(:markus_config_repository_type).and_return('git')
 
         @assignment = create(:assignment,
                              allow_web_submits: true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 # Loads lib repo stuff.
 require 'repo/repository'
 require 'repo/git_repository'
-require 'repo/subversion_repository'
+# require 'repo/subversion_repository'
 require 'database_cleaner'
 require 'time-warp'
 


### PR DESCRIPTION
SVN takes a long time to install and apache mirrors are really unreliable. Also, our tests don't actually require us to have SVN installed.  
If we do want to re-implement this in the future though, simply uncomment the line in the .travis.yml file and the spec_helper file. 