### PR TITLE
i18n: fix incorrect interpolation variable for dashboard

### DIFF
--- a/config/locales/views/statistics/en.yml
+++ b/config/locales/views/statistics/en.yml
@@ -10,7 +10,7 @@ en:
   num_zeros: "Number of zeros"
   outstanding_remark_request:
     one: "%{count} outstanding remark request"
-    other: "%{request_count} outstanding remark requests"
+    other: "%{count} outstanding remark requests"
   refresh_graph: "Refresh the graph"
 
   # app/views/main/_grader_summary.erb


### PR DESCRIPTION
Note @mishaschwartz: `count` is treated specially by `I18n` (https://guides.rubyonrails.org/i18n.html#pluralization). So the lookup key doesn't need to change, just the variable.