### PR TITLE
submission table: filter on section

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -102,14 +102,11 @@ class RawSubmissionTable extends React.Component {
       id: 'section',
       show: this.props.show_sections,
       minWidth: 70,
-      Cell: ({ value }) => {
-        return this.state.sections[value] || ''
-      },
       filterMethod: (filter, row) => {
         if (filter.value === 'all') {
           return true;
         } else {
-          return this.state.sections[row[filter.id]] === filter.value;
+          return filter.value === row[filter.id];
         }
       },
       Filter: ({ filter, onChange }) =>

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1381,7 +1381,7 @@ class Assignment < ApplicationRecord
     section_data = groupings
                    .joins(inviter: :section)
                    .pluck('groupings.id', 'sections.name')
-                   .group_by { |gid, _| gid }
+                   .to_h
 
     # This is the submission data that's actually returned
     data.map do |g|


### PR DESCRIPTION
Fixes a bug caused by passing the `section` data to the react component for each grouping as a list of lists as opposed to a string representing the section name. 

grouping data before (example): 
```
[{..., _id: 1, section: [[1, "test1"]], ...}, ...]
```
grouping data now (example):
```
[{..., _id: 1, section: "test1", ...}, ...]
```