### PR TITLE
Use RubyGems version 3 in vagrant

### DIFF
--- a/script/install-markus.sh
+++ b/script/install-markus.sh
@@ -22,6 +22,7 @@ sudo apt-get install software-properties-common -y
 sudo add-apt-repository ppa:brightbox/ruby-ng
 sudo apt-get update
 sudo apt-get install ruby2.5 ruby2.5-dev -y
+sudo gem update --system
 sudo update-alternatives --config ruby
 sudo update-alternatives --config gem
 sudo gem install bundler


### PR DESCRIPTION
This resolves the issue outlined [here](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html) which occurs when using bundler version 2+ with a RubyGems version < 3.0

This change can be reverted in the future when/if RubyGems backports the fix to previous versions 