### PR TITLE
Clean up repos at the beginning of seeding rather than before groups

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,6 @@
+# clean up existing repos first
+FileUtils.rm_rf(Dir.glob('data/dev/repos/*'))
+# run tasks
 Rake::Task['db:admin'].invoke
 Rake::Task['db:tas'].invoke
 Rake::Task['db:test_servers'].invoke

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -4,9 +4,6 @@ namespace :db do
   task :groups => :environment do
     puts 'Assign Groups/Students for Assignments'
 
-    # remove previously existing group repos to create room for new ones
-    FileUtils.rm_rf(Dir.glob('data/dev/repos/*'))
-
     students = Student.all
     Assignment.all.each do |assignment|
       num_groups = (assignment.short_identifier == 'A1' || assignment.short_identifier == 'A3') ? students.length : 15


### PR DESCRIPTION
Starter code repos were created for the first 4 assignments and then deleted.