### PR TITLE
send correct form values when downloading assignment summary csv files

### DIFF
--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -114,12 +114,14 @@ class AssignmentSummaryTable extends React.Component {
               method='get'>
           <button
             type='submit'
-            name='download'>
+            name='download'
+            value='download'>
             {I18n.t('download')}
           </button>
           <button
             type='submit'
-            name='download'>
+            name='download'
+            value='detailed_download'>
             {'Old: ' + I18n.t('submissions.detailed_csv_report')}
           </button>
         </form>

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -424,7 +424,7 @@ class AssignmentsController < ApplicationController
 
   def csv_summary
     assignment = Assignment.find(params[:id])
-    if params[:download] == 'Download'
+    if params[:download] == 'download'
       data = assignment.summary_csv(@current_user)
       filename = "#{assignment.short_identifier}_summary.csv"
     else


### PR DESCRIPTION
This fixes a bug which meant that the deprecated detailed assignment report was always downloaded no matter which button was pressed. 