### PR TITLE
Don't collect if a released submission already exists

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -208,11 +208,12 @@ class SubmissionsController < ApplicationController
     some_released = Grouping.joins(current_submission_used: :results)
                             .where('results.released_to_students': true)
                             .where(id: groupings)
+                            .pluck(:id).to_set
     groupings.each do |grouping|
       section = grouping.inviter.present? ? grouping.inviter.section : nil
       collect_now = assignment.submission_rule.can_collect_now?(section)
       some_before_due = true unless collect_now
-      next if !collect_now || some_released.include?(grouping)
+      next if !collect_now || some_released.include?(grouping.id)
       collectable << grouping
     end
     success = ''

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -3,7 +3,8 @@ en:
     collect:
       apply_late_penalty: "Apply late penalty/Deduct grace tokens (Leaving this box unchecked means the submission will not be penalized, regardless of submission time.)"
       collection_job_started_for_groups: "Submission collection for selected groupings for assignment %{assignment_identifier} has begun. The complete process may take some time, but you can access submissions as they become available."
-      could_not_collect_some: "Could not collect submissions for some groupings and assignment %{assignment_identifier} - the collection date has not been reached for these groupings."
+      could_not_collect_some_due: "Could not collect submissions for some groupings and assignment %{assignment_identifier} - the collection date has not been reached for these groupings."
+      could_not_collect_some_released: "Could not collect submissions for some groupings and assignment %{assignment_identifier} - the submission has already been released."
       manual_collection: "Manual Collection"
       overwrite_warning: "Collecting and grading this revision will overwrite any previous collections/grading done for this group on this assignment.  Are you sure you want to do this?"
       progress: "%{count}/%{size} submissions collected"

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -7,9 +7,11 @@ es:
       collection_job_started_for_groups: "La recolección de las entregas para las agrupaciones seleccionadas del
                                           proyecto %{assignment_identifier} ha iniciado. El proceso puede demorar,
                                           pero usted puede acceder las entregas tan pronto como se vuelvan disponibles."
-      could_not_collect_some: "No se pudo recolectar las entregas para algunas agrupaciones del proyecto
+      could_not_collect_some_due: "No se pudo recolectar las entregas para algunas agrupaciones del proyecto
                                %{assignment_identifier} -  la fecha de recolección para estas
                                agrupaciones no ha llegado."
+      could_not_collect_some_released: "No se pudo recolectar las entregas para algunas agrupaciones del proyecto
+                               %{assignment_identifier}."
       overwrite_warning: "Recolectar y calificar esta revisión reescribirá toda
                           recolección/calificación realizada anteriormente para este grupo en el
                           proyecto. ¿Está seguro/a de querer hacer esto?"

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -3,7 +3,8 @@ fr:
     collect:
       apply_late_penalty: "Appliquer pénalité de retard / Déduire jetons de grâce ( Laissant cette case cochée signifie la soumission ne sera pas pénalisé , indépendamment du moment de la soumission . )"
       collection_job_started_for_groups: "La récupération des envois pour les groupements sélectionnés pour le projet %{assignment_identifier} a débuté. Cela peut prendre du temps, mais vous avez accès aux envois dès qu'ils sont disponibles."
-      could_not_collect_some: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier} - la date de collecte n'a pas été atteint pour ces groupes."
+      could_not_collect_some_due: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier} - la date de collecte n'a pas été atteint pour ces groupes."
+      could_not_collect_some_released: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier}."
       overwrite_warning: "Récupérer et noter cette révision effacera les précédentes récupération et évaluations de ce groupe sur ce projet. Êtes-vous sûr de vouloir faire cela ?"
       progress: "%{count}/%{size} envois récupérés"
       results_loss_warning: "Attention : cette action effacera vos annotations et évaluations. Êtes-vous sûr de vouloir continuer ?"

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -5,7 +5,8 @@ pt:
                            ( Deixando esta caixa desmarcada , a apresentação não
                            será penalizado , independentemente do tempo de apresentação . )"
       collection_job_started_for_groups: "Coleta das submissões para grupos selecionados para o projeto %{assignment_identifier} começou. O processo pode demorar, você poderá acessar as submissões assim que elas tornarem-se disponíveis."
-      could_not_collect_some: "Não foi possível recolher inscrições para alguns grupos e projecto %{assignment_identifier} - a data de coleta não foi alcançado por estes agrupamentos."
+      could_not_collect_some_due: "Não foi possível recolher inscrições para alguns grupos e projecto %{assignment_identifier} - a data de coleta não foi alcançado por estes agrupamentos."
+      could_not_collect_some_released: "Não foi possível recolher inscrições para alguns grupos e projecto %{assignment_identifier}."
       overwrite_warning: "Coletando e avaliando essa revisão irá sobrescrever coletas/avalições anteriores feitas para esse grupo no projeto. Tem certeza que quer fazer isso?"
       progress: "%{count}/%{size} submissões coletadas"
       results_loss_warning: "Nota: Isso apagará qualquer avaliação e anotações que já foram feitas. Tem certeza que deseja continuar?"


### PR DESCRIPTION
You can still manually collect an individual submission even if the result is released from the repository view