### PR TITLE
rq-dashboard port forwarding for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 3000, host: 3000
   # Webpack-dev-server listens on port 3035.
   config.vm.network "forwarded_port", guest: 3035, host: 3035
-
+  # rq-dashboard
+  config.vm.network "forwarded_port", guest: 9181, host: 9181
+  
   # The autotesting server must be running when MarkUs populates the seed database
   config.vm.provision "install-markus-autotesting", type: "shell" do |s|
     s.path = "script/install-markus-autotesting.sh"


### PR DESCRIPTION
Include port forwarding for port 9181 which is the default port used by rq-dashboard. This will allow us to use rq-dashboard to inspect rq jobs, workers, queues, etc. that are running on a vagrant machine.