### PR TITLE
Add fields to User new/edit forms

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -55,6 +55,6 @@ class AdminsController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:user_name, :first_name, :last_name)
+    params.require(:user).permit(:user_name, :first_name, :last_name, :email)
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -172,6 +172,8 @@ class StudentsController < ApplicationController
     params.require(:user).permit(:user_name,
                                  :last_name,
                                  :first_name,
+                                 :email,
+                                 :id_number,
                                  :grace_credits,
                                  :section_id)
   end

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -110,6 +110,6 @@ class TasController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:user_name, :last_name, :first_name)
+    params.require(:user).permit(:user_name, :last_name, :first_name, :email)
   end
 end

--- a/app/views/layouts/_userform.html.erb
+++ b/app/views/layouts/_userform.html.erb
@@ -19,6 +19,11 @@
         <td><%= raw(f.label(:user_name, I18n.t('user.first_name'))) %>:</td>
         <td><%= raw(f.text_field :first_name) %></td>
       </tr>
+
+      <tr>
+        <td><%= raw(f.label(:email, I18n.t('user.email'))) %>:</td>
+        <td><%= raw(f.text_field :email) %></td>
+      </tr>
     </table>
 
     <%= f.hidden_field :id %>

--- a/app/views/students/_student_form.html.erb
+++ b/app/views/students/_student_form.html.erb
@@ -22,6 +22,16 @@
       </tr>
 
       <tr>
+        <td><%= raw(f.label(:email, t('user.email'))) %>:</td>
+        <td><%= raw(f.text_field :email) %></td>
+      </tr>
+
+      <tr>
+        <td><%= raw(f.label(:id_number, t('user.id_number'))) %>:</td>
+        <td><%= raw(f.text_field :id_number) %></td>
+      </tr>
+
+      <tr>
         <td><%= raw(f.label(:grace_credits, t('user.grace_credits'))) %>:</td>
         <td><%= raw(f.text_field :grace_credits) %></td>
       </tr>


### PR DESCRIPTION
Fixed #3363 issue.

Added Email and Id number fields to new/edit student forms.

The fields are added in _student_form.html.erb under app->views->students
![image](https://user-images.githubusercontent.com/25095051/40091610-bf182f8a-5886-11e8-8e5c-3bea87e02e9c.png)

Also updated the student_controller so the fields get added to the DB.

Added Email field to new/edit Graders and Admins' forms:
The field is added in _userform.html.erb under app->views->layouts

![image](https://user-images.githubusercontent.com/25095051/40091763-983cb9d4-5887-11e8-80dd-45fb8f67f5eb.png)

tas_controller and admin_controller have also been updated.