### PR TITLE
Unify exporting student files for autotesting

### DIFF
--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -42,31 +42,6 @@ class AutotestRunJob < ApplicationJob
     end
   end
 
-  # Verify that MarkUs has student files to run the test.
-  # Note: this does not guarantee all required files are presented.
-  # Instead, it checks if there is at least one source file is successfully exported.
-  def repo_files_available?(test_run)
-    grouping = test_run.grouping
-    submission = test_run.submission
-    assignment = grouping.assignment
-    group = grouping.group
-    repo_dir = File.join(TestRun::STUDENTS_DIR, group.repo_name)
-    unless submission.nil?
-      # no commits in the submission
-      return false if submission.revision_identifier.nil?
-      # no commits after starter code initialization
-      return false if submission.revision_identifier == grouping.starter_code_revision_identifier
-    end
-    assignment_dir = File.join(repo_dir, assignment.repository_folder)
-    # no assignment directory
-    return false unless File.exist?(assignment_dir)
-    entries = Dir.entries(assignment_dir) - ['.', '..'] - Repository.get_class.internal_file_names
-    # no files
-    return false if entries.size <= 0
-
-    true
-  end
-
   def get_server_api_key
     server_host = MarkusConfigurator.autotest_server_host
     server_user = TestServer.find_or_create_by(user_name: server_host) do |user|
@@ -84,20 +59,25 @@ class AutotestRunJob < ApplicationJob
 
   def enqueue_test_run(test_run, host_with_port, test_group_ids, test_specs_name, hooks_script_name, ssh = nil)
     params_file = nil
-    export_group_repo(test_run)
-    unless repo_files_available?(test_run)
-      # create empty test results for no submission files
-      error = { name: I18n.t('automated_tests.results.all_tests'),
-                message: I18n.t('automated_tests.results.no_source_files') }
-      test_run.create_error_for_all_test_groups(test_group_ids, error)
-      return
-    end
-
     grouping = test_run.grouping
     assignment = grouping.assignment
     group = grouping.group
-    repo_dir = File.join(TestRun::STUDENTS_DIR, group.repo_name)
-    submission_path = File.join(repo_dir, assignment.repository_folder)
+    error_no_files = { name: I18n.t('automated_tests.results.all_tests'),
+                       message: I18n.t('automated_tests.results.no_source_files') }
+    # no commits in the submission, or no commits after starter code initialization
+    if test_run.revision_identifier.nil? || test_run.revision_identifier == grouping.starter_code_revision_identifier
+      test_run.create_error_for_all_test_groups(test_group_ids, error_no_files)
+      return
+    end
+    export_group_repo(test_run)
+    submission_path = File.join(TestRun::STUDENTS_DIR, group.repo_name, assignment.repository_folder)
+    # no assignment directory, or no files
+    if !File.exist?(submission_path) ||
+         (Dir.entries(submission_path) - ['.', '..'] - Repository.get_class.internal_file_names).size <= 0
+      test_run.create_error_for_all_test_groups(test_group_ids, error_no_files)
+      return
+    end
+
     if Rails.application.config.action_controller.relative_url_root.nil?
       markus_address = host_with_port
     else
@@ -142,8 +122,7 @@ class AutotestRunJob < ApplicationJob
     test_run.time_to_service_estimate = output.to_i
     test_run.save
   ensure
-    params_file&.close
-    params_file&.unlink
+    params_file&.close! # close + unlink
   end
 
   def perform(host_with_port, user_id, test_group_ids, test_specs_name, hooks_script_name, test_runs)

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -105,19 +105,18 @@ class SubmissionFile < ApplicationRecord
     all_annotations
   end
 
-  # Return the contents of this SubmissionFile.  Include annotations in the
+  # Return the contents of this SubmissionFile. Include annotations in the
   # file if include_annotations is true.
   def retrieve_file(include_annotations = false, repo = nil)
     student_group = self.submission.grouping.group
     revision_identifier = self.submission.revision_identifier
-    retrieved_file = ''
     close_repo = false
     if repo.nil?
       repo = student_group.repo
       close_repo = true
     end
     revision = repo.get_revision(revision_identifier)
-    revision_file = revision.files_at_path(self.path)[self.filename]
+    revision_file = revision.files_at_path(self.path, with_attrs: false)[self.filename]
     if revision_file.nil?
       raise I18n.t('results.could_not_find_file',
                    filename: self.filename,

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -105,18 +105,19 @@ class SubmissionFile < ApplicationRecord
     all_annotations
   end
 
-  # Return the contents of this SubmissionFile. Include annotations in the
+  # Return the contents of this SubmissionFile.  Include annotations in the
   # file if include_annotations is true.
   def retrieve_file(include_annotations = false, repo = nil)
     student_group = self.submission.grouping.group
     revision_identifier = self.submission.revision_identifier
+    retrieved_file = ''
     close_repo = false
     if repo.nil?
       repo = student_group.repo
       close_repo = true
     end
     revision = repo.get_revision(revision_identifier)
-    revision_file = revision.files_at_path(self.path, with_attrs: false)[self.filename]
+    revision_file = revision.files_at_path(self.path)[self.filename]
     if revision_file.nil?
       raise I18n.t('results.could_not_find_file',
                    filename: self.filename,


### PR DESCRIPTION
Don't export the whole repo for student tests any more, only the assignment files and only the required files. This unifies the behavior with the instructor tests, allowing cross-caching of exported files as well.