### PR TITLE
Set empty email addresses to nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,7 +312,6 @@ class User < ApplicationRecord
   end
 
   def nillify_empty_email
-    self.email.present? || self.email = nil
+    self.email = nil if self.email.blank?
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ require 'base64' # required for {set,reset}_api_token
 # If there are added columns, add the default values to default_values
 class User < ApplicationRecord
   before_validation :strip_name
+  before_validation :nillify_empty_email
 
   # Group relationships
   has_many :memberships, dependent: :delete_all
@@ -308,6 +309,10 @@ class User < ApplicationRecord
     if self.email
       self.email = self.email.strip
     end
+  end
+
+  def nillify_empty_email
+    self.email.present? || self.email = nil
   end
 
 end


### PR DESCRIPTION
Previously, not filling in the 'email' input when editing a user's information would set the user's email to the empty string.  If there were multiple users edited in this way, this would cause a validation failure since there would be multiple identical email addresses (multiple empty strings). This converts all empty/whitespace strings to nil before validating email addresses. 