### PR TITLE
Remove 'complete_with_errors' status

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,6 @@ en:
             complete: "complete"
             in_progress: "in progress"
             cancelled: "cancelled"
-            complete_with_errors: "complete with errors"
     peer_review:
         assign: "Assign Peer Reviews"
         review: "Review "

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -168,7 +168,6 @@ es:
             complete: "UPDATE ME"
             in_progress: "UPDATE ME"
             cancelled: "UPDATE ME"
-            complete_with_errors: "UPDATE ME"
     peer_review:
         assign:                               "Asignar revisiones por pares"
         review:                               "Revisión"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -137,7 +137,6 @@ fr:
             complete: "UPDATE ME"
             in_progress: "UPDATE ME"
             cancelled: "UPDATE ME"
-            complete_with_errors: "UPDATE ME"
     peer_review:
         assign: "Attribuer examen par les pairs"
         review: "Avis "

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -138,7 +138,6 @@ pt:
             complete: "UPDATE ME"
             in_progress: "UPDATE ME"
             cancelled: "UPDATE ME"
-            complete_with_errors: "UPDATE ME"
     peer_review:
         assign: "Atribuir avaliações pelos pares"
         review: "Revisão "


### PR DESCRIPTION
Now just use the `'complete'` status even if there were errors in the result