### PR TITLE
Set jsroutes prefix on each page load

### DIFF
--- a/app/views/layouts/_jsroutes_config.html.erb
+++ b/app/views/layouts/_jsroutes_config.html.erb
@@ -1,0 +1,9 @@
+<script>
+  Routes.configure({
+    url_links: true,
+    <% if Rails.application.config.relative_url_root %>
+      prefix: '<%= Rails.application.config.relative_url_root %>'
+    <% end %>
+  });
+  Routes.config();
+</script>

--- a/app/views/layouts/assignment_content.html.erb
+++ b/app/views/layouts/assignment_content.html.erb
@@ -8,6 +8,7 @@
   <% unless MarkusConfigurator.markus_config_remote_user_auth %>
     <%= javascript_include_tag 'check_timeout' %>
   <% end %>
+  <%= render partial: 'layouts/jsroutes_config' %>
   <%= yield :head %>
 </head>
 <body>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -8,6 +8,7 @@
   <% unless MarkusConfigurator.markus_config_remote_user_auth %>
     <%= javascript_include_tag 'check_timeout' %>
   <% end %>
+  <%= render partial: 'layouts/jsroutes_config' %>
   <%= yield :head %>
 </head>
 <body>


### PR DESCRIPTION
dynamically set jsroutes prefix on every page load so that individual instances that have distinct relative_url_routes but share precompiled assets, generate their routes properly. 