### PR TITLE
Serialize repository access in repo_browser component

### DIFF
--- a/app/assets/javascripts/Components/repo_browser.jsx
+++ b/app/assets/javascripts/Components/repo_browser.jsx
@@ -6,16 +6,14 @@ import { SubmissionFileManager } from './submission_file_manager'
 class RepoBrowser extends React.Component {
   constructor(props) {
     super(props);
-    this.submissionFileManagerRef = React.createRef();
     this.state = {
-      revision_identifier: props.collected_revision_id,
+      revision_identifier: undefined,
       revisions: []
     };
   }
 
   componentDidMount() {
     this.fetchRevisions();
-    this.submissionFileManagerRef.current.fetchData();
   }
 
   // Update the list of revisions and set the currently-viewed revision to the most recent one.
@@ -78,7 +76,6 @@ class RepoBrowser extends React.Component {
           </select>
         </h3>
         <SubmissionFileManager
-          ref={this.submissionFileManagerRef}
           assignment_id={this.props.assignment_id}
           grouping_id={this.props.grouping_id}
           revision_identifier={this.state.revision_identifier}

--- a/app/assets/javascripts/Components/repo_browser.jsx
+++ b/app/assets/javascripts/Components/repo_browser.jsx
@@ -6,6 +6,7 @@ import { SubmissionFileManager } from './submission_file_manager'
 class RepoBrowser extends React.Component {
   constructor(props) {
     super(props);
+    this.submissionFileManagerRef = React.createRef();
     this.state = {
       revision_identifier: props.collected_revision_id,
       revisions: []
@@ -14,6 +15,7 @@ class RepoBrowser extends React.Component {
 
   componentDidMount() {
     this.fetchRevisions();
+    this.submissionFileManagerRef.current.fetchData();
   }
 
   // Update the list of revisions and set the currently-viewed revision to the most recent one.
@@ -76,10 +78,12 @@ class RepoBrowser extends React.Component {
           </select>
         </h3>
         <SubmissionFileManager
+          ref={this.submissionFileManagerRef}
           assignment_id={this.props.assignment_id}
           grouping_id={this.props.grouping_id}
           revision_identifier={this.state.revision_identifier}
           onChange={this.fetchRevisions}
+          fetchOnMount={false}
         />
         <ManualCollectionForm
           assignment_id={this.props.assignment_id}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -12,9 +12,15 @@ class SubmissionFileManager extends React.Component {
     };
   }
 
+  static defaultProps = {
+    fetchOnMount: true
+  };
+
   componentDidMount() {
     window.modal_addnew = new ModalMarkus('#addnew_dialog');
-    this.fetchData();
+    if (this.props.fetchOnMount) {
+      this.fetchData();
+    }
   }
 
   fetchData = () => {


### PR DESCRIPTION
Get file data only after the revision data has been collected to prevent multiple concurrent requests to access the same repo object. 
This was happening because the calls to the server to fetch various repo information that were made in each components' `componentDidMount` calls were overlapping. Subsequent calls to update that data once the components have mounted should happen in sequence since the file data is only updated if the revision identifier has been changed. 