### PR TITLE
Fixed name search in Spreadsheet/Grader tables

### DIFF
--- a/app/assets/javascripts/Components/marks_graders_manager.jsx
+++ b/app/assets/javascripts/Components/marks_graders_manager.jsx
@@ -156,7 +156,16 @@ class RawGradersTable extends React.Component {
     {
       Header: I18n.t('activerecord.attributes.user.full_name'),
       Cell: row => `${row.original.first_name} ${row.original.last_name}`,
-      minWidth: 170
+      minWidth: 170,
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          if (row._original.first_name.includes(filter.value) || row._original.last_name.includes(filter.value)){
+            return true;
+          }
+        } else {
+          return true;
+        }
+      },
     },
     {
       Header: I18n.t('activerecord.models.student.other'),
@@ -210,7 +219,16 @@ class RawMarksStudentsTable extends React.Component {
       {
         Header: I18n.t('activerecord.attributes.user.full_name'),
         Cell: row => `${row.original.first_name} ${row.original.last_name}`,
-        minWidth: 170
+        minWidth: 170,
+        filterMethod: (filter, row) => {
+          if (filter.value) {
+            if (row._original.first_name.includes(filter.value) || row._original.last_name.includes(filter.value)){
+              return true;
+            }
+          } else {
+            return true;
+          }
+        },
       },
       {
         Header: I18n.t('activerecord.models.ta.other'),


### PR DESCRIPTION
The search utility of the "Name" columns in the Grader tables of the spreadsheets used to not work.
Added custom filter functions to the code to fix it.

Search works for both the first and last names.

<img width="1238" alt="screen shot 2018-08-08 at 9 46 14 pm" src="https://user-images.githubusercontent.com/25095051/43873436-972ad55c-9b54-11e8-9241-c05361d9bdb2.png">
