### PR TITLE
Convert null bytes reported by tester

### DIFF
--- a/app/models/test_script_result.rb
+++ b/app/models/test_script_result.rb
@@ -52,6 +52,10 @@ class TestScriptResult < ApplicationRecord
     actual = json_test.fetch('actual', '')
     time = json_test['time']
     status = json_test['status']
+    # User code sometimes produces null bytes that are reported back to MarkUs
+    # in the input, actual, or expected. ActiveRecord cannot store null bytes so they
+    # must be converted to a non-null representation.
+    [input, expected, actual].each { |s| s.gsub!("\u0000", "\\u0000") }
     # check first if we have to stop
     if !status.nil? && status == 'error_all'
       stop_processing = true


### PR DESCRIPTION
If the autotester returns a string that contains a null byte, the TestResult object cannot be created since ActiveRecord does not allow the creation of an object with an attribute containing a null byte (https://github.com/rails/rails/issues/26891). This raises an Argument Error which in turn invalidates the entire test script result. 

This converts null bytes in potentially dangerous fields (of the json returned by the autotester) so that the TestResult objects can be created properly.  