### PR TITLE
submission-file: Fix get-file encoding and subdirectory issues

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,7 +499,7 @@ en:
         no_marks_available: "No marks are available."
         external_submit_only: "MarkUs is only accepting external submits"
         invalid_file_name: "Invalid file name on submitted file"
-        missing_file: "Could not download %{file_name}: %{message}.  File may be missing."
+        missing_file: "Could not download %{file_name}.  File may be missing."
         no_files_available: "No files available"
         no_groupings_available: "No group available"
         no_revision_available: "No revision available"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -608,7 +608,7 @@ es:
         no_marks_available:               "No existen notas disponibles."
         external_submit_only:             "MarkUs solo aceptará envíos externos por el momento"
         invalid_file_name:                "El nombre del archivo enviado no es válido"
-        missing_file:                     "No se pudo descargar %{file_name}: %{message}. Puede que el archivo no haya
+        missing_file:                     "No se pudo descargar %{file_name}. Puede que el archivo no haya
                                            sido encontrado."
         no_files_available:               "No existen archivos disponibles"
         no_groupings_available:           "No existe ningún grupo disponible"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -486,7 +486,7 @@ fr:
         no_marks_available: "Pas de note disponible."
         external_submit_only: "MarkUs n'accepte que les envois externes"
         invalid_file_name: "Le nom du fichier envoyé est invalide"
-        missing_file: "%{file_name} n'a pas pu être téléchargé : %{message}. Le fichier est sans doute manquant."
+        missing_file: "%{file_name} n'a pas pu être téléchargé. Le fichier est sans doute manquant."
         no_files_available: "Aucun fichier disponible"
         no_groupings_available: "Aucun groupe disponible"
         no_revision_available: "Aucune révision disponible"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -459,7 +459,7 @@ pt:
         no_marks_available: "Não há avaliações disponíveis."
         external_submit_only: "MarkUs está aceitando apenas envios externos."
         invalid_file_name: "Nome inválido para o arquivo enviado."
-        missing_file: "Não foi possível baixar %{file_name}: %{message}.  O arquivo pode estar faltando."
+        missing_file: "Não foi possível baixar %{file_name}.  O arquivo pode estar faltando."
         no_files_available: "Nenhum arquivo disponível"
         no_groupings_available: "Nenhum grupo disponível"
         no_revision_available: "Nenhuma revisão disponível"


### PR DESCRIPTION
@adisandro I assumed you didn't have time to do this last week, so I took a stab at it today. Please review, and try out in svn.

Two fixes:
1. Using String#force_encoding (doesn't modify the bytes, does modify what encoding is interpreted as). This has the plus side that actual UTF-8 files in svn *should* be actually rendered properly. This has the downside that non-UTF-8 encoded files won't be. If you have time to look into other options that would be good, otherwise I'm inclined to merge this in for now.

2. Fixes loading of plaintext files in subdirectories (before, they wouldn't load). This is a bug that should have affected both git and svn, so I'm surprised this hasn't been reported yet.

I also changed the error-reporting to something that would actually show up on the page. Couldn't get the flash message to work with this AJAX request, maybe because we're using `fetch` rather than `$.ajax` for this one. Something to look into later.