### PR TITLE
Bugfix: git repository recovery

### DIFF
--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -140,7 +140,6 @@ class GitRepository < Repository::AbstractRepository
 
   # static method that should yield to a git repo and then close it
   def self.access(connect_string)
-    repo = nil
     repo = GitRepository.open(connect_string)
     yield repo
   ensure

--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -48,7 +48,7 @@ class GitRepository < Repository::AbstractRepository
   def self.reclone_repo(connect_string)
     repo_path, _sep, repo_name = connect_string.rpartition(File::SEPARATOR)
     bare_path = File.join(repo_path, 'bare', "#{repo_name}.git")
-    raise "Cannot reclone from non-existant bare repository #{bare_path}" unless Dir.exist?(bare_path)
+    raise 'Repository does not exist' unless Dir.exist?(bare_path)
     if Dir.exist?(connect_string)
       bad_repo_path = "#{connect_string}.bad"
       FileUtils.rm_rf(bad_repo_path)
@@ -140,6 +140,7 @@ class GitRepository < Repository::AbstractRepository
 
   # static method that should yield to a git repo and then close it
   def self.access(connect_string)
+    repo = nil
     repo = GitRepository.open(connect_string)
     yield repo
   ensure

--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -140,12 +140,10 @@ class GitRepository < Repository::AbstractRepository
 
   # static method that should yield to a git repo and then close it
   def self.access(connect_string)
-    begin
-      repo = GitRepository.open(connect_string)
-      yield repo
-    ensure
-      repo&.close
-    end
+    repo = GitRepository.open(connect_string)
+    yield repo
+  ensure
+    repo&.close
   end
 
   # static method that deletes the git repo

--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -36,29 +36,28 @@ class GitRepository < Repository::AbstractRepository
         rescue Rugged::ReferenceError   # It seems the master branch might not be correctly setup at first.
         end
         @repos.reset('origin/master', :hard) # align to whatever is in origin/master
-      rescue StandardError # TODO this shouldn't be necessary. It catches the case when a local repo is corrupted,
-                           #      we need to prevent the corruption instead/as well
-        GitRepository.reclone_repo(connect_string)
+      rescue Rugged::IndexError, Rugged::OSError
+        reclone_repo
       end
     else
-      GitRepository.reclone_repo(connect_string)
+      reclone_repo
     end
   end
 
-  def self.reclone_repo(connect_string)
-    repo_path, _sep, repo_name = connect_string.rpartition(File::SEPARATOR)
+  def reclone_repo
+    repo_path, _sep, repo_name = @repos_path.rpartition(File::SEPARATOR)
     bare_path = File.join(repo_path, 'bare', "#{repo_name}.git")
     raise 'Repository does not exist' unless Dir.exist?(bare_path)
-    if Dir.exist?(connect_string)
-      bad_repo_path = "#{connect_string}.bad"
+    if Dir.exist?(@repos_path)
+      bad_repo_path = "#{@repos_path}.bad"
       FileUtils.rm_rf(bad_repo_path)
-      FileUtils.mv(connect_string, bad_repo_path)
+      FileUtils.mv(@repos_path, bad_repo_path)
     end
-    @repos = Rugged::Repository.clone_at(bare_path, connect_string)
+    @repos = Rugged::Repository.clone_at(bare_path, @repos_path)
     m_logger = MarkusLogger.instance
-    m_logger.log "Recloned corrupted or missing git repo: #{connect_string}"
+    m_logger.log "Recloned corrupted or missing git repo: #{@repos_path}"
   rescue StandardError
-    msg = "Failed to clone corrupted or missing git repo: #{connect_string}"
+    msg = "Failed to clone corrupted or missing git repo: #{@repos_path}"
     m_logger = MarkusLogger.instance
     m_logger.log msg
     raise

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -192,10 +192,13 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Memory repository and closes it afterwards
   def self.access(connect_string)
-    repository = MemoryRepository.open(connect_string)
-    yield repository
-  ensure
-    repository.close
+    raise 'Respository does not exist' unless MemoryRepository.repository_exists? connect_string
+    begin
+      repository = self.open(connect_string)
+      yield repository
+    ensure
+      repository.close
+    end
   end
 
   # Closes the repository.

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -190,8 +190,7 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Memory repository and closes it afterwards
   def self.access(connect_string)
-    repository = nil
-    repository = self.open(connect_string)
+    repository = MemoryRepository.open(connect_string)
     yield repository
   ensure
     repository&.close

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -41,9 +41,7 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Open repository at specified location
   def self.open(location)
-    unless MemoryRepository.repository_exists?(location)
-      raise "Could not open repository at location #{location}"
-    end
+    raise 'Respository does not exist' unless MemoryRepository.repository_exists? location
     return @@repositories[location] # return reference in question
   end
 
@@ -197,7 +195,7 @@ class MemoryRepository < Repository::AbstractRepository
       repository = self.open(connect_string)
       yield repository
     ensure
-      repository.close
+      repository&.close
     end
   end
 

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -41,7 +41,7 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Open repository at specified location
   def self.open(location)
-    raise 'Respository does not exist' unless MemoryRepository.repository_exists? location
+    raise 'Repository does not exist' unless MemoryRepository.repository_exists? location
     return @@repositories[location] # return reference in question
   end
 
@@ -190,13 +190,11 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Memory repository and closes it afterwards
   def self.access(connect_string)
-    raise 'Respository does not exist' unless MemoryRepository.repository_exists? connect_string
-    begin
-      repository = self.open(connect_string)
-      yield repository
-    ensure
-      repository&.close
-    end
+    repository = nil
+    repository = self.open(connect_string)
+    yield repository
+  ensure
+    repository&.close
   end
 
   # Closes the repository.

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -63,8 +63,7 @@ class SubversionRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Subversion repository and closes it afterwards
   def self.access(connect_string)
-    repository = nil
-    repository = self.open(connect_string)
+    repository = SubversionRepository.open(connect_string)
     yield repository
   ensure
     repository&.close

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -57,10 +57,8 @@ class SubversionRepository < Repository::AbstractRepository
   # Static method: Opens an existing Subversion repository
   # at location 'connect_string'
   def self.open(connect_string)
-    unless SubversionRepository.repository_exists?(location)
-      raise "Could not open repository at location #{location}"
-    end
-    return SubversionRepository.new(connect_string)
+    raise 'Respository does not exist' unless SubversionRepository.repository_exists? connect_string
+    SubversionRepository.new(connect_string)
   end
 
   # Static method: Yields an existing Subversion repository and closes it afterwards
@@ -70,7 +68,7 @@ class SubversionRepository < Repository::AbstractRepository
       repository = self.open(connect_string)
       yield repository
     ensure
-      repository.close
+      repository&.close
     end
   end
 

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -57,6 +57,9 @@ class SubversionRepository < Repository::AbstractRepository
   # Static method: Opens an existing Subversion repository
   # at location 'connect_string'
   def self.open(connect_string)
+    unless SubversionRepository.repository_exists?(location)
+      raise "Could not open repository at location #{location}"
+    end
     return SubversionRepository.new(connect_string)
   end
 

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -62,10 +62,13 @@ class SubversionRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Subversion repository and closes it afterwards
   def self.access(connect_string)
-    repository = self.open(connect_string)
-    yield repository
-  ensure
-    repository.close
+    raise 'Respository does not exist' unless SubversionRepository.repository_exists? connect_string
+    begin
+      repository = self.open(connect_string)
+      yield repository
+    ensure
+      repository.close
+    end
   end
 
   # Static method: Deletes an existing Subversion repository

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -57,19 +57,17 @@ class SubversionRepository < Repository::AbstractRepository
   # Static method: Opens an existing Subversion repository
   # at location 'connect_string'
   def self.open(connect_string)
-    raise 'Respository does not exist' unless SubversionRepository.repository_exists? connect_string
+    raise 'Repository does not exist' unless SubversionRepository.repository_exists? connect_string
     SubversionRepository.new(connect_string)
   end
 
   # Static method: Yields an existing Subversion repository and closes it afterwards
   def self.access(connect_string)
-    raise 'Respository does not exist' unless SubversionRepository.repository_exists? connect_string
-    begin
-      repository = self.open(connect_string)
-      yield repository
-    ensure
-      repository&.close
-    end
+    repository = nil
+    repository = self.open(connect_string)
+    yield repository
+  ensure
+    repository&.close
   end
 
   # Static method: Deletes an existing Subversion repository

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1121,17 +1121,11 @@ class Assignment < ApplicationRecord
 
   # Return a repository object, if possible
   def starter_code_repo
-    unless Repository.get_class.repository_exists?(starter_code_repo_path)
-      raise 'Repository not found'
-    end
     Repository.get_class.open(starter_code_repo_path)
   end
 
   #Yields a repository object, if possible, and closes it after it is finished
   def access_starter_code_repo(&block)
-    unless Repository.get_class.repository_exists?(starter_code_repo_path)
-      raise 'Repository not found'
-    end
     Repository.get_class.access(starter_code_repo_path, &block)
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -84,17 +84,11 @@ class Group < ApplicationRecord
 
   # Return a repository object, if possible
   def repo
-    unless Repository.get_class.repository_exists?(repo_path)
-      raise 'Repository not found'
-    end
     Repository.get_class.open(repo_path)
   end
 
   #Yields a repository object, if possible, and closes it after it is finished
   def access_repo(&block)
-    unless Repository.get_class.repository_exists?(repo_path)
-      raise 'Repository not found'
-    end
     Repository.get_class.access(repo_path, &block)
   end
 end


### PR DESCRIPTION
This builds on #3887 and #3869 so that git reclones local repos from the remote if the local repo does not exist or if the local repo is corrupted (the previous behaviour did not reclone if the local repo was missing entirely). 

Repos were (likely) missing because they were removed prior to being recloned (if an error was raised while trying to access the repo) and then if there was an error that occurred during recloning due to a concurrency conflict, the repo would never be recloned at all.

With this PR, if a git repo does not exist the user will initially receive a 500 error but then the repo will be recloned so the next time that page is revisited (refreshed) the page will load as normal. In the case where there are multiple successive failures, the user may have to refresh the page several times but eventually the repo should be recloned properly and exist in a stable state. 

This is meant as a temporary fix so that there is only a minor disruption for the user as opposed to a total failure which requires manually recloning the missing repo to fix. 

