### PR TITLE
A1 and A3 Individual Groups

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -9,7 +9,7 @@ namespace :db do
 
     students = Student.all
     Assignment.all.each do |assignment|
-      num_groups = (assignment.short_identifier == 'A1' && ENV['A1_GROUP_AMOUNT']) ? ENV['A1_GROUP_AMOUNT'].to_i : 15
+      num_groups = (assignment.short_identifier == 'A1' || assignment.short_identifier == 'A3') ? students.length : 15
       num_groups.times do |time|
         student = students[time]
         # if this is an individual assignment


### PR DESCRIPTION
## Ready for Review

### Summary
Previously, there was only the default of 15 students in individual groups for the individual assignments A1 and A3, this has now been changed so that all 216 students defined in `db\data\students.csv` are assigned their own group. Note that this does not include the students added in `lib\tasks\autotest.rake`.

### Details
Both A1 and A3 look the same, so only A1 will be displayed.
<details>
<summary>A1 prior to pull request, note the quantity of groups.</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40691455-e9fc0a98-6379-11e8-8951-8f8dc5403025.PNG" alt="before.png">
</p>
</details>

<details>
<summary>A1 after the pull request, again noting the quantity of groups.</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40691479-09391b9e-637a-11e8-94c8-f9c7ec15eba1.PNG" alt="after.png">
</p>
</details>

<details>
<summary>The "students" that were not added by autotest.rake</summary>
<p>
<img src="https://user-images.githubusercontent.com/13205417/40691485-162b6d8e-637a-11e8-9452-2777ec4aae09.PNG" alt="unassigned_students.png">
</p>
</details>