### PR TITLE
Only open repos through the access methods 

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -969,11 +969,6 @@ class Assignment < ApplicationRecord
     File.join(MarkusConfigurator.markus_config_repository_storage, STARTER_CODE_REPO_NAME)
   end
 
-  # Return a repository object, if possible
-  def starter_code_repo
-    Repository.get_class.open(starter_code_repo_path)
-  end
-
   #Yields a repository object, if possible, and closes it after it is finished
   def access_starter_code_repo(&block)
     Repository.get_class.access(starter_code_repo_path, &block)

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -181,29 +181,29 @@ class ExamTemplate < ApplicationRecord
           assignment_folder = self.assignment.repository_folder
           txn = repo.get_transaction(Admin.first.user_name)
           self.template_divisions.each do |template_division|
-            if template_division.start <= page_num.to_i && page_num.to_i <= template_division.end
-              submission_file = CombinePDF.new
-              (template_division.start..template_division.end).each do |i|
-                path = File.join(incomplete_dir, "#{i}.pdf")
-                if File.exists? path
-                  pdf = CombinePDF.load path
-                  submission_file << pdf.pages[0]
-                end
+            next unless template_division.start <= page_num.to_i && page_num.to_i <= template_division.end
+
+            submission_file = CombinePDF.new
+            (template_division.start..template_division.end).each do |i|
+              path = File.join(incomplete_dir, "#{i}.pdf")
+              if File.exist? path
+                pdf = CombinePDF.load path
+                submission_file << pdf.pages[0]
               end
-              target_path = File.join(assignment_folder, "#{template_division.label}.pdf")
-              if revision.path_exists? target_path
-                txn.replace(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf,
-                            'application/pdf', revision.revision_identifier)
-              else
-                txn.add(target_path, submission_file.to_pdf)
-              end
+            end
+            target_path = File.join(assignment_folder, "#{template_division.label}.pdf")
+            if revision.path_exists? target_path
+              txn.replace(File.join(assignment_folder, "#{template_division.label}.pdf"), submission_file.to_pdf,
+                          'application/pdf', revision.revision_identifier)
+            else
+              txn.add(target_path, submission_file.to_pdf)
             end
           end
 
           # update COVER.pdf if error page given is first page of exam template
           if page_num.to_i == 1
             path = File.join(incomplete_dir, "#{page_num}.pdf")
-            if File.exists? path
+            if File.exist? path
               cover_pdf = CombinePDF.new
               pdf = CombinePDF.load path
               cover_pdf << pdf.pages[0]
@@ -219,17 +219,19 @@ class ExamTemplate < ApplicationRecord
 
           # update EXTRA.pdf
           extra_pdf = CombinePDF.new
-          if Dir.exists?(incomplete_dir)
-            Dir.entries(incomplete_dir).sort.each do |filename|
-              path = File.join(incomplete_dir, filename)
-              basename = File.basename filename # For example, 3 from 3.pdf
+          if Dir.exist?(incomplete_dir)
+            Dir.entries(incomplete_dir).sort.each do |file_in_dir|
+              path = File.join(incomplete_dir, file_in_dir)
+              basename = File.basename file_in_dir # For example, 3 from 3.pdf
               page_number = basename.to_i
               # if it is an extra page, add it to extra_pdf
-              if File.exists?(path) && !filename.start_with?('.') &&
-                template_divisions.all? { |division| division.start > page_number || division.end < page_number } && page_number != 1
-                pdf = CombinePDF.load path
-                extra_pdf << pdf.pages[0]
-              end
+              next unless File.exist? path
+              next if file_in_dir.start_with? '.'
+              next unless template_divisions.all? { |div| div.start > page_number || div.end < page_number }
+              next if page_number == 1
+
+              pdf = CombinePDF.load path
+              extra_pdf << pdf.pages[0]
             end
             target_path = File.join(assignment_folder, 'EXTRA.pdf')
             if revision.path_exists? target_path

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -73,11 +73,6 @@ class Group < ApplicationRecord
     File.join(MarkusConfigurator.markus_config_repository_storage, self.repository_name)
   end
 
-  # Return a repository object, if possible
-  def repo
-    Repository.get_class.open(repo_path)
-  end
-
   #Yields a repository object, if possible, and closes it after it is finished
   def access_repo(&block)
     Repository.get_class.access(repo_path, &block)

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -110,21 +110,24 @@ class SubmissionFile < ApplicationRecord
   def retrieve_file(include_annotations = false, repo = nil)
     student_group = self.submission.grouping.group
     revision_identifier = self.submission.revision_identifier
-    close_repo = false
+
+    get_retrieved_file = lambda do |open_repo|
+      revision = open_repo.get_revision(revision_identifier)
+      revision_file = revision.files_at_path(self.path, with_attrs: false)[self.filename]
+      if revision_file.nil?
+        raise I18n.t('results.could_not_find_file',
+                     filename: self.filename,
+                     repository_name: student_group.repository_name)
+      end
+      open_repo.download_as_string(revision_file)
+    end
+
     if repo.nil?
-      repo = student_group.repo
-      close_repo = true
-    end
-    revision = repo.get_revision(revision_identifier)
-    revision_file = revision.files_at_path(self.path, with_attrs: false)[self.filename]
-    if revision_file.nil?
-      raise I18n.t('results.could_not_find_file',
-                   filename: self.filename,
-                   repository_name: student_group.repository_name)
-    end
-    retrieved_file = repo.download_as_string(revision_file)
-    if close_repo
-      repo.close
+      retrieved_file = student_group.access_repo do |repo|
+        get_retrieved_file.call(repo)
+      end
+    else
+      retrieved_file = get_retrieved_file.call(repo)
     end
     if include_annotations
       retrieved_file = add_annotations(retrieved_file)

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -123,8 +123,8 @@ class SubmissionFile < ApplicationRecord
     end
 
     if repo.nil?
-      retrieved_file = student_group.access_repo do |repo|
-        get_retrieved_file.call(repo)
+      retrieved_file = student_group.access_repo do |open_repo|
+        get_retrieved_file.call(open_repo)
       end
     else
       retrieved_file = get_retrieved_file.call(repo)

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -164,7 +164,6 @@ namespace :markus do
             assignment.save!
 
             grouping.group.access_repo do |assignment_repo|
-
               txn = assignment_repo.get_transaction(student_user_name)
               file_data = %|class assignment {
         // This method should sum only positive values
@@ -180,7 +179,7 @@ namespace :markus do
           System.out.println("The sum of the positive values is: " + sum);
         }
       }|
-              folder_name = assignment_short_identifier + "/" + assignment_short_identifier + ".java"
+              folder_name = assignment_short_identifier + '/' + assignment_short_identifier + '.java'
               puts folder_name
               txn.add(folder_name, file_data, 'text/java')
               assignment_repo.commit(txn)

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -163,9 +163,10 @@ namespace :markus do
             assignment.groupings << grouping
             assignment.save!
 
-            assignment_repo = grouping.group.repo
-            txn = assignment_repo.get_transaction(student_user_name)
-            file_data = %|class assignment {
+            grouping.group.access_repo do |assignment_repo|
+
+              txn = assignment_repo.get_transaction(student_user_name)
+              file_data = %|class assignment {
         // This method should sum only positive values
         public static void main(String args[]) {
           // First, I create an array
@@ -179,10 +180,11 @@ namespace :markus do
           System.out.println("The sum of the positive values is: " + sum);
         }
       }|
-            folder_name = assignment_short_identifier + "/" + assignment_short_identifier + ".java"
-            puts folder_name
-            txn.add(folder_name, file_data, 'text/java')
-            assignment_repo.commit(txn)
+              folder_name = assignment_short_identifier + "/" + assignment_short_identifier + ".java"
+              puts folder_name
+              txn.add(folder_name, file_data, 'text/java')
+              assignment_repo.commit(txn)
+            end
             assignment.save!
 
             num_of_submissions = rand(4)

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -169,9 +169,8 @@ describe ResultsController do
                                              annotation_text: create(:annotation_text, user: admin),
                                              result: complete_result,
                                              creator: admin
-        grouping.group.access_repo do |repo|
-          file_name_snippet = "#{assignment.short_identifier}_#{grouping.group.group_name}" +
-            "_r#{repo.get_latest_revision.revision_identifier}"
+        file_name_snippet = grouping.group.access_repo do |repo|
+          "#{assignment.short_identifier}_#{grouping.group.group_name}_r#{repo.get_latest_revision.revision_identifier}"
         end
         @file_path_ann = File.join 'tmp', "#{file_name_snippet}_ann.zip"
         @file_path = File.join 'tmp', "#{file_name_snippet}.zip"

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -169,8 +169,10 @@ describe ResultsController do
                                              annotation_text: create(:annotation_text, user: admin),
                                              result: complete_result,
                                              creator: admin
-        file_name_snippet = "#{assignment.short_identifier}_#{grouping.group.group_name}" +
-          "_r#{grouping.group.repo.get_latest_revision.revision_identifier}"
+        grouping.group.access_repo do |repo|
+          file_name_snippet = "#{assignment.short_identifier}_#{grouping.group.group_name}" +
+            "_r#{repo.get_latest_revision.revision_identifier}"
+        end
         @file_path_ann = File.join 'tmp', "#{file_name_snippet}_ann.zip"
         @file_path = File.join 'tmp', "#{file_name_snippet}.zip"
         submission_file_dir = "#{assignment.repository_folder}-#{grouping.group.repo_name}"

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -218,19 +218,21 @@ describe SubmissionsController do
                               grouping: @grouping)
     end
     it 'should be able to access the repository browser.' do
+      revision_identifier = Grouping.last.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
       get_as @ta_membership.user,
              :repo_browser,
              params: { assignment_id: @assignment.id, id: Grouping.last.id,
-                       revision_identifier: Grouping.last.group.repo.get_latest_revision.revision_identifier,
+                       revision_identifier: revision_identifier,
                        path: '/' }
       is_expected.to respond_with(:success)
     end
 
     it 'should render with the assignment_content layout' do
+      revision_identifier = Grouping.last.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
       get_as @ta_membership.user,
              :repo_browser,
              params: { assignment_id: @assignment.id, id: Grouping.last.id,
-                       revision_identifier: Grouping.last.group.repo.get_latest_revision.revision_identifier,
+                       revision_identifier: revision_identifier,
                        path: '/' }
       expect(response).to render_template('layouts/assignment_content')
     end
@@ -423,9 +425,9 @@ describe SubmissionsController do
 
       expect('application/zip').to eq(response.header['Content-Type'])
       is_expected.to respond_with(:success)
+      revision_identifier = @grouping.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
       zip_path = "tmp/#{@assignment.short_identifier}_" +
-                 "#{@grouping.group.group_name}_#{@grouping.group.repo
-                     .get_latest_revision.revision_identifier}.zip"
+                 "#{@grouping.group.group_name}_#{revision_identifier}.zip"
       Zip::File.open(zip_path) do |zip_file|
         file1_path = File.join("#{@assignment.short_identifier}-" +
                                    "#{@grouping.group.group_name}",

--- a/spec/jobs/create_groups_job_spec.rb
+++ b/spec/jobs/create_groups_job_spec.rb
@@ -28,7 +28,9 @@ describe CreateGroupsJob do
     if groups_diff.positive?
       it 'should create a new repo' do
         CreateGroupsJob.perform_now(assignment, @data)
-        expect(Group.find_by_group_name('group1').repo).to be_an_instance_of(MemoryRepository)
+        Group.find_by_group_name('group1').access_repo do |repo|
+          expect(repo).to be_an_instance_of(MemoryRepository)
+        end
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -77,14 +77,6 @@ describe Group do
     end
   end
 
-  describe '#repo' do
-    let(:group) { create(:group) }
-
-    it 'returns a repository object' do
-      expect(group.repo).to be_truthy
-    end
-  end
-
   describe '#access_repo' do
     context 'when repository exists' do
       let(:group) { create(:group) }

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -72,7 +72,7 @@ describe Student do
       mock_repo = class_double('Repository::AbstractRepository')
       allow_any_instance_of(mock_repo).to receive(:close).and_return(true)
       allow_any_instance_of(mock_repo).to receive(:remove_user).and_return(Repository::UserNotFound)
-      allow_any_instance_of(Group).to receive(:repo).and_return(mock_repo)
+      allow_any_instance_of(Group).to receive(:access_repo).and_yield(mock_repo)
 
       Student.hide_students(@student_id_list)
     end
@@ -118,7 +118,7 @@ describe Student do
       mock_repo = class_double('Repository::AbstractRepository')
       allow_any_instance_of(mock_repo).to receive(:close).and_return(true)
       allow_any_instance_of(mock_repo).to receive(:add_user).and_return(Repository::UserAlreadyExistent)
-      allow_any_instance_of(Group).to receive(:repo).and_return(mock_repo)
+      allow_any_instance_of(Group).to receive(:access_repo).and_yield(mock_repo)
 
       Student.unhide_students(@student_id_list)
     end


### PR DESCRIPTION
Ensure that repo access occurs through the repo_class.access calls only not through an explicit call to open or close. This will ensure that repos are always closed properly and should prevent some concurrency issues when multiple processes are attempting to access repos simultaneously or in quick succession. 