### PR TITLE
Replace thin server with puma in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@
 source 'https://rubygems.org'
 
 # Bundler requires these gems in all environments
+gem 'puma'
 gem 'rails'
 gem 'sprockets'
-gem 'puma'
 
 # Models and database interactions
 gem 'activerecord-import'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ source 'https://rubygems.org'
 # Bundler requires these gems in all environments
 gem 'rails'
 gem 'sprockets'
-gem 'thin'
+gem 'puma'
 
 # Models and database interactions
 gem 'activerecord-import'
@@ -100,7 +100,6 @@ group :development do
   gem 'brakeman', require: false
   gem 'bullet'
   gem 'rails-erd'
-  gem 'puma'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ group :development do
   gem 'brakeman', require: false
   gem 'bullet'
   gem 'rails-erd'
+  gem 'puma'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
       prawn (>= 1)
       rqrcode (>= 0.4.1)
     psych (3.1.0)
+    puma (3.12.1)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -409,6 +410,7 @@ DEPENDENCIES
   pluck_to_hash
   prawn
   prawn-qrcode
+  puma
   railroady
   rails
   rails-controller-testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,14 +96,12 @@ GEM
     cookies_eu (1.7.5)
       js_cookie_rails (~> 2.2.0)
     crass (1.0.4)
-    daemons (1.2.6)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     descriptive_statistics (2.5.1)
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.8.0)
-    eventmachine (1.2.7)
     execjs (2.7.0)
     factory_bot (5.0.0)
       activesupport (>= 4.2.0)
@@ -337,10 +335,6 @@ GEM
     sqlite3 (1.4.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -434,7 +428,6 @@ DEPENDENCIES
   simplecov
   sprockets
   sqlite3
-  thin
   time-warp
   uglifier
   unicorn

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,8 @@
+workers 3
+preload_app!
+
+on_worker_boot do
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
Puma gives us a server that can handle true multiprocessing in development. This is useful for uncovering concurrency related bugs before they make their way to production. 