### PR TITLE
Names Absent from Submission Tab

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -186,7 +186,7 @@ class Grouping < ApplicationRecord
   end
 
   def get_group_name
-    return group.group_name if assignment.group_max == 1
+    return group.group_name if assignment.group_max == 1 && !assignment.scanned_exam
 
     name = group.group_name
     student_names = accepted_students.map &:user_name


### PR DESCRIPTION
## Ready for Review
### Summary
Previously, when viewing the submissions tab of a scanned assignment, the "Group Name" column would not include the students contained in that group. This has now been changed so that it includes the student names.

Resolves #3288

### Details
<details>
<summary>Before comparing, note the group on the right.</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40381383-8c496bee-5dc9-11e8-8c22-62da4ca3bbc1.PNG" alt="group_snapshot">
</p>
</details>

<details>
<summary>Previously, the students of the group were not included in the group name.</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40381444-ae782fe8-5dc9-11e8-84ce-32ad064a98d9.PNG" alt="submissions_before">
</p>
</details>

<details>
<summary>Now, the students name are visible after the group name.</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40381483-cb4767b0-5dc9-11e8-89f2-80ac73b86393.PNG" alt="submissions_after">
</p>
</details>