### PR TITLE
Upload add/remove file API and refactor file upload/delete code

### DIFF
--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -34,7 +34,6 @@ module Api
     end
 
     def destroy
-      byebug
       render 'shared/http_status', locals: {code: '404', message:
         HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -34,6 +34,7 @@ module Api
     end
 
     def destroy
+      byebug
       render 'shared/http_status', locals: {code: '404', message:
         HttpStatusHelper::ERROR_CODE['message']['404'] }, status: 404
     end

--- a/app/controllers/api/submission_files_controller.rb
+++ b/app/controllers/api/submission_files_controller.rb
@@ -138,37 +138,37 @@ module Api
     def remove_file
       grouping = Grouping.find_by_group_id_and_assignment_id(params[:group_id], params[:assignment_id])
       if grouping.nil?
-        render 'shared/http_status', locals: {code: '404', message:
-          'No group with that id exists for the given assignment'}, status: 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'No group with that id exists for the given assignment' }, status: 404
         return
       end
 
       if has_missing_params?([:filename])
         # incomplete/invalid HTTP params
-        render 'shared/http_status', locals: {code: '422', message:
-          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
+        render 'shared/http_status', locals: { code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422'] }, status: 422
         return
       end
 
       begin
         success, messages = grouping.remove_files([params[:filename]], @current_user)
       rescue Repository::FileDoesNotExist
-        render 'shared/http_status', locals: {code: '404', message:
-          'No file exists at that path.'}, status: 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'No file exists at that path.' }, status: 404
         return
       end
 
-      message_string = messages.map { |type, *msg| "#{type}: #{msg}"}.join("\n")
+      message_string = messages.map { |type, *msg| "#{type}: #{msg}" }.join("\n")
 
       if success
         # It worked, render success
         message = "#{HttpStatusHelper::ERROR_CODE['message']['200']}\n\n#{message_string}"
-        render 'shared/http_status', locals: {code: '200', message: message}, status: 200
+        render 'shared/http_status', locals: { code: '200', message: message }, status: 200
       else
         # Some other error occurred
         message = "#{HttpStatusHelper::ERROR_CODE['message']['500']}\n\n#{message_string}"
-        render 'shared/http_status', locals: { code: '500', message: message}, status: 500
+        render 'shared/http_status', locals: { code: '500', message: message }, status: 500
       end
     end
-  end # end SubmissionFilesController
+  end
 end

--- a/app/controllers/api/submission_files_controller.rb
+++ b/app/controllers/api/submission_files_controller.rb
@@ -95,15 +95,15 @@ module Api
     def create
       grouping = Grouping.find_by_group_id_and_assignment_id(params[:group_id], params[:assignment_id])
       if grouping.nil?
-        render 'shared/http_status', locals: {code: '404', message:
-          'No group with that id exists for the given assignment'}, status: 404
+        render 'shared/http_status', locals: { code: '404', message:
+          'No group with that id exists for the given assignment' }, status: 404
         return
       end
 
       if has_missing_params?([:filename, :mime_type, :file_content])
         # incomplete/invalid HTTP params
-        render 'shared/http_status', locals: {code: '422', message:
-          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
+        render 'shared/http_status', locals: { code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422'] }, status: 422
         return
       end
 
@@ -123,15 +123,15 @@ module Api
       ensure
         tmpfile.close!
       end
-      message_string = messages.map { |type, *msg| "#{type}: #{msg}"}.join("\n")
+      message_string = messages.map { |type, *msg| "#{type}: #{msg}" }.join("\n")
       if success
         # It worked, render success
         message = "#{HttpStatusHelper::ERROR_CODE['message']['201']}\n\n#{message_string}"
-        render 'shared/http_status', locals: {code: '201', message: message}, status: 201
+        render 'shared/http_status', locals: { code: '201', message: message }, status: 201
       else
         # Some other error occurred
         message = "#{HttpStatusHelper::ERROR_CODE['message']['500']}\n\n#{message_string}"
-        render 'shared/http_status', locals: { code: '500', message: message}, status: 500
+        render 'shared/http_status', locals: { code: '500', message: message }, status: 500
       end
     end
 

--- a/app/controllers/api/submission_files_controller.rb
+++ b/app/controllers/api/submission_files_controller.rb
@@ -1,7 +1,7 @@
 module Api
   # Allows for downloading of submission files and their annotations
   # Uses Rails' RESTful routes (check 'rake routes' for the configured routes)
-  class SubmissionDownloadsController < MainApiController
+  class SubmissionFilesController < MainApiController
 
     # Returns the requested submission file, or a zip containing all submission
     # files, including all annotations if requested
@@ -92,5 +92,83 @@ module Api
       end
     end
 
-  end # end SubmissionDownloadsController
+    def create
+      grouping = Grouping.find_by_group_id_and_assignment_id(params[:group_id], params[:assignment_id])
+      if grouping.nil?
+        render 'shared/http_status', locals: {code: '404', message:
+          'No group with that id exists for the given assignment'}, status: 404
+        return
+      end
+
+      if has_missing_params?([:filename, :mime_type, :file_content])
+        # incomplete/invalid HTTP params
+        render 'shared/http_status', locals: {code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
+        return
+      end
+
+      tmpfile = Tempfile.new
+      begin
+        if params[:file_content].respond_to? :read # binary data
+          content = params[:file_content].read
+        else
+          content = params[:file_content]
+        end
+        tmpfile.write(content)
+        tmpfile.rewind
+        file = ActionDispatch::Http::UploadedFile.new(tempfile: tmpfile,
+                                                      filename: params[:filename],
+                                                      type: params[:mime_type])
+        success, messages = grouping.add_files([file], @current_user)
+      ensure
+        tmpfile.close!
+      end
+      message_string = messages.map { |type, *msg| "#{type}: #{msg}"}.join("\n")
+      if success
+        # It worked, render success
+        message = "#{HttpStatusHelper::ERROR_CODE['message']['201']}\n\n#{message_string}"
+        render 'shared/http_status', locals: {code: '201', message: message}, status: 201
+      else
+        # Some other error occurred
+        message = "#{HttpStatusHelper::ERROR_CODE['message']['500']}\n\n#{message_string}"
+        render 'shared/http_status', locals: { code: '500', message: message}, status: 500
+      end
+    end
+
+    def remove_file
+      grouping = Grouping.find_by_group_id_and_assignment_id(params[:group_id], params[:assignment_id])
+      if grouping.nil?
+        render 'shared/http_status', locals: {code: '404', message:
+          'No group with that id exists for the given assignment'}, status: 404
+        return
+      end
+
+      if has_missing_params?([:filename])
+        # incomplete/invalid HTTP params
+        render 'shared/http_status', locals: {code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422']}, status: 422
+        return
+      end
+
+      begin
+        success, messages = grouping.remove_files([params[:filename]], @current_user)
+      rescue Repository::FileDoesNotExist
+        render 'shared/http_status', locals: {code: '404', message:
+          'No file exists at that path.'}, status: 404
+        return
+      end
+
+      message_string = messages.map { |type, *msg| "#{type}: #{msg}"}.join("\n")
+
+      if success
+        # It worked, render success
+        message = "#{HttpStatusHelper::ERROR_CODE['message']['200']}\n\n#{message_string}"
+        render 'shared/http_status', locals: {code: '200', message: message}, status: 200
+      else
+        # Some other error occurred
+        message = "#{HttpStatusHelper::ERROR_CODE['message']['500']}\n\n#{message_string}"
+        render 'shared/http_status', locals: { code: '500', message: message}, status: 500
+      end
+    end
+  end # end SubmissionFilesController
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -331,10 +331,8 @@ class SubmissionsController < ApplicationController
       if current_user.student? && !@assignment.allow_web_submits
         raise t('student.submission.external_submit_only')
       end
-
-      required_files = AssignmentFile.where(assignment_id: @assignment).pluck(:filename)
-      filenames = []
       @path = params[:path].blank? ? '/' : params[:path]
+
       if current_user.student?
         @grouping = current_user.accepted_grouping_for(assignment_id)
         unless @grouping.is_valid?
@@ -344,125 +342,53 @@ class SubmissionsController < ApplicationController
       else
         @grouping = @assignment.groupings.find(params[:grouping_id])
       end
-      unless params[:new_files].nil?
-        params[:new_files].each do |f|
-          if f.size > MarkusConfigurator.markus_config_max_file_size
-            flash_message(
-              :error,
-              t('student.submission.file_too_large',
-                file_name: f.original_filename,
-                max_size: (MarkusConfigurator.markus_config_max_file_size / 1_000_000.00).round(2))
-            )
-            return
-          elsif f.size == 0
-            flash_message(:warning, t('student.submission.empty_file_warning', file_name: f.original_filename))
+
+      # Get the revision numbers for the files that we've seen - these
+      # values will be the "expected revision numbers" that we'll provide
+      # to the transaction to ensure that we don't overwrite a file that's
+      # been revised since the user last saw it.
+      file_revisions = params[:file_revisions].nil? ? {} : params[:file_revisions]
+
+      # The files that will be deleted
+      delete_files = params[:delete_files].nil? ? [] : params[:delete_files]
+
+      # The files that will be added
+      new_files = params[:new_files].nil? ? {} : params[:new_files]
+
+      if delete_files.empty? && new_files.empty?
+        flash_message(:warning, I18n.t('student.submission.no_action_detected'))
+      else
+        messages = []
+        @grouping.group.access_repo do |repo|
+          # Create transaction, setting the author.  Timestamp is implicit.
+          txn = repo.get_transaction(current_user.user_name)
+          should_commit = true
+          if delete_files.present?
+            success, msgs = @grouping.remove_files(file_revisions.slice(*delete_files), current_user,
+                                                   path: @path, repo: repo, txn: txn)
+            should_commit &&= success
+            messages = messages.concat msgs
+          end
+          if new_files.present?
+            success, msgs = @grouping.add_files(new_files, current_user,
+                                                path: @path, repo: repo, txn: txn)
+            should_commit &&= success
+            messages = messages.concat msgs
+          end
+          if should_commit
+            if txn.has_jobs?
+              if repo.commit(txn)
+                messages << [:success, I18n.t('update_files.success')]
+              else
+                messages << [:error, partial: 'submissions/file_conflicts_list', locals: { conflicts: txn.conflicts }]
+              end
+            else
+              messages << [:warning, I18n.t('student.submission.no_action_detected')]
+            end
           end
         end
-      end
-      @grouping.group.access_repo do |repo|
-
-        assignment_path = Pathname.new(@assignment.repository_folder)
-        current_path = assignment_path.join(@path[1..-1]) # remove leading '/' to make relative path
-
-        # Get the revision numbers for the files that we've seen - these
-        # values will be the "expected revision numbers" that we'll provide
-        # to the transaction to ensure that we don't overwrite a file that's
-        # been revised since the user last saw it.
-        file_revisions = params[:file_revisions].nil? ? {} : params[:file_revisions]
-
-        # The files that will be deleted
-        delete_files = params[:delete_files].nil? ? [] : params[:delete_files]
-
-        # The files that will be added
-        new_files = params[:new_files].nil? ? {} : params[:new_files]
-
-        # Create transaction, setting the author.  Timestamp is implicit.
-        txn = repo.get_transaction(current_user.user_name)
-
-        log_messages = []
-        begin
-          if new_files.empty?
-            # delete files marked for deletion
-            delete_files.each do |filename|
-              file_path = assignment_path.join(filename)
-              file_path = file_path.to_s
-              txn.remove(file_path, file_revisions[filename])
-              log_messages.push("Student '#{current_user.user_name}' deleted file '#{file_path}' "\
-                                "for assignment '#{@assignment.short_identifier}'.")
-            end
-          else
-            # prepare repo revision for next block
-            revision = repo.get_latest_revision
-          end
-
-          # Add new files and replace existing files
-          new_files.each do |file_object|
-            filename = file_object.original_filename
-            if filename.nil?
-              raise I18n.t('student.submission.invalid_file_name')
-            end
-            filename = sanitize_file_name(filename)
-            file_path = current_path.join(filename)
-            file_path_relative = file_path.relative_path_from(assignment_path).to_s
-            file_path = file_path.to_s
-            # Sometimes the file pointer of file_object is at the end of the file.
-            # In order to avoid empty uploaded files, rewind it to be safe.
-            file_object.rewind
-
-            # Branch on whether the file is new or a replacement
-            if revision.path_exists?(file_path)
-              txn.replace(file_path, file_object.read, file_object.content_type, revision.revision_identifier)
-              log_messages.push("Student '#{current_user.user_name}' replaced file '#{file_path_relative}' "\
-                                "for assignment '#{@assignment.short_identifier}'.")
-            else
-              filenames << file_path_relative
-              txn.add(file_path, file_object.read, file_object.content_type)
-              log_messages.push("Student '#{current_user.user_name}' submitted file '#{file_path_relative}' "\
-                                "for assignment '#{@assignment.short_identifier}'.")
-            end
-          end
-
-          # check if only required files are allowed for a submission
-          unless filenames.empty? ||
-                 required_files.empty? ||
-                 !@assignment.only_required_files
-            if !(filenames - required_files).empty?
-              flash_message(:error, t('assignment.upload_file_requirement'))
-              return
-            else
-              required_files = required_files - filenames
-            end
-          end
-          # finish transaction
-          unless txn.has_jobs?
-            flash_message(:warning, I18n.t('student.submission.no_action_detected'))
-            set_filebrowser_vars(@grouping)
-            return
-          end
-          if repo.commit(txn)
-            flash_message(:success, I18n.t('update_files.success'))
-            # flush log messages
-            m_logger = MarkusLogger.instance
-            log_messages.each do |msg|
-              m_logger.log(msg)
-            end
-          else
-            flash_message(:error, partial: 'submissions/file_conflicts_list', locals: { conflicts: txn.conflicts })
-          end
-          # Are we past collection time?
-          if current_user.student? && @assignment.submission_rule.can_collect_now?(current_user.section)
-            flash_message(:warning,
-                          @assignment.submission_rule.class.human_attribute_name(:commit_after_collection_message))
-          end
-          # can't use redirect_to here. See comment of this action for details.
-          set_filebrowser_vars(@grouping)
-
-        rescue  => e
-          m_logger = MarkusLogger.instance
-          m_logger.log(e.message)
-          flash_message(:warning, e.message)
-          set_filebrowser_vars(@grouping)
-        end
+        messages.each { |flash_args| flash_message(*flash_args) }
+        set_filebrowser_vars(@grouping)
       end
     ensure
       redirect_back(fallback_location: root_path)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -3,6 +3,7 @@ require 'set'
 # Represents a collection of students working together on an assignment in a group
 class Grouping < ApplicationRecord
   include ActiveRecordCreator
+  include SubmissionsHelper
 
   after_create_commit :create_grouping_repository_folder
   after_commit :update_repo_permissions_after_save, on: [:create, :update]
@@ -880,5 +881,159 @@ class Grouping < ApplicationRecord
     else
       true
     end
+  end
+
+  # Add new files or overwrite existing files in this group's repo. +files+ should be a list
+  # of ActionDispatch::Http::UploadedFile objects, +user+ is the user that is responsible for
+  # the repository transaction, +path+ is the relative path from the root of the repository
+  # to prepend to each filename.
+  #
+  # If files should be added to a repo that is already open, the open repo object can be passed
+  # as the +repo+ keyword argument, otherwise the repo for this group will be used.
+  #
+  # If files should be added as part of an existent transaction, the transaction object can be
+  # passed as the +txn+ keyword argument, otherwise a new transaction will be created. If the +txn+
+  # argument is not nil, the transaction will be commited before returning, otherwise the transaction
+  # object will not be commited and so should be commited later on by the caller.
+  #
+  # Returns a tuple containing a boolean and an array. If the +txn+ argument was nil, the boolean
+  # indicates whether the transaction was completed without errors. If the +txn+ argument was not
+  # nil, the boolean indicates whether any errors were encountered which mean the caller should not
+  # commit the transaction. The array contains any error or warning messages as arrays of arguments
+  # (each of which can be passed directly to flash_message from a controller).
+  def add_files(files, user, path: '/', repo: nil, txn: nil)
+    messages = []
+    if repo.nil?
+      group.access_repo do |open_repo|
+        return add_files(files, user, path: path, repo: open_repo, txn: txn)
+      end
+    end
+
+    if txn.nil?
+      txn = repo.get_transaction(user.user_name)
+      commit_txn = true
+    else
+      commit_txn = false
+    end
+
+    revision = repo.get_latest_revision
+    assignment_path = Pathname.new(assignment.repository_folder)
+    current_path = assignment_path.join(path.gsub(/^\//, '')) # remove leading '/' to make relative path
+    new_files = []
+    files.each do |f|
+      if f.size > MarkusConfigurator.markus_config_max_file_size
+        messages << [:error, I18n.t('student.submission.file_too_large',
+                             file_name: f.original_filename,
+                             max_size: (MarkusConfigurator.markus_config_max_file_size / 1_000_000.00).round(2))]
+      elsif f.size == 0
+        messages << [:warning, I18n.t('student.submission.empty_file_warning', file_name: f.original_filename)]
+      end
+      filename = f.original_filename
+      if filename.nil?
+        messages << [:error, I18n.t('student.submission.invalid_file_name')]
+        return false, messages
+      end
+      subdir_path, filename = File.split(filename)
+      filename = sanitize_file_name(filename)
+      file_path = current_path.join(subdir_path).join(filename)
+      file_path_relative = file_path.relative_path_from(assignment_path).to_s
+      file_path = file_path.to_s
+      # Sometimes the file pointer of file_object is at the end of the file.
+      # In order to avoid empty uploaded files, rewind it to be safe.
+      f.rewind
+      # Branch on whether the file is new or a replacement
+      if revision.path_exists?(file_path)
+        txn.replace(file_path, f.read, f.content_type, revision.revision_identifier)
+      else
+        new_files << file_path_relative
+        txn.add(file_path, f.read, f.content_type)
+      end
+    end
+    # check if only required files are allowed for a submission
+    required_files = assignment.assignment_files.pluck(:filename)
+    if required_files.present? && assignment.only_required_files && (new_files - required_files).present?
+      messages << [:error, I18n.t('assignment.upload_file_requirement')]
+      return false, messages
+    end
+
+    if commit_txn
+      success, txn_messages = commit_transaction repo, txn
+      [success, messages + txn_messages]
+    else
+      [true, messages]
+    end
+  end
+
+  # Delete files in this group's repo. +file_revisions+ should be a Hash mapping file names to
+  # the expected revision that contains the file to be deleted. +file_revisions+ can also be an
+  # array and if so, the expected revision that contains the file will default to the most recent
+  # revision. +user+ is the user that is responsible for the repository transaction, and
+  # +path+ is the relative path from the root of the repository to prepend to each filename.
+  #
+  # If files should be added to a repo that is already open, the open repo object can be passed
+  # as the +repo+ keyword argument, otherwise the repo for this group will be used.
+  #
+  # If files should be added as part of an existent transaction, the transaction object can be
+  # passed as the +txn+ keyword argument, otherwise a new transaction will be created. If the +txn+
+  # argument is not nil, the transaction will be commited before returning, otherwise the transaction
+  # object will not be commited and so should be commited later on by the caller.
+  #
+  # Returns a tuple containing a boolean and an array. If the +txn+ argument was nil, the boolean
+  # indicates whether the transaction was completed without errors. If the +txn+ argument was not
+  # nil, the boolean indicates whether any errors were encountered which mean the caller should not
+  # commit the transaction. The array contains any error or warning messages as arrays of arguments
+  # (each of which can be passed directly to flash_message from a controller).
+  def remove_files(file_revisions, user, path: '/', repo: nil, txn: nil)
+    messages = []
+    if repo.nil?
+      group.access_repo do |open_repo|
+        return remove_files(file_revisions, user, path: path, repo: open_repo, txn: txn)
+      end
+    end
+
+    if txn.nil?
+      txn = repo.get_transaction(user.user_name)
+      commit_txn = true
+    else
+      commit_txn = false
+    end
+
+    assignment_path = Pathname.new(assignment.repository_folder)
+    current_path = assignment_path.join(path.gsub(/^\//, ''))
+
+    current_revision = repo.get_latest_revision.revision_identifier
+
+    file_revisions.each do |file_path, revision|
+      subdir_path, basename = File.split(file_path)
+      basename = sanitize_file_name(basename)
+      file_path = current_path.join(subdir_path).join(basename)
+      file_path = file_path.to_s
+      txn.remove(file_path, revision || current_revision)
+    end
+
+    if commit_txn
+      success, txn_messages = commit_transaction repo, txn
+      [success, messages + txn_messages]
+    else
+      [true, messages]
+    end
+  end
+
+  private
+
+  # Helper method that commits a transaction +txn+ in repo +repo+. Returns a boolean and an array
+  # where the boolean indicates whether the transaction was commited successfully and an array
+  # containing any error or warning messages.
+  #
+  # Does not attempt to commit the transaction if there are no jobs present to commit.
+  def commit_transaction(repo, txn)
+    if txn.has_jobs?
+      if repo.commit(txn)
+        return true, []
+      else
+        return false, [:error, partial: 'submissions/file_conflicts_list', locals: { conflicts: txn.conflicts }]
+      end
+    end
+    [false, [:warning, I18n.t('student.submission.no_action_detected')]]
   end
 end # end class Grouping

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
             get 'annotations'
             get 'group_ids_by_name'
           end
-          resources :submission_downloads, except: [:new, :edit]
+          resources :submission_files, except: [:new, :edit] do
+            collection do
+              delete 'remove_file'
+            end
+          end
           resources :feedback_files, except: [:new, :edit]
           resources :test_group_results, except: [:new, :edit] do
             resources :test_results, except: [:new, :edit]

--- a/test/functional/api/submission_downloads_controller_test.rb
+++ b/test/functional/api/submission_downloads_controller_test.rb
@@ -6,7 +6,7 @@ require 'shoulda'
 require 'base64'
 require 'stringio'
 
-class Api::SubmissionDownloadsControllerTest < ActionController::TestCase
+class Api::SubmissionFilesControllerTest < ActionController::TestCase
 
   # Testing unauthenticated requests
   context 'An unauthenticated request to submission_downloads' do


### PR DESCRIPTION
- add API route to upload a file directly to a group's repo for a given assignment
- add API route to remove a file in a group's repo for a given assignment
- move upload/delete code from the submission controller to the grouping model
- update upload/delete code to handle uploading/deleting files in subdirectories

Todo after this PR:
- update wiki to reflect new routes
- update [markus-api] project to support new routes