### PR TITLE
Parse nil section due date types

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -688,7 +688,7 @@ class AssignmentsController < ApplicationController
                          num_files_before != assignment.assignment_files.length
 
     # if there are no section due dates, destroy the objects that were created
-    if params[:assignment][:section_due_dates_type] == '0'
+    if ['0', nil].include? params[:assignment][:section_due_dates_type]
       assignment.section_due_dates.each(&:destroy)
       assignment.section_due_dates_type = false
       assignment.section_groups_only = false

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -236,7 +236,7 @@ class Assignment < ApplicationRecord
   end
 
   def past_all_collection_dates?
-    if section_due_dates_type
+    if section_due_dates_type && Section.any?
       Section.all.all? do |s|
         past_collection_date? s
       end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1316,6 +1316,48 @@ describe Assignment do
     end
   end
 
+  describe '#past_all_collection_dates?' do
+    context 'when before due with no submission rule' do
+      before :each do
+        @assignment = create(:assignment, due_date: 2.days.from_now)
+      end
+
+      it 'returns false' do
+        expect(@assignment.past_all_collection_dates?).to be(false)
+      end
+
+      context 'and section_due_dates_type is true' do
+        before :each do
+          @assignment.update_attributes(section_due_dates_type: true)
+        end
+
+        context 'and there are sections' do
+          before :each do
+            @section = create(:section, name: 'section_name')
+            SectionDueDate.create(section: @section,
+                                  assignment: @assignment,
+                                  due_date: 1.day.ago)
+            student = create(:student, section: @section)
+            @grouping = create(:grouping, assignment: @assignment)
+            create(:accepted_student_membership,
+                   grouping: @grouping,
+                   user: student,
+                   membership_status: StudentMembership::STATUSES[:inviter])
+          end
+
+          it 'returns true' do
+            expect(@assignment.past_all_collection_dates?).to be(true)
+          end
+        end
+        context 'and there are no sections' do
+          it 'returns false' do
+            expect(@assignment.past_all_collection_dates?).to be(false)
+          end
+        end
+      end
+    end
+  end
+
   describe '#update_results_stats' do
     before :each do
       allow(assignment).to receive(:max_mark).and_return(10)


### PR DESCRIPTION
During assignment creation, the `section_due_dates_type` field was incorrectly being processed as `true` even if the value was `nil`.  This meant that by default the `section_due_dates_type` was set to `true` for all assignments. 

If there happened to be no sections created as well, then the `past_all_collection_dates?` function in the `assignments` model was trivially returning `true` (`all` called on an empty relation is always `true`). This meant that any date was considered as being past the collection date. 
