### PR TITLE
query TestRun status more easily

### DIFF
--- a/app/jobs/autotest_cancel_job.rb
+++ b/app/jobs/autotest_cancel_job.rb
@@ -27,7 +27,7 @@ class AutotestCancelJob < ApplicationJob
         Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
           out = ssh.exec!(cancel_command)
           # TODO: use out to check if test_runs were cancelled and only set time_to_service if successful
-          TestRun.find(test_run_ids).each { |test_run| test_run.update_attributes!(time_to_service: 0) }
+          TestRun.find(test_run_ids).each { |test_run| test_run.update_attributes!(time_to_service: -1) }
         end
       end
     rescue StandardError => e

--- a/app/jobs/autotest_cancel_job.rb
+++ b/app/jobs/autotest_cancel_job.rb
@@ -26,7 +26,8 @@ class AutotestCancelJob < ApplicationJob
         # local or remote cancellation with authentication
         Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
           out = ssh.exec!(cancel_command)
-          # TODO: use out for something?
+          # TODO: use out to check if test_runs were cancelled and only set time_to_service if successful
+          TestRun.find(test_run_ids).each { |test_run| test_run.update_attributes!(time_to_service: 0) }
         end
       end
     rescue StandardError => e

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -7,7 +7,7 @@ class TestRun < ApplicationRecord
 
   validates_presence_of :revision_identifier
   validates_numericality_of :time_to_service_estimate, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
-  validates_numericality_of :time_to_service, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
+  validates_numericality_of :time_to_service, greater_than_or_equal_to: -1, only_integer: true, allow_nil: true
 
   STATUSES = {
     complete: 'complete',
@@ -17,7 +17,7 @@ class TestRun < ApplicationRecord
 
   def status
     return STATUSES[:complete] unless test_script_results.empty?
-    return STATUSES[:cancelled] if time_to_service&.zero?
+    return STATUSES[:cancelled] if time_to_service&.negative?
     STATUSES[:in_progress]
   end
 


### PR DESCRIPTION
Added a `status` method to the TestRun model. This method can return one of the following:

- `'complete'`
- `'in_progress'`
- `'cancelled'`

Also added the following methods to query for a specific status (returns a boolean) if the current status is the same as the method name:

- `complete?`
- `in_progress?`
- `cancelled?`

When a TestRun job is cancelled, its time_to_completion attribute is set to `0` which indicates that it has been cancelled.  Note that if the cancellation is unsuccessful for any reason (maybe the cancellation request was sent too late and the job is no longer in the queue) then a result from that test _will_ be created meaning the status of the TestRun will become `'complete'` (not `'cancelled'`).  