### PR TITLE
Dont show parent link at the top level of an assignment

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -194,7 +194,9 @@ module SubmissionsHelper
 
   def get_repo_browser_table_info(assignment, revision, revision_identifier, path,
                                   previous_path, grouping_id)
-    exit_directory = get_exit_directory(previous_path, grouping_id,
+
+    # Exit Directory link is not needed for root directory path
+    exit_directory = path == '/' ? [] : get_exit_directory(previous_path, grouping_id,
                                         revision_identifier, revision,
                                         assignment.repository_folder,
                                         'repo_browser')
@@ -208,6 +210,7 @@ module SubmissionsHelper
       directories = revision.directories_at_path(full_path)
       directories_info = get_directories_info(directories, revision_identifier,
                                               path, grouping_id, 'repo_browser')
+
       return exit_directory + files_info + directories_info
     else
       return exit_directory

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -89,15 +89,21 @@
       <%
         path_memory = '/'
         absolute_path = @grouping.assignment.repository_folder + @path
-        absolute_path.split('/').each do |folder|
+        absolute_path_decomp = absolute_path.split('/')
+        absolute_path_decomp.each do |folder|
           if folder != @grouping.assignment.repository_folder
             path_memory = File.join(path_memory, folder)
           end %>
-          <%= link_to(" / #{folder}",
+          <%=
+            if folder == absolute_path_decomp.last
+              t(" / #{folder} ")
+            else
+              link_to(" / #{folder}",
                       action: 'repo_browser',
                       path: path_memory,
                       id: @grouping.id,
-                      revision_identifier: @revision.revision_identifier).html_safe %>
+                      revision_identifier: @revision.revision_identifier).html_safe
+            end %>
       <% end %>
     </p>
 


### PR DESCRIPTION
Top level and current directory links will not be available as they navigate to the same page.

Fixes https://github.com/MarkUsProject/Markus/issues/3364