### PR TITLE
Use responders gem to display errors for admin and ta creation/modification

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -42,6 +42,7 @@ class AdminsController < ApplicationController
   end
 
   def flash_interpolation_options
-    { resource_name: @user.user_name }
+    { resource_name: @user.user_name.blank? ? @user.model_name.human : @user.user_name,
+      errors: @user.errors.full_messages.join('; ')}
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -157,7 +157,7 @@ class StudentsController < ApplicationController
   end
 
   def flash_interpolation_options
-    { resource_name: @user.user_name,
+    { resource_name: @user.user_name.blank? ? @user.model_name.human : @user.user_name,
       errors: @user.errors.full_messages.join('; ')}
   end
 end

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -92,6 +92,7 @@ class TasController < ApplicationController
   end
 
   def flash_interpolation_options
-    { resource_name: @user.user_name }
+    { resource_name: @user.user_name.blank? ? @user.model_name.human : @user.user_name,
+      errors: @user.errors.full_messages.join('; ')}
   end
 end

--- a/app/views/layouts/_userform.html.erb
+++ b/app/views/layouts/_userform.html.erb
@@ -1,9 +1,5 @@
 <div class='section'>
   <%= form_for @user, as: :user do |f| %>
-
-    <%= render partial: 'shared/error_explanation',
-               locals: { model: @user } %>
-
     <table>
       <tr>
         <td><%= raw(f.label(:user_name, User.human_attribute_name(:user_name))) %>:</td>

--- a/config/locales/defaults/responders/en.yml
+++ b/config/locales/defaults/responders/en.yml
@@ -18,3 +18,13 @@ en:
         error: "%{resource_name} could not be created due to the following error(s): %{errors}."
       update:
         error: "%{resource_name} could not be updated due to the following error(s): %{errors}."
+    admins:
+      create:
+        error: "%{resource_name} could not be created due to the following error(s): %{errors}."
+      update:
+        error: "%{resource_name} could not be updated due to the following error(s): %{errors}."
+    tas:
+      create:
+        error: "%{resource_name} could not be created due to the following error(s): %{errors}."
+      update:
+        error: "%{resource_name} could not be updated due to the following error(s): %{errors}."

--- a/config/locales/defaults/responders/es.yml
+++ b/config/locales/defaults/responders/es.yml
@@ -10,3 +10,21 @@ es:
       destroy:
         success: "%{resource_name} ha sido eliminado exitosamente."
         error: "No se pudo eliminar %{resource_name}."
+    criteria:
+      destroy:
+        success: "Criterion ha sido eliminado exitosamente."
+    students:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+    admins:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+    tas:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."

--- a/config/locales/defaults/responders/fr.yml
+++ b/config/locales/defaults/responders/fr.yml
@@ -10,3 +10,21 @@ fr:
       destroy:
         success: "Supprimé avec succès %{resource_name}."
         error: "Impossible de supprimer %{resource_name}."
+    criteria:
+      destroy:
+        success: "Criterion supprimé avec succès"
+    students:
+      create:
+        error: "%{resource_name} ne peut pas être créé à cause de: %{errors}."
+      update:
+        error: "%{resource_name} ne peut pas être modifié à cause de: %{errors}."
+    admins:
+      create:
+        error: "%{resource_name} ne peut pas être créé à cause de: %{errors}."
+      update:
+        error: "%{resource_name} ne peut pas être modifié à cause de: %{errors}."
+    tas:
+      create:
+        error: "%{resource_name} ne peut pas être créé à cause de: %{errors}."
+      update:
+        error: "%{resource_name} ne peut pas être modifié à cause de: %{errors}."

--- a/config/locales/defaults/responders/pt.yml
+++ b/config/locales/defaults/responders/pt.yml
@@ -10,3 +10,21 @@ pt:
       destroy:
         success: "%{resource_name} suprimido com sucesso."
         error: "Falha ao atualizar suprimido %{resource_name}."
+    criteria:
+      destroy:
+        success: "Criterion suprimido com sucesso."
+    students:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+    admins:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+    tas:
+      create:
+        error: "%{resource_name} UPDATE ME: %{errors}."
+      update:
+        error: "%{resource_name} UPDATE ME: %{errors}."


### PR DESCRIPTION
* This brings them in line with the changes made for student creation/modification in PR #3680 
* Error message now displays `user_name` if it is non-blank otherwise it displays the class name