### PR TITLE
Update vagrant file for scanned exams

### DIFF
--- a/script/install-markus.sh
+++ b/script/install-markus.sh
@@ -17,6 +17,9 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -
 echo "- - - Installing Dependencies - - -"
 sudo apt-get install -y build-essential libv8-dev imagemagick libmagickwand-dev redis-server cmake libssh2-1-dev ghostscript libaprutil1-dev swig graphviz
 
+# update imagemagick policy file to read PDFs
+sudo sed -ri 's/(rights=")none("\s+pattern="PDF")/\1read\2/' /etc/ImageMagick-6/policy.xml
+
 # Install Ruby
 sudo apt-get install software-properties-common -y
 sudo add-apt-repository ppa:brightbox/ruby-ng
@@ -116,5 +119,7 @@ echo "- - - Installing Python Libraries - - -"
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get update
 sudo apt-get install python3.7
+sudo apt install python3-pip
+python3.7 -m pip install pip
 python3.7 -m pip install --user --no-cache-dir -r lib/scanner/requirements.txt
 EOL


### PR DESCRIPTION
When installing markus on the vagrant server make sure that:

- the imagemagick policy file permits reading of PDF files. For more information see [this discussion](https://stackoverflow.com/questions/52703123/override-default-imagemagick-policy-xml)
- `pip` is installed before attempting to install python packages (the python3.7 version from deadsnakes doesn't include pip by default)