### PR TITLE
Explicitly whitelist locales that should be in translations.js

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,12 +22,6 @@ module Markus
     # Set the timezone
     config.time_zone = 'Eastern Time (US & Canada)'
 
-    # Add all config/locales subdirs
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-
-    # Explicitly whitelist available locales for i18n-js
-    config.i18n.available_locales = [:en, :fr, :es, :pt]
-
     # Use Resque for background jobs
     config.active_job.queue_adapter = :resque
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,9 @@ module Markus
     # Add all config/locales subdirs
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
+    # Explicitly whitelist available locales for i18n-js
+    config.i18n.available_locales = [:en, :fr, :es, :pt]
+
     # Use Resque for background jobs
     config.active_job.queue_adapter = :resque
 

--- a/config/initializers/02_i18n.rb
+++ b/config/initializers/02_i18n.rb
@@ -1,3 +1,9 @@
+# Add all config/locales subdirs
+I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+
+# Explicitly whitelist available locales for i18n-js
+I18n.available_locales = [:en, :fr, :es, :pt]
+
 # set English as default
 I18n.default_locale = MarkusConfigurator.markus_config_default_language
 I18n.locale = MarkusConfigurator.markus_config_default_language

--- a/config/initializers/i18n_js.rb
+++ b/config/initializers/i18n_js.rb
@@ -1,4 +1,4 @@
 # Configuration for the 'i18n-js' gem
 
-# Explicit activation for use with webpacker
+# Generate public/javascripts/{i18n.js,translations.js}
 Rails.application.config.middleware.use I18n::JS::Middleware


### PR DESCRIPTION
(otherwise i18n-js puts all sorts of locales into translations.js, making it bigger than it should)