### PR TITLE
Optimize getting the right push time when asking for entries from a git repository

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -627,6 +627,7 @@ class AssignmentsController < ApplicationController
     return [] unless revision.path_exists?(full_path)
 
     entries = revision.tree_at_path(full_path)
+                      .sort { |a, b| a[0].count(File::SEPARATOR) <=> b[0].count(File::SEPARATOR) } # less nested first
                       .select { |_, obj| obj.is_a? Repository::RevisionFile }.map do |file_name, file_obj|
       data = get_file_info(file_name, file_obj, assignment.id, path)
       data[:key] = path.blank? ? data[:raw_name] : File.join(path, data[:raw_name])

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -770,6 +770,7 @@ class SubmissionsController < ApplicationController
     return [] unless revision.path_exists?(full_path)
 
     entries = revision.tree_at_path(full_path)
+                      .sort { |a, b| a[0].count(File::SEPARATOR) <=> b[0].count(File::SEPARATOR) } # less nested first
                       .select { |_, obj| obj.is_a? Repository::RevisionFile }.map do |file_name, file_obj|
       data = get_file_info(file_name, file_obj, grouping.assignment.id, revision.revision_identifier, path, grouping.id)
       next if data.nil?

--- a/app/jobs/update_starter_code_job.rb
+++ b/app/jobs/update_starter_code_job.rb
@@ -9,7 +9,7 @@ class UpdateStarterCodeJob < ApplicationJob
     assignment.access_starter_code_repo do |starter_repo|
       starter_revision = starter_repo.get_latest_revision
       next unless starter_revision.path_exists?(assignment_folder)
-      starter_tree = starter_revision.tree_at_path(assignment_folder)
+      starter_tree = starter_revision.tree_at_path(assignment_folder, with_attrs: false)
       starter_files = {} # cache of starter code files
       assignment.each_group_repo do |group_repo|
         txn = assignment.update_starter_code_files(group_repo, starter_repo, starter_tree, overwrite: overwrite,

--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -653,18 +653,11 @@ class GitRevision < Repository::AbstractRevision
     entries
   end
 
-  # Walks all files and subdirectories starting at +path+ and
-  # returns an array of tuples containing [path, revision_object]
-  # for every file and directory discovered in this way
-  #
-  # It returns an array to ensure ordering, so that a directory
-  # will always appear before any of the files or subdirectories
-  # contained within it
   def tree_at_path(path, with_attrs: true)
     entries = entries_at_path(path, recursive: true)
     if with_attrs && !entries.empty?
       add_entries_info(entries, path)
     end
-    entries.to_a.sort! { |a, b| a[0].count(File::SEPARATOR) <=> b[0].count(File::SEPARATOR) }
+    entries
   end
 end

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -456,11 +456,11 @@ class MemoryRevision < Repository::AbstractRevision
   end
 
   def tree_at_path(path, with_attrs: true)
-    result = files_at_path(path)
-    dirs = directories_at_path(path)
+    result = files_at_path(path, with_attrs: with_attrs)
+    dirs = directories_at_path(path, with_attrs: with_attrs)
     result.merge!(dirs)
     dirs.each do |dir_path, _|
-      result.merge!(tree_at_path(File.join(path, dir_path))
+      result.merge!(tree_at_path(File.join(path, dir_path), with_attrs: with_attrs)
                       .transform_keys! { |sub_path| File.join(dir_path, sub_path) })
     end
     result

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -439,7 +439,7 @@ class MemoryRevision < Repository::AbstractRevision
   end
 
   # Return all of the files in this repository at the root directory
-  def files_at_path(path="/")
+  def files_at_path(path="/", with_attrs: true)
     return Hash.new if @files.empty?
     return files_at_path_helper(path)
   end
@@ -450,7 +450,7 @@ class MemoryRevision < Repository::AbstractRevision
     revision_at_path_helper(path)
   end
 
-  def directories_at_path(path = '/')
+  def directories_at_path(path = '/', with_attrs: true)
     return Hash.new if @files.empty?
     return files_at_path_helper(path, false, Repository::RevisionDirectory)
   end
@@ -462,7 +462,7 @@ class MemoryRevision < Repository::AbstractRevision
   # It returns an array to ensure ordering, so that a directory
   # will always appear before any of the files or subdirectories
   # contained within it
-  def tree_at_path(path)
+  def tree_at_path(path, with_attrs: true)
     result = files_at_path(path).to_a
     dirs = directories_at_path(path)
     result.push(*dirs.to_a)

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -455,19 +455,13 @@ class MemoryRevision < Repository::AbstractRevision
     return files_at_path_helper(path, false, Repository::RevisionDirectory)
   end
 
-  # Walks all files and subdirectories starting at +path+ and
-  # returns an array of tuples containing [path, revision_object]
-  # for every file and directory discovered in this way
-  #
-  # It returns an array to ensure ordering, so that a directory
-  # will always appear before any of the files or subdirectories
-  # contained within it
   def tree_at_path(path, with_attrs: true)
-    result = files_at_path(path).to_a
+    result = files_at_path(path)
     dirs = directories_at_path(path)
-    result.push(*dirs.to_a)
+    result.merge!(dirs)
     dirs.each do |dir_path, _|
-      result.push(*(tree_at_path(File.join(path, dir_path)).map { |sub_pth, obj| [File.join(dir_path, sub_pth), obj] }))
+      result.merge!(tree_at_path(File.join(path, dir_path))
+                      .transform_keys! { |sub_path| File.join(dir_path, sub_path) })
     end
     result
   end

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -306,12 +306,12 @@ module Repository
     end
 
     # Returns all the files under +path+ (but not in subdirectories) in this revision of the repository.
-    def files_at_path(path)
+    def files_at_path(path, with_attrs: true)
       raise NotImplementedError, "Revision.files_at_path not yet implemented"
     end
 
     # Returns all the directories under +path+ (but not in subdirectories) in this revision of the repository.
-    def directories_at_path(path)
+    def directories_at_path(path, with_attrs: true)
       raise NotImplementedError, "Revision.directories_at_path not yet implemented"
     end
 

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -782,11 +782,11 @@ class SubversionRevision < Repository::AbstractRevision
   end
 
   def tree_at_path(path, with_attrs: true)
-    result = files_at_path(path)
-    dirs = directories_at_path(path)
+    result = files_at_path(path, with_attrs: with_attrs)
+    dirs = directories_at_path(path, with_attrs: with_attrs)
     result.merge!(dirs)
     dirs.each do |dir_path, _|
-      result.merge!(tree_at_path(File.join(path, dir_path))
+      result.merge!(tree_at_path(File.join(path, dir_path), with_attrs: with_attrs)
                       .transform_keys! { |sub_path| File.join(dir_path, sub_path) })
     end
     result

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -781,19 +781,13 @@ class SubversionRevision < Repository::AbstractRevision
     # p.start_with?(path) only would be wrong, there can be two assignments named like 'aX' and 'aXsuffix'
   end
 
-  # Walks all files and subdirectories starting at +path+ and
-  # returns an array of tuples containing [path, revision_object]
-  # for every file and directory discovered in this way
-  #
-  # It returns an array to ensure ordering, so that a directory
-  # will always appear before any of the files or subdirectories
-  # contained within it
   def tree_at_path(path, with_attrs: true)
-    result = files_at_path(path).to_a
+    result = files_at_path(path)
     dirs = directories_at_path(path)
-    result.push(*dirs.to_a)
+    result.merge!(dirs)
     dirs.each do |dir_path, _|
-      result.push(*(tree_at_path(File.join(path, dir_path)).map { |sub_pth, obj| [File.join(dir_path, sub_pth), obj] }))
+      result.merge!(tree_at_path(File.join(path, dir_path))
+                      .transform_keys! { |sub_path| File.join(dir_path, sub_path) })
     end
     result
   end

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -735,7 +735,7 @@ class SubversionRevision < Repository::AbstractRevision
   end
 
   # Return all of the files in this repository at the root directory
-  def files_at_path(path)
+  def files_at_path(path, with_attrs: true)
     files_at_path_helper(path)
   end
 
@@ -744,7 +744,7 @@ class SubversionRevision < Repository::AbstractRevision
   end
 
   # Return all directories at 'path' (including subfolders?!)
-  def directories_at_path(path = '/')
+  def directories_at_path(path = '/', with_attrs: true)
     result = Hash.new(nil)
     raw_contents = @repo.__get_files(path, @revision_identifier)
     raw_contents.each do |file_name, type|
@@ -788,7 +788,7 @@ class SubversionRevision < Repository::AbstractRevision
   # It returns an array to ensure ordering, so that a directory
   # will always appear before any of the files or subdirectories
   # contained within it
-  def tree_at_path(path)
+  def tree_at_path(path, with_attrs: true)
     result = files_at_path(path).to_a
     dirs = directories_at_path(path)
     result.push(*dirs.to_a)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1166,7 +1166,8 @@ class Assignment < ApplicationRecord
                                                       assignment: self.short_identifier))
     group_revision = group_repo.get_latest_revision
     internal_file_names = Repository.get_class.internal_file_names
-    starter_tree.each do |starter_obj_name, starter_obj|
+    starter_tree.sort { |a, b| a[0].count(File::SEPARATOR) <=> b[0].count(File::SEPARATOR) } # less nested first
+                .each do |starter_obj_name, starter_obj|
       next if internal_file_names.include?(File.basename(starter_obj_name))
       starter_obj_path = File.join(self.repository_folder, starter_obj_name)
       already_exists = group_revision.path_exists?(starter_obj_path)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -527,7 +527,7 @@ class Grouping < ApplicationRecord
       self.assignment.access_starter_code_repo do |starter_repo|
         starter_revision = starter_repo.get_latest_revision
         next unless starter_revision.path_exists?(assignment_folder)
-        starter_tree = starter_revision.tree_at_path(assignment_folder)
+        starter_tree = starter_revision.tree_at_path(assignment_folder, with_attrs: false)
         txn = self.assignment.update_starter_code_files(group_repo, starter_repo, starter_tree)
         if txn.has_jobs?
           result = group_repo.commit(txn)


### PR DESCRIPTION
Git optimizations on top of #3787:

1. Split `entries_at_path` from `add_entries_info`, making the reflog + walk optional
2. Refactor `tree_at_path` to only walk once if needed, and return a hash like the others `X_at_path`
3. Change svn and memory to match the modified api.

Tested on both git and svn, but please review carefully at least the svn part.
(there are no optimizations done in svn, only the api unification part)

There's now also some nice low hanging fruit for a student here, to look at all usages of `files_at_path` and `directories_at_path` and decide whether they need the extended attributes or not.