### PR TITLE
Enable basic auth login for testing 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,8 +44,15 @@ class ApplicationController < ActionController::Base
   end
 
   def set_remote_user
-    unless request.env['HTTP_X_FORWARDED_USER'].blank?
+    if request.env['HTTP_X_FORWARDED_USER'].present?
       @markus_auth_remote_user = request.env['HTTP_X_FORWARDED_USER']
+    elsif MarkusConfigurator.markus_config_remote_user_auth && !Rails.env.production?
+      # This is only used in non-production modes to test Markus behaviours specific to
+      # external authentication. This should not be used in the place of any real
+      # authentication (basic or otherwise)!
+      authenticate_or_request_with_http_basic do |username, _|
+        @markus_auth_remote_user = username
+      end
     end
   end
 


### PR DESCRIPTION
add option to login with basic auth in (non-production environments). Only for testing/development purposes