### PR TITLE
Added out-of mark to the assignment submission and summary tables

### DIFF
--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -98,7 +98,7 @@ class AssignmentSummaryTable extends React.Component {
     {
       Header: I18n.t('activerecord.attributes.result.total_mark'),
       accessor: 'final_grade',
-      Cell: ({value}) => <span>{value? value + '/' + this.props.max_mark : ''}</span>,
+      Cell: ({value}) => value ? value + ' / ' + this.props.max_mark : '',
       className: 'number',
       filterable: false,
       defaultSortDesc: true,

--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -98,6 +98,7 @@ class AssignmentSummaryTable extends React.Component {
     {
       Header: I18n.t('activerecord.attributes.result.total_mark'),
       accessor: 'final_grade',
+      Cell: ({value}) => <span>{value? value + '/' + this.props.max_mark : ''}</span>,
       className: 'number',
       filterable: false,
       defaultSortDesc: true,

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -159,9 +159,8 @@ class RawSubmissionTable extends React.Component {
     {
       Header: I18n.t('activerecord.attributes.result.total_mark'),
       accessor: 'final_grade',
-      Cell: ({value}) => <span>{value? value + '/' + this.props.max_mark : ''}</span>,
+      Cell: ({value}) => value ? value + ' / ' + this.props.max_mark : '',
       className: 'number',
-      style: {textAlign: 'right'},
       minWidth: 80,
       filterable: false,
       defaultSortDesc: true,

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -159,7 +159,9 @@ class RawSubmissionTable extends React.Component {
     {
       Header: I18n.t('activerecord.attributes.result.total_mark'),
       accessor: 'final_grade',
+      Cell: ({value}) => <span>{value? value + '/' + this.props.max_mark : ''}</span>,
       className: 'number',
+      style: {textAlign: 'right'},
       minWidth: 80,
       filterable: false,
       defaultSortDesc: true,

--- a/app/views/assignments/summary.html.erb
+++ b/app/views/assignments/summary.html.erb
@@ -5,7 +5,8 @@
         document.getElementById('assignment_summary_table'),
         {
           assignment_id: <%= @assignment.id %>,
-          is_admin: <%= @current_user.admin? %>
+          is_admin: <%= @current_user.admin? %>,
+          max_mark: <%= @assignment.max_mark %>,
         }
       );
     });

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -12,6 +12,7 @@
             <%= @assignment.group_max > 1 || @assignment.scanned_exam? %>,
           is_admin: <%= @current_user.admin? %>,
           can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
+          max_mark: <%= @assignment.max_mark %>,
         }
       );
     });


### PR DESCRIPTION
"Total Mark" column now shows the max mark for the assignment.

### How the table used to look like:
<img width="1235" alt="screen shot 2018-08-07 at 8 39 53 pm" src="https://user-images.githubusercontent.com/25095051/43809814-653211e6-9a82-11e8-84ae-0ea673c1d142.png">
<img width="787" alt="screen shot 2018-08-07 at 8 39 46 pm" src="https://user-images.githubusercontent.com/25095051/43809816-675ee3b8-9a82-11e8-88ee-355fbad5da4d.png">


### And this is how they look like now:
<img width="1250" alt="screen shot 2018-08-07 at 8 39 01 pm" src="https://user-images.githubusercontent.com/25095051/43809821-70d7466a-9a82-11e8-944e-00c735580cf5.png">
<img width="833" alt="screen shot 2018-08-07 at 8 39 13 pm" src="https://user-images.githubusercontent.com/25095051/43809822-726ea72a-9a82-11e8-8166-00cefe62a097.png">
