### PR TITLE
Display dialog above toolbars and other elements with high z-index values

### DIFF
--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -552,7 +552,7 @@ ul.tags {
   box-shadow: 0 0 10px $grey;
   max-width: 100%;
   padding: 2.5em 1.5em;
-  z-index: 10000;
+  z-index: 10000 !important;
 
   .dialog-actions {
     text-align: center;


### PR DESCRIPTION
label the z-index as important for dialogs so that it won't be overriden by other styling