### PR TITLE
csv: enable updating user information on csv upload

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,7 +200,9 @@ class User < ApplicationRecord
     begin
       imported = nil
       User.transaction do
-        imported = user_class.import user_columns, users
+        imported = user_class.import user_columns, users, on_duplicate_key_update: {
+          conflict_target: [:user_name], columns: [:last_name, :first_name, :section_id, :email, :id_number]
+        }
       end
       unless imported.failed_instances.empty?
         if parsed[:invalid_lines].blank?

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -23,8 +23,8 @@ en:
     not_successfully_added_message_4: "Each field is separated by a comma (no spaces)."
     not_successfully_added_message_5: "Each line has the required fields specified near the upload form."
     upload:
-      select_csv_file: "Select a CSV file of the following form: <code>user_name,last_name,first_name(,section,id_number,email)</code>"
-      student_same_number: "If a student with the same username exists, then the student's information is updated."
+      select_csv_file: "Select a CSV file of the following form: <code>user_name,last_name,first_name,section,id_number,email</code>.<br> The last three columns can be blank."
+      student_same_number: "If a student with the same username exists, then the student's information is updated. WARNING: when an update occurs, if you have a blank value in one of the last three columns (e.g., email), but the student already has a value for that column, then the existing value will be deleted!"
 
   tas:
     all: "All graders"


### PR DESCRIPTION
Note: `:on_duplicate_key_update` only works on Postgresql 9.5+. 

See: https://github.com/zdennis/activerecord-import/wiki/On-Duplicate-Key-Update

It's not good to hard-code the updated columns; ideally this would be based on `user_class::CSV_UPLOAD_ORDER`. I'll make an issue for that.