### PR TITLE
Fix infinite dependency loop (with ruby 2.3) 

### DIFF
--- a/app/lib/markus_csv.rb
+++ b/app/lib/markus_csv.rb
@@ -46,15 +46,15 @@ class MarkusCSV
       end
       # Return string representation of the erroneous lines.
       unless invalid_lines.empty?
-        result[:invalid_lines] = t('csv_invalid_lines') + invalid_lines.take(MAX_INVALID_LINES).join(INVALID_LINE_SEP)
+        result[:invalid_lines] = I18n.t('csv_invalid_lines') + invalid_lines.take(MAX_INVALID_LINES).join(INVALID_LINE_SEP)
       end
       if valid_line_count > 0
         result[:valid_lines] = I18n.t('csv_valid_lines', valid_line_count: valid_line_count - header_count)
       end
     rescue CSV::MalformedCSVError
-      result[:invalid_lines] = t('upload_errors.malformed_csv')
+      result[:invalid_lines] = I18n.t('upload_errors.malformed_csv')
     rescue ArgumentError => e
-      result[:invalid_lines] = t('csv.upload.non_text_file_with_csv_extension')
+      result[:invalid_lines] = I18n.t('csv.upload.non_text_file_with_csv_extension')
     end
     result
   end

--- a/app/lib/markus_csv.rb
+++ b/app/lib/markus_csv.rb
@@ -1,5 +1,4 @@
 require 'csv'
-include ActionView::Helpers::TranslationHelper
 
 class MarkusCSV
   MAX_INVALID_LINES = 10

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -8,6 +8,7 @@
   <% unless MarkusConfigurator.markus_config_remote_user_auth %>
     <%= javascript_include_tag 'check_timeout' %>
   <% end %>
+  <%= render partial: 'layouts/jsroutes_config' %>
   <%= yield :head %>
 </head>
 <body>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Markus::Application.configure do
   config.action_controller.perform_caching = true
 
   # Compress both stylesheets and JavaScripts
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :sass
 
   # Set this to change the location of precompiled assets (RAILS_ENV=production bin/rails assets:precompile)

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -101,7 +101,7 @@ describe AnnotationCategoriesController do
       expect(response.status).to eq(302)
       expect(flash[:error]).to_not be_empty
       expect(flash[:error].map { |f| extract_text f })
-                            .to eq([t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
+                            .to eq([I18n.t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
       expect(response).to redirect_to(action: 'index',
                                       id: assignment.id)
     end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -93,7 +93,7 @@ describe AssignmentsController do
       expect(response.status).to eq(302)
       expect(flash[:error]).to_not be_empty
       expect(flash[:error].map { |f| extract_text f })
-        .to eq([t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
+        .to eq([I18n.t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
       expect(response).to redirect_to(action: 'index',
                                       controller: 'assignments')
     end

--- a/spec/controllers/marks_graders_controller_spec.rb
+++ b/spec/controllers/marks_graders_controller_spec.rb
@@ -109,7 +109,7 @@ describe MarksGradersController do
       expect(response.status).to eq(302)
       expect(flash[:error]).to_not be_empty
       expect(flash[:error].map { |f| extract_text f })
-        .to eq([t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
+        .to eq([I18n.t('csv.upload.non_text_file_with_csv_extension')].map { |f| extract_text f })
       expect(response).to redirect_to(action: 'index',
                                       grade_entry_form_id:
                                           grade_entry_form_with_data.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'rails/test_help'
 require 'minitest/unit'
 require 'mocha/mini_test'
 require 'sham'
-include ActionView::Helpers::TranslationHelper
 
 class ActiveSupport::TestCase
 


### PR DESCRIPTION
Doing an explicit "include" of a gem module when using ruby 2.3 (current production) causes an infinite dependency loop. In this case the problem was caused by including the TranslationHelper module from the I18n gem. Note that this does not appear to cause problems if using ruby 2.5