### PR TITLE
Copy files to autotest server using rsync instead of scp

### DIFF
--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -141,12 +141,12 @@ class AutotestRunJob < ApplicationJob
       # tests executed locally or remotely with authentication
       mkdir_command = "mktemp -d --tmpdir='#{server_path}'"
       server_path = ssh.exec!(mkdir_command).strip # create temp subfolder
-      # copy all files using passwordless scp (natively, the net-scp gem has poor performance)
+      # copy all files using rsync
       server_host = MarkusConfigurator.autotest_server_host
       server_username = MarkusConfigurator.autotest_server_username
-      scp_command = ['scp', '-o', 'PasswordAuthentication=no', '-o', 'ChallengeResponseAuthentication=no', '-rq',
-                     "#{submission_path}/.", "#{server_username}@#{server_host}:#{server_path}"]
-      Open3.capture3(*scp_command)
+      rsync_command = ['rsync', '-a',
+                       "#{submission_path}/.", "#{server_username}@#{server_host}:#{server_path}" ]
+      Open3.capture3(*rsync_command)
       run_command = "#{server_command} run -f '#{server_path}/#{File.basename(params_file.path)}'"
       output = ssh.exec!(run_command)
       if output.exitstatus != 0

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -145,7 +145,7 @@ class AutotestRunJob < ApplicationJob
       server_host = MarkusConfigurator.autotest_server_host
       server_username = MarkusConfigurator.autotest_server_username
       rsync_command = ['rsync', '-a',
-                       "#{submission_path}/.", "#{server_username}@#{server_host}:#{server_path}" ]
+                       "#{submission_path}/.", "#{server_username}@#{server_host}:#{server_path}"]
       Open3.capture3(*rsync_command)
       run_command = "#{server_command} run -f '#{server_path}/#{File.basename(params_file.path)}'"
       output = ssh.exec!(run_command)

--- a/app/jobs/autotest_scripts_job.rb
+++ b/app/jobs/autotest_scripts_job.rb
@@ -33,7 +33,7 @@ class AutotestScriptsJob < ApplicationJob
           server_path = ssh.exec!(mkdir_command).strip # create temp subfolder
           # copy all files using rsync
           rsync_command = ['rsync', '-a',
-                           "#{assignment_tests_path}/.", "#{server_username}@#{server_host}:#{server_path}" ]
+                           "#{assignment_tests_path}/.", "#{server_username}@#{server_host}:#{server_path}"]
           Open3.capture3(*rsync_command)
           server_params[:files_path] = server_path
           scripts_command = "#{server_command} scripts -j '#{JSON.generate(server_params)}'"

--- a/app/jobs/autotest_scripts_job.rb
+++ b/app/jobs/autotest_scripts_job.rb
@@ -31,10 +31,10 @@ class AutotestScriptsJob < ApplicationJob
         Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
           mkdir_command = "mktemp -d --tmpdir='#{server_path}'"
           server_path = ssh.exec!(mkdir_command).strip # create temp subfolder
-          # copy all files using passwordless scp (natively, the net-scp gem has poor performance)
-          scp_command = ['scp', '-o', 'PasswordAuthentication=no', '-o', 'ChallengeResponseAuthentication=no', '-rq',
-                         "#{assignment_tests_path}/.", "#{server_username}@#{server_host}:#{server_path}"]
-          Open3.capture3(*scp_command)
+          # copy all files using rsync
+          rsync_command = ['rsync', '-a',
+                           "#{assignment_tests_path}/.", "#{server_username}@#{server_host}:#{server_path}" ]
+          Open3.capture3(*rsync_command)
           server_params[:files_path] = server_path
           scripts_command = "#{server_command} scripts -j '#{JSON.generate(server_params)}'"
           output = ssh.exec!(scripts_command)


### PR DESCRIPTION
scp no longer supports the `dirname/.` syntax for security reasons:

> [scp] doesn't accept "." as an implicit destination (e.g.
>         scp -r /foo/bar/. host:/wherever
> ) because this could change permissions on the target directory itself
> (i.e. "/whatever" in the above case) 

see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20685