### PR TITLE
Implement lock for repository access

### DIFF
--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -139,10 +139,12 @@ class GitRepository < Repository::AbstractRepository
 
   # static method that should yield to a git repo and then close it
   def self.access(connect_string)
-    repo = GitRepository.open(connect_string)
-    yield repo
-  ensure
-    repo&.close
+    self.redis_exclusive_lock(connect_string, namespace: :repo_lock) do
+      repo = GitRepository.open(connect_string)
+      yield repo
+    ensure
+      repo&.close
+    end
   end
 
   # static method that deletes the git repo

--- a/app/lib/memory_repository.rb
+++ b/app/lib/memory_repository.rb
@@ -190,10 +190,12 @@ class MemoryRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Memory repository and closes it afterwards
   def self.access(connect_string)
-    repository = MemoryRepository.open(connect_string)
-    yield repository
-  ensure
-    repository&.close
+    self.redis_exclusive_lock(connect_string, namespace: :repo_lock) do
+      repository = MemoryRepository.open(connect_string)
+      yield repository
+    ensure
+      repository&.close
+    end
   end
 
   # Closes the repository.

--- a/app/lib/subversion_repository.rb
+++ b/app/lib/subversion_repository.rb
@@ -63,10 +63,12 @@ class SubversionRepository < Repository::AbstractRepository
 
   # Static method: Yields an existing Subversion repository and closes it afterwards
   def self.access(connect_string)
-    repository = SubversionRepository.open(connect_string)
-    yield repository
-  ensure
-    repository&.close
+    self.redis_exclusive_lock(connect_string, namespace: :repo_lock) do
+      repository = SubversionRepository.open(connect_string)
+      yield repository
+    ensure
+      repository&.close
+    end
   end
 
   # Static method: Deletes an existing Subversion repository


### PR DESCRIPTION
The lock is implemented in Redis so that the lock can potentially apply across all MarkUs instances, processes, and threads.  The lock is also designed to ensure that threads gain access to the resource in the order that they request access.  

See the [docstring](https://github.com/MarkUsProject/Markus/compare/master...mishaschwartz:repo-locking?expand=1#diff-4c37b9a601d7cd784f915888de88bddeR281) for the `redis_exclusive_lock` function for more info