### PR TITLE
Make Upload Started Code table work again

### DIFF
--- a/app/assets/javascripts/file_manager.js
+++ b/app/assets/javascripts/file_manager.js
@@ -1,0 +1,7 @@
+$(document).ready(function (){
+  window.modal_addnew = new ModalMarkus('#addnew_dialog');
+});
+
+function submitFile(e) {
+  e.submit();
+}


### PR DESCRIPTION
`file_manager.js` was removed in #3409 but was still used in `assignments/_file_manger.html.erb`. This adds it back, since we need it render the `Upload Starter Code` div without errors.   

I'm not sure why we are only noticing this now.  It may have something to do with the upgrade to Rails 5.2 but I'm not entirely sure.  