### PR TITLE
Don't display flash message if not authorized to run tests in results view

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -132,7 +132,6 @@ class ResultsController < ApplicationController
       @authorized = true
     rescue ActionPolicy::Unauthorized => e
       @authorized = false
-      flash_now(:notice, e.result.reasons.full_messages.join(' '))
     end
 
     m_logger = MarkusLogger.instance

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -132,6 +132,9 @@ class ResultsController < ApplicationController
       @authorized = true
     rescue ActionPolicy::Unauthorized => e
       @authorized = false
+      if @assignment.enable_test
+        flash_now(:notice, e.result.reasons.full_messages.join(' '))
+      end
     end
 
     m_logger = MarkusLogger.instance


### PR DESCRIPTION
If tests are not enabled for an assignment then the "Test Results" tab in hidden anyway. This makes a flash message about not being able run tests potentially confusing. 

If there are additional reasons why you are not authorized to run tests then these will be triggered by the `run_tests` method in the `ResultsController` when the user actually attempts to run the tests