### PR TITLE
Fixed the issue where the order of grade_entry_item weren't preserved

### DIFF
--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -34,7 +34,7 @@ module GradeEntryFormsHelper
       max_position = 1
       grade_entry_items.each do |_, item|
         # Some items are being deleted so don't update those
-        if item[:_destroy] != 1
+        unless item[:_destroy] == 1
           item[:position] = max_position
           max_position += 1
         end

--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -33,12 +33,9 @@ module GradeEntryFormsHelper
       # Update the attributes hash
       max_position = 1
       grade_entry_items.each do |_, item|
-        puts "name: #{item[:name]}"
-        puts "is #{item[:name]} destroyed? #{item[:_destroy]}"
         # Some items are being deleted so don't update those
         if item[:_destroy] != 1
           item[:position] = max_position
-          puts "max position: #{max_position}"
           max_position += 1
         end
       end

--- a/app/helpers/grade_entry_forms_helper.rb
+++ b/app/helpers/grade_entry_forms_helper.rb
@@ -33,9 +33,12 @@ module GradeEntryFormsHelper
       # Update the attributes hash
       max_position = 1
       grade_entry_items.each do |_, item|
+        puts "name: #{item[:name]}"
+        puts "is #{item[:name]} destroyed? #{item[:_destroy]}"
         # Some items are being deleted so don't update those
-        unless item[:_destroy]
+        if item[:_destroy] != 1
           item[:position] = max_position
+          puts "max position: #{max_position}"
           max_position += 1
         end
       end


### PR DESCRIPTION
The issue: 
When more than one grade_entry_items are added, the order of these items became messed up, not conforming to the order in which they are added. 

The problem: 
```ruby
unless item[:_destroy]
           item[:position] = max_position
           max_position += 1
end
```
[:_destroy] gives out value of 1/0 instead of true/false. In addition, the newly added grade_entry_item does not have attribute [:_destroy], so it holds the value of nil. The problem with the above code is that both 0 and 1 are treated as true(truthy), the previous grade_entry_item(which unless they are deleted, holds the value of 0) will not be run in this code block, thus not be taken into account of the new positioning. 

The solution:
```ruby
unless item[:_destroy] == 1
           item[:position] = max_position
           max_position += 1
end
```
I changed the condition to condition on 1/everything_else instead of true/false.

