### PR TITLE
Add time delay between failed login attempts 

### DIFF
--- a/app/lib/markus_configurator.rb
+++ b/app/lib/markus_configurator.rb
@@ -109,6 +109,14 @@ module MarkusConfigurator
     end
   end
 
+  def markus_login_info_dir
+    if defined? LOGIN_INFO_STORAGE
+      return LOGIN_INFO_STORAGE
+    else
+      return nil
+    end
+  end
+
   def markus_config_remote_user_auth
     if defined? REMOTE_USER_AUTH
       return REMOTE_USER_AUTH

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -115,6 +115,14 @@ Markus::Application.configure do
   LOGOUT_REDIRECT = 'DEFAULT'
 
   ###################################################################
+  # Directory to store files containing login information based on username
+  # and IP address. These files are used to slow down repeated login attempts
+  # with bad passwords in order to prevent a brute force password guessing
+  # attack
+
+  LOGIN_INFO_STORAGE = "#{::Rails.root.to_s}/data/dev/logins"
+
+  ###################################################################
   # File storage (Repository) settings
   ###################################################################
   # Options for Repository_type are 'svn','git' and 'mem'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,6 +116,14 @@ Markus::Application.configure do
   LOGOUT_REDIRECT = "DEFAULT"
 
   ###################################################################
+  # Directory to store files containing login information based on username
+  # and IP address. These files are used to slow down repeated login attempts
+  # with bad passwords in order to prevent a brute force password guessing
+  # attack
+
+  LOGIN_INFO_STORAGE = "#{::Rails.root.to_s}/data/prod/logins"
+
+  ###################################################################
   # File storage (Repository) settings
   ###################################################################
   # Options for Repository_type are 'svn','git' and 'mem'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -108,6 +108,14 @@ Markus::Application.configure do
   LOGOUT_REDIRECT = "DEFAULT"
 
   ###################################################################
+  # Directory to store files containing login information based on username
+  # and IP address. These files are used to slow down repeated login attempts
+  # with bad passwords in order to prevent a brute force password guessing
+  # attack
+
+  LOGIN_INFO_STORAGE = "#{::Rails.root.to_s}/data/test/logins"
+
+  ###################################################################
   # File storage (Repository) settings
   ###################################################################
   # Options for Repository_type are 'svn' and 'memory'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -800,6 +800,7 @@ en:
     external_authentication_not_supported: "External authentication not supported on your platform!"
     account_disabled: "This account has been disabled"
     additional_information: "Additional Information"
+    wait_for_login: "Please wait and try again"
 
     #app/views/job_messages/_job_poller.js.erb
     job_poller:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -922,6 +922,7 @@ es:
     external_authentication_not_supported: "La autenticación externa no es soportada en su plataforma!"
     account_disabled:                      "Esta cuenta ha sido desabilitada"
     additional_information:                "Información Adicional"
+    wait_for_login:                        "UPDATE ME"
 
     #app/views/job_messages/_job_poller.js.erb
     job_poller:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -673,6 +673,7 @@ fr:
     external_authentication_not_supported: "L'authentification externe n'est pas supportée sur votre plateforme"
     account_disabled: "Ce compte a été désactivé"
     additional_information: "Informations Complémentaires"
+    wait_for_login: "Veuillez patienter et réessayer"
 
     #app/views/job_messages/_job_poller.js.erb
     job_poller:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -669,6 +669,7 @@ pt:
     external_authentication_not_supported: "Autenticação externa não é suportada pela sua plataforma!"
     account_disabled: "Essa conta foi desativada"
     additional_information: "Informações Adicionais"
+    wait_for_login: "UPDATE ME"
 
     #app/helpers/submissions_helper.rb
     assign_folder_missing:      "Oh não! Falta pasta Assignment."


### PR DESCRIPTION
If a login attempt fails because of an invalid password, do not allow another login attempt for another `n` seconds where `n` is equal to the number of failed login attempts in a row. 

This delay is enforced for the user and for the IP address. For example, if I try to login as user `example_user` from the IP address `127.0.0.1` and I type in a wrong password, I will have to wait one second to login as `example_user` from **any** IP address, and I will have to wait one second to login as **any** user from `127.0.0.1`.  If I try again with the wrong password, this delay is increased to two seconds, three seconds, etc. 

This resolves one of the suggestions from the security audit