### PR TITLE
Autotest form validation

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -152,7 +152,7 @@ class AutomatedTestsController < ApplicationController
 
   def download_file
     assignment = Assignment.find(params[:assignment_id])
-    file_path = File.join(assignment.autotest_path, params[:file_name])
+    file_path = File.join(assignment.autotest_files_dir, params[:file_name])
     if File.exist?(file_path)
       send_file file_path, filename: params[:file_name]
     else

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -11,7 +11,6 @@ class AutomatedTestsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     test_specs_path = assignment.autotest_settings_file
     test_specs = params[:schema_form_data]
-    File.open(test_specs_path, 'w') { |f| f.write test_specs.to_json }
     begin
       Assignment.transaction do
         # update assignment autotest parameters
@@ -19,12 +18,12 @@ class AutomatedTestsController < ApplicationController
         # create/modify test groups based on the autotest specs
         test_group_ids = []
         test_specs['testers'].each do |tester_specs|
-          tester_specs['test_data'].each do |test_group_specs|
-            extra_data_specs = test_group_specs['extra_data']
-            next if extra_data_specs.nil?
-            test_group_name = test_group_specs['name']
+          tester_specs['test_data'].each_with_index do |test_group_specs, i|
+            test_group_specs['extra_info'] ||= {}
+            extra_data_specs = test_group_specs['extra_info']
+            test_group_name = test_group_specs['name'] || "#{tester_specs['tester_type']}: #{i}"
             test_group_id = extra_data_specs['test_group_id']
-            display_output = extra_data_specs['display_output']
+            display_output = extra_data_specs['display_output'] || TestGroup.display_outputs.keys.first
             criterion_id = nil
             criterion_type = nil
             if !extra_data_specs['criterion'].nil? && extra_data_specs['criterion'].include?('_')
@@ -50,11 +49,12 @@ class AutomatedTestsController < ApplicationController
         end
         deleted_test_groups.delete_all
         # save modified specs and send them to the autotesting server in the background
-        File.write(test_specs_path, JSON.generate(test_specs))
+        File.open(test_specs_path, 'w') { |f| f.write test_specs.to_json }
         AutotestSpecsJob.perform_later(request.protocol + request.host_with_port, assignment.id)
         flash_message(:success,
                       t('flash.actions.update.success', resource_name: Assignment.model_name.human))
       rescue StandardError => e
+        File.open(test_specs_path, 'w') { |f| f.write test_specs.to_json }
         flash_message(:error, e.message)
       end
     end

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -16,8 +16,7 @@ module AutomatedTestsHelper
           enumNames: criterion_names || []
         }
       },
-      required: %w[display_output]
-    }
+      required: %w[display_output] }
   end
 
   def fill_in_schema_data!(schema_data, files, assignment)

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -7,14 +7,17 @@ module AutomatedTestsHelper
       properties: {
         display_output: {
           type: :string,
-          enum: TestGroup.display_outputs.keys
+          enum: TestGroup.display_outputs.keys,
+          default: TestGroup.display_outputs.keys.first
         },
         criterion: {
           type: :string,
           enum: criterion_disambig || [],
           enumNames: criterion_names || []
         }
-      } }
+      },
+      required: %w[display_output]
+    }
   end
 
   def fill_in_schema_data!(schema_data, files, assignment)

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -76,7 +76,7 @@ class TestRun < ApplicationRecord
 
   def create_test_group_result_from_json(json_test_group, hooks_error_all: '')
     # create test script result
-    test_group_id = json_test_group['extra_data']['test_group_id']
+    test_group_id = json_test_group['extra_info']['test_group_id']
     time = json_test_group.fetch('time', 0)
     stderr = json_test_group['stderr']
     malformed = json_test_group['malformed']
@@ -170,7 +170,7 @@ class TestRun < ApplicationRecord
     # process results
     new_test_group_results = {}
     json_root.fetch('test_groups', []).each do |json_test_group|
-      test_group_id = json_test_group['extra_data']['test_group_id']
+      test_group_id = json_test_group['extra_info']['test_group_id']
       new_test_group_result = create_test_group_result_from_json(json_test_group, hooks_error_all: hooks_error_all)
       new_test_group_results[test_group_id] = new_test_group_result
     end

--- a/lib/tasks/autotest.rake
+++ b/lib/tasks/autotest.rake
@@ -62,7 +62,7 @@ class AutotestSetup
       tokens_per_period: 0,
       token_start_date: DateTime.now,
       token_period: 1,
-      only_required_files: true,
+      only_required_files: false,
       enable_student_tests: true,
       unlimited_tokens: true
     )


### PR DESCRIPTION
- pass schema to the autotester so that it can validate the form data
- when parsing the `extra_info`, don't assume defaults will be set
- use `extra_info` instead of `extra_data` exclusively