### PR TITLE
Fix the filter method for members in assignment group table

### DIFF
--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -240,6 +240,21 @@ class RawGroupsTable extends React.Component {
           );
         }
       },
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          let flag = false;
+          row._original.members.map (member => {
+            if(member[0].includes(filter.value)){
+              flag = true;
+            }
+          });
+          
+          return flag;
+
+        } else {
+          return true;
+        }
+      },
       sortable: false,
     },
     {


### PR DESCRIPTION
The filter used to only filter the first group member and not all.
Added a custom filtering to search for all members

### How it worked before:
<img width="652" alt="screen shot 2018-08-02 at 4 51 58 pm" src="https://user-images.githubusercontent.com/25095051/43610747-02a46ef4-9675-11e8-8497-9a87d44aaa83.png">

### How it filters now:
<img width="627" alt="screen shot 2018-08-02 at 4 45 49 pm" src="https://user-images.githubusercontent.com/25095051/43610773-1112fa28-9675-11e8-9a50-ddeadd162c43.png">
