### PR TITLE
Ignore rubocop block length warning for certain rspec blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,1 @@
-inherit_from: .rubocop.yml
+config/.rubocop.yml

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -35,6 +35,10 @@ Layout/MultilineOperationIndentation:
 Metrics/AbcSize:
   Enabled: false
 
+# Disable max block length for rspec blocks
+Metrics/BlockLength:
+  ExcludedMethods: ['describe', 'context', 'shared_examples', 'shared_context']
+
 Metrics/LineLength:
   Max: 120
 


### PR DESCRIPTION
This is in response to the request made in PR #3774