### PR TITLE
Optionally pass remote_ip to validation script

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -371,8 +371,10 @@ private
 
     if login
       # Two stage user verification: authentication and authorization
+      ip = MarkusConfigurator.markus_config_validate_ip? ? request.remote_ip : nil
       authenticate_response = User.authenticate(real_user,
-                                                password)
+                                                password,
+                                                ip: ip)
       if authenticate_response == User::AUTHENTICATE_BAD_PLATFORM
         validation_result[:error] = I18n.t('external_authentication_not_supported')
         return validation_result

--- a/app/lib/markus_configurator.rb
+++ b/app/lib/markus_configurator.rb
@@ -196,6 +196,14 @@ module MarkusConfigurator
     end
   end
 
+  def markus_config_validate_ip?
+    if defined? VALIDATE_IP
+      return VALIDATE_IP
+    else
+      return false
+    end
+  end
+
   def markus_config_logging_rotate_by_interval
     if defined? MARKUS_LOGGING_ROTATE_BY_INTERVAL
       return MARKUS_LOGGING_ROTATE_BY_INTERVAL

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
 
   # Authenticates login against its password
   # through a script specified by config VALIDATE_FILE
-  def self.authenticate(login, password)
+  def self.authenticate(login, password, ip: nil)
     # Do not allow the following characters in usernames/passwords
     # Right now, this is \n and \0 only, since username and password
     # are delimited by \n and C programs use \0 to terminate strings
@@ -76,7 +76,8 @@ class User < ApplicationRecord
       #  2 means bad password
       #  3 is used for other error exits
       pipe = IO.popen("'#{MarkusConfigurator.markus_config_validate_file}'", 'w+') # quotes to avoid choking on spaces
-      pipe.puts("#{login}\n#{password}") # write to stdin of markus_config_validate
+      to_stdin = [login, password, ip].reject(&:nil?).join("\n")
+      pipe.puts(to_stdin) # write to stdin of markus_config_validate
       pipe.close
       m_logger = MarkusLogger.instance
       if (defined? VALIDATE_CUSTOM_EXIT_STATUS) && $?.exitstatus == VALIDATE_CUSTOM_EXIT_STATUS

--- a/config/dummy_validate.sh
+++ b/config/dummy_validate.sh
@@ -13,13 +13,14 @@ if [ "$#" -ne 0 ]; then
 fi
 
 # Username is passed on the first line from stdin, the users
-# password as the second line.
+# password as the second line. ip address might optionally be passed
+# as a third line
 # WARNING: username and/or password may contain any characters except \n
 # 		   and \0. I.e. don't trust that data in any case. Thus, make
 #		   sure your script/program accounts for that!
 read user
 read password
-
+read ip
 
 ########################################################################
 # Do your password validation here

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,8 @@ Markus::Application.configure do
   # MarkUs relies on external user authentication: An external script
   # (ideally a small C program) is called with username and password
   # piped to stdin of that program (first line is username, second line
-  # is password).
+  # is password). If VALIDATE_IP is true, markus will also pass the
+  # remote ip address as a third line to stdin
   #
   # If and only if it exits with a return code of 0, the username/password
   # combination is considered valid and the user is authenticated. Moreover,
@@ -53,6 +54,8 @@ Markus::Application.configure do
   # That is why MarkUs does not allow usernames/passwords which contain
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root}/config/dummy_validate.sh"
+
+  VALIDATE_IP = false
 
   # Normally exit status 0 means successful, 1 means no such user,
   # and 2 means wrong password.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,8 @@ Markus::Application.configure do
   # MarkUs relies on external user authentication: An external script
   # (ideally a small C program) is called with username and password
   # piped to stdin of that program (first line is username, second line
-  # is password).
+  # is password). If VALIDATE_IP is true, markus will also pass the
+  # remote ip address as a third line to stdin
   #
   # If and only if it exits with a return code of 0, the username/password
   # combination is considered valid and the user is authenticated. Moreover,
@@ -54,6 +55,8 @@ Markus::Application.configure do
   # That is why MarkUs does not allow usernames/passwords which contain
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root.to_s}/config/dummy_validate.sh"
+
+  VALIDATE_IP = false
 
   # Normally exit status 0 means successful, 1 means no such user,
   # and 2 means wrong password.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,7 +37,8 @@ Markus::Application.configure do
   # MarkUs relies on external user authentication: An external script
   # (ideally a small C program) is called with username and password
   # piped to stdin of that program (first line is username, second line
-  # is password).
+  # is password). If VALIDATE_IP is true, markus will also pass the
+  # remote ip address as a third line to stdin
   #
   # If and only if it exits with a return code of 0, the username/password
   # combination is considered valid and the user is authenticated. Moreover,
@@ -46,6 +47,8 @@ Markus::Application.configure do
   # That is why MarkUs does not allow usernames/passwords which contain
   # \n or \0. These are the only restrictions.
   VALIDATE_FILE = "#{::Rails.root.to_s}/config/dummy_validate.sh"
+
+  VALIDATE_IP = false
 
   # Normally exit status 0 means successful, 1 means no such user,
   # and 2 means wrong password.


### PR DESCRIPTION
Added new config parameter which ensures that the `remote_ip` address is passed to the validation script if set to true.