### PR TITLE
repsonders: Fix flash message configuration for responders gem

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -157,6 +157,7 @@ class StudentsController < ApplicationController
   end
 
   def flash_interpolation_options
-    { resource_name: @user.user_name }
+    { resource_name: @user.user_name,
+      errors: @user.errors.full_messages.join('; ')}
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,10 @@ module Markus
     # Precompile additional assets.
     config.assets.precompile = %w(manifest.js)
 
+    # Configure responders gem flash keys.
+    # NOTE: This didn't work when put in config/initializers/responders.rb.
+    config.responders.flash_keys = [:success, :error]
+
     # TODO review initializers 01 and 02
     # TODO review markus custom config format
     # TODO handle namespaces properly for app/lib

--- a/config/initializers/responders.rb
+++ b/config/initializers/responders.rb
@@ -1,4 +1,3 @@
 # Configuration for the 'responders' gem
 
-Rails.application.config.responders.flash_keys = [:success, :error]
 Rails.application.config.app_generators.scaffold_controller :responders_controller

--- a/config/locales/defaults/responders/en.yml
+++ b/config/locales/defaults/responders/en.yml
@@ -13,3 +13,8 @@ en:
     criteria:
       destroy:
         success: "Criterion and all associated marks were successfully deleted."
+    students:
+      create:
+        error: "%{resource_name} could not be created due to the following error(s): %{errors}."
+      update:
+        error: "%{resource_name} could not be updated due to the following error(s): %{errors}."


### PR DESCRIPTION
@adisandro it looks like the setting `config.responders.flash_keys` didn't work in the initializer file. Maybe you know why?