### PR TITLE
Ensure autotest workers are restarted after vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     s.privileged = false
   end
 
+  config.vm.provision "start-autotest-workers", type: "shell", run: "always" do |s|
+    s.path = "script/start-autotest-workers.sh"
+    s.privileged = false
+  end
+
   config.vm.provision "install-svn", type: "shell", run: "never" do |s|
     s.path = "script/install-svn.sh"
     s.privileged = false

--- a/lib/tasks/autotest.rake
+++ b/lib/tasks/autotest.rake
@@ -185,6 +185,7 @@ class AutotestSetup
     # autotester uses the names as part of a hash key
     AutotestScriptsJob.perform_now('http://0.0.0.0:3000', @assignment.id)
     AutotestScriptsJob.perform_now('http://localhost:3000', @assignment.id)
+    AutotestScriptsJob.perform_now('http://127.0.0.1:3000', @assignment.id)
   end
 
   def collect_submissions

--- a/script/start-autotest-workers.sh
+++ b/script/start-autotest-workers.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# start up autotest (rq) workers which are managed by supervisor
+source /home/vagrant/markus-autotesting/server/venv/bin/activate
+supervisord -c /home/vagrant/markus-autotesting/server/supervisord.conf
+deactivate


### PR DESCRIPTION
- ensure that autotest workers are restarted after a `vagrant halt` followed by a `vagrant up` command
- seed autotester with test scripts using the hostname 127.0.0.1 (as well as localhost and 0.0.0.0). This allows someone working in development mode to run autotests immediately, regardless of the hostname they are using to point to their local machine. 