### PR TITLE
Initial fixes so student peer review page can be displayed

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -128,8 +128,11 @@ class AssignmentsController < ApplicationController
     @penalty = @assignment.submission_rule
     @enum_penalty = Period.where(submission_rule_id: @penalty.id).sort
 
-    @prs = @student.grouping_for(@assignment.parent_assignment.id).
-        peer_reviews.where(results: { released_to_students: true })
+    @prs = @student.grouping_for(@assignment.parent_assignment.id)&.
+        peer_reviews&.where(results: { released_to_students: true })
+    if @prs.nil?
+      @prs = []
+    end
 
     if @student.section &&
         !@student.section.section_due_date_for(@assignment.id).nil?

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -49,9 +49,8 @@ class ResultsController < ApplicationController
     reviewer_access = false
     if @result.is_a_review?
       if @current_user.is_reviewer_for?(@assignment.pr_assignment, @result)
-        @mark_criteria = @assignment.get_criteria(:peer)
         assignment = @assignment.pr_assignment
-        reviewer_access = true
+        @mark_criteria = assignment.get_criteria(:peer)
       else
         @mark_criteria = @assignment.pr_assignment.get_criteria(:ta)
       end
@@ -100,8 +99,6 @@ class ResultsController < ApplicationController
       end
     end
 
-    group_order = reviewer_access ? 'grouping.id' : 'group_name'
-    all_groupings = assignment.groupings.joins(:group).order(group_order)
     if current_user.ta?
       assigned_groupings = current_user.groupings
                              .where(assignment: assignment)
@@ -109,7 +106,13 @@ class ResultsController < ApplicationController
                              .order('group_name')
       @next_grouping = assigned_groupings.where('group_name > ?', @group.group_name).first
       @previous_grouping = assigned_groupings.where('group_name < ?', @group.group_name).last
+    elsif @result.is_a_review? && @current_user.is_reviewer_for?(@assignment, @result)
+      user_group = @current_user.grouping_for(@assignment.id)
+      assigned_prs = user_group.peer_reviews_to_others
+      @next_grouping = assigned_prs.where('peer_reviews.id < ?', @result.peer_review_id).last
+      @previous_grouping = assigned_prs.where('peer_reviews.id > ?', @result.peer_review_id).first
     else
+      all_groupings = assignment.groupings.joins(:group).order('group_name')
       @next_grouping = all_groupings.where('group_name > ?', @group.group_name).first
       @previous_grouping = all_groupings.where('group_name < ?', @group.group_name).last
     end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -106,8 +106,8 @@ class ResultsController < ApplicationController
                              .order('group_name')
       @next_grouping = assigned_groupings.where('group_name > ?', @group.group_name).first
       @previous_grouping = assigned_groupings.where('group_name < ?', @group.group_name).last
-    elsif @result.is_a_review? && @current_user.is_reviewer_for?(@assignment, @result)
-      user_group = @current_user.grouping_for(@assignment.id)
+    elsif @result.is_a_review? && @current_user.is_reviewer_for?(assignment, @result)
+      user_group = @current_user.grouping_for(assignment.id)
       assigned_prs = user_group.peer_reviews_to_others
       @next_grouping = assigned_prs.where('peer_reviews.id < ?', @result.peer_review_id).last
       @previous_grouping = assigned_prs.where('peer_reviews.id > ?', @result.peer_review_id).first
@@ -234,25 +234,24 @@ class ResultsController < ApplicationController
   end
 
   def next_grouping
-    grouping = Grouping.find(params[:grouping_id])
     assignment = Assignment.find(params[:assignment_id])
     result = Result.find(params[:id])
 
-    if grouping.has_submission? && grouping.is_collected?
-      if @current_user.is_reviewer_for?(assignment.pr_assignment, result)
-        reviewer = @current_user.grouping_for(assignment.pr_assignment.id)
-        next_pr = reviewer.review_for(grouping)
-        next_result = Result.find(next_pr.result_id)
+    if @current_user.is_reviewer_for?(assignment.pr_assignment, result)
+      next_pr = PeerReview.find(params[:grouping_id])
+      next_result = Result.find(next_pr.result_id)
 
-        redirect_to action: 'edit',
-                    id: next_result.id
-      else
+      redirect_to action: 'edit',
+                  id: next_result.id
+    else
+      grouping = Grouping.find(params[:grouping_id])
+      if grouping.has_submission? && grouping.is_collected?
         redirect_to action: 'edit',
                     id: grouping.current_submission_used.get_latest_result.id
+      else
+        redirect_to controller: 'submissions',
+                    action: 'browse'
       end
-    else
-      redirect_to controller: 'submissions',
-                  action: 'browse'
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -466,9 +466,7 @@ class SubmissionsController < ApplicationController
     submission = Submission.find(params[:id])
     grouping = submission.grouping
 
-    # TODO: allow for peer reviewers.
-    # current_user.is_reviewer_for?(assignment.pr_assignment, <any result>)
-    if @current_user.student? &&
+    if !@current_user.is_a_reviewer?(assignment.pr_assignment) && @current_user.student? &&
         @current_user.accepted_grouping_for(assignment.id).id != grouping.id
       flash_message(:error,
                     t('submission_file.error.no_access',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,7 +211,7 @@ en:
       files: "files"
       missing_required_files: "<span class=\"info_number\">%{missing_files}</span><span class=\"info %{style_class}\"> missing required file(s)</span>"
       no_peer_submission_yet: "You have no submissions to review yet."
-      no_reviews: "No one has reviewed you yet."
+      no_reviews: "No one has reviewed your submissions yet."
       submission:
         file_manager: "%{short_identifier}: File Manager"
         conflicts: "Conflicts"


### PR DESCRIPTION
**Summary:** 

1. Fixed minor query error when finding reviewee results. 
2. Get correct (peer) marking criteria.
3. Allow student reviewers to see reviewee submissions.
4. Changed message when no peer review has been submitted for current student.
5. Added default for when student did not submit parent assignment.
6. Fixed links to go between submissions.