### PR TITLE
update all uses of `render :text` to `render :plain`

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -822,7 +822,7 @@ class AssignmentsController < ApplicationController
                                                  path))[params[:file_name]]
         file_contents = repo.download_as_string(file)
       rescue Exception => e
-        render text: I18n.t('student.submission.missing_file',
+        render plain: I18n.t('student.submission.missing_file',
                             file_name: params[:file_name], message: e.message)
         return
       end
@@ -835,7 +835,7 @@ class AssignmentsController < ApplicationController
       else
         # Otherwise, sanitize it for HTML and blast it out to the screen
         sanitized_contents = ERB::Util.html_escape(file_contents)
-        render text: sanitized_contents, layout: 'sanitized_html'
+        render plain: sanitized_contents, layout: 'sanitized_html'
       end
     end
   end

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -95,7 +95,7 @@ class GradeEntryFormsController < ApplicationController
     grade.update(grade: params[:updated_grade])
     grade_entry_student.save # Refresh total grade
     grade_entry_student.reload
-    render text: grade_entry_student.total_grade
+    render plain: grade_entry_student.total_grade
   end
 
   # For students

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -332,7 +332,7 @@ class ResultsController < ApplicationController
 
     submission = Submission.find(params[:submission_id])
     if submission.revision_identifier.nil?
-      render text: t('student.submission.no_files_available')
+      render plain: t('student.submission.no_files_available')
       return
     end
 
@@ -360,7 +360,7 @@ class ResultsController < ApplicationController
             file_content = file.retrieve_file
           end
         rescue Exception => e
-          render text: t('student.submission.missing_file',
+          render plain: t('student.submission.missing_file',
                             file_name: file.filename, message: e.message)
           return
         end
@@ -425,7 +425,7 @@ class ResultsController < ApplicationController
         num_marked = assignment.get_num_marked(@current_user.id)
         num_assigned = assignment.get_num_assigned(@current_user.id)
       end
-      render text: "#{result_mark.mark.to_f}," +
+      render plain: "#{result_mark.mark.to_f}," +
                    "#{result_mark.result.get_subtotal(user_visibility: visibility)}," +
                    "#{result_mark.result.total_mark}," +
                    "#{num_marked}," +
@@ -437,7 +437,7 @@ class ResultsController < ApplicationController
                    "Assignment: #{assignment.short_identifier}, " +
                    "Group: #{group.group_name}.",
                    MarkusLogger::ERROR)
-      render text: result_mark.errors.full_messages.join, status: :bad_request
+      render plain: result_mark.errors.full_messages.join, status: :bad_request
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -481,14 +481,14 @@ class SubmissionsController < ApplicationController
                                                   path))[file.filename]
           file_contents = repo.download_as_string(raw_file)
         rescue Exception => e
-          render text: I18n.t('student.submission.missing_file',
+          render plain: I18n.t('student.submission.missing_file',
                               file_name: file.filename, message: e.message)
           next  # exit the block
         end
 
         if SubmissionFile.is_binary?(file_contents)
           # If the file appears to be binary, send it as a download
-          render text: 'not a plaintext file'
+          render plain: 'not a plaintext file'
         else
           render json: { content: file_contents.to_json, type: file.get_file_type }
         end
@@ -515,7 +515,7 @@ class SubmissionsController < ApplicationController
                                                  path))[params[:file_name]]
         file_contents = repo.download_as_string(file)
       rescue Exception => e
-        render text: I18n.t('student.submission.missing_file',
+        render plain: I18n.t('student.submission.missing_file',
                             file_name: params[:file_name], message: e.message)
         return
       end
@@ -528,7 +528,7 @@ class SubmissionsController < ApplicationController
       else
         # Otherwise, sanitize it for HTML and blast it out to the screen
         sanitized_contents = ERB::Util.html_escape(file_contents)
-        render text: sanitized_contents, layout: 'sanitized_html'
+        render plain: sanitized_contents, layout: 'sanitized_html'
       end
     end
   end
@@ -748,7 +748,7 @@ class SubmissionsController < ApplicationController
 
   # This action is called periodically from file_manager.
   def server_time
-    render text: l(Time.zone.now)
+    render plain: l(Time.zone.now)
   end
 
   private


### PR DESCRIPTION
After Rails 5.1, `render :text` has been removed in favour of `render :plain`

http://guides.rubyonrails.org/layouts_and_rendering.html#rendering-text