### PR TITLE
Removed .gitkeep

### DIFF
--- a/app/views/results/common/_file_selector_dropdown.html.erb
+++ b/app/views/results/common/_file_selector_dropdown.html.erb
@@ -20,12 +20,14 @@
           <% end %>
           <% if dir[:files] != nil %>
               <% dir[:files].each do |file| %>
+                <% if file.filename != ".gitkeep" %>
                   <li class="file_item" data-path="<%= file.path %>/<%= file.filename %>" data-id="<%= file.id %>">
                     <a onclick='open_file(<%= file.id %>, "<%= file.path %>/<%= file.filename %>")'
                        onmouseover='close_submenu_recursive(
                            this.parentNode.parentNode, null)'>
                       <%= file.filename %>
                     </a></li>
+                <% end %>
               <% end %>
           <% end %>
       <% end %>

--- a/app/views/submissions/_react_file_manager_boot_table.js.jsx.erb
+++ b/app/views/submissions/_react_file_manager_boot_table.js.jsx.erb
@@ -63,6 +63,13 @@
         data: { path: '<%= @path  %>'},
         dataType: 'json',
         success: function(data) {
+          function isGitkeep(file) {
+            return file.raw_name === '.gitkeep';
+          }
+          var index = data.indexOf(data.find(isGitkeep));
+          if (index > -1) {
+            data.splice(index, 1);
+          }
           this.setState({
             files: data,
           });


### PR DESCRIPTION
This PR addresses issue #3361 
Summary: I removed .gitkeep file from the drop_down_menu in the marker's view and from the file submissions in a repo in the student's view.
Before: (Drop down menu)

![screen shot 2018-05-18 at 7 40 04 pm](https://user-images.githubusercontent.com/25258598/40262471-9b9f7986-5ad5-11e8-90c3-ccd8fea78d33.png)

After: (Drop down menu)
![screen shot 2018-05-18 at 7 41 41 pm](https://user-images.githubusercontent.com/25258598/40262483-bba2283c-5ad5-11e8-951e-1546db3c7d3b.png)

Before: (File submissions)

![screen shot 2018-05-18 at 7 42 57 pm](https://user-images.githubusercontent.com/25258598/40262489-c691e570-5ad5-11e8-9937-75ad1faab5e1.png)

After: (File submissions)

![screen shot 2018-05-18 at 7 43 37 pm](https://user-images.githubusercontent.com/25258598/40262495-ce9ca106-5ad5-11e8-971e-b3a575e42f8d.png)


**NOTE**:
The first selected file in the drop-down menu is hardcoded to be .gitkeep so regardless of whether the file is in the menu, it will still appear. I am open to suggestions on whether I should leave it and it will be an easy fix or do I get the first file (and what if there is no file).
