### PR TITLE
API: get annotations even if they don't belong to a category

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -143,42 +143,31 @@ module Api
         grouping_relation = Grouping
       end
 
-      annotations = grouping_relation.joins(accepted_student_memberships: :user)
-                                     .joins(current_submission_used:
+      pluck_keys = ['annotations.type as type',
+                    'annotation_texts.content as content',
+                    'submission_files.filename as filename',
+                    'submission_files.path as path',
+                    'annotations.page as page',
+                    'group_id',
+                    'annotation_categories.annotation_category_name as category',
+                    'annotations.creator_id as creator_id',
+                    'annotation_texts.creator_id as content_creator_id',
+                    'annotations.line_end as line_end',
+                    'annotations.line_start as line_start',
+                    'annotations.column_start as column_start',
+                    'annotations.column_end as column_end',
+                    'annotations.x1 as x1',
+                    'annotations.y1 as y1',
+                    'annotations.x2 as x2',
+                    'annotations.y2 as y2']
+
+      annotations = grouping_relation.left_joins(current_submission_used:
                                               [submission_files:
                                                  [annotations:
                                                     [annotation_text: :annotation_category]]])
                                      .where('assignment_id': params[:assignment_id])
-                                     .pluck_to_hash('annotations.type',
-                                                    'annotation_texts.content',
-                                                    'submission_files.filename',
-                                                    'submission_files.path',
-                                                    'annotations.line_end',
-                                                    'annotations.line_start',
-                                                    'annotations.page',
-                                                    'group_id',
-                                                    'users.user_name',
-                                                    'annotation_categories.annotation_category_name',
-                                                    'annotations.creator_id',
-                                                    'annotation_texts.creator_id')
-
-      creator_ids = annotations.map { |a| a['annotations.creator_id'] }
-      creator_ids += annotations.map { |a| a['annotation_texts.creator_id'] }
-      creators = User.where(id: creator_ids).pluck(:id, :user_name).to_h
-
-      annotations = annotations.group_by { |h| h['group_id'] }
-                               .transform_values do |v|
-        group_members = v.group_by { |g| g['users.user_name'] }.keys
-        v.map do |h|
-          h['groups.members'] = group_members
-          h.delete('users.user_name')
-          h['annotations.creator'] = creators[h['annotations.creator_id']]
-          h.delete('annotations.creator_id')
-          h['annotation_texts.creator'] = creators[h['annotation_texts.creator_id']]
-          h.delete('annotation_texts.creator_id')
-          h
-        end
-      end.values.flatten
+                                     .where.not('annotations.id': nil)
+                                     .pluck_to_hash(*pluck_keys)
       respond_to do |format|
         format.xml do
           render xml: annotations.to_xml(root: 'annotations', skip_types: 'true')


### PR DESCRIPTION
Also simplifies the key names and return ids instead of usernames (this simplifies things when chaining api calls)