### PR TITLE
don't do csrf token authorization for api calls

### DIFF
--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -12,6 +12,8 @@ module Api
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+    skip_before_action :verify_authenticity_token
+
     # Unless overridden by a subclass, all routes are 404's by default
     def index
       render 'shared/http_status', locals: {code: '404', message:


### PR DESCRIPTION
seems to be new behaviour for rails5