### PR TITLE
Don't fetch extended revision info when retrieving a submission file

### DIFF
--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -117,7 +117,7 @@ class SubmissionFile < ApplicationRecord
       close_repo = true
     end
     revision = repo.get_revision(revision_identifier)
-    revision_file = revision.files_at_path(self.path)[self.filename]
+    revision_file = revision.files_at_path(self.path, with_attrs: false)[self.filename]
     if revision_file.nil?
       raise I18n.t('results.could_not_find_file',
                    filename: self.filename,

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -105,12 +105,11 @@ class SubmissionFile < ApplicationRecord
     all_annotations
   end
 
-  # Return the contents of this SubmissionFile.  Include annotations in the
+  # Return the contents of this SubmissionFile. Include annotations in the
   # file if include_annotations is true.
   def retrieve_file(include_annotations = false, repo = nil)
     student_group = self.submission.grouping.group
     revision_identifier = self.submission.revision_identifier
-    retrieved_file = ''
     close_repo = false
     if repo.nil?
       repo = student_group.repo


### PR DESCRIPTION
This is a very simple optimization extracted from #3879:
When we just want to get the submission file contents, fetching extended revision info is useless (e.g. the push date in git, which requires walking the commit history and the reflog)