### PR TITLE
Use rails-ujs instead of jquery-ujs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,6 @@
 //
 //= require jquery
 //= require jquery-ui
-//= require jquery_ujs
 //= require jquery.easyModal
 //= require js-routes
 //= require job_poller

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,10 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+// rails-ujs initialization
+import Rails from 'rails-ujs';
+Rails.start();
+
 import 'javascripts/help-system';
 import 'javascripts/layouts';
 import 'javascripts/menu';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "babel-preset-react": "^6.24.1",
     "coffeescript": "1.12.7",
     "prop-types": "^15.6.0",
+    "rails-ujs": "^5.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-keyed-file-browser": "^1.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,6 +4969,10 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+rails-ujs@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.1.tgz#2869c6d54fdfefac3aaa257f4efe211d8f5a7169"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"


### PR DESCRIPTION
The Rails' default from 5.1 for the ajax helpers is rails-ujs rather than jquery-ujs.

The gem jquery-rails should still be kept, until jquery (which we use in many javascript files) is loaded through webpacker.