### PR TITLE
Add test cases for downloading a list of graders in XML format

### DIFF
--- a/spec/controllers/tas_controller_spec.rb
+++ b/spec/controllers/tas_controller_spec.rb
@@ -139,5 +139,40 @@ describe TasController do
         expect(response.content_type).to eq 'text/csv'
       end
     end
+
+    #In MarkUs, users are able to download a list of graders in YML format but not XML format
+    #'Download in YML format' gives back a XML file
+    context 'xml' do
+      let(:xml_options) do
+        {
+          type: 'text/xml',
+          filename: 'ta_list.xml',
+          disposition: 'attachment'
+        }
+      end
+
+      before :each do
+        (0..4).each do
+          create(:ta)
+        end
+        @tas = Ta.order(:user_name)
+      end
+
+      it 'responds with appropriate status' do
+        get :download_ta_list, format: 'xml'
+        expect(response.status).to eq(200)
+      end
+
+      it 'sets disposition as attachment' do
+        get :download_ta_list, format: 'xml'
+        d = response.header['Content-Disposition'].split.first
+        expect(d).to eq 'attachment;'
+      end
+
+      it 'returns text/xml type' do
+        get :download_ta_list, format: 'xml'
+        expect(response.content_type).to eq 'text/xml'
+      end
+    end
   end
 end

--- a/spec/controllers/tas_controller_spec.rb
+++ b/spec/controllers/tas_controller_spec.rb
@@ -140,8 +140,8 @@ describe TasController do
       end
     end
 
-    #In MarkUs, users are able to download a list of graders in YML format but not XML format
-    #'Download in YML format' gives back a XML file
+    # In MarkUs, users are able to download a list of graders in YML format but not XML format
+    # 'Download in YML format' gives back a XML file
     context 'xml' do
       let(:xml_options) do
         {
@@ -152,7 +152,7 @@ describe TasController do
       end
 
       before :each do
-        (0..4).each do
+        4.times do
           create(:ta)
         end
         @tas = Ta.order(:user_name)


### PR DESCRIPTION
In MarkUs, `Users-->Graders`, admins are able to download a list of graders they upload in YML/XML format. However, the front end webpage shows `Download in YML format`. 