### PR TITLE
Remove wrong webpacker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "react-dom": "^16.2.0",
     "react-keyed-file-browser": "^1.2.9",
     "react-table": "^6.7.6",
-    "react-tabs": "^2.2.2",
-    "webpacker": "^0.0.3"
+    "react-tabs": "^2.2.2"
   },
   "devDependencies": {
     "webpack-dev-server": "2.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6352,10 +6352,6 @@ webpack@^3.11.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-webpacker@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/webpacker/-/webpacker-0.0.3.tgz#e90398e037cd4935c85b903bb7e71188cacf486f"
-
 websocket-driver@>=0.5.1:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"


### PR DESCRIPTION
This is a useless dependency, added by mistake at some point.
@rails/webpacker is the right one.