### PR TITLE
Don't display deadline including grace tokens until the group has been created

### DIFF
--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -25,10 +25,12 @@
       <% acc = 0 %>
       <% if @penalty.type == "GracePeriodSubmissionRule" %>
         <%# Relative remaining grace credits for the grouping %>
-        <% unless @grouping.nil? %>
-          <span class='prop_label'>
+        <span class='prop_label'>
             <%= t('grace_period_submission_rules.deadline_html') %>
-          </span>
+        </span>
+        <% if @grouping.nil? %>
+          <%= t('grace_period_submission_rules.no_group_yet') %>
+        <% else %>
           <% remaining_credits = @grouping.available_grace_credits %>
           <% @enum_penalty.each do |p| %>
             <% unless remaining_credits <= 0 %>

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -26,7 +26,7 @@
       <% if @penalty.type == "GracePeriodSubmissionRule" %>
         <%# Relative remaining grace credits for the grouping %>
         <span class='prop_label'>
-            <%= t('grace_period_submission_rules.deadline_html') %>
+          <%= t('grace_period_submission_rules.deadline_html') %>
         </span>
         <% if @grouping.nil? %>
           <%= t('grace_period_submission_rules.no_group_yet') %>

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -24,11 +24,11 @@
     <div class ='sub_block'>
       <% acc = 0 %>
       <% if @penalty.type == "GracePeriodSubmissionRule" %>
-        <span class='prop_label'>
-          <%= t('grace_period_submission_rules.deadline_html') %>
-        </span>
         <%# Relative remaining grace credits for the grouping %>
-        <% if !@grouping.nil? %>
+        <% unless @grouping.nil? %>
+          <span class='prop_label'>
+            <%= t('grace_period_submission_rules.deadline_html') %>
+          </span>
           <% remaining_credits = @grouping.available_grace_credits %>
           <% @enum_penalty.each do |p| %>
             <% unless remaining_credits <= 0 %>
@@ -36,14 +36,15 @@
               <% remaining_credits -= 1 %>
             <% end %>
           <% end %>
+          <%= I18n.l(@assignment.due_date + acc.hours) %>
         <% end %>
       <% else %>
         <span class='prop_label'>
           <%= t('penalty_period_submission_rules.deadline_html') %>
         </span>
         <% @enum_penalty.each { |p| acc += p.hours } %>
+        <%= I18n.l(@assignment.due_date + acc.hours) %>
       <% end %>
-      <%= I18n.l(@assignment.due_date + acc.hours) %>
     </div>
 
     <div class='sub_block'>

--- a/config/locales/views/submission_rules/en.yml
+++ b/config/locales/views/submission_rules/en.yml
@@ -19,7 +19,7 @@ en:
       other: "%{count} credits"
     deadline_html: "Deadline using all <br> remaining grace <br> credits"
     group_credits_html: "Your group has <strong>%{available_grace_credits}</strong> available grace credit(s)."
-    no_group_yet: "Form a group to determine how many grace tokens are available for this assignment."
+    no_group_yet: "Form a group to determine how many grace credits you have available for this assignment."
     overtime_message_with_credits_left: "The due date for this assignment has passed. However, you have %{grace_credits_remaining} grace credit(s) left. If you submit files during this period, you will be spending %{grace_credits_to_use} of those credits."
     overtime_message_without_credits_left: "The due date for this assignment has passed, and you do not have enough grace credits to submit new work."
 

--- a/config/locales/views/submission_rules/en.yml
+++ b/config/locales/views/submission_rules/en.yml
@@ -19,6 +19,7 @@ en:
       other: "%{count} credits"
     deadline_html: "Deadline using all <br> remaining grace <br> credits"
     group_credits_html: "Your group has <strong>%{available_grace_credits}</strong> available grace credit(s)."
+    no_group_yet: "Form a group to determine how many grace tokens are available for this assignment."
     overtime_message_with_credits_left: "The due date for this assignment has passed. However, you have %{grace_credits_remaining} grace credit(s) left. If you submit files during this period, you will be spending %{grace_credits_to_use} of those credits."
     overtime_message_without_credits_left: "The due date for this assignment has passed, and you do not have enough grace credits to submit new work."
 

--- a/config/locales/views/submission_rules/es.yml
+++ b/config/locales/views/submission_rules/es.yml
@@ -20,6 +20,7 @@ es:
       other: "%{count} créditos"
     deadline_html: "Fecha límite utilizando todos los <br> aplazamientos de gracia restantes <br>"
     group_credits_html: "Su grupo tiene <strong>%{available_grace_credits}</strong> créditos de gracia disponibles."
+    no_group_yet: "UPDATE ME"
     overtime_message_with_credits_left:
       "El último plazo para este proyecto ha pasado. Sin embargo, usted tiene
        %{grace_credits_remaining} crédito(s) de aplazamiento de gracia restantes.

--- a/config/locales/views/submission_rules/fr.yml
+++ b/config/locales/views/submission_rules/fr.yml
@@ -19,6 +19,7 @@ fr:
       other: "%{count} crédits"
     deadline_html: "Date limite en <br> utilisant tous les <br> jetons de grâce <br> restants"
     group_credits_html: "Votre groupe a <strong>%{available_grace_credits}</strong> crédit(s) de grâce disponible(s)."
+    no_group_yet: "Formez un groupe pour déterminer le nombre de jetons de grâce disponible pour ce projet."
     overtime_message_with_credits_left: "La date de retour pour ce projet est passée. Cependant, il vous reste %{grace_credits_remaining} crédit(s) de grâce.  Si vous envoyez un (des) fichier(s) ou faites des changements durant cette période, vous utiliserez %{grace_credits_to_use} de ces crédits."
     overtime_message_without_credits_left: "La date de retour pour ce projet est passée et vous ne pouvez plus utiliser de jours de grâce."
 

--- a/config/locales/views/submission_rules/pt.yml
+++ b/config/locales/views/submission_rules/pt.yml
@@ -19,6 +19,7 @@ pt:
       other: "%{count} créditos"
     deadline_html: "Prazo usando todos <br> os restantes fichas <br> de carência"
     group_credits_html: "O seu grupo tem disponível <strong>%{available_grace_credits}</strong> créditos de tolerância."
+    no_group_yet: "UPDATE ME"
     overtime_message_with_credits_left: "A data de entrega para este projeto já passou. No entanto, você tem %{grace_credits_remaining} crédito (s) créditos de tolerância. Se você enviar arquivos, ou fazer alterações durante este período, vai ser gasto %{grace_credits_to_use} desses créditos."
     overtime_message_without_credits_left: "A data de entrega para este projeto já passou, e você já não são capazes de usar os dias de tolerância."
 


### PR DESCRIPTION
Before this, the modified deadline would always be the same as the original deadline regardless of the number of grace tokens the student currently has. 

Since the minimum of the grace tokens of the members of the grouping is what counts it doesn't make sense to display this information until the grouping is created. 