### PR TITLE
fake external login/authorization in dev/test environments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,13 @@ class ApplicationController < ActionController::Base
   def set_remote_user
     unless request.env['HTTP_X_FORWARDED_USER'].blank?
       @markus_auth_remote_user = request.env['HTTP_X_FORWARDED_USER']
+      return
+    end
+    unless Rails.env.production?
+      uid = session[:real_uid] || session[:uid]
+      unless uid.blank?
+        @markus_auth_remote_user = User.find(uid).user_name
+      end
     end
   end
 

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -311,9 +311,16 @@ class MainController < ApplicationController
       #The user was not assuming another role
       m_logger.log("WARNING: Possible break in attempt from '#{current_user.user_name}'.")
     end
+    real_user_id = session[:real_uid]
     clear_session
     cookies.delete :auth_token
     reset_session
+    unless Rails.env.production?
+      # only used to reset current user if we are faking the external login
+      # in test/development environments
+      redirect_to action: 'login', user_login: User.find(real_user_id).user_name
+      return
+    end
     redirect_to action: 'login'
   end
 

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -27,6 +27,15 @@ class MainController < ApplicationController
 
     # external auth has been done, skip markus authorization
     if MarkusConfigurator.markus_config_remote_user_auth
+      # if not in production environment, this fakes an external authentication
+      unless Rails.env.production?
+        if params[:user_login].nil?
+          render 'login'
+          return
+        else
+          @markus_auth_remote_user = params[:user_login]
+        end
+      end
       if @markus_auth_remote_user.nil?
         render 'shared/http_status', formats: [:html], locals: { code: '403', message: HttpStatusHelper::ERROR_CODE['message']['403'] }, status: 403, layout: false
         return


### PR DESCRIPTION
Allows us to fake an external login in development and test environments. This will be helpful in developing application behaviours specific to the external login without having to set up real external authorization on a development server.

This works by using the form in the normal login view to get the relevant login data (username) and then using the session hash to set the remote user for every subsequent request. 

This is a first step to addressing #3341