### PR TITLE
Fix internationalization string discovery in marks_graders table

### DIFF
--- a/app/assets/javascripts/Components/marks_graders_manager.jsx
+++ b/app/assets/javascripts/Components/marks_graders_manager.jsx
@@ -144,7 +144,7 @@ class MarksGradersManager extends React.Component {
 
 
 class RawGradersTable extends React.Component {
-  static columns = [
+  columns = [
     {
       show: false,
       accessor: '_id',
@@ -183,7 +183,7 @@ class RawGradersTable extends React.Component {
         ref={(r) => this.checkboxTable = r}
 
         data={this.props.graders}
-        columns={RawGradersTable.columns}
+        columns={this.columns}
         defaultSorted={[
           {
             id: 'user_name'


### PR DESCRIPTION
It looks like I18n can't discover the correct string properly if it is called from within a static structure