### PR TITLE
Update config variables' names for starter-code

### DIFF
--- a/app/jobs/update_starter_code_job.rb
+++ b/app/jobs/update_starter_code_job.rb
@@ -1,6 +1,6 @@
 class UpdateStarterCodeJob < ApplicationJob
 
-  queue_as MarkusConfigurator.markus_job_update_starter_code_queue_name
+  queue_as MarkusConfigurator.markus_job_update_starter_code_queue
 
   def perform(assignment_id, overwrite)
     assignment = Assignment.includes(groupings: :group).find(assignment_id)

--- a/app/lib/markus_configurator.rb
+++ b/app/lib/markus_configurator.rb
@@ -353,8 +353,8 @@ module MarkusConfigurator
   ###################################################################
   # Global flag to enable/disable starter code feature.
   def markus_starter_code_on
-    if defined? EXPERIMENTAL_STARTER_CODE_ON
-      EXPERIMENTAL_STARTER_CODE_ON
+    if defined? STARTER_CODE_ON
+      STARTER_CODE_ON
     else
       false
     end
@@ -441,9 +441,9 @@ module MarkusConfigurator
     end
   end
 
-  def markus_job_update_starter_code_queue_name
-    if defined? JOB_UPDATE_STARTER_CODE
-      JOB_UPDATE_STARTER_CODE
+  def markus_job_update_starter_code_queue
+    if defined? JOB_UPDATE_STARTER_CODE_QUEUE
+      JOB_UPDATE_STARTER_CODE_QUEUE
     else
       'jobs'
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -191,7 +191,7 @@ Markus::Application.configure do
   # Starter code settings
   ###################################################################
   # Global flag to enable/disable starter code feature.
-  EXPERIMENTAL_STARTER_CODE_ON = true
+  STARTER_CODE_ON = true
 
   ###################################################################
   # Set this to the desired default language MarkUs should load if
@@ -262,7 +262,7 @@ Markus::Application.configure do
   JOB_GENERATE_QUEUE_NAME = 'CSC108'
   JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108'
   # The name of the queue where jobs to update starter code files to student repos wait to be executed.
-  JOB_UPDATE_STARTER_CODE = 'CSC108'
+  JOB_UPDATE_STARTER_CODE_QUEUE = 'CSC108'
 
   ###################################################################
   # Automated Testing Engine settings

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -188,7 +188,7 @@ Markus::Application.configure do
   # Starter code settings
   ###################################################################
   # Global flag to enable/disable starter code feature.
-  EXPERIMENTAL_STARTER_CODE_ON = true
+  STARTER_CODE_ON = true
 
   ###################################################################
   # Set this to the desired default language MarkUs should load if
@@ -259,7 +259,7 @@ Markus::Application.configure do
   JOB_GENERATE_QUEUE_NAME = 'CSC108'
   JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108'
   # The name of the queue where jobs to update starter code files to student repos wait to be executed.
-  JOB_UPDATE_STARTER_CODE = 'CSC108'
+  JOB_UPDATE_STARTER_CODE_QUEUE = 'CSC108'
 
   ###################################################################
   # Automated Testing Engine settings

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -180,7 +180,7 @@ Markus::Application.configure do
   # Starter code settings
   ###################################################################
   # Global flag to enable/disable starter code feature.
-  EXPERIMENTAL_STARTER_CODE_ON = true
+  STARTER_CODE_ON = true
 
   ###################################################################
   # Set this to the desired default language MarkUs should load if
@@ -252,7 +252,7 @@ Markus::Application.configure do
   JOB_GENERATE_QUEUE_NAME = 'CSC108'
   JOB_SPLIT_PDF_QUEUE_NAME = 'CSC108'
   # The name of the queue where jobs to update starter code files to student repos wait to be executed.
-  JOB_UPDATE_STARTER_CODE = 'CSC108'
+  JOB_UPDATE_STARTER_CODE_QUEUE = 'CSC108'
 
   ###################################################################
   # Automated Testing Engine settings


### PR DESCRIPTION
* Fix the queue variable name (aligning it with the autotest style, _QUEUE only instead of _QUEUE_NAME)
* Remove the experimental label, hopefully this is going to be a "normal" feature from next term, now that we allow updates at any time.