### PR TITLE
Fix test runs for submissions with nil revision

### DIFF
--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -5,7 +5,6 @@ class TestRun < ApplicationRecord
   belongs_to :grouping
   belongs_to :user
 
-  validates_presence_of :revision_identifier
   validates_numericality_of :time_to_service_estimate, greater_than_or_equal_to: 0, only_integer: true, allow_nil: true
   validates_numericality_of :time_to_service, greater_than_or_equal_to: -1, only_integer: true, allow_nil: true
 

--- a/db/migrate/20180924215139_change_test_runs_revision_nullable.rb
+++ b/db/migrate/20180924215139_change_test_runs_revision_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeTestRunsRevisionNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :test_runs, :revision_identifier, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_08_134554) do
+ActiveRecord::Schema.define(version: 2018_09_24_215139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -540,7 +540,7 @@ ActiveRecord::Schema.define(version: 2018_06_08_134554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "submission_id"
-    t.text "revision_identifier", null: false
+    t.text "revision_identifier"
     t.index ["grouping_id"], name: "index_test_runs_on_grouping_id"
     t.index ["submission_id"], name: "index_test_runs_on_submission_id"
     t.index ["test_batch_id"], name: "index_test_runs_on_test_batch_id"


### PR DESCRIPTION
Back in the spring we introduced nil as a valid value for submission.revision_identifier, for a collection that has seen no relevant commits.

Well, the test_runs table does not support a nil value for it, even if we have an optimization to not run tests in that case :(