### PR TITLE
Use strict topological order when walking commits in git

### DIFF
--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -177,7 +177,7 @@ class GitRepository < Repository::AbstractRepository
     return nil if current_reflog_entry.empty?
     # find first commit that changes path, topologically equal or before the push
     walker = Rugged::Walker.new(@repos)
-    walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_DATE)
+    walker.sorting(Rugged::SORT_TOPO)
     walker.push(current_reflog_entry[:sha])
     walker.each do |commit|
       GitRepository.try_advance_reflog!(reflog, current_reflog_entry, commit.oid)
@@ -203,7 +203,7 @@ class GitRepository < Repository::AbstractRepository
     current_reflog_entry = { index: -1 }
     # walk through the commits and get revisions
     walker = Rugged::Walker.new(@repos)
-    walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_DATE)
+    walker.sorting(Rugged::SORT_TOPO)
     walker.push(@repos.last_commit)
     walker.map do |commit|
       GitRepository.try_advance_reflog!(reflog, current_reflog_entry, commit.oid)
@@ -615,7 +615,7 @@ class GitRevision < Repository::AbstractRevision
     current_reflog_entry = { index: -1 }
     found = false
     walker = Rugged::Walker.new(@repo)
-    walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_DATE)
+    walker.sorting(Rugged::SORT_TOPO)
     walker.push(@repo.last_commit)
     walker.each do |commit|
       GitRepository.try_advance_reflog!(reflog, current_reflog_entry, commit.oid)


### PR DESCRIPTION
Avoids problems with merged commits that interleave.
(the previous setting was equivalent to what you get from `git log`, which tries to be nice and sorts by commit date too)

git log:
![image](https://user-images.githubusercontent.com/6097798/53427058-7c2c8880-39e8-11e9-9135-910abdcdf52b.png)
"topological" log:
![image](https://user-images.githubusercontent.com/6097798/53427376-21476100-39e9-11e9-834e-5739275a911d.png)
Time order:
In the first merge, there is a commit on the branch 'to-merge', then a commit on master, then master is pushed, then 'to-merge' is merged into master, then master is pushed again.
In the second merge, there is a commit on the branch 'second-merge', then a commit on master, then 'second-merge' is merged into master, then master is pushed.