### PR TITLE
Make criteria upload more efficient

### DIFF
--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -7,8 +7,8 @@ class CriteriaController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:assignment_id])
-    if @assignment.past_all_due_dates?
-      flash_now(:notice, I18n.t('past_due_date_warning'))
+    if @assignment.marking_started?
+      flash_now(:notice, I18n.t('marking_started_warning'))
     end
     @criteria = @assignment.get_criteria
   end
@@ -71,8 +71,8 @@ class CriteriaController < ApplicationController
 
   def update
     criterion_type = params[:criterion_type]
-    @assignment = @criterion.assignment
     @criterion = criterion_type.constantize.find(params[:id])
+    @assignment = @criterion.assignment
     if @assignment.released_marks.any?
       flash_now(:error, t('criteria.errors.messages.released_marks'))
       return

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -15,6 +15,11 @@ class CriteriaController < ApplicationController
 
   def new
     @assignment = Assignment.find(params[:assignment_id])
+    if @assignment.released_marks.any?
+      flash_message(:error, t('criteria.errors.messages.released_marks'))
+      render :index
+      return
+    end
   end
 
   def create
@@ -37,6 +42,12 @@ class CriteriaController < ApplicationController
 
   def edit
     @criterion = params[:criterion_type].constantize.find(params[:id])
+    @assignment = @criterion.assignment
+    if @assignment.released_marks.any?
+      flash_message(:error, t('criteria.errors.messages.released_marks'))
+      render :index
+      return
+    end
   end
 
   def destroy
@@ -111,7 +122,11 @@ class CriteriaController < ApplicationController
 
   def upload_yml
     assignment = Assignment.find(params[:assignment_id])
-
+    if assignment.released_marks.any?
+      flash_message(:error, t('criteria.errors.messages.released_marks'))
+      redirect_to action: 'index', id: assignment.id
+      return
+    end
     # Check for errors in the request or in the file uploaded.
     unless request.post?
       redirect_to action: 'index', id: assignment.id

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -454,7 +454,7 @@ class ResultsController < ApplicationController
         num_assigned = assignment.get_num_assigned(@current_user.id)
       end
       render text: "#{result_mark.mark.to_f}," +
-                   "#{result_mark.result.get_subtotal(visibility)}," +
+                   "#{result_mark.result.get_subtotal(user_visibility: visibility)}," +
                    "#{result_mark.result.total_mark}," +
                    "#{num_marked}," +
                    "#{num_assigned}"

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -233,6 +233,11 @@ class Assignment < ActiveRecord::Base
     invalid_override || group_max > 1
   end
 
+  # Return all released marks for this assignment
+  def released_marks
+    submissions.joins(:results).where(results: {released_to_students: true})
+  end
+
   # Returns the group by the user for this assignment. If pending=true,
   # it will return the group that the user has a pending invitation to.
   # Returns nil if user does not have a group for this assignment, or if it is

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -265,6 +265,17 @@ class Assignment < ActiveRecord::Base
     s.nil? ? 0 : s.round(2)
   end
 
+  # Returns a boolean indicating whether marking has started for at least
+  # one submission for this assignment.  Only the most recently collected
+  # submissions are considered.
+  def marking_started?
+    Result.joins(:marks, submission: :grouping)
+          .where(groupings: { assignment_id: id },
+                 submissions: { submission_version_used: true })
+          .where.not(marks: { mark: nil })
+          .any?
+  end
+
   # calculates summary statistics of released results for this assignment
   def update_results_stats
     marks = Result.student_marks_by_assignment(id)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -235,7 +235,7 @@ class Assignment < ActiveRecord::Base
 
   # Return all released marks for this assignment
   def released_marks
-    submissions.joins(:results).where(results: {released_to_students: true})
+    submissions.joins(:results).where(results: { released_to_students: true })
   end
 
   # Returns the group by the user for this assignment. If pending=true,

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -1,7 +1,7 @@
 # The abstract base class that defines common behavior for all types of
 # criterion.
 class Criterion < ActiveRecord::Base
-  after_save :scale_marks_when_max_mark_updated
+  after_update :scale_marks
 
   has_many :criteria_assignment_files_joins,
            as: :criterion,
@@ -141,23 +141,22 @@ class Criterion < ActiveRecord::Base
   end
 
   # When max_mark of criterion is changed, all associated marks should have their mark value scaled to the change.
-  def scale_marks_when_max_mark_updated
-    if self.max_mark_changed? # if max_mark is updated
+  def scale_marks
+    if max_mark_changed? && !max_mark_was.nil?  # if max_mark is updated
       # results with specific assignment
-      results = Result.joins(submission: :grouping)
+      results = Result.includes(submission: :grouping)
                       .where(groupings: {assignment_id: assignment_id})
+      all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
+      # all associated marks should have their mark value scaled to the change.
+      all_marks.each do |m|
+        m.scale_mark(max_mark, max_mark_was)
+      end
+      a = Assignment.find(assignment_id)
       results.each do |r|
-        # all associated marks should have their mark value scaled to the change.
-        marks = self.marks.where(result_id: r.id)
-        marks.each do |m|
-          unless m.mark.nil?
-            m.scale_mark(max_mark, max_mark_was)
-          end
-        end
-        r.update_total_mark
+        r.update_total_mark(assignment: a)
       end
 
-      Assignment.find(assignment_id).assignment_stat.refresh_grade_distribution
+      a.assignment_stat.refresh_grade_distribution
     end
   end
 end

--- a/app/models/mark.rb
+++ b/app/models/mark.rb
@@ -36,19 +36,21 @@ class Mark < ActiveRecord::Base
     end
   end
 
-  def scale_mark(curr_max_mark, prev_max_mark)
-    return if prev_max_mark == 0 || mark == 0 # no scaling occurs if prev_max_mark is 0 or mark is 0
+  def scale_mark(curr_max_mark, prev_max_mark, update: true)
+    return if mark.nil?
+    return 0 if prev_max_mark == 0 || mark == 0 # no scaling occurs if prev_max_mark is 0 or mark is 0
     if markable.is_a? RubricCriterion
-      new_mark = mark * (curr_max_mark / prev_max_mark)
-      # Use update_columns to skip validations.
-      update_columns(mark: new_mark.round(1))
+      new_mark = (mark * (curr_max_mark / prev_max_mark)).round(1)
     elsif markable.is_a? FlexibleCriterion
-      new_mark = mark * (curr_max_mark.to_f / prev_max_mark)
-      update_columns(mark: new_mark.round(2))
+      new_mark = (mark * (curr_max_mark.to_f / prev_max_mark)).round(2)
     else # if it is CheckboxCriterion
-      new_mark = (mark / prev_max_mark) * curr_max_mark
-      update_columns(mark: new_mark.round(0))
+      new_mark = ((mark / prev_max_mark) * curr_max_mark).round(0)
     end
+    if update
+      # Use update_columns to skip validations.
+      update_columns(mark: new_mark)
+    end
+    new_mark
   end
 
   private

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -66,7 +66,7 @@ class Result < ActiveRecord::Base
     user_visibility = is_a_review? ? :peer : :ta
     subtotal = get_subtotal(user_visibility: user_visibility, assignment: assignment)
     extra_marks = get_total_extra_marks(user_visibility: user_visibility, assignment: assignment)
-    [0, subtotal+extra_marks].max
+    [0, subtotal + extra_marks].max
   end
 
   # The sum of the marks not including bonuses/deductions
@@ -100,22 +100,22 @@ class Result < ActiveRecord::Base
 
   # The sum of the bonuses and deductions, other than late penalty
   def get_total_extra_points
-    extra_marks.points&.map(&:extra_mark).reduce(0, :+).round(1)
+    extra_marks.points.map(&:extra_mark).reduce(0, :+).round(1)
   end
 
   # The sum of all the positive extra marks
   def get_positive_extra_points
-    extra_marks.positive.points&.map(&:extra_mark).reduce(0, :+).round(1)
+    extra_marks.positive.points.map(&:extra_mark).reduce(0, :+).round(1)
   end
 
   # The sum of all the negative extra marks
   def get_negative_extra_points
-    extra_marks.negative.points&.map(&:extra_mark).reduce(0, :+).round(1)
+    extra_marks.negative.points.map(&:extra_mark).reduce(0, :+).round(1)
   end
 
   # Percentage deduction for late penalty
   def get_total_extra_percentage
-    extra_marks.percentage&.map(&:extra_mark).reduce(0, :+).round(1)
+    extra_marks.percentage.map(&:extra_mark).reduce(0, :+).round(1)
   end
 
   # Point deduction for late penalty

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -7,8 +7,6 @@ class RubricCriterion < Criterion
   validates_numericality_of :max_mark
   before_save :round_max_mark
 
-  after_save :update_existing_results
-
   has_many :marks, as: :markable, dependent: :destroy
   accepts_nested_attributes_for :marks
 
@@ -277,11 +275,6 @@ class RubricCriterion < Criterion
       Ta.find_by(user_name: ta_user_name)
     end.compact
     add_tas(result)
-  end
-
-  # Updates results already entered with new criteria
-  def update_existing_results
-    self.assignment.submissions.each { |submission| submission.get_latest_result.update_total_mark }
   end
 
   # Checks if the criterion is visible to either the ta or the peer reviewer.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1257,6 +1257,7 @@ en:
           assignment_association: "Association is not strong with an assignment."
           assignment_id:          "Can only be whole number greater than 0."
           input_number:           "Must be a number greater than 0.0."
+          released_marks:         "Cannot update criteria for an assignment with released marks"
       ta_visible:       "Make visible to teaching assistants"
       peer_visible:     "Make visible to peer reviewers"
       visibility_error: "Select at least one box in the visibility section"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1402,6 +1402,7 @@ en:
       Criteria names, descriptions, maximum values and visibility can be modified."
     past_due_date_warning: "Due date for this assignment is in the past."
     past_due_date_notice: "Due date for this assignment is in the past for: "
+    marking_started_warning: "Marking has already started for this assignment"
 
     section:
       help:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1623,6 +1623,7 @@ es:
                                              valores máximos y la visibilidad pueden ser modificados."
     past_due_date_warning:                  "El último plazo de entrega para este proyecto está en el pasado."
     past_due_date_notice:                   "El último plazo de entrega para este proyecto está en el pasado por: "
+    marking_started_warning:                "TODO"
 
     section:
       help:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1475,6 +1475,7 @@ es:
           assignment_association: "La asociación con el proyecto no es lo suficientemente fuerte."
           assignment_id:          "Sólo puede ser un número entero mayor a cero."
           input_number:           "Debe ser un número mayor a 0.0."
+          released_marks:         "TODO"
       ta_visible:       "Hacer visible a los asistentes de cátedra"
       peer_visible:     "Hacer visible a los revisores de compañeros"
       visibility_error: "Seleccionar al menos una opción en la sección de visibilidad"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1246,6 +1246,7 @@ fr:
     Les nom des critères, leurs descriptions, les notes maximales et visibilité peuvent être modifiés."
     past_due_date_warning: "La date de retour de ce projet est passée."
     past_due_date_notice: "La date de retour de ce projet est passée pour : "
+    marking_started_warning: "TODO"
 
     date:
       formats:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1117,6 +1117,7 @@ fr:
           assignment_association: "Association est pas forte avec une mission."
           assignment_id:          "Ne peut être un nombre entier supérieur à 0."
           input_number:           "Doit être un nombre supérieur à 0.0."
+          released_marks:         "TODO"
       ta_visible:       "Rendre visible aux assistants d'enseignement"
       peer_visible:     "Rendre visible à leurs auteurs pairs"
       visibility_error: "Sélectionnez au moins une case dans la section de visibilité"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1233,6 +1233,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
       Nome do critério, descrição, valores máximos e visibilidade podem ser modificados."
     past_due_date_warning: "Já se passou do prazo de entrega do projeto."
     past_due_date_notice: "Já se passou do prazo de entrega do projeto: "
+    marking_started_warning: "TODO"
 
     date:
       formats:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1087,6 +1087,7 @@ Aplicar pênalti no final / Deduzir fichas de carência ( Deixando esta caixa de
           assignment_association: "Associação não é forte com uma atribuição."
           assignment_id:          "Só pode ser o número inteiro maior que 0."
           input_number:           "Deve ser um número maior do que 0.0."
+          released_marks:         "TODO"
       ta_visible:       "Tornar visível para assistentes de ensino"
       peer_visible:     "Tornar visível a perscrutar revisores"
       visibility_error: "Selecione pelo menos uma caixa na seção visibilidade"


### PR DESCRIPTION
- make criteria creation more efficient so uploading multiple criteria (from a .yml file) doesn't cause the server to time out.
- prevent creation, deletion, or modification of criteria if an assignment has any released marks
