### PR TITLE
APIs now return data in xml format again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'activerecord-session_store'
 gem 'cookies_eu'
 gem 'rails-html-sanitizer'
 gem 'responders'
+gem 'activemodel-serializers-xml'
 
 # If you are a MarkUs developer and use PostgreSQL, make sure you have
 # PostgreSQL header files installed (e.g. libpq-dev on Debian/Ubuntu).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.2.1)
       activesupport (= 5.2.1)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (5.2.1)
       activemodel (= 5.2.1)
       activesupport (= 5.2.1)
@@ -351,6 +355,7 @@ PLATFORMS
 DEPENDENCIES
   action_policy
   activejob-status!
+  activemodel-serializers-xml
   activerecord-import
   activerecord-session_store
   autoprefixer-rails


### PR DESCRIPTION
added [activemodel-serializers-xml](https://github.com/rails/activemodel-serializers-xml) gem which used to be part of the Rails core but was [extracted into a separate gem](https://github.com/rails/rails/pull/21161) for Rails 5