### PR TITLE
Fix remote hook to check required files correctly

### DIFF
--- a/lib/repo/git_hooks/update.d/01-block_forced_push_master.py
+++ b/lib/repo/git_hooks/update.d/01-block_forced_push_master.py
@@ -8,11 +8,13 @@ if __name__ == '__main__':
     ref_name = sys.argv[1]
     old_commit = sys.argv[2]
     new_commit = sys.argv[3]
-    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
-    if ref_name == 'refs/heads/master':
-        # check if there are commits reachable from old_commit but not from new_commit, i.e. the old tree was replaced
-        rev_list = subprocess.run(['git', 'rev-list', old_commit, '^{}'.format(new_commit)], stdout=subprocess.PIPE,
-                                  universal_newlines=True)
-        if rev_list.stdout:
-            print('[MARKUS] Error: forced push is not allowed on master!')
-            exit(1)
+    # check 1: allow branches other than master
+    if ref_name != 'refs/heads/master':
+        sys.exit()
+    # no need to check at this point if old_commit or new_commit are 0, since master can't be deleted or created
+    # check 2: forbid commits reachable from old_commit but not from new_commit, i.e. the old tree was replaced
+    rev_list = subprocess.run(['git', 'rev-list', old_commit, '^{}'.format(new_commit)], stdout=subprocess.PIPE,
+                              universal_newlines=True)
+    if rev_list.stdout:
+        print('[MARKUS] Error: forced push is not allowed on master!')
+        sys.exit(1)

--- a/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
+++ b/lib/repo/git_hooks/update.d/02-block_change_top_level_master.py
@@ -9,19 +9,24 @@ if __name__ == '__main__':
     ref_name = sys.argv[1]
     old_commit = sys.argv[2]
     new_commit = sys.argv[3]
-    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
-    if ref_name == 'refs/heads/master' and os.environ.get('REMOTE_USER') is not None:  # push not coming from MarkUs
-        # check 1: created/deleted top level files/directories
-        old_ls = subprocess.run(['git', 'ls-tree', '--name-only', old_commit], stdout=subprocess.PIPE,
-                                universal_newlines=True)
-        new_ls = subprocess.run(['git', 'ls-tree', '--name-only', new_commit], stdout=subprocess.PIPE,
-                                universal_newlines=True)
-        if old_ls.stdout != new_ls.stdout:
-            print('[MARKUS] Error: creating/deleting top level files and directories is not allowed on master!')
-            exit(1)
-        # check 2: modified top level files
-        changes = subprocess.run(['git', 'diff', '--name-only', '--no-renames', old_commit, new_commit],
-                                 stdout=subprocess.PIPE, universal_newlines=True)
-        if any(os.sep not in change for change in changes.stdout.splitlines()):
-            print('[MARKUS] Error: modifying top level files is not allowed on master!')
-            exit(1)
+    # check 1: allow branches other than master
+    if ref_name != 'refs/heads/master':
+        sys.exit()
+    # no need to check at this point if old_commit or new_commit are 0, master can't be deleted or created
+    # check 2: allow MarkUs through
+    if os.environ.get('REMOTE_USER') is None:
+        sys.exit()
+    # check 3: forbid creating/deleting top-level files/directories
+    old_ls = subprocess.run(['git', 'ls-tree', '--name-only', old_commit], stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    new_ls = subprocess.run(['git', 'ls-tree', '--name-only', new_commit], stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    if old_ls.stdout != new_ls.stdout:
+        print('[MARKUS] Error: creating/deleting top level files and directories is not allowed on master!')
+        sys.exit(1)
+    # check 4: forbid modifying top-level files
+    changes = subprocess.run(['git', 'diff', '--name-only', '--no-renames', old_commit, new_commit],
+                             stdout=subprocess.PIPE, universal_newlines=True)
+    if any(os.sep not in change for change in changes.stdout.splitlines()):
+        print('[MARKUS] Error: modifying top level files is not allowed on master!')
+        sys.exit(1)

--- a/lib/repo/git_hooks/update.d/03-check_required_files_master.py
+++ b/lib/repo/git_hooks/update.d/03-check_required_files_master.py
@@ -10,51 +10,57 @@ if __name__ == '__main__':
     ref_name = sys.argv[1]
     old_commit = sys.argv[2]
     new_commit = sys.argv[3]
-    # no need to check if old_commit or new_commit are 0, master can't be deleted or created
-    if ref_name == 'refs/heads/master' and os.environ.get('REMOTE_USER') is not None:  # push not coming from MarkUs
-        requirements = subprocess.run(['git', 'show', '{}:{}'.format(old_commit, '.required.json')],
-                                      stdout=subprocess.PIPE, universal_newlines=True)
-        required_files = json.loads(requirements.stdout)
-        changes = subprocess.run(['git', 'diff', '--name-status', '--no-renames', old_commit, new_commit],
-                                 stdout=subprocess.PIPE, universal_newlines=True)
-        # check if the assignment forbids adding non-required files; everything else is allowed, which is safe against
-        # changes to the assignment after students already pushed some work:
-        # A required is ok
-        # A non-required is rejected
-        # D required is warned
-        # D non-required is ok
-        # M required is ok
-        # M non-required is warned
-        for change in changes.stdout.splitlines():
-            status, path = change.split(maxsplit=1)
-            assignment, file_path = path.split('/', maxsplit=1)  # it can never be a top level file/dir
-            req = required_files.get(assignment)
-            if req is None:
-                # this can happen only if an assignment becomes hidden after being visible for a while
-                # (the top level hook prevents the creation of an arbitrary assignment directory)
-                print("[MARKUS] Warning: assignment '{}' is currently hidden".format(assignment))
-                continue
-            if status == 'A':
-                if file_path not in req['required']:
-                    msg = "you are adding '{}' to assignment '{}', but it only requires '{}'".format(
-                          file_path, assignment, ', '.join(req['required']))
-                    if req['required_only']:
-                        print('[MARKUS] Error: {}!'.format(msg))
-                        exit(1)
-                    else:
-                        print('[MARKUS] Warning: {}.'.format(msg))
-            elif status == 'D' and file_path in req['required']:
-                print("[MARKUS] Warning: you are deleting '{}' from assignment '{}', but it requires it.".format(
-                      file_path, assignment))
-            elif status == 'M' and file_path not in req['required']:
-                print("[MARKUS] Warning: you are modifying '{}' in assignment '{}', but it only requires '{}'.".format(
-                      file_path, assignment, ', '.join(req['required'])))
-        # warn about missing files
-        new_ls = subprocess.run(['git', 'ls-tree', '-r', '--name-only', new_commit], stdout=subprocess.PIPE,
-                                universal_newlines=True)
-        files = {tuple(path.split('/', maxsplit=1)) for path in new_ls.stdout.splitlines()}
-        for assignment in required_files.keys():
-            for file_path in required_files[assignment]['required']:
-                if (assignment, file_path) not in files:
-                    print("[MARKUS] Warning: required file '{}' is missing in assignment '{}'.".format(
-                          file_path, assignment))
+    # check 1: allow branches other than master
+    if ref_name != 'refs/heads/master':
+        sys.exit()
+    # no need to check at this point if old_commit or new_commit are 0, master can't be deleted or created
+    # check 2: allow MarkUs through
+    if os.environ.get('REMOTE_USER') is None:
+        sys.exit()
+    req = subprocess.run(['git', 'show', '{}:{}'.format(old_commit, '.required.json')], stdout=subprocess.PIPE,
+                         universal_newlines=True)
+    requirements = json.loads(req.stdout)
+    changes = subprocess.run(['git', 'diff', '--name-status', '--no-renames', old_commit, new_commit],
+                             stdout=subprocess.PIPE, universal_newlines=True)
+    # check 3: honor required files
+    # check if the assignment forbids adding non-required files; everything else is allowed, which is safe against
+    # changes to the assignment after students already pushed some work:
+    # A required is ok
+    # A non-required is rejected or warned, depending on required_only flag
+    # D required is warned
+    # D non-required is ok
+    # M required is ok
+    # M non-required is warned
+    for change in changes.stdout.splitlines():
+        status, path = change.split(maxsplit=1)
+        assignment, file = path.split('/', maxsplit=1)  # it can never be a top level file/dir
+        assignment_req = requirements.get(assignment)
+        if assignment_req is None:
+            # this can happen only if an assignment becomes hidden after being visible for a while
+            # (the top level hook prevents the creation of an arbitrary assignment directory)
+            continue
+        req_files = assignment_req['required']
+        if not req_files:
+            continue
+        if status == 'A':
+            if file not in req_files:
+                msg = f"you are adding non-required '{file}' to assignment '{assignment}', which only requires " \
+                      f"'{', '.join(req_files)}'"
+                if assignment_req['required_only']:
+                    print(f'[MARKUS] Error: {msg}!')
+                    sys.exit(1)
+                else:
+                    print(f'[MARKUS] Warning: {msg}.')
+        elif status == 'D' and file in req_files:
+            print(f"[MARKUS] Warning: you are deleting required '{file}' from assignment '{assignment}'.")
+        elif status == 'M' and file not in req_files:
+            print(f"[MARKUS] Warning: you are modifying non-required '{file}' in assignment '{assignment}', which only "
+                  f"requires '{', '.join(req_files)}'.")
+    # check 4: warn about missing files
+    new_ls = subprocess.run(['git', 'ls-tree', '-r', '--name-only', new_commit], stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    files = {tuple(path.split('/', maxsplit=1)) for path in new_ls.stdout.splitlines()}
+    for assignment in requirements.keys():
+        for req_file in requirements[assignment]['required']:
+            if (assignment, req_file) not in files:
+                print(f"[MARKUS] Warning: required '{req_file}' is missing in assignment '{assignment}'.")


### PR DESCRIPTION
It currently outputs spurious warnings when zero required files are set.

Looks like the fix was already in the client hooks. There are readability (variable names and f-strings) and indentation improvements (avoiding a top-level if) in this version of the hooks, will harmonize later with the client ones.