### PR TITLE
Fix bug that prevented test script from being sent to autotester

### DIFF
--- a/app/jobs/autotest_scripts_job.rb
+++ b/app/jobs/autotest_scripts_job.rb
@@ -34,7 +34,7 @@ class AutotestScriptsJob < ApplicationJob
           server_path = ssh.exec!("mktemp -d --tmpdir='#{server_path}'").strip # create temp subfolder
           # copy all files using passwordless scp (natively, the net-scp gem has poor performance)
           Open3.capture3('scp', '-o', 'PasswordAuthentication=no', '-o', 'ChallengeResponseAuthentication=no', '-rq',
-                         "'#{assignment_tests_path}'/.", "#{server_username}@#{server_host}:'#{server_path}'")
+                         "#{assignment_tests_path}/.", "#{server_username}@#{server_host}:'#{server_path}'")
           server_params[:files_path] = server_path
           out = ssh.exec!("#{server_command} scripts '#{JSON.generate(server_params)}'")
           # TODO: use out for something?


### PR DESCRIPTION
this corrects the way that the destination path is quoted when sending test scripts over scp to the autotest server