### PR TITLE
Changed the layout of the two buttons in assignment summary table

### DIFF
--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -108,17 +108,19 @@ class AssignmentSummaryTable extends React.Component {
     return (
       <div>
         {this.props.is_admin &&
-         <form action={Routes.csv_summary_assignment_path(this.props.assignment_id)}
-               method='get'>
-           <input type='submit'
-                  name='download'
-                  value={I18n.t('download')}>
-           </input>
-           <input type='submit'
-                  name='download'
-                  value={'Old: ' + I18n.t('submissions.detailed_csv_report')}>
-           </input>
-         </form>
+        <form className='rt-action-box' action={Routes.csv_summary_assignment_path(this.props.assignment_id)}
+              method='get'>
+          <button
+            type='submit'
+            name='download'>
+            {I18n.t('download')}
+          </button>
+          <button
+            type='submit'
+            name='download'>
+            {'Old: ' + I18n.t('submissions.detailed_csv_report')}
+          </button>
+        </form>
         }
         <ReactTable
           data={data}


### PR DESCRIPTION
The buttons are now like buttons in assignment submission table:

They used to be like this:
<img width="1245" alt="screen shot 2018-07-31 at 7 56 19 pm" src="https://user-images.githubusercontent.com/25095051/43493400-e4b23fea-94fb-11e8-80de-e14877f77d8b.png">

How the buttons look like now:
<img width="1245" alt="screen shot 2018-07-31 at 7 53 49 pm" src="https://user-images.githubusercontent.com/25095051/43493407-e7c276a0-94fb-11e8-8aed-e1c1bd2ced8a.png">
