### PR TITLE
Use test_runs.problems instead of creating fake test results when autotest global errors happen

### DIFF
--- a/app/assets/javascripts/Components/test_run_table.jsx
+++ b/app/assets/javascripts/Components/test_run_table.jsx
@@ -174,6 +174,11 @@ class TestGroupResultTable extends React.Component {
   ];
 
   render() {
+    const problems = this.props.data[0]['test_runs.problems'];
+    if (problems) {
+      return (<div>{problems}</div>);
+    }
+
     const extraInfo = this.props.data[0]['test_group_results.extra_info'];
     let extraInfoDisplay;
     if (extraInfo) {

--- a/app/assets/javascripts/Components/test_run_table.jsx
+++ b/app/assets/javascripts/Components/test_run_table.jsx
@@ -55,6 +55,7 @@ export class TestRunTable extends React.Component {
             'test_runs.created_at': test_data[0]['test_runs.created_at'],
             'users.user_name': test_data[0]['users.user_name'],
             'test_runs.status': test_data[0]['test_runs.status'],
+            'test_runs.problems': test_data[0]['test_runs.problems'],
             'test_results': [],
           };
           test_data.forEach(data => {
@@ -93,9 +94,9 @@ export class TestRunTable extends React.Component {
             }
           ]}
           SubComponent={ row => (
-            <TestGroupResultTable
-              data={row.original['test_results']}
-            />
+            row.original['test_runs.problems'] ?
+              row.original['test_runs.problems'] :
+              <TestGroupResultTable data={row.original['test_results']}/>
           )}
           noDataText={I18n.t('automated_tests.no_results')}
           getTheadThProps={ () => {
@@ -174,11 +175,6 @@ class TestGroupResultTable extends React.Component {
   ];
 
   render() {
-    const problems = this.props.data[0]['test_runs.problems'];
-    if (problems) {
-      return (<div>{problems}</div>);
-    }
-
     const extraInfo = this.props.data[0]['test_group_results.extra_info'];
     let extraInfoDisplay;
     if (extraInfo) {

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -803,7 +803,8 @@ class Grouping < ApplicationRecord
 
   def self.group_hash_list(hash_list)
     new_hash_list = []
-    group_by_keys = ['test_runs.id', 'test_runs.created_at', 'users.user_name', 'test_groups.name']
+    group_by_keys = ['test_runs.id', 'test_runs.created_at', 'test_runs.problems', 'users.user_name',
+                     'test_groups.name']
     hash_list.group_by { |g| g.values_at(*group_by_keys) }.values.each do |val|
       h = Hash.new
       group_by_keys.each do |key|

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -134,7 +134,6 @@ class TestRun < ApplicationRecord
 
   def create_test_group_results_from_json(test_output)
     # check that the output is well-formed
-    test_groups = self.grouping.assignment.test_groups.to_a
     json_root = nil
     begin
       json_root = JSON.parse(test_output)
@@ -156,8 +155,8 @@ class TestRun < ApplicationRecord
     server_error = json_root['error']
     hooks_error_all = json_root['hooks_error'] || ''
     unless server_error.blank?
-      self.problems = I18n.t('automated_tests.results.bad_server', hostname: MarkusConfigurator.autotest_server_host,
-                             error: server_error) +
+      self.problems = I18n.t('automated_tests.results.bad_server',
+                             hostname: MarkusConfigurator.autotest_server_host, error: server_error) +
                       I18n.t('automated_tests.results.extra_raw_output', extra: test_output)
       save
       return


### PR DESCRIPTION
Didn't care about formatting in the test runs table, since we want to revamp it anyway.