### PR TITLE
Set job status to cancelled when cancelling autotest job

### DIFF
--- a/app/jobs/autotest_cancel_job.rb
+++ b/app/jobs/autotest_cancel_job.rb
@@ -26,10 +26,10 @@ class AutotestCancelJob < ApplicationJob
         # local or remote cancellation with authentication
         Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
           out = ssh.exec!(cancel_command)
-          # TODO: use out to check if test_runs were cancelled and only set time_to_service if successful
-          TestRun.find(test_run_ids).each { |test_run| test_run.update_attributes!(time_to_service: -1) }
+          # TODO: use out for something?
         end
       end
+      TestRun.find(test_run_ids).each { |test_run| test_run.update_attributes!(time_to_service: -1) }
     rescue StandardError => e
       # TODO: where to show failure?
     end


### PR DESCRIPTION
before it was only setting it to cancelled if the autotest server required an ssh connection