### PR TITLE
Add db changes for autotesting wip features

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -49,6 +49,7 @@ class Grouping < ApplicationRecord
 
   has_one :token
 
+  has_many :test_runs, dependent: :destroy
   has_many :test_script_results,
            -> { order 'created_at DESC' },
            dependent: :destroy

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -24,6 +24,7 @@ class Submission < ApplicationRecord
 
   has_many   :submission_files, dependent: :destroy
   has_many   :annotations, through: :submission_files
+  has_many   :test_runs, dependent: :nullify
   has_many   :test_script_results,
              -> { order 'created_at DESC' },
              dependent: :destroy

--- a/app/models/test_batch.rb
+++ b/app/models/test_batch.rb
@@ -1,0 +1,3 @@
+class TestBatch < ApplicationRecord
+  has_many :test_runs, dependent: :nullify
+end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -18,22 +18,20 @@
 #############################################################
 
 class TestResult < ApplicationRecord
-  belongs_to :test_script_result
-  validates_presence_of :test_script_result
+  belongs_to :test_script_result, required: true
 
   validates_presence_of :name
   validates_presence_of :completion_status
   validates_presence_of :marks_earned
   validates_presence_of :marks_total
-
+  # input, actual_output and expected_output could be empty in some situations
+  validates_presence_of :input, if: "input.nil?"
+  validates_presence_of :actual_output, if: "actual_output.nil?"
+  validates_presence_of :expected_output, if: "expected_output.nil?"
   validates_inclusion_of :completion_status,
                          in: %w(pass partial fail error),
                          message: "%{value} is not a valid status"
   validates_numericality_of :marks_earned, greater_than_or_equal_to: 0
   validates_numericality_of :marks_total, greater_than_or_equal_to: 0
-
-  # input, actual_output and expected_output could be empty in some situations
-  validates_presence_of :input, if: "input.nil?"
-  validates_presence_of :actual_output, if: "actual_output.nil?"
-  validates_presence_of :expected_output, if: "expected_output.nil?"
+  validates_numericality_of :time, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
 end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -25,9 +25,9 @@ class TestResult < ApplicationRecord
   validates_presence_of :marks_earned
   validates_presence_of :marks_total
   # input, actual_output and expected_output could be empty in some situations
-  validates_presence_of :input, if: "input.nil?"
-  validates_presence_of :actual_output, if: "actual_output.nil?"
-  validates_presence_of :expected_output, if: "expected_output.nil?"
+  validates_presence_of :input, if: 'input.nil?'
+  validates_presence_of :actual_output, if: 'actual_output.nil?'
+  validates_presence_of :expected_output, if: 'expected_output.nil?'
   validates_inclusion_of :completion_status,
                          in: %w(pass partial fail error),
                          message: "%{value} is not a valid status"

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -1,9 +1,11 @@
 class TestRun < ApplicationRecord
   has_many :test_script_results, dependent: :destroy
   belongs_to :test_batch
+  belongs_to :submission
   belongs_to :grouping, required: true
   belongs_to :user, required: true
 
+  validates_presence_of :revision_identifier
   validates_numericality_of :queue_len, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
   validates_numericality_of :avg_pop_interval, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
 end

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -1,0 +1,9 @@
+class TestRun < ApplicationRecord
+  has_many :test_script_results, dependent: :destroy
+  belongs_to :test_batch
+  belongs_to :grouping, required: true
+  belongs_to :user, required: true
+
+  validates_numericality_of :queue_len, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
+  validates_numericality_of :avg_pop_interval, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
+end

--- a/app/models/test_script_result.rb
+++ b/app/models/test_script_result.rb
@@ -23,8 +23,8 @@ class TestScriptResult < ApplicationRecord
   belongs_to :submission
   belongs_to :test_script, required: true
   belongs_to :test_run, required: true
-  belongs_to :grouping, required: true, validate: true #TODO delete
-  belongs_to :requested_by, class_name: 'User', inverse_of: :test_script_results, required: true #TODO delete
+  belongs_to :grouping, required: true, validate: true # TODO delete
+  belongs_to :requested_by, class_name: 'User', inverse_of: :test_script_results, required: true # TODO delete
 
   validates_presence_of :marks_earned
   validates_presence_of :marks_total

--- a/app/models/test_script_result.rb
+++ b/app/models/test_script_result.rb
@@ -19,23 +19,19 @@
 #############################################################
 
 class TestScriptResult < ApplicationRecord
-  belongs_to :submission, required: false
-  belongs_to :test_script
-  belongs_to :grouping
-  belongs_to :requested_by, class_name: 'User', inverse_of: :test_script_results
-
   has_many :test_results, dependent: :destroy
+  belongs_to :submission
+  belongs_to :test_script, required: true
+  belongs_to :test_run, required: true
+  belongs_to :grouping, required: true, validate: true #TODO delete
+  belongs_to :requested_by, class_name: 'User', inverse_of: :test_script_results, required: true #TODO delete
 
-  validates_presence_of :grouping   # we require an associated grouping
-  validates_associated  :grouping   # grouping need to be valid
-
-  validates_presence_of :test_script
   validates_presence_of :marks_earned
   validates_presence_of :marks_total
-
+  validates_presence_of :time
   validates_numericality_of :marks_earned, greater_than_or_equal_to: 0
   validates_numericality_of :marks_total, greater_than_or_equal_to: 0
-  validates_numericality_of :time, only_integer: true, greater_than_or_equal_to: 0
+  validates_numericality_of :time, greater_than_or_equal_to: 0, only_integer: true
 
   def create_test_result(name, input, actual, expected, marks_earned, marks_total, status)
     self.test_results.create(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
            -> { where membership_status: [StudentMembership::STATUSES[:accepted], StudentMembership::STATUSES[:inviter]] },
            class_name: 'Membership'
   has_many :annotations, as: :creator
+  has_many :test_runs, dependent: :destroy
   has_many :test_script_results, foreign_key: 'requested_by_id', dependent: :delete_all, inverse_of: :requested_by
   has_many :split_pdf_logs
 

--- a/db/migrate/20180516181356_track_autotest_runs.rb
+++ b/db/migrate/20180516181356_track_autotest_runs.rb
@@ -1,0 +1,22 @@
+class TrackAutotestRuns < ActiveRecord::Migration
+  def change
+    create_table :test_batches do |t|
+      t.timestamps null: false
+    end
+
+    create_table :test_runs do |t|
+      t.integer :queue_len
+      t.integer :avg_pop_interval, limit: 8
+      t.references :test_batch, index: true, foreign_key: true
+      t.references :grouping, index: true, foreign_key: true, null: false
+      t.references :user, index: true, foreign_key: true, null: false
+
+      t.timestamps null: false
+    end
+
+    add_reference :test_script_results, :test_run, index: true, foreign_key: true, null: false
+    add_column :test_script_results, :stderr, :text
+
+    add_column :test_results, :time, :bigint
+  end
+end

--- a/db/migrate/20180517143503_track_autotest_runs2.rb
+++ b/db/migrate/20180517143503_track_autotest_runs2.rb
@@ -1,0 +1,6 @@
+class TrackAutotestRuns2 < ActiveRecord::Migration
+  def change
+    add_reference :test_runs, :submission, index: true, foreign_key: true
+    add_column :test_runs, :revision_identifier, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180430184545) do
+ActiveRecord::Schema.define(version: 20180516181356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -545,18 +545,38 @@ ActiveRecord::Schema.define(version: 20180430184545) do
 
   add_index "template_divisions", ["exam_template_id"], name: "index_template_divisions_on_exam_template_id", using: :btree
 
+  create_table "test_batches", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "test_results", force: :cascade do |t|
     t.integer  "test_script_result_id"
     t.string   "name"
-    t.string   "completion_status",                   null: false
-    t.float    "marks_earned",          default: 0.0, null: false
-    t.text     "input",                 default: "",  null: false
-    t.text     "actual_output",         default: "",  null: false
-    t.text     "expected_output",       default: "",  null: false
+    t.string   "completion_status",                             null: false
+    t.float    "marks_earned",                    default: 0.0, null: false
+    t.text     "input",                           default: "",  null: false
+    t.text     "actual_output",                   default: "",  null: false
+    t.text     "expected_output",                 default: "",  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.float    "marks_total",           default: 0.0, null: false
+    t.float    "marks_total",                     default: 0.0, null: false
+    t.integer  "time",                  limit: 8
   end
+
+  create_table "test_runs", force: :cascade do |t|
+    t.integer  "queue_len"
+    t.integer  "avg_pop_interval", limit: 8
+    t.integer  "test_batch_id"
+    t.integer  "grouping_id",                null: false
+    t.integer  "user_id",                    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "test_runs", ["grouping_id"], name: "index_test_runs_on_grouping_id", using: :btree
+  add_index "test_runs", ["test_batch_id"], name: "index_test_runs_on_test_batch_id", using: :btree
+  add_index "test_runs", ["user_id"], name: "index_test_runs_on_user_id", using: :btree
 
   create_table "test_script_results", force: :cascade do |t|
     t.integer  "grouping_id"
@@ -569,9 +589,12 @@ ActiveRecord::Schema.define(version: 20180430184545) do
     t.integer  "requested_by_id"
     t.integer  "time",            limit: 8,               null: false
     t.float    "marks_total",               default: 0.0, null: false
+    t.integer  "test_run_id",                             null: false
+    t.text     "stderr"
   end
 
   add_index "test_script_results", ["requested_by_id"], name: "index_test_script_results_on_requested_by_id", using: :btree
+  add_index "test_script_results", ["test_run_id"], name: "index_test_script_results_on_test_run_id", using: :btree
 
   create_table "test_scripts", force: :cascade do |t|
     t.integer "assignment_id",           null: false
@@ -656,6 +679,10 @@ ActiveRecord::Schema.define(version: 20180430184545) do
   add_foreign_key "tags", "users"
   add_foreign_key "template_divisions", "assignment_files"
   add_foreign_key "template_divisions", "exam_templates"
+  add_foreign_key "test_runs", "groupings"
+  add_foreign_key "test_runs", "test_batches"
+  add_foreign_key "test_runs", "users"
+  add_foreign_key "test_script_results", "test_runs"
   add_foreign_key "test_script_results", "users", column: "requested_by_id"
   add_foreign_key "tokens", "groupings"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180516181356) do
+ActiveRecord::Schema.define(version: 20180517143503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -566,15 +566,18 @@ ActiveRecord::Schema.define(version: 20180516181356) do
 
   create_table "test_runs", force: :cascade do |t|
     t.integer  "queue_len"
-    t.integer  "avg_pop_interval", limit: 8
+    t.integer  "avg_pop_interval",    limit: 8
     t.integer  "test_batch_id"
-    t.integer  "grouping_id",                null: false
-    t.integer  "user_id",                    null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.integer  "grouping_id",                   null: false
+    t.integer  "user_id",                       null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "submission_id"
+    t.text     "revision_identifier",           null: false
   end
 
   add_index "test_runs", ["grouping_id"], name: "index_test_runs_on_grouping_id", using: :btree
+  add_index "test_runs", ["submission_id"], name: "index_test_runs_on_submission_id", using: :btree
   add_index "test_runs", ["test_batch_id"], name: "index_test_runs_on_test_batch_id", using: :btree
   add_index "test_runs", ["user_id"], name: "index_test_runs_on_user_id", using: :btree
 
@@ -680,6 +683,7 @@ ActiveRecord::Schema.define(version: 20180516181356) do
   add_foreign_key "template_divisions", "assignment_files"
   add_foreign_key "template_divisions", "exam_templates"
   add_foreign_key "test_runs", "groupings"
+  add_foreign_key "test_runs", "submissions"
   add_foreign_key "test_runs", "test_batches"
   add_foreign_key "test_runs", "users"
   add_foreign_key "test_script_results", "test_runs"

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -17,7 +17,7 @@ describe TestResult do
       @asst = create(:assignment)
       @grouping = create(:grouping, assignment: @asst)
       @sub = create(:submission, grouping: @grouping)
-      @user = create(:user)
+      @user = create(:admin)
       @test_script = TestScript.create(
         assignment_id: @asst.id,
         seq_num: 1,

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -36,7 +36,8 @@ describe TestResult do
       )
       @test_run = TestRun.create(
         grouping: @grouping,
-        user: @user
+        user: @user,
+        revision_identifier: '1'
       )
       @test_script_result = TestScriptResult.create(
         submission: @sub,

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -10,12 +10,14 @@ describe TestResult do
   it { is_expected.to validate_presence_of(:marks_total) }
   it { is_expected.to validate_numericality_of(:marks_earned) }
   it { is_expected.to validate_numericality_of(:marks_total) }
+  it { is_expected.to validate_numericality_of(:time) }
 
   context 'test result' do
     before(:each) do
       @asst = create(:assignment)
       @grouping = create(:grouping, assignment: @asst)
       @sub = create(:submission, grouping: @grouping)
+      @user = create(:user)
       @test_script = TestScript.create(
         assignment_id: @asst.id,
         seq_num: 1,
@@ -32,10 +34,16 @@ describe TestResult do
         display_expected_output: 'do_not_display',
         display_actual_output: 'do_not_display'
       )
+      @test_run = TestRun.create(
+        grouping: @grouping,
+        user: @user
+      )
       @test_script_result = TestScriptResult.create(
         submission: @sub,
         grouping: @sub.grouping,
         test_script: @test_script,
+        test_run: @test_run,
+        requested_by: @user,
         marks_earned: 1,
         marks_total: 1,
         repo_revision: 0,
@@ -115,6 +123,12 @@ describe TestResult do
         expect(@test_result.save).to be true
       end
 
+      it 'can have nil time' do
+        @test_result.time = nil
+        expect(@test_result).to be_valid
+        expect(@test_result.save).to be true
+      end
+
       it 'can be deleted' do
         expect(@test_result).to be_valid
         expect{@test_result.destroy}.to change {TestResult.count}.by(-1)
@@ -122,12 +136,6 @@ describe TestResult do
     end
 
     context 'An invalid test result' do
-
-      it 'has a nil test script result' do
-        @test_result.test_script_result = nil
-        @test_result.save
-        expect(@test_result).not_to be_valid
-      end
 
       it 'has a nil input' do
         @test_result.input = nil
@@ -161,6 +169,11 @@ describe TestResult do
 
       it 'has nil marks total' do
         @test_result.marks_total = nil
+        expect(@test_result).not_to be_valid
+      end
+
+      it 'has negative time' do
+        @test_result.time = -1
         expect(@test_result).not_to be_valid
       end
     end

--- a/spec/models/test_script_result_spec.rb
+++ b/spec/models/test_script_result_spec.rb
@@ -2,19 +2,25 @@ require 'spec_helper'
 
 describe TestScriptResult do
 
+  it { is_expected.to have_many(:test_results) }
   it { is_expected.to belong_to(:submission) }
   it { is_expected.to belong_to(:test_script) }
+  it { is_expected.to belong_to(:test_run) }
   it { is_expected.to validate_presence_of(:test_script) }
+  it { is_expected.to validate_presence_of(:test_run) }
   it { is_expected.to validate_presence_of(:marks_earned) }
   it { is_expected.to validate_presence_of(:marks_total) }
+  it { is_expected.to validate_presence_of(:time) }
   it { is_expected.to validate_numericality_of(:marks_earned) }
   it { is_expected.to validate_numericality_of(:marks_total) }
+  it { is_expected.to validate_numericality_of(:time) }
 
   context 'test script result' do
     before(:each) do
       @asst = create(:assignment)
       @grouping = create(:grouping, assignment: @asst)
       @sub = create(:submission, grouping: @grouping)
+      @user = create(:user)
       @test_script = TestScript.create(
         assignment_id: @asst.id,
         seq_num: 1,
@@ -31,10 +37,16 @@ describe TestScriptResult do
         display_expected_output: 'do_not_display',
         display_actual_output: 'do_not_display'
       )
+      @test_run = TestRun.create(
+        grouping: @grouping,
+        user: @user
+      )
       @test_script_result = TestScriptResult.create(
         submission: @sub,
         grouping: @sub.grouping,
         test_script: @test_script,
+        test_run: @test_run,
+        requested_by: @user,
         marks_earned: 1,
         marks_total: 1,
         repo_revision: 0,
@@ -94,28 +106,13 @@ describe TestScriptResult do
 
     context 'An invalid test script result' do
 
-      it 'has a nil test script' do
-        @test_script_result.test_script = nil
-        expect(@test_script_result).not_to be_valid
-      end
-
       it 'has negative marks earned' do
         @test_script_result.marks_earned = -1
         expect(@test_script_result).not_to be_valid
       end
 
-      it 'has nil marks earned' do
-        @test_script_result.marks_earned = nil
-        expect(@test_script_result).not_to be_valid
-      end
-
       it 'has negative marks total' do
         @test_script_result.marks_total = -1
-        expect(@test_script_result).not_to be_valid
-      end
-
-      it 'has nil marks total' do
-        @test_script_result.marks_total = nil
         expect(@test_script_result).not_to be_valid
       end
 

--- a/spec/models/test_script_result_spec.rb
+++ b/spec/models/test_script_result_spec.rb
@@ -39,7 +39,8 @@ describe TestScriptResult do
       )
       @test_run = TestRun.create(
         grouping: @grouping,
-        user: @user
+        user: @user,
+        revision_identifier: '1'
       )
       @test_script_result = TestScriptResult.create(
         submission: @sub,

--- a/spec/models/test_script_result_spec.rb
+++ b/spec/models/test_script_result_spec.rb
@@ -20,7 +20,7 @@ describe TestScriptResult do
       @asst = create(:assignment)
       @grouping = create(:grouping, assignment: @asst)
       @sub = create(:submission, grouping: @grouping)
-      @user = create(:user)
+      @user = create(:admin)
       @test_script = TestScript.create(
         assignment_id: @asst.id,
         seq_num: 1,


### PR DESCRIPTION
This pull request adds all db changes (hopefully) for the upcoming autotesting work.

@david-yz-liu There are some redundant fields in ```test_script_results```, moved to ```test_runs```. They're still there to not break things, after a future code refactoring there is going to be a new migration to remove them. This is otherwise ready for students to work on ui stuff.