### PR TITLE
Allow switching locales with relative url root

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,12 +7,19 @@
     <%= I18n.t(:choose_language) %>
     <%= #gets the relative path without the language choice, then on change of the language,
         #it adds this relative path to the end of the new language that was chosen.
-        relative = request.path
-        relative = relative.gsub("/#{I18n.locale}", "")
+        relative_root = Rails.application.config.action_controller.relative_url_root || ''
+        curr_path = request.path.gsub(relative_root, "").gsub(Regexp.compile("(?<=/)#{I18n.locale}/"), "")
 
         select_tag(:locale, options_for_select(@available_locales,
                    selected: "#{I18n.locale}"),
-                   { onchange: "javascript:window.location.href = '/' + this.options[this.selectedIndex].value + '#{relative}';" }) %>
+                   { onchange: "javascript:
+                                    window.location.href =
+                                         '#{relative_root}/' +
+                                         this.options[this.selectedIndex].value +
+                                         '#{curr_path}';"
+                   }
+        )
+    %>
   </span>
 
   <% if @current_user.admin? or @current_user.ta? %>


### PR DESCRIPTION
This fixes a bug where switching locales when the `Rails.application.config.action_controller.relative_url_root` value was not `nil` resulted in the new locale being inserted into the url **before** the `relative_url_root` instead of after. 

This fix allows for switching locales both when the `relative_url_root` is `nil` and when it is set.

This resolves one of the suggestions from the security audit