### PR TITLE
Allow due date extensions for individual groupings

### DIFF
--- a/app/assets/javascripts/Components/Modals/extension_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/extension_modal.jsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+
+class ExtensionModal extends React.Component {
+
+  static defaultProps = {
+    weeks: 0,
+    days: 0,
+    hours: 0,
+    note: '',
+    penalty: false,
+    updating: false
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      weeks: props.weeks,
+      days: props.days,
+      hours: props.hours,
+      note: props.note,
+      penalty: props.penalty
+    }
+  }
+
+  componentDidMount() {
+    Modal.setAppElement('body');
+  }
+
+  stateHasChanged = () => {
+    for (let s of Object.keys(this.state)) {
+      if (this.state[s] !== this.props[s]) {
+        return true
+      }
+    }
+    return false
+  };
+
+  submitForm = (event) => {
+    event.preventDefault();
+    if (this.stateHasChanged()) {
+      $.post({
+        url: Routes.create_or_update_extensions_path(),
+        data: {
+          weeks: this.state.weeks,
+          days: this.state.days,
+          hours: this.state.hours,
+          note: this.state.note,
+          penalty: this.state.penalty,
+          grouping_id: this.props.grouping_id
+        }
+      }).then(this.props.onRequestClose(true));
+    } else {
+      this.props.onRequestClose(false)
+    }
+  };
+
+  deleteExtension = (event) => {
+    event.preventDefault();
+    $.ajax({
+      type: "DELETE",
+      url: Routes.delete_by_grouping_extensions_path(),
+      data: {grouping_id: this.props.grouping_id}
+    }).then(this.props.onRequestClose(true))
+  };
+
+  handleModalInputChange = (event) => {
+    const target = event.target;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
+    const name = target.name;
+
+    this.setState({
+      [name]: value
+    });
+  };
+
+  render() {
+    return (
+      <Modal
+        className="ReactModal"
+        isOpen={this.props.isOpen}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <h2>{I18n.t("activerecord.models.extensions.one")}</h2>
+        <form onSubmit={this.submitForm}>
+          <div className={'extension-container vertical'}>
+            <div className={'extension-container'}>
+              <label>
+                <input
+                  type="number"
+                  value={this.state.weeks}
+                  max={999}
+                  min={0}
+                  name={'weeks'}
+                  onChange={this.handleModalInputChange}
+                /> {I18n.t('extensions.weeks')}
+              </label>
+              <label>
+                <input
+                  type="number"
+                  value={this.state.days}
+                  max={999}
+                  min={0}
+                  name={'days'}
+                  onChange={this.handleModalInputChange}
+                /> {I18n.t('extensions.days')}
+              </label>
+              <label>
+                <input
+                  type="number"
+                  value={this.state.hours}
+                  max={999}
+                  min={0}
+                  name={'hours'}
+                  onChange={this.handleModalInputChange}
+                /> {I18n.t('extensions.hours')}
+              </label>
+            </div>
+            <br/>
+            <div>
+              <label>
+                <input
+                  type="checkbox"
+                  value={this.state.penalty}
+                  checked={this.state.penalty}
+                  name={'penalty'}
+                  onChange={this.handleModalInputChange}
+                /> {I18n.t('extensions.apply_penalty')}
+              </label>
+            </div>
+            <div>
+              <label>
+                <textarea
+                  className={'extension-note'}
+                  placeholder={I18n.t('activerecord.attributes.extensions.note') + '...'}
+                  value={this.state.note}
+                  name={'note'}
+                  onChange={this.handleModalInputChange}
+                />
+              </label>
+            </div>
+            <div className={"extension-container"}>
+              <input type="submit" value={I18n.t("save")} />
+              <button
+                onClick={this.deleteExtension}
+                disabled={!this.props.updating}
+              >
+                {I18n.t("delete")}
+                </button>
+            </div>
+          </div>
+        </form>
+      </Modal>
+    )
+  }
+}
+
+export default ExtensionModal;

--- a/app/assets/javascripts/Components/Modals/extension_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/extension_modal.jsx
@@ -78,13 +78,13 @@ class ExtensionModal extends React.Component {
   render() {
     return (
       <Modal
-        className="ReactModal"
+        className="react-modal"
         isOpen={this.props.isOpen}
         onRequestClose={this.props.onRequestClose}
       >
         <h2>{I18n.t("activerecord.models.extensions.one")}</h2>
         <form onSubmit={this.submitForm}>
-          <div className={'extension-container vertical'}>
+          <div className={'extension-container-vertical'}>
             <div className={'extension-container'}>
               <label>
                 <input

--- a/app/assets/javascripts/Components/Modals/extension_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/extension_modal.jsx
@@ -21,7 +21,7 @@ class ExtensionModal extends React.Component {
       hours: props.hours,
       note: props.note,
       penalty: props.penalty
-    }
+    };
   }
 
   componentDidMount() {
@@ -40,17 +40,26 @@ class ExtensionModal extends React.Component {
   submitForm = (event) => {
     event.preventDefault();
     if (this.stateHasChanged()) {
-      $.post({
-        url: Routes.create_or_update_extensions_path(),
-        data: {
-          weeks: this.state.weeks,
-          days: this.state.days,
-          hours: this.state.hours,
-          note: this.state.note,
-          penalty: this.state.penalty,
-          grouping_id: this.props.grouping_id
-        }
-      }).then(this.props.onRequestClose(true));
+      let data = {
+        weeks: this.state.weeks,
+        days: this.state.days,
+        hours: this.state.hours,
+        note: this.state.note,
+        penalty: this.state.penalty,
+        grouping_id: this.props.grouping_id
+      };
+      if (!!this.props.extension_id) {
+        $.ajax({
+          type: "PUT",
+          url: Routes.extension_path(this.props.extension_id),
+          data: data
+        }).then(() => this.props.onRequestClose(true));
+      } else {
+        $.post({
+          url: Routes.extensions_path(),
+          data: data
+        }).then(() => this.props.onRequestClose(true));
+      }
     } else {
       this.props.onRequestClose(false)
     }
@@ -60,9 +69,8 @@ class ExtensionModal extends React.Component {
     event.preventDefault();
     $.ajax({
       type: "DELETE",
-      url: Routes.delete_by_grouping_extensions_path(),
-      data: {grouping_id: this.props.grouping_id}
-    }).then(this.props.onRequestClose(true))
+      url: Routes.extension_path(this.props.extension_id)
+    }).then(() => this.props.onRequestClose(true));
   };
 
   handleModalInputChange = (event) => {
@@ -147,7 +155,7 @@ class ExtensionModal extends React.Component {
                 disabled={!this.props.updating}
               >
                 {I18n.t("delete")}
-                </button>
+              </button>
             </div>
           </div>
         </form>

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -329,7 +329,16 @@ class RawGroupsTable extends React.Component {
           let extension = Object.keys(row.original.extension).map(
             (key) => {
               if (row.original.extension[key]) {
-                return I18n.t('extensions.durations.' + key, {count: row.original.extension[key]})
+                // don't build these strings dynamically or they will be missed by the i18n-tasks checkers.
+                if (key === 'weeks') {
+                  return I18n.t('extensions.durations.weeks', {count: row.original.extension[key]});
+                } else if (key === 'days') {
+                  return I18n.t('extensions.durations.days', {count: row.original.extension[key]});
+                } else if (key === 'hours') {
+                  return I18n.t('extensions.durations.hours', {count: row.original.extension[key]});
+                } else {
+                  return '';
+                }
               }
             }
           ).filter(Boolean).join(', ');

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -291,6 +291,37 @@ class RawGroupsTable extends React.Component {
       minWidth: 30,
       sortable: false
     },
+    {
+      Header: I18n.t('groups.extension'),
+      accessor: 'extension',
+      Cell: row => {
+        if (row.original.extension) {
+          let extension = Object.keys(row.original.extension).map(
+            (key) => {
+              if (row.original.extension[key]) {
+                return I18n.t('extensions.' + key, {count: row.original.extension[key]})
+              }
+            }
+          ).filter(Boolean).join(', ');
+          return <div>
+            <a href={'#'} onClick={() => {}}>
+            {extension}
+            </a>
+            <a href='#'
+               className="remove-icon"
+               onClick={() => {}}
+               title={I18n.t('delete')}
+            />
+          </div>
+        } else {
+          return <a href='#'
+                    className="add-icon"
+                    onClick={() => {}}
+                    title={I18n.t('delete')}
+          />
+        }
+      }
+    }
   ];
 
   render() {

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render} from 'react-dom';
 
 import {withSelection, CheckboxTable} from './markus_with_selection_hoc';
-import ExtensionModal from "./Modals/extension_modal";
+import ExtensionModal from './Modals/extension_modal';
 
 class GroupsManager extends React.Component {
   constructor(props) {
@@ -11,9 +11,7 @@ class GroupsManager extends React.Component {
       graders: [],
       students: [],
       show_modal: false,
-      selected_row_data: {
-        extension: {}
-      },
+      selected_extension_data: {},
       updating_extension: false,
       loading: true
     }
@@ -153,8 +151,8 @@ class GroupsManager extends React.Component {
     }).then(this.fetchData);
   };
 
-  handleShowModal = (row_data, updating) => {
-    this.setState({show_modal: true, selected_row_data: row_data, updating_extension: updating})
+  handleShowModal = (extension_data, updating) => {
+    this.setState({show_modal: true, selected_extension_data: extension_data, updating_extension: updating})
   };
 
   handleCloseModal = (updated) => {
@@ -200,14 +198,15 @@ class GroupsManager extends React.Component {
         <ExtensionModal
           isOpen={this.state.show_modal}
           onRequestClose={this.handleCloseModal}
-          weeks={this.state.selected_row_data.extension.weeks}
-          days={this.state.selected_row_data.extension.days}
-          hours={this.state.selected_row_data.extension.hours}
-          note={this.state.selected_row_data.note}
-          penalty={this.state.selected_row_data.apply_penalty}
-          grouping_id={this.state.selected_row_data._id}
+          weeks={this.state.selected_extension_data.weeks}
+          days={this.state.selected_extension_data.days}
+          hours={this.state.selected_extension_data.hours}
+          note={this.state.selected_extension_data.note}
+          penalty={this.state.selected_extension_data.apply_penalty}
+          grouping_id={this.state.selected_extension_data.grouping_id}
+          extension_id={this.state.selected_extension_data.id}
           updating={this.state.updating_extension}
-          key={this.state.selected_row_data._id} // this causes the ExtensionModal to be recreated if this value changes
+          key={this.state.selected_extension_data.id} // this causes the ExtensionModal to be recreated if this value changes
         />
       </div>
     );
@@ -325,32 +324,32 @@ class RawGroupsTable extends React.Component {
       Header: I18n.t('groups.extension'),
       accessor: 'extension',
       Cell: row => {
-        if (row.original.extension !== null && Object.entries(row.original.extension).length) {
-          let extension = Object.keys(row.original.extension).map(
-            (key) => {
-              if (row.original.extension[key]) {
-                // don't build these strings dynamically or they will be missed by the i18n-tasks checkers.
-                if (key === 'weeks') {
-                  return I18n.t('extensions.durations.weeks', {count: row.original.extension[key]});
-                } else if (key === 'days') {
-                  return I18n.t('extensions.durations.days', {count: row.original.extension[key]});
-                } else if (key === 'hours') {
-                  return I18n.t('extensions.durations.hours', {count: row.original.extension[key]});
-                } else {
-                  return '';
-                }
+        let extension = ['weeks', 'days', 'hours'].map(
+          (key) => {
+            if (row.original.extension[key]) {
+              // don't build these strings dynamically or they will be missed by the i18n-tasks checkers.
+              if (key === 'weeks') {
+                return I18n.t('extensions.durations.weeks', {count: row.original.extension[key]});
+              } else if (key === 'days') {
+                return I18n.t('extensions.durations.days', {count: row.original.extension[key]});
+              } else if (key === 'hours') {
+                return I18n.t('extensions.durations.hours', {count: row.original.extension[key]});
+              } else {
+                return '';
               }
             }
-          ).filter(Boolean).join(', ');
+          }
+        ).filter(Boolean).join(', ');
+        if (!!extension) {
           return <div>
-            <a href={'#'} onClick={() => this.props.onExtensionModal(row.original, true)}>
+            <a href={'#'} onClick={() => this.props.onExtensionModal(row.original.extension, true)}>
             {extension}
             </a>
           </div>
         } else {
           return <a href='#'
                     className="add-icon"
-                    onClick={() => this.props.onExtensionModal(row.original, false)}
+                    onClick={() => this.props.onExtensionModal(row.original.extension, false)}
                     title={I18n.t('add')}
           />
         }

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -345,6 +345,18 @@ class RawGroupsTable extends React.Component {
                     title={I18n.t('add')}
           />
         }
+      },
+      filterable: false,
+      sortMethod: (a, b) =>  {
+        a = [a.weeks || -1, a.days || -1, a.hours || -1];
+        b = [b.weeks || -1, b.days || -1, b.hours || -1];
+        if (a < b) {
+          return 1
+        } else if (b < a) {
+          return -1
+        } else {
+          return 0
+        }
       }
     }
   ];

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -155,6 +155,9 @@ class RawSubmissionTable extends React.Component {
           case 'remark':
             marking_state = I18n.t('results.state.remark_requested');
             break;
+          case 'before_due_date':
+            marking_state = I18n.t('results.state.before_due_date');
+            break;
           default:
             // should not get here
             marking_state = row.original.marking_state
@@ -176,6 +179,7 @@ class RawSubmissionTable extends React.Component {
         >
           <option value='all'>{I18n.t('all')}</option>
           <option value='not_collected'>{I18n.t('results.state.not_collected')}</option>
+          <option value='before_due_date'>{I18n.t('results.state.before_due_date')}</option>
           <option value='incomplete'>{I18n.t('results.state.in_progress')}</option>
           <option value='complete'>{I18n.t('results.state.complete')}</option>
           <option value='released'>{I18n.t('results.state.released')}</option>
@@ -213,7 +217,8 @@ class RawSubmissionTable extends React.Component {
   // Custom getTrProps function to highlight submissions that have been collected.
   getTrProps = (state, ri, ci, instance) => {
     if (ri.original.marking_state === undefined ||
-        ri.original.marking_state === 'not_collected') {
+        ri.original.marking_state === 'not_collected' ||
+      ri.original.marking_state === 'before_due_date') {
       return {ri};
     } else {
       return {ri, className: 'submission_collected'};

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -218,7 +218,7 @@ class RawSubmissionTable extends React.Component {
   getTrProps = (state, ri, ci, instance) => {
     if (ri.original.marking_state === undefined ||
         ri.original.marking_state === 'not_collected' ||
-      ri.original.marking_state === 'before_due_date') {
+        ri.original.marking_state === 'before_due_date') {
       return {ri};
     } else {
       return {ri, className: 'submission_collected'};

--- a/app/assets/stylesheets/common/_modals.scss
+++ b/app/assets/stylesheets/common/_modals.scss
@@ -1,0 +1,11 @@
+.ReactModal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border: 1px solid #ccc;
+  background: #fff;
+  overflow: auto;
+  outline: none;
+  padding: 20px;
+}

--- a/app/assets/stylesheets/common/_modals.scss
+++ b/app/assets/stylesheets/common/_modals.scss
@@ -1,6 +1,8 @@
+@import 'constants';
+
 .react-modal {
-  background: white;
-  border: 1px solid gray;
+  background: $white;
+  border: 1px solid $grey;
   left: 50%;
   outline: none;
   overflow: auto;

--- a/app/assets/stylesheets/common/_modals.scss
+++ b/app/assets/stylesheets/common/_modals.scss
@@ -1,11 +1,11 @@
-.ReactModal {
+.react-modal {
+  background: white;
+  border: 1px solid gray;
+  left: 50%;
+  outline: none;
+  overflow: auto;
+  padding: 20px;
   position: absolute;
   top: 50%;
-  left: 50%;
   transform: translate(-50%, -50%);
-  border: 1px solid #ccc;
-  background: #fff;
-  overflow: auto;
-  outline: none;
-  padding: 20px;
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -4,6 +4,8 @@
 
 @import 'common/assignment_dropdown';
 
+@import 'common/modals';
+
 .col-left {
   width: 45%;
 }
@@ -119,4 +121,20 @@
 */
 * html .ui-autocomplete {
   height: 250px;
+}
+
+.extension-container {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.extension-container.vertical {
+  flex-direction: column;
+  padding: 5px;
+  > * {
+    margin: 5px;
+  }
+}
+.extension-note {
+  width: 100%
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -33,6 +33,12 @@
   vertical-align: text-top;
 }
 
+.add-icon::after {
+  content: asset_url('icons/add.png');
+  padding-left: 5px;
+  vertical-align: text-top;
+}
+
 .rename-link {
   background: asset_url('icons/pencil.png') no-repeat;
   cursor: pointer;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -128,13 +128,17 @@
   justify-content: space-evenly;
 }
 
-.extension-container.vertical {
+.extension-container-vertical {
+  display: flex;
   flex-direction: column;
+  justify-content: space-evenly;
   padding: 5px;
+
   > * {
     margin: 5px;
   }
 }
+
 .extension-note {
-  width: 100%
+  width: 100%;
 }

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -67,15 +67,7 @@ class AssignmentsController < ApplicationController
     @grouping = @student.accepted_grouping_for(@assignment.id)
     @penalty = SubmissionRule.find_by_assignment_id(@assignment.id)
     @enum_penalty = Period.where(submission_rule_id: @penalty.id).sort
-
-    if @student.section &&
-       !@student.section.section_due_date_for(@assignment.id).nil?
-      @due_date =
-        @student.section.section_due_date_for(@assignment.id).due_date
-    end
-    if @due_date.nil?
-      @due_date = @assignment.due_date
-    end
+    @due_date = @student.due_date_for_assignment(@assignment)
     if @student.has_pending_groupings_for?(@assignment.id)
       @pending_grouping = @student.pending_groupings_for(@assignment.id)
     end
@@ -126,21 +118,13 @@ class AssignmentsController < ApplicationController
     @grouping = @student.accepted_grouping_for(@assignment.id)
     @penalty = @assignment.submission_rule
     @enum_penalty = Period.where(submission_rule_id: @penalty.id).sort
-
+    @due_date = @student.due_date_for_assignment(@assignment)
     @prs = @student.grouping_for(@assignment.parent_assignment.id)&.
         peer_reviews&.where(results: { released_to_students: true })
     if @prs.nil?
       @prs = []
     end
 
-    if @student.section &&
-        !@student.section.section_due_date_for(@assignment.id).nil?
-      @due_date =
-          @student.section.section_due_date_for(@assignment.id).due_date
-    end
-    if @due_date.nil?
-      @due_date = @assignment.due_date
-    end
     if @assignment.past_all_collection_dates?
       flash_now(:notice, t('submissions.grading_can_begin'))
     else

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -3,15 +3,21 @@ class ExtensionsController < ApplicationController
 
   def create_or_update
     time_delta = params[:weeks].to_i.weeks + params[:days].to_i.days + params[:hours].to_i.hours
-    Extension.find_or_initialize_by(grouping_id: params[:grouping_id])
-             .update_attributes(time_delta: time_delta,
-                                apply_penalty: params[:penalty],
-                                note: params[:note])
+    extension = Extension.find_or_initialize_by(grouping_id: params[:grouping_id])
+    if extension.update_attributes(time_delta: time_delta, apply_penalty: params[:penalty], note: params[:note])
+      flash_now(:success, I18n.t('extensions.create.success'))
+    else
+      flash_now(:error, I18n.t('extensions.create.error'))
+    end
     head :ok
   end
 
   def delete_by_grouping
-    Extension.find_by_grouping_id(params[:grouping_id]).destroy
+    if Extension.find_by_grouping_id(params[:grouping_id]).destroy
+      flash_now(:success, I18n.t('extensions.delete.success'))
+    else
+      flash_now(:error, I18n.t('extensions.delete.error'))
+    end
     head :ok
   end
 end

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -4,10 +4,11 @@ class ExtensionsController < ApplicationController
 
   def create
     params = extension_params
-    if Extension.create(grouping_id: params[:grouping_id],
-                        time_delta: duration_from_params,
-                        apply_penalty: params[:penalty],
-                        note: params[:note])
+    extension = Extension.new(grouping_id: params[:grouping_id],
+                              time_delta: duration_from_params,
+                              apply_penalty: params[:penalty],
+                              note: params[:note])
+    if extension.save
       flash_now(:success, I18n.t('extensions.create.success'))
     else
       flash_now(:error, I18n.t('extensions.create.error'))
@@ -30,7 +31,7 @@ class ExtensionsController < ApplicationController
   end
 
   def destroy
-    if Extension.find(params[:id])&.destroy
+    if Extension.find(params[:id])&.destroy&.destroyed?
       flash_now(:success, I18n.t('extensions.delete.success'))
     else
       flash_now(:error, I18n.t('extensions.delete.error'))

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -1,0 +1,17 @@
+class ExtensionsController < ApplicationController
+  before_action :authorize_only_for_admin
+
+  def create_or_update
+    time_delta = params[:weeks].to_i.weeks + params[:days].to_i.days + params[:hours].to_i.hours
+    Extension.find_or_initialize_by(grouping_id: params[:grouping_id])
+             .update_attributes(time_delta: time_delta,
+                                apply_penalty: params[:penalty],
+                                note: params[:note])
+    head :ok
+  end
+
+  def delete_by_grouping
+    Extension.find_by_grouping_id(params[:grouping_id]).destroy
+    head :ok
+  end
+end

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -1,6 +1,9 @@
+# Controller responsible for managing due date extensions
 class ExtensionsController < ApplicationController
   before_action :authorize_only_for_admin
 
+  # Create a new extension object for the grouping with id=+params[:grouping_id]+ or
+  # update the existing extension object for that grouping.
   def create_or_update
     time_delta = params[:weeks].to_i.weeks + params[:days].to_i.days + params[:hours].to_i.hours
     extension = Extension.find_or_initialize_by(grouping_id: params[:grouping_id])
@@ -12,6 +15,7 @@ class ExtensionsController < ApplicationController
     head :ok
   end
 
+  # Delete an extension object for the grouping with id=+params[:grouping_id]+
   def delete_by_grouping
     if Extension.find_by_grouping_id(params[:grouping_id]).destroy
       flash_now(:success, I18n.t('extensions.delete.success'))

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -2,15 +2,12 @@
 class ExtensionsController < ApplicationController
   before_action :authorize_only_for_admin
 
-  # Create a new extension object for the grouping with id=+params[:grouping_id]+ or
-  # update the existing extension object for that grouping.
-  def create_or_update
+  def create
     params = extension_params
-    extension = Extension.find_or_initialize_by(grouping_id: params[:grouping_id])
-    if extension.update_attributes(grouping_id: params[:grouping_id],
-                                   time_delta: duration_from_params,
-                                   apply_penalty: params[:penalty],
-                                   note: params[:note])
+    if Extension.create(grouping_id: params[:grouping_id],
+                        time_delta: duration_from_params,
+                        apply_penalty: params[:penalty],
+                        note: params[:note])
       flash_now(:success, I18n.t('extensions.create.success'))
     else
       flash_now(:error, I18n.t('extensions.create.error'))
@@ -18,10 +15,22 @@ class ExtensionsController < ApplicationController
     head :ok
   end
 
-  # Delete an extension object for the grouping with id=+params[:grouping_id]+
-  def delete_by_grouping
+  def update
     params = extension_params
-    if Extension.find_by_grouping_id(params[:grouping_id])&.destroy
+    extension = Extension.find(params[:id])
+    if extension&.update_attributes(grouping_id: params[:grouping_id],
+                                    time_delta: duration_from_params,
+                                    apply_penalty: params[:penalty],
+                                    note: params[:note])
+      flash_now(:success, I18n.t('extensions.create.success'))
+    else
+      flash_now(:error, I18n.t('extensions.create.error'))
+    end
+    head :ok
+  end
+
+  def destroy
+    if Extension.find(params[:id])&.destroy
       flash_now(:success, I18n.t('extensions.delete.success'))
     else
       flash_now(:error, I18n.t('extensions.delete.error'))
@@ -37,6 +46,6 @@ class ExtensionsController < ApplicationController
   end
 
   def extension_params
-    params.permit(*Extension::PARTS, :grouping_id, :penalty, :note)
+    params.permit(*Extension::PARTS, :grouping_id, :penalty, :note, :id)
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -203,11 +203,12 @@ class SubmissionsController < ApplicationController
                             .where('results.released_to_students': true)
                             .where(id: groupings)
                             .pluck(:id).to_set
+    collection_dates = assignment.all_grouping_collection_dates
     groupings.each do |grouping|
-      section = grouping.inviter.present? ? grouping.inviter.section : nil
-      collect_now = assignment.submission_rule.can_collect_now?(section)
+      collect_now = collection_dates[grouping.id] <= Time.current
       some_before_due = true unless collect_now
       next if !collect_now || some_released.include?(grouping.id)
+
       collectable << grouping
     end
     success = ''

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -38,6 +38,8 @@ class SubmissionsJob < ApplicationJob
           assignment.submission_rule.remove_deductions(grouping)
         end
 
+        options[:apply_late_penalty] ||= grouping.extension&.apply_penalty
+
         if options[:apply_late_penalty].nil? || options[:apply_late_penalty]
           new_submission = assignment.submission_rule.apply_submission_rule(
             new_submission)

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -38,8 +38,6 @@ class SubmissionsJob < ApplicationJob
           assignment.submission_rule.remove_deductions(grouping)
         end
 
-        options[:apply_late_penalty] ||= grouping.extension&.apply_penalty
-
         if options[:apply_late_penalty].nil? || options[:apply_late_penalty]
           new_submission = assignment.submission_rule.apply_submission_rule(
             new_submission)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -399,7 +399,7 @@ class Assignment < ApplicationRecord
     end
     ids = Set.new
     groupings = grouping_data.map do |data|
-      next if ids.include? data['groupings.id']  # distinct on the query doesn't seem to work
+      next if ids.include? data['groupings.id'] # distinct on the query doesn't seem to work
 
       ids << data['groupings.id']
       if data['extensions.time_delta'].nil?

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -397,7 +397,11 @@ class Assignment < ApplicationRecord
         students[data['users.user_name']][:assigned] = true
       end
     end
+    ids = Set.new
     groupings = grouping_data.map do |data|
+      next if ids.include? data['groupings.id']  # distinct on the query doesn't seem to work
+
+      ids << data['groupings.id']
       if data['extensions.time_delta'].nil?
         data['extensions.time_delta'] = {}
       else
@@ -412,7 +416,7 @@ class Assignment < ApplicationRecord
         note: data['extensions.note'] || '',
         members: members[data['groupings.id']]
       }
-    end
+    end.compact
 
     {
       students: students.values,

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -5,6 +5,23 @@ class Extension < ApplicationRecord
 
   after_create :remove_pending_memberships
 
+  PARTS = [:weeks, :days, :hours].freeze
+
+  def self.to_parts(duration)
+    parts = PARTS.zip([0] * PARTS.size).to_h
+    if duration
+      PARTS.each do |part|
+        parts[part] = duration / 1.send(part)
+        duration %= 1.send(part)
+      end
+    end
+    parts
+  end
+
+  def to_parts
+    Extension.to_parts(time_delta)
+  end
+
   private
 
   def remove_pending_memberships

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -3,6 +3,8 @@ class Extension < ApplicationRecord
 
   attribute :time_delta, :duration
 
+  validates :time_delta, numericality: { greater_than: 0 }
+
   after_create :remove_pending_memberships
 
   PARTS = [:weeks, :days, :hours].freeze

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -1,0 +1,14 @@
+class Extension < ApplicationRecord
+  belongs_to :grouping
+
+  attribute :time_delta, :time_interval
+
+  after_create :remove_pending_memberships
+
+  private
+
+  def remove_pending_memberships
+    grouping.pending_student_memberships.destroy_all
+    grouping.validate_grouping
+  end
+end

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -10,14 +10,11 @@ class Extension < ApplicationRecord
   PARTS = [:weeks, :days, :hours].freeze
 
   def self.to_parts(duration)
-    parts = PARTS.zip([0] * PARTS.size).to_h
-    if duration
-      PARTS.each do |part|
-        parts[part] = duration / 1.send(part)
-        duration %= 1.send(part)
-      end
-    end
-    parts
+    PARTS.map do |part|
+      amt = (duration / 1.send(part)).to_i
+      duration -= amt.send(part)
+      [part, amt]
+    end.to_h
   end
 
   def to_parts

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -1,7 +1,7 @@
 class Extension < ApplicationRecord
   belongs_to :grouping
 
-  attribute :time_delta, :time_interval
+  attribute :time_delta, :duration
 
   after_create :remove_pending_memberships
 

--- a/app/models/grace_period_submission_rule.rb
+++ b/app/models/grace_period_submission_rule.rb
@@ -6,10 +6,8 @@ class GracePeriodSubmissionRule < SubmissionRule
 
     # We need to know how many grace credits this grouping has left...
     grace_credits_remaining = grouping.available_grace_credits
-    # We need to know the section, in case there is a section due date
-    section = grouping.inviter.section
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.zone.now, section)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now, grouping)
     grace_credits_to_use = calculate_deduction_amount(overtime_hours)
     if grace_credits_remaining < grace_credits_to_use
       # This grouping doesn't have enough grace credits.
@@ -34,14 +32,15 @@ class GracePeriodSubmissionRule < SubmissionRule
 
     # So we're overtime.  How far are we overtime?
     collection_time = submission.revision_timestamp
+    grouping = submission.grouping
 
-    overtime_hours = calculate_overtime_hours_from(collection_time, section)
+    overtime_hours = calculate_overtime_hours_from(collection_time, grouping)
     # Now we need to figure out how many Grace Credits to deduct
     deduction_amount = calculate_deduction_amount(overtime_hours)
 
     #Get rid of any previous deductions for this assignment, so as not to
     #give duplicate deductions upon multiple calls to this method
-    remove_deductions(submission.grouping)
+    remove_deductions(grouping)
 
     # And how many grace credits are available to this grouping
     available_grace_credits = submission.grouping.available_grace_credits

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -535,6 +535,8 @@ class Grouping < ApplicationRecord
     end
   end
 
+  # Return the due date for this grouping. If this grouping has an extension, the time_delta
+  # of the extension is added to the due date.
   def due_date
     if inviter.blank? || inviter.section.blank? || assignment.section_due_dates.blank?
       assignment_due_date = assignment.due_date

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -294,7 +294,7 @@ class Grouping < ApplicationRecord
   def can_invite?(user)
     if self.inviter == user
       raise I18n.t('groups.invite_member.errors.inviting_self')
-    elsif extension&.time_delta.present?
+    elsif !extension.nil?
       raise I18n.t('groups.invite_member.errors.extension_exists')
     elsif self.student_membership_number >= self.assignment.group_max
       raise I18n.t('groups.invite_member.errors.group_max_reached', user_name: user.user_name)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -19,7 +19,7 @@ class Grouping < ApplicationRecord
            class_name: 'StudentMembership'
 
   has_many :pending_student_memberships,
-           -> { where 'memberships.membership_status': StudentMembership::STATUSES[:pending]},
+           -> { where 'memberships.membership_status': StudentMembership::STATUSES[:pending] },
            class_name: 'StudentMembership'
 
   has_many :notes, as: :noteable, dependent: :destroy
@@ -569,7 +569,6 @@ class Grouping < ApplicationRecord
   def past_collection_date?
     collection_date > Time.current
   end
-
 
   def self.get_groupings_for_assignment(assignment, user)
     if user.ta?

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -847,4 +847,13 @@ class Grouping < ApplicationRecord
       true
     end
   end
+
+  private
+
+  def use_section_due_date?
+    assignment.section_due_dates_type &&
+      inviter.present? &&
+      inviter.section.present? &&
+      assignment.section_due_dates.present?
+  end
 end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -538,10 +538,10 @@ class Grouping < ApplicationRecord
   # Return the due date for this grouping. If this grouping has an extension, the time_delta
   # of the extension is added to the due date.
   def due_date
-    if inviter.blank? || inviter.section.blank? || assignment.section_due_dates.blank?
-      assignment_due_date = assignment.due_date
-    else
+    if use_section_due_date?
       assignment_due_date = assignment.section_due_dates.find_by(section_id: inviter.section.id).due_date
+    else
+      assignment_due_date = assignment.due_date
     end
     return assignment_due_date + extension.time_delta if extension.present?
 

--- a/app/models/penalty_decay_period_submission_rule.rb
+++ b/app/models/penalty_decay_period_submission_rule.rb
@@ -3,10 +3,8 @@ class PenaltyDecayPeriodSubmissionRule < SubmissionRule
   # This message will be dislayed to Students on viewing their file manager
   # after the due date has passed, but before the calculated collection date.
   def overtime_message(grouping)
-    # We need to know the section, in case there is a section due date
-    section = grouping.inviter.section
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.zone.now, section)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now, grouping)
     # Calculate the penalty that the grouping will suffer
     potential_penalty = calculate_penalty(overtime_hours)
 
@@ -14,12 +12,10 @@ class PenaltyDecayPeriodSubmissionRule < SubmissionRule
   end
 
   def apply_submission_rule(submission)
-    # We need to know the section, in case there is a section due date
-    section = submission.grouping.inviter.section
     # Calculate the appropriate penalty, and attach the ExtraMark to the
     # submission Result
     result = submission.get_original_result
-    overtime_hours = calculate_overtime_hours_from(submission.revision_timestamp, section)
+    overtime_hours = calculate_overtime_hours_from(submission.revision_timestamp, submission.grouping)
     penalty_amount = calculate_penalty(overtime_hours)
     if penalty_amount > 0
       penalty = ExtraMark.new

--- a/app/models/penalty_period_submission_rule.rb
+++ b/app/models/penalty_period_submission_rule.rb
@@ -3,10 +3,8 @@ class PenaltyPeriodSubmissionRule < SubmissionRule
   # This message will be dislayed to Students on viewing their file manager
   # after the due date has passed, but before the calculated collection date.
   def overtime_message(grouping)
-    # We need to know the section, in case there is a section due date
-    section = grouping.inviter.section
     # How far are we into overtime?
-    overtime_hours = calculate_overtime_hours_from(Time.zone.now, section)
+    overtime_hours = calculate_overtime_hours_from(Time.zone.now, grouping)
     # Calculate the penalty that the grouping will suffer
     potential_penalty = calculate_penalty(overtime_hours)
 
@@ -20,12 +18,10 @@ class PenaltyPeriodSubmissionRule < SubmissionRule
   end
 
   def apply_submission_rule(submission)
-    # We need to know the section, in case there is a section due date
-    section = submission.grouping.inviter.section
     # Calculate the appropriate penalty, and attach the ExtraMark to the
     # submission Result
     result = submission.get_original_result
-    overtime_hours = calculate_overtime_hours_from(submission.revision_timestamp, section)
+    overtime_hours = calculate_overtime_hours_from(submission.revision_timestamp, submission.grouping)
     penalty_amount = calculate_penalty(overtime_hours)
     if penalty_amount > 0
       penalty = ExtraMark.new

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -242,4 +242,13 @@ class Student < User
     end
   end
 
+  # Return the due date for this student for +assignment+.
+  # +assignment+ can be either an Assignment object or an id.
+  def due_date_for_assignment(assignment)
+    grouping = accepted_grouping_for(assignment)
+    grouping&.due_date ||
+      section&.section_due_date_for(assignment)&.due_date ||
+      assignment&.due_date ||
+      Assignment.find(assignment).due_date
+  end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -242,13 +242,12 @@ class Student < User
     end
   end
 
-  # Return the due date for this student for +assignment+.
-  # +assignment+ can be either an Assignment object or an id.
-  def due_date_for_assignment(assignment)
+  # Return the due date for this student for assignment with id +assignment_id+.
+  def due_date_for_assignment(assignment_id)
+    assignment = Assignment.find(assignment_id)
     grouping = accepted_grouping_for(assignment)
     grouping&.due_date ||
       section&.section_due_date_for(assignment)&.due_date ||
-      assignment&.due_date ||
-      Assignment.find(assignment).due_date
+      assignment&.due_date
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -189,7 +189,7 @@ class Submission < ApplicationRecord
       f.user = user
       f.filename = file.original_filename
       f.submitted_at = submission_time
-      f.submission_file_status = 'late' if assignment.due_date < submission_time
+      f.submission_file_status = 'late' if grouping.due_date < submission_time
     end
 
     # upload file contents to file system

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -84,8 +84,8 @@ class SubmissionRule < ApplicationRecord
   private
 
   # Over time hours could be a fraction. This is mostly used for testing
-  def calculate_overtime_hours_from(from_time, section)
-    overtime_hours = (from_time - assignment.section_due_date(section)) / 1.hour
+  def calculate_overtime_hours_from(from_time, grouping)
+    overtime_hours = (from_time - grouping.due_date) / 1.hour
     # If the overtime is less than 0, that means it was submitted early, so
     # just return 0 - otherwise, return overtime_hours.
     [0, overtime_hours].max

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -52,7 +52,11 @@ class SubmissionRule < ApplicationRecord
   end
 
   def calculate_grouping_collection_time(grouping)
-    grouping.due_date + hours_sum.hours
+    if grouping.extension.nil? || grouping.extension.apply_penalty
+      grouping.due_date + hours_sum.hours
+    else
+      grouping.due_date
+    end
   end
 
   # When we're past the due date, the File Manager for the students will display

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -52,12 +52,7 @@ class SubmissionRule < ApplicationRecord
   end
 
   def calculate_grouping_collection_time(grouping)
-    if !grouping.inviter.nil? && grouping.inviter.section
-      SectionDueDate.due_date_for(grouping.inviter.section,
-                                         assignment)
-    else
-      assignment.due_date + hours_sum.hours
-    end
+    grouping.due_date + hours_sum.hours
   end
 
   # When we're past the due date, the File Manager for the students will display

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -27,7 +27,7 @@ class AssignmentPolicy < ApplicationPolicy
   end
 
   def create_group?
-    check?(:due_date_passed?) &&
+    check?(:collection_date_passed?) &&
       check?(:students_form_groups?) &&
       check?(:not_yet_in_group?)
   end
@@ -37,7 +37,7 @@ class AssignmentPolicy < ApplicationPolicy
     record.group_min == 1
   end
 
-  def due_date_passed?
+  def collection_date_passed?
     !record.past_collection_date?(user.section)
   end
 

--- a/app/policies/grouping_policy.rb
+++ b/app/policies/grouping_policy.rb
@@ -21,7 +21,7 @@ class GroupingPolicy < ApplicationPolicy
   # Policies for group invitations.
   def invite_member?
     allowed_to?(:students_form_groups?) &&
-      !record.extension.exists? &&
+      allowed_to?(:no_extension?) &&
       allowed_to?(:before_due_date?)
   end
 
@@ -47,5 +47,9 @@ class GroupingPolicy < ApplicationPolicy
 
   def no_submission?
     !record.has_submission?
+  end
+
+  def no_extension?
+    !record.extension.exists?
   end
 end

--- a/app/policies/grouping_policy.rb
+++ b/app/policies/grouping_policy.rb
@@ -21,7 +21,8 @@ class GroupingPolicy < ApplicationPolicy
   # Policies for group invitations.
   def invite_member?
     allowed_to?(:students_form_groups?) &&
-    allowed_to?(:before_due_date?)
+      !record.extension.exists? &&
+      allowed_to?(:before_due_date?)
   end
 
   def students_form_groups?

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -38,14 +38,14 @@
               <% remaining_credits -= 1 %>
             <% end %>
           <% end %>
-          <%= I18n.l(@assignment.due_date + acc.hours) %>
+          <%= I18n.l(@grouping.due_date + acc.hours) %>
         <% end %>
       <% else %>
         <span class='prop_label'>
           <%= t('penalty_period_submission_rules.deadline_html') %>
         </span>
         <% @enum_penalty.each { |p| acc += p.hours } %>
-        <%= I18n.l(@assignment.due_date + acc.hours) %>
+        <%= I18n.l(@grouping.due_date + acc.hours) %>
       <% end %>
     </div>
 

--- a/app/views/assignments/student_interface.html.erb
+++ b/app/views/assignments/student_interface.html.erb
@@ -189,7 +189,8 @@
             <% # Student not reached the group max and is not working alone
                if @grouping.inviter == @current_user &&
                   @assignment.student_form_groups &&
-                  !@assignment.past_collection_date?(@student.section) %>
+                  !@assignment.past_collection_date?(@student.section) &&
+                  !@grouping.extension.exists?%>
               <% # Student has reached the group max and is not working alone
                  if @grouping.student_membership_number < @assignment.group_max &&
                          @group.group_name != @current_user.user_name %>
@@ -209,7 +210,8 @@
                   !@assignment.past_collection_date?(@student.section) &&
                   !@grouping.has_submission? %>
               <% if @grouping.inviter == @current_user &&
-                    @grouping.accepted_students.size == 1 %>
+                    @grouping.accepted_students.size == 1 &&
+                    !@grouping.extension.exists? %>
                 <div class='group-button'>
                   <%= button_to t('helpers.submit.delete', model: Group.model_name.human),
                                 assignment_group_path(@assignment.id),

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,3 +1,5 @@
+# ActiveRecord type that records a time duration. It should store a string
+# type to the database that is a valid iso8601 string.
 class DurationType < ActiveRecord::Type::String
   def cast(value)
     return value if value.blank? || value.is_a?(ActiveSupport::Duration)
@@ -11,6 +13,8 @@ class DurationType < ActiveRecord::Type::String
 
   private
 
+  # Convert weeks into days for a Duration object since iso8601 strings do not allow
+  # weeks and days to be specified together.
   # TODO: remove this after https://github.com/rails/rails/pull/34683 is pulled in
   def remove_weeks(duration)
     days_per_week = 7
@@ -21,6 +25,10 @@ class DurationType < ActiveRecord::Type::String
     end
   end
 
+  # Convert a Duration object into another Duration object with the same total duration
+  # but with parts with the smallest total values possible.
+  #
+  # For example: converts a duration with parts: {days: 10} to one with parts: {weeks: 1, days: 3}
   # TODO: remove this after https://github.com/rails/rails/pull/34683 is pulled in
   def normalize_duration(duration)
     ActiveSupport::Duration.build(duration)

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,5 +1,4 @@
 class DurationType < ActiveRecord::Type::String
-
   def cast(value)
     return value if value.blank? || value.is_a?(ActiveSupport::Duration)
 

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,6 +1,13 @@
-class TimeIntervalType < ActiveRecord::Type::UnsignedInteger
-  def deserialize(value)
-    ActiveSupport::Duration.build(value)
+class DurationType < ActiveRecord::Type::String
+  def cast(value)
+    return value if value.blank? || value.is_a?(ActiveSupport::Duration)
+
+    ActiveSupport::Duration.parse(value)
+  end
+
+  def serialize(duration)
+    duration ? duration.iso8601 : nil
   end
 end
-ActiveRecord::Type.register(:time_interval, TimeIntervalType)
+
+ActiveRecord::Type.register(:duration, DurationType)

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,12 +1,30 @@
 class DurationType < ActiveRecord::Type::String
+
   def cast(value)
     return value if value.blank? || value.is_a?(ActiveSupport::Duration)
 
-    ActiveSupport::Duration.parse(value)
+    normalize_duration(ActiveSupport::Duration.parse(value))
   end
 
   def serialize(duration)
-    duration ? duration.iso8601 : nil
+    duration ? remove_weeks(duration).iso8601 : nil
+  end
+
+  private
+
+  # TODO: remove this after https://github.com/rails/rails/pull/34683 is pulled in
+  def remove_weeks(duration)
+    days_per_week = 7
+    if duration.parts[:weeks] > 0
+      duration - duration.parts[:weeks].weeks + (duration.parts[:weeks] * days_per_week).days
+    else
+      duration
+    end
+  end
+
+  # TODO: remove this after https://github.com/rails/rails/pull/34683 is pulled in
+  def normalize_duration(duration)
+    ActiveSupport::Duration.build(duration)
   end
 end
 

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,0 +1,6 @@
+class TimeIntervalType < ActiveRecord::Type::UnsignedInteger
+  def deserialize(value)
+    ActiveSupport::Duration.build(value)
+  end
+end
+ActiveRecord::Type.register(:time_interval, TimeIntervalType)

--- a/config/locales/common/en.yml
+++ b/config/locales/common/en.yml
@@ -1,5 +1,6 @@
 en:
   actions: "Actions"
+  add: "Add"
   all: "All"
   apply: "Apply"
   cancel: "Cancel"

--- a/config/locales/common/es.yml
+++ b/config/locales/common/es.yml
@@ -1,5 +1,6 @@
 es:
   actions: "Acciones"
+  add: "Añadir"
   all: "Todos"
   apply: "Aplicar"
   cancel: "Cancelar"

--- a/config/locales/common/fr.yml
+++ b/config/locales/common/fr.yml
@@ -1,5 +1,6 @@
 fr:
   actions: "Actes"
+  add: "Ajouter"
   all: "Tous"
   apply: "Appliquer"
   cancel: "Annuler"

--- a/config/locales/common/pt.yml
+++ b/config/locales/common/pt.yml
@@ -1,5 +1,6 @@
 pt:
   actions: "Ações"
+  add: "Adicionar"
   all: "Todos"
   apply: "Aplicar"
   cancel: "Cancelar"

--- a/config/locales/models/extensions/en.yml
+++ b/config/locales/models/extensions/en.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    models:
+      extensions:
+        one: "Extension"
+    attributes:
+      extensions:
+        note: "Note"

--- a/config/locales/models/extensions/es.yml
+++ b/config/locales/models/extensions/es.yml
@@ -1,0 +1,8 @@
+es:
+  activerecord:
+    models:
+      extensions:
+        one: "Extensión"
+    attributes:
+      extensions:
+        note: "Nota"

--- a/config/locales/models/extensions/fr.yml
+++ b/config/locales/models/extensions/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  activerecord:
+    models:
+      extensions:
+        one: "Extension"
+    attributes:
+      extensions:
+        note: "Commentaire"

--- a/config/locales/models/extensions/pt.yml
+++ b/config/locales/models/extensions/pt.yml
@@ -1,0 +1,8 @@
+pt:
+  activerecord:
+    models:
+      extensions:
+        one: "Extensão"
+    attributes:
+      extensions:
+        note: "Nota"

--- a/config/locales/policies/en.yml
+++ b/config/locales/policies/en.yml
@@ -4,7 +4,7 @@ en:
       assignment:
         autogenerate_group_name?: "This assignment does automatically generate group names."
         before_due_date?: "You cannot run tests because the due date for this assignment has passed."
-        due_date_passed?: "Could not create group: the due date for this assignment has passed."
+        collection_date_passed?: "Could not create group: the due date for this assignment has passed."
         enabled?: "You cannot run tests because they are not enabled for this assignment."
         not_a_ta?: "You cannot run tests because graders are not allowed to."
         not_yet_in_group?: "You already have a group, and cannot create another."
@@ -17,6 +17,7 @@ en:
         deletable_by?: "You are not allowed to delete the group."
         delete_rejected?: "Only the inviter can delete a declined invitation."
         member?: "You cannot run tests because you do not have a group yet, or your group is not valid."
+        no_extension?: "This group has an extension. You cannot update the group membership."
         no_submission?: "You already submitted something. You cannot delete your group."
         not_in_progress?: "You cannot run tests because you or your group have a test already enqueued for execution, please wait for the results."
         tokens_available?: "You cannot run tests because you or your group do not have tokens available."

--- a/config/locales/policies/es.yml
+++ b/config/locales/policies/es.yml
@@ -3,7 +3,7 @@ es:
     policy:
       assignment:
         before_due_date?: "Usted no puede lanzar las prueba debido a que el último plazo de entrega para este proyecto ha pasado."
-        due_date_passed?: "No se pudo crear el grupo: el último plazo para este proyecto ha pasado."
+        collection_date_passed?: "No se pudo crear el grupo: el último plazo para este proyecto ha pasado."
         enabled?: "UPDATE ME."
         not_a_ta?: "UPDATE ME."
         not_yet_in_group?: "Usted ya tiene un grupo, y no puede crear otro."
@@ -16,6 +16,7 @@ es:
         deletable_by?: "Usted no tiene permiso para eliminar el grupo."
         delete_rejected?: "Sólo el invitador puede declinar una invitación."
         member?: "UPDATE ME."
+        no_extension?: "UPDATE ME."
         no_submission?: "Usted ya ha enviado su entrega. Usted no puede eliminar el grupo."
         not_in_progress?: "UPDATE ME."
         tokens_available?: "No se encontraron fichas para este estudiante y para este proyecto."

--- a/config/locales/policies/fr.yml
+++ b/config/locales/policies/fr.yml
@@ -3,7 +3,7 @@ fr:
     policy:
       assignment:
         before_due_date?: "La date d'échéance est déjà pasée."
-        due_date_passed?: "Impossible de créer le groupe: la date de retour pour ce projet est passée et il n'y a pas de temps supplémentaire alloué ou le temps supplémentaire alloué est terminé."
+        collection_date_passed?: "Impossible de créer le groupe: la date de retour pour ce projet est passée et il n'y a pas de temps supplémentaire alloué ou le temps supplémentaire alloué est terminé."
         enabled?: "Les tests ne sont pas activés pour ce projet."
         not_a_ta?: "Les correcteurs ne sont pas autorisés à éxecuter des tests."
         not_yet_in_group?: "Vous avez déjà un groupe, vous ne pouvez pas en créer d'autres."
@@ -16,6 +16,7 @@ fr:
         deletable_by?: "Vous ne pouvez pas supprimer ce groupe."
         delete_rejected?: "Seul(e) celui (celle) qui a invité un(e) autre étudiant(e) peut supprimer une invitation déclinée."
         member?: "Votre groupe n'éxiste pas, où il n'est pas valide."
+        no_extension?: "Vous ne pouvez pas modifier un groupe avec une extension à la date d'échéance."
         no_submission?: "Vous avez déjà envoyé un fichier. Vous ne pouvez pas supprimer votre groupe."
         not_in_progress?: "Il y a déjà un test mis en file d'attente, attendez les résultats s'il vous plait."
         tokens_available?: "Aucun jeton trouvé pour cet(te) étudiant(e) où pour ce projet."

--- a/config/locales/policies/pt.yml
+++ b/config/locales/policies/pt.yml
@@ -3,7 +3,7 @@ pt:
     policy:
       assignment:
         before_due_date?: "Você não pode executar o teste pois a sua entrega está fora do prazo."
-        due_date_passed?: "Não foi possível criar grupo: a data de entrega para este projeto já passou e ou não há períodos de carência permitidos, ou o período de tolerância para este projeto já terminou."
+        collection_date_passed?: "Não foi possível criar grupo: a data de entrega para este projeto já passou e ou não há períodos de carência permitidos, ou o período de tolerância para este projeto já terminou."
         enabled?: "UPDATE ME."
         not_a_ta?: "UPDATE ME."
         not_yet_in_group?: "Você já tem um grupo, e não pode criar outro"
@@ -16,6 +16,7 @@ pt:
         deletable_by?: "Você não tem permissão para deletar este grupo."
         delete_rejected?: "Apenas o anfitrião pode excluir um convite recusado."
         member?: "UPDATE ME."
+        no_extension?: "UPDATE ME."
         no_submission?: "Você já enviou algo. Não pode deletar seu grupo."
         not_in_progress?: "UPDATE ME."
         tokens_available?: "Nenhum token foi encontrado para esse estudante e para esse projeto."

--- a/config/locales/views/extensions/en.yml
+++ b/config/locales/views/extensions/en.yml
@@ -4,6 +4,12 @@ en:
     days: days
     weeks: weeks
     apply_penalty: "Apply late submission policies when collecting this group's submissions"
+    create:
+      success: "Extension added"
+      error: "Failed to create extension"
+    delete:
+      success: "Extension removed"
+      error: "Failed to remove extension"
     durations:
       hours:
         one: 1 hour

--- a/config/locales/views/extensions/en.yml
+++ b/config/locales/views/extensions/en.yml
@@ -3,7 +3,7 @@ en:
     hours: hours
     days: days
     weeks: weeks
-    apply_penalty: "Apply late submission policies when collecting this group's submissions"
+    apply_penalty: "Apply late submission policy when collecting this group's submissions"
     create:
       success: "Extension added"
       error: "Failed to create extension"

--- a/config/locales/views/extensions/en.yml
+++ b/config/locales/views/extensions/en.yml
@@ -1,11 +1,16 @@
 en:
   extensions:
-    hours:
-      one: 1 hour
-      other: "%{count} hours"
-    days:
-      one: 1 day
-      other: "%{count} days"
-    weeks:
-      one: 1 week
-      other: "%{count} weeks"
+    hours: hours
+    days: days
+    weeks: weeks
+    apply_penalty: "Apply late submission policies when collecting this group's submissions"
+    durations:
+      hours:
+        one: 1 hour
+        other: "%{count} hours"
+      days:
+        one: 1 day
+        other: "%{count} days"
+      weeks:
+        one: 1 week
+        other: "%{count} weeks"

--- a/config/locales/views/extensions/en.yml
+++ b/config/locales/views/extensions/en.yml
@@ -1,0 +1,11 @@
+en:
+  extensions:
+    hours:
+      one: 1 hour
+      other: "%{count} hours"
+    days:
+      one: 1 day
+      other: "%{count} days"
+    weeks:
+      one: 1 week
+      other: "%{count} weeks"

--- a/config/locales/views/extensions/es.yml
+++ b/config/locales/views/extensions/es.yml
@@ -4,6 +4,12 @@ es:
     days: días
     weeks: semanas
     apply_penalty: "UPDATE ME"
+    create:
+      success: "UPDATE ME"
+      error: "UPDATE ME"
+    delete:
+      success: "UPDATE ME"
+      error: "UPDATE ME"
     durations:
       hours:
         one: 1 hora

--- a/config/locales/views/extensions/es.yml
+++ b/config/locales/views/extensions/es.yml
@@ -1,11 +1,16 @@
 es:
   extensions:
-    hours:
-      one: 1 hora
-      other: "%{count} horas"
-    days:
-      one: 1 día
-      other: "%{count} días"
-    weeks:
-      one: 1 semana
-      other: "%{count} semanas"
+    hours: horas
+    days: días
+    weeks: semanas
+    apply_penalty: "UPDATE ME"
+    durations:
+      hours:
+        one: 1 hora
+        other: "%{count} horas"
+      days:
+        one: 1 día
+        other: "%{count} días"
+      weeks:
+        one: 1 semana
+        other: "%{count} semanas"

--- a/config/locales/views/extensions/es.yml
+++ b/config/locales/views/extensions/es.yml
@@ -1,0 +1,11 @@
+es:
+  extensions:
+    hours:
+      one: 1 hora
+      other: "%{count} horas"
+    days:
+      one: 1 día
+      other: "%{count} días"
+    weeks:
+      one: 1 semana
+      other: "%{count} semanas"

--- a/config/locales/views/extensions/fr.yml
+++ b/config/locales/views/extensions/fr.yml
@@ -4,6 +4,12 @@ fr:
     days: jours
     weeks: semaines
     apply_penalty: "UPDATE ME"
+    create:
+      success: "Extension créée"
+      error: "Extension non créée"
+    delete:
+      success: "Extension supprimée"
+      error: "Extension non supprimée"
     durations:
       hours:
         one: 1 heur

--- a/config/locales/views/extensions/fr.yml
+++ b/config/locales/views/extensions/fr.yml
@@ -1,11 +1,16 @@
 fr:
   extensions:
-    hours:
-      one: 1 heur
-      other: "%{count} heurs"
-    days:
-      one: 1 jour
-      other: "%{count} days"
-    weeks:
-      one: 1 semaine
-      other: "%{count} semaines"
+    hours: heurs
+    days: jours
+    weeks: semaines
+    apply_penalty: "UPDATE ME"
+    durations:
+      hours:
+        one: 1 heur
+        other: "%{count} heurs"
+      days:
+        one: 1 jour
+        other: "%{count} days"
+      weeks:
+        one: 1 semaine
+        other: "%{count} semaines"

--- a/config/locales/views/extensions/fr.yml
+++ b/config/locales/views/extensions/fr.yml
@@ -1,0 +1,11 @@
+fr:
+  extensions:
+    hours:
+      one: 1 heur
+      other: "%{count} heurs"
+    days:
+      one: 1 jour
+      other: "%{count} days"
+    weeks:
+      one: 1 semaine
+      other: "%{count} semaines"

--- a/config/locales/views/extensions/pt.yml
+++ b/config/locales/views/extensions/pt.yml
@@ -4,6 +4,12 @@ pt:
     days: dias
     weeks: semanas
     apply_penalty: "UPDATE ME"
+    create:
+      success: "UPDATE ME"
+      error: "UPDATE ME"
+    delete:
+      success: "UPDATE ME"
+      error: "UPDATE ME"
     durations:
       hours:
         one: 1 hora

--- a/config/locales/views/extensions/pt.yml
+++ b/config/locales/views/extensions/pt.yml
@@ -1,11 +1,16 @@
 pt:
   extensions:
-    hours:
-      one: 1 hora
-      other: "%{count} horas"
-    days:
-      one: 1 dia
-      other: "%{count} dias"
-    weeks:
-      one: 1 semana
-      other: "%{count} semanas"
+    hours: horas
+    days: dias
+    weeks: semanas
+    apply_penalty: "UPDATE ME"
+    durations:
+      hours:
+        one: 1 hora
+        other: "%{count} horas"
+      days:
+        one: 1 dia
+        other: "%{count} dias"
+      weeks:
+        one: 1 semana
+        other: "%{count} semanas"

--- a/config/locales/views/extensions/pt.yml
+++ b/config/locales/views/extensions/pt.yml
@@ -1,0 +1,11 @@
+pt:
+  extensions:
+    hours:
+      one: 1 hora
+      other: "%{count} horas"
+    days:
+      one: 1 dia
+      other: "%{count} dias"
+    weeks:
+      one: 1 semana
+      other: "%{count} semanas"

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -82,4 +82,5 @@ en:
         need_to_create_group: "You must create a group before you can invite members."
         not_found: "No student '%{user_name}' could be found."
         not_same_section: "Could not invite %{user_name}: this student is not in your section."
+        extension_exists: "You cannot modify a group with an extension to the due date. Please contact your instructor if you wish to make changes."
       success: "Invitation(s) successful."

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -25,6 +25,7 @@ en:
     select_a_group: "Select a group"
     select_a_student: "Select a student"
     select_only_one_group: "You may only assign each student to one group."
+    extension: "Due Date Extension"
 
     # Student interface
     student_interface:

--- a/config/locales/views/groups/es.yml
+++ b/config/locales/views/groups/es.yml
@@ -32,6 +32,7 @@ es:
     unassigned_students: "No asignados"
     validate_confirm: "Esto le permitirá a este grupo realizar el envío sin el número requerido de
                       estudiantes. ¿Está seguro/a de hacer esto?"
+    extension: "UPDATE ME"
 
     # Student interface
     student_interface:

--- a/config/locales/views/groups/es.yml
+++ b/config/locales/views/groups/es.yml
@@ -90,4 +90,5 @@ es:
         need_to_create_group: "Usted debe crear un grupo antes poder invitar usuarios."
         not_found: "No se pudo invitar %{user_name}: este estudiante no existe."
         not_same_section: "El estudiante %{user_name} no está en su sección."
+        extension_exists: "UPDATE ME"
       success: "Las invitaciones han sido exitosas."

--- a/config/locales/views/groups/fr.yml
+++ b/config/locales/views/groups/fr.yml
@@ -80,4 +80,5 @@ fr:
         need_to_create_group: "Vous devez créer un groupe avant de pouvoir inviter des étudiants."
         not_found: "%{user_name} ne peut pas être invité(e) : cet(te) étudiant(e) n'existe pas."
         not_same_section: "L'étudiant(e) %{user_name} n'est pas dans votre section."
+        extension_exists: "Vous ne pouvez pas éditer un groupe avec une extension à la date d'échéance. Veuillez contacter votre instructeur si vous souhaitez apporter des modifications."
       success: "L'étudiant(e) a été invité(e)."

--- a/config/locales/views/groups/fr.yml
+++ b/config/locales/views/groups/fr.yml
@@ -22,6 +22,7 @@ fr:
     select_only_one_group: "Vous ne pouvez assigner un(e) étudiant(e) qu'à un seul groupe."
     unassigned_students: "Non assigné(s)"
     validate_confirm: "Ceci autorisera ce groupe à poster sans avoir le nombre requis d'étudiants. Est-ce correct ?"
+    extension: "Extension de la date d'échéance"
 
     # Student interface
     student_interface:

--- a/config/locales/views/groups/pt.yml
+++ b/config/locales/views/groups/pt.yml
@@ -23,6 +23,7 @@ pt:
     unassigned_students: "Não-atribuíd"
     validate_confirm: "Isso permitirá que o grupo envie sem o número exigido de alunos. Você tem certeza disso?"
     valid: "Válido?"
+    extension: "UPDATE ME"
 
     # Student interface
     student_interface:

--- a/config/locales/views/groups/pt.yml
+++ b/config/locales/views/groups/pt.yml
@@ -80,4 +80,5 @@ pt:
         need_to_create_group: "Você deve criar um grupo antes de poder convidar usuários"
         not_found: "Não foi possível convidar %{user_name}: esse estudante não existe."
         not_same_section: "Aluno %{user_name} está fora de sua sessão."
+        extension_exists: "UPDATE ME"
       success: "Convites enviados com sucesso."

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -21,11 +21,11 @@ en:
     state:
       complete: "Complete"
       incomplete: "Incomplete"
-      released: "released"
       not_collected: "Not Collected"
       in_progress: "In Progress"
       released: "Released"
       remark_requested: "Remark Requested"
+      before_due_date: "Before Due Date"
     subtotal: "Subtotal"
     summary: "Summary"
     total_extra_marks: "Total Extra Marks"

--- a/config/locales/views/results/es.yml
+++ b/config/locales/views/results/es.yml
@@ -26,6 +26,7 @@ es:
       not_collected: "No ha sido recolectado"
       released: "Publicado"
       remark_requested: "Recalificación solicitada"
+      before_due_date: "UPDATE ME"
     subtotal: "Subtotal"
     summary: "Resumen"
     total_extra_marks: "Notas Adicionales Totales"

--- a/config/locales/views/results/fr.yml
+++ b/config/locales/views/results/fr.yml
@@ -22,6 +22,7 @@ fr:
       complete: "Terminé"
       released: "Affiché"
       remark_requested: "Réévaluation demandée"
+      before_due_date: "Avant la date d'échéance"
     subtotal: "Sous-total"
     summary: "Récapitulatif"
     total_extra_marks: "Total Notes Supplémentaires"

--- a/config/locales/views/results/pt.yml
+++ b/config/locales/views/results/pt.yml
@@ -22,6 +22,7 @@ pt:
       not_collected: "Não coletado"
       released: "Liberado"
       remark_requested: "Pedido de revisão"
+      before_due_date: "UPDATE ME"
     subtotal: "Subtotal"
     summary: "Resumo"
     total_extra_marks: "Nota extra total"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,12 +401,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :extensions do
-      collection do
-        post 'create_or_update'
-        delete 'delete_by_grouping'
-      end
-    end
+    resources :extensions
   end
 
   resources :job_messages, only: %w(show), param: :job_id do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,13 @@ Rails.application.routes.draw do
         post 'fetch_testers'
       end
     end
+
+    resources :extensions do
+      collection do
+        post 'create_or_update'
+        delete 'delete_by_grouping'
+      end
+    end
   end
 
   resources :job_messages, only: %w(show), param: :job_id do

--- a/db/migrate/20190508132638_create_extensions.rb
+++ b/db/migrate/20190508132638_create_extensions.rb
@@ -1,0 +1,12 @@
+class CreateExtensions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :extensions do |t|
+      t.integer :time_delta, null: false
+      t.boolean :apply_penalty, null: false, default: false
+      t.references :grouping, index: { unique: true }, foreign_key: true
+      t.string :note
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20190508132638_create_extensions.rb
+++ b/db/migrate/20190508132638_create_extensions.rb
@@ -3,7 +3,7 @@ class CreateExtensions < ActiveRecord::Migration[5.2]
     create_table :extensions do |t|
       t.string :time_delta, null: false
       t.boolean :apply_penalty, null: false, default: false
-      t.references :grouping, index: { unique: true }, foreign_key: true
+      t.references :grouping, index: { unique: true }, foreign_key: true, null: false
       t.string :note
 
       t.timestamps null: false

--- a/db/migrate/20190508132638_create_extensions.rb
+++ b/db/migrate/20190508132638_create_extensions.rb
@@ -1,7 +1,7 @@
 class CreateExtensions < ActiveRecord::Migration[5.2]
   def change
     create_table :extensions do |t|
-      t.integer :time_delta, null: false
+      t.string :time_delta, null: false
       t.boolean :apply_penalty, null: false, default: false
       t.references :grouping, index: { unique: true }, foreign_key: true
       t.string :note

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_155205) do
+ActiveRecord::Schema.define(version: 2019_05_08_132638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,16 @@ ActiveRecord::Schema.define(version: 2019_04_23_155205) do
     t.decimal "crop_width"
     t.decimal "crop_height"
     t.index ["assignment_id"], name: "index_exam_templates_on_assignment_id"
+  end
+
+  create_table "extensions", force: :cascade do |t|
+    t.integer "time_delta", null: false
+    t.boolean "apply_penalty", default: false, null: false
+    t.bigint "grouping_id"
+    t.string "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grouping_id"], name: "index_extensions_on_grouping_id", unique: true
   end
 
   create_table "extra_marks", id: :serial, force: :cascade do |t|
@@ -591,6 +601,7 @@ ActiveRecord::Schema.define(version: 2019_04_23_155205) do
   add_foreign_key "checkbox_criteria", "assignments"
   add_foreign_key "criteria_assignment_files_joins", "assignment_files"
   add_foreign_key "exam_templates", "assignments"
+  add_foreign_key "extensions", "groupings"
   add_foreign_key "extra_marks", "results", name: "fk_extra_marks_results", on_delete: :cascade
   add_foreign_key "feedback_files", "submissions"
   add_foreign_key "groupings", "assignments", name: "fk_groupings_assignments"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -172,7 +172,7 @@ ActiveRecord::Schema.define(version: 2019_05_08_132638) do
   create_table "extensions", force: :cascade do |t|
     t.string "time_delta", null: false
     t.boolean "apply_penalty", default: false, null: false
-    t.bigint "grouping_id"
+    t.bigint "grouping_id", null: false
     t.string "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2019_05_08_132638) do
   end
 
   create_table "extensions", force: :cascade do |t|
-    t.integer "time_delta", null: false
+    t.string "time_delta", null: false
     t.boolean "apply_penalty", default: false, null: false
     t.bigint "grouping_id"
     t.string "note"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^16.8.6",
     "react-jsonschema-form": "^1.5.0",
     "react-keyed-file-browser": "^1.5.0",
+    "react-modal": "^3.8.1",
     "react-table": "^6.9.2",
     "react-tabs": "^3.0.0"
   },

--- a/spec/controllers/extensions_controller_spec.rb
+++ b/spec/controllers/extensions_controller_spec.rb
@@ -1,90 +1,110 @@
-shared_examples 'set attributes and flash' do
-  it 'should flash a message on success' do
-    expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
-    post_as admin, :create_or_update, params: params
-  end
-  it 'should flash a message on error' do
-    expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
-    params[:grouping_id] = nil
-    post_as admin, :create_or_update, params: params
-  end
-  describe 'it should update the attibute:' do
-    before :each do
-      post_as admin, :create_or_update, params: params
-      extension.reload
-    end
-    it 'time_delta' do
-      expected_duration = Extension::PARTS.map { |part| params[part].to_i.send(part) }.sum
-      expect(extension.time_delta).to eq(expected_duration)
-    end
-    it 'note' do
-      expect(extension.note).to eq(params[:note])
-    end
-    it 'apply_penalty' do
-      expect(extension.apply_penalty).to eq(params[:penalty])
-    end
-  end
-end
-
 describe ExtensionsController do
   describe 'as an admin' do
     let(:admin) { create :admin }
     let(:grouping) { create :grouping }
-    describe '#create_or_update' do
-      context 'and extension exists' do
-        let(:extension) { create :extension, grouping: grouping }
-        let(:params) do
-          parts = extension.to_parts
-          {
-            grouping_id: grouping.id,
-            weeks: parts[:weeks] + 1,
-            days: parts[:days] + 1,
-            hours: parts[:hours] + 1,
-            note: 'something',
-            penalty: true
-          }
-        end
-        it 'should not create a new extension' do
-          extension # make sure the object is created before the call
-          expect { post_as admin, :create_or_update, params: params }.to_not change { Extension.count }
-        end
-        include_examples 'set attributes and flash'
+    describe '#update' do
+      let(:extension) { create :extension, grouping: grouping }
+      let(:params) do
+        parts = extension.to_parts
+        {
+          id: extension.id,
+          grouping_id: grouping.id,
+          weeks: parts[:weeks] + 1,
+          days: parts[:days] + 1,
+          hours: parts[:hours] + 1,
+          note: 'something',
+          penalty: true
+        }
       end
-      context 'and extension does not exist' do
-        let(:extension) { Extension.find_by_grouping_id(grouping.id) }
-        let(:params) do
-          {
-            grouping_id: grouping.id,
-            weeks: rand(1..10),
-            days: rand(1..10),
-            hours: rand(1..10),
-            note: 'something',
-            penalty: true
-          }
+      it 'should not create a new extension' do
+        extension # make sure the object is created before the call
+        expect { put_as admin, :update, params: params }.to_not change { Extension.count }
+      end
+      it 'should flash a message on success' do
+        expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
+        put_as admin, :update, params: params
+      end
+      it 'should flash a message on error' do
+        expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
+        params[:grouping_id] = nil
+        put_as admin, :update, params: params
+      end
+      describe 'it should update the attibute:' do
+        before :each do
+          put_as admin, :update, params: params
+          extension.reload
         end
-        it 'should create a new extension' do
-          expect { post_as admin, :create_or_update, params: params }.to change { Extension.count }.by(1)
+        it 'time_delta' do
+          expected_duration = Extension::PARTS.map { |part| params[part].to_i.send(part) }.sum
+          expect(extension.time_delta).to eq(expected_duration)
         end
-        include_examples 'set attributes and flash'
+        it 'note' do
+          expect(extension.note).to eq(params[:note])
+        end
+        it 'apply_penalty' do
+          expect(extension.apply_penalty).to eq(params[:penalty])
+        end
       end
     end
-    describe '#delete_by_grouping' do
+    describe '#create' do
+      let(:extension) { Extension.find_by_grouping_id(grouping.id) }
+      let(:params) do
+        {
+          grouping_id: grouping.id,
+          weeks: rand(1..10),
+          days: rand(1..10),
+          hours: rand(1..10),
+          note: 'something',
+          penalty: true
+        }
+      end
+      it 'should create a new extension' do
+        expect { post_as admin, :create, params: params }.to change { Extension.count }.by(1)
+      end
+      it 'should flash a message on success' do
+        expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
+        post_as admin, :create, params: params
+      end
+      it 'should flash a message on error' do
+        expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
+        params[:grouping_id] = nil
+        post_as admin, :create, params: params
+      end
+      describe 'it should update the attibute:' do
+        before :each do
+          post_as admin, :create, params: params
+          extension.reload
+        end
+        it 'time_delta' do
+          expected_duration = Extension::PARTS.map { |part| params[part].to_i.send(part) }.sum
+          expect(extension.time_delta).to eq(expected_duration)
+        end
+        it 'note' do
+          expect(extension.note).to eq(params[:note])
+        end
+        it 'apply_penalty' do
+          expect(extension.apply_penalty).to eq(params[:penalty])
+        end
+      end
+    end
+    describe '#destroy' do
       context 'and the extension exists' do
         let(:extension) { create :extension, grouping: grouping }
         it 'should delete the extension' do
           extension # make sure the object is created before the call
           expect do
-            post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
+            delete_as admin, :destroy, params: { id: extension.id }
           end.to change { Extension.count }.by(-1)
         end
         it 'should flash an success on success' do
           extension # make sure the object is created before the call
           expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
-          post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
+          delete_as admin, :destroy, params: { id: extension.id }
         end
         it 'should flash an error on error' do
           expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
-          post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
+          allow_any_instance_of(Extension).to receive(:destroyed?).and_return(false)
+          delete_as admin, :destroy, params: { id: extension.id }
         end
       end
     end

--- a/spec/controllers/extensions_controller_spec.rb
+++ b/spec/controllers/extensions_controller_spec.rb
@@ -1,0 +1,92 @@
+shared_examples 'set attributes and flash' do
+  it 'should flash a message on success' do
+    expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
+    post_as admin, :create_or_update, params: params
+  end
+  it 'should flash a message on error' do
+    expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
+    params[:grouping_id] = nil
+    post_as admin, :create_or_update, params: params
+  end
+  describe 'it should update the attibute:' do
+    before :each do
+      post_as admin, :create_or_update, params: params
+      extension.reload
+    end
+    it 'time_delta' do
+      expected_duration = Extension::PARTS.map { |part| params[part].to_i.send(part) }.sum
+      expect(extension.time_delta).to eq(expected_duration)
+    end
+    it 'note' do
+      expect(extension.note).to eq(params[:note])
+    end
+    it 'apply_penalty' do
+      expect(extension.apply_penalty).to eq(params[:penalty])
+    end
+  end
+end
+
+describe ExtensionsController do
+  describe 'as an admin' do
+    let(:admin) { create :admin }
+    let(:grouping) { create :grouping }
+    describe '#create_or_update' do
+      context 'and extension exists' do
+        let(:extension) { create :extension, grouping: grouping }
+        let(:params) do
+          parts = extension.to_parts
+          {
+            grouping_id: grouping.id,
+            weeks: parts[:weeks] + 1,
+            days: parts[:days] + 1,
+            hours: parts[:hours] + 1,
+            note: 'something',
+            penalty: true
+          }
+        end
+        it 'should not create a new extension' do
+          extension # make sure the object is created before the call
+          expect { post_as admin, :create_or_update, params: params }.to_not change { Extension.count }
+        end
+        include_examples 'set attributes and flash'
+      end
+      context 'and extension does not exist' do
+        let(:extension) { Extension.find_by_grouping_id(grouping.id) }
+        let(:params) do
+          {
+            grouping_id: grouping.id,
+            weeks: rand(1..10),
+            days: rand(1..10),
+            hours: rand(1..10),
+            note: 'something',
+            penalty: true
+          }
+        end
+        it 'should create a new extension' do
+          expect { post_as admin, :create_or_update, params: params }.to change { Extension.count }.by(1)
+        end
+        include_examples 'set attributes and flash'
+      end
+    end
+    describe '#delete_by_grouping' do
+      context 'and the extension exists' do
+        let(:extension) { create :extension, grouping: grouping }
+        it 'should delete the extension' do
+          extension # make sure the object is created before the call
+          expect do
+            post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+          end.to change { Extension.count }.by(-1)
+        end
+        it 'should flash an success on success' do
+          extension # make sure the object is created before the call
+          expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
+          post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+        end
+        it 'should flash an error on error' do
+          expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
+          post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/extensions_controller_spec.rb
+++ b/spec/controllers/extensions_controller_spec.rb
@@ -74,17 +74,17 @@ describe ExtensionsController do
         it 'should delete the extension' do
           extension # make sure the object is created before the call
           expect do
-            post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+            post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
           end.to change { Extension.count }.by(-1)
         end
         it 'should flash an success on success' do
           extension # make sure the object is created before the call
           expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:success, anything)
-          post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+          post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
         end
         it 'should flash an error on error' do
           expect_any_instance_of(ExtensionsController).to receive(:flash_now).with(:error, anything)
-          post_as admin, :delete_by_grouping, params: {grouping_id: grouping.id}
+          post_as admin, :delete_by_grouping, params: { grouping_id: grouping.id }
         end
       end
     end

--- a/spec/factories/extensions.rb
+++ b/spec/factories/extensions.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :extension do
+    association :grouping
+    time_delta { rand(1..10).weeks + rand(1..10).days + rand(1..10).hours }
+  end
+end

--- a/spec/factories/section_due_date.rb
+++ b/spec/factories/section_due_date.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
 
   factory :section_due_date do
-    assignment
-    section
+    association :assignment
+    association :section
     due_date { 1.minute.from_now }
   end
 

--- a/spec/factories/student_memberships.rb
+++ b/spec/factories/student_memberships.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :student_membership, class: StudentMembership, parent: :membership do
     association :user, factory: :student
-    grouping
+    association :grouping
     membership_status {StudentMembership::STATUSES[:pending]}
 
     factory :inviter_student_membership do

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :student, class: Student, parent: :user do
     grace_credits { 5 }
-    section
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1109,7 +1109,6 @@ describe Assignment do
         end
 
         it 'returns false' do
-          pending 'pending discussion on intended functionality'
           expect(@assignment.past_all_due_dates?).to be false
         end
       end
@@ -1159,9 +1158,10 @@ describe Assignment do
 
       context 'when a grouping is specified' do
         it 'returns based on due date of the assignment' do
-          grouping = create(:grouping)
-          expect(@due_assignment.grouping_past_due_date?(grouping)).to be true
-          expect(@not_due_assignment.grouping_past_due_date?(grouping))
+          due_grouping = create(:grouping, assignment: @due_assignment)
+          not_due_grouping = create(:grouping, assignment: @not_due_assignment)
+          expect(@due_assignment.grouping_past_due_date?(due_grouping)).to be true
+          expect(@not_due_assignment.grouping_past_due_date?(not_due_grouping))
             .to be false
         end
       end
@@ -1174,7 +1174,6 @@ describe Assignment do
 
       context 'when no grouping is specified' do
         it 'returns based on due date of the assignment' do
-          pending 'waiting on resolution for pending past_due_date example'
           @assignment.update_attributes(due_date: 1.days.ago)
           expect(@assignment.grouping_past_due_date?(nil)).to be true
           @assignment.update_attributes(due_date: 1.days.from_now)

--- a/spec/models/extension_spec.rb
+++ b/spec/models/extension_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Extension, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/extension_spec.rb
+++ b/spec/models/extension_spec.rb
@@ -1,5 +1,43 @@
-require 'rails_helper'
-
-RSpec.describe Extension, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Extension do
+  let(:grouping) { create :grouping }
+  let(:extension) { create :extension, grouping: grouping }
+  it { is_expected.to belong_to(:grouping) }
+  describe 'check validations' do
+    it 'should not be valid with a negative time_delta' do
+      extension = Extension.new(grouping_id: grouping, time_delta: -1.day)
+      expect(extension.valid?).to be(false)
+    end
+    it 'should be valid with a positive time_delta' do
+      extension = Extension.new(grouping: grouping, time_delta: 1.day)
+      expect(extension.valid?).to be(true)
+    end
+  end
+  describe 'check callbacks' do
+    it 'should remove pending memberships on creation' do
+      create :student_membership, grouping: grouping
+      expect { extension }.to change { Membership.count }.by(-1)
+    end
+  end
+  describe '#to_parts' do
+    it 'should return the time_delta attribute calculated as PARTS' do
+      time_delta = extension.time_delta
+      parts = extension.to_parts
+      duration_from_parts = Extension::PARTS.map { |part| parts[part].to_i.send(part) }.sum
+      expect(time_delta).to eq(duration_from_parts)
+    end
+    it 'should return only the parts in PARTS' do
+      expect(extension.to_parts.keys).to contain_exactly(*Extension::PARTS)
+    end
+  end
+  describe '.to_parts' do
+    let(:duration) { Extension::PARTS.map { |part| rand(1..10).send(part) }.sum }
+    it 'should return the duration calculated as PARTS' do
+      parts = Extension.to_parts duration
+      duration_from_parts = Extension::PARTS.map { |part| parts[part].to_i.send(part) }.sum
+      expect(duration).to eq(duration_from_parts)
+    end
+    it 'should return only the parts in PARTS' do
+      expect(Extension.to_parts(duration).keys).to contain_exactly(*Extension::PARTS)
+    end
+  end
 end

--- a/spec/models/grace_period_submission_rule_spec.rb
+++ b/spec/models/grace_period_submission_rule_spec.rb
@@ -40,18 +40,6 @@ describe GracePeriodSubmissionRule do
       destroy_repos
     end
 
-    describe '#calculate_collection_time' do
-      it 'is before the current time' do
-        expect(Time.now).to be > @rule.calculate_collection_time
-      end
-    end
-
-    describe '#calculate_grouping_collection_time' do
-      it 'is equal to the assignment due date' do
-        expect(@rule.calculate_grouping_collection_time(@membership.grouping).to_a).to eq @assignment.due_date.to_a
-      end
-    end
-
     describe '#apply_submission_rule' do
       before :each do
         # The Student submits their files before the due date

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -952,7 +952,6 @@ describe Grouping do
     let(:assignment) { create :assignment }
     let(:grouping) { create :grouping_with_inviter, assignment: assignment }
     context 'with an assignment due date' do
-
       it 'should return the assigment due date' do
         expect(grouping.due_date).to be_within(1.second).of(assignment.due_date)
       end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -948,6 +948,72 @@ describe Grouping do
     end
   end
 
+  describe '#due_date' do
+    let(:assignment) { create :assignment }
+    let(:grouping) { create :grouping_with_inviter, assignment: assignment }
+    context 'with an assignment due date' do
+
+      it 'should return the assigment due date' do
+        expect(grouping.due_date).to eq(assignment.due_date)
+      end
+
+      context 'and a grouping extension' do
+        let(:extension) { create :extension, grouping: grouping }
+
+        it 'should return the assignment due date plus the extension' do
+          expected_due_date = assignment.due_date + extension.time_delta
+          expect(grouping.due_date).to eq(expected_due_date)
+        end
+      end
+
+      context 'and a section due date' do
+        let(:section) { create :section }
+        let(:section_due_date) { create :section_due_date, assignment: assignment, section: section }
+
+        before :each do
+          grouping.inviter.update_attributes!(section: section)
+        end
+
+        context 'and section_due_dates_type is false' do
+          before :each do
+            assignment.update_attributes!(section_due_dates_type: false)
+          end
+
+          it 'should return the assignment due date' do
+            expect(grouping.due_date).to eq(assignment.due_date)
+          end
+
+          context 'and a grouping extension' do
+            let(:extension) { create :extension, grouping: grouping }
+
+            it 'should return the assignment due date plus the extension' do
+              expected_due_date = assignment.due_date + extension.time_delta
+              expect(grouping.due_date).to eq(expected_due_date)
+            end
+          end
+        end
+        context 'and section_due_dates_type is true' do
+          before :each do
+            assignment.update_attributes!(section_due_dates_type: true)
+          end
+
+          it 'should return the section due date' do
+            expected_due_date = section_due_date.due_date
+            expect(grouping.due_date).to eq(expected_due_date)
+          end
+
+          context 'and a grouping extension' do
+            let(:extension) { create :extension, grouping: grouping }
+
+            it 'should return the section due date plus the extension' do
+              expected_due_date = section_due_date.due_date + extension.time_delta
+              expect(grouping.due_date).to eq(expected_due_date)
+            end
+          end
+        end
+      end
+    end
+  end
   describe '#past_due_date?' do
     context 'with an assignment' do
       before :each do

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -954,7 +954,7 @@ describe Grouping do
     context 'with an assignment due date' do
 
       it 'should return the assigment due date' do
-        expect(grouping.due_date).to eq(assignment.due_date)
+        expect(grouping.due_date).to be_within(1.second).of(assignment.due_date)
       end
 
       context 'and a grouping extension' do
@@ -962,7 +962,7 @@ describe Grouping do
 
         it 'should return the assignment due date plus the extension' do
           expected_due_date = assignment.due_date + extension.time_delta
-          expect(grouping.due_date).to eq(expected_due_date)
+          expect(grouping.due_date).to be_within(1.second).of(expected_due_date)
         end
       end
 
@@ -980,7 +980,7 @@ describe Grouping do
           end
 
           it 'should return the assignment due date' do
-            expect(grouping.due_date).to eq(assignment.due_date)
+            expect(grouping.due_date).to be_within(1.second).of(assignment.due_date)
           end
 
           context 'and a grouping extension' do
@@ -988,7 +988,7 @@ describe Grouping do
 
             it 'should return the assignment due date plus the extension' do
               expected_due_date = assignment.due_date + extension.time_delta
-              expect(grouping.due_date).to eq(expected_due_date)
+              expect(grouping.due_date).to be_within(1.second).of(expected_due_date)
             end
           end
         end
@@ -999,7 +999,7 @@ describe Grouping do
 
           it 'should return the section due date' do
             expected_due_date = section_due_date.due_date
-            expect(grouping.due_date).to eq(expected_due_date)
+            expect(grouping.due_date).to be_within(1.second).of(expected_due_date)
           end
 
           context 'and a grouping extension' do
@@ -1007,7 +1007,7 @@ describe Grouping do
 
             it 'should return the section due date plus the extension' do
               expected_due_date = section_due_date.due_date + extension.time_delta
-              expect(grouping.due_date).to eq(expected_due_date)
+              expect(grouping.due_date).to be_within(1.second).of(expected_due_date)
             end
           end
         end

--- a/spec/models/penalty_decay_period_submission_rule_spec.rb
+++ b/spec/models/penalty_decay_period_submission_rule_spec.rb
@@ -41,7 +41,8 @@ describe PenaltyDecayPeriodSubmissionRule do
 
     it 'be able to calculate collection time for a grouping' do
       expect(Time.now).to be < @assignment.due_date
-      expect(@assignment.due_date.to_a).to eq @rule.calculate_grouping_collection_time(@membership.grouping).to_a
+      due_date_plus_period = @assignment.due_date + 2.days
+      expect(due_date_plus_period.to_a).to eq @rule.calculate_grouping_collection_time(@membership.grouping).to_a
     end
 
     it 'not apply decay period deductions for on-time submissions' do

--- a/spec/models/submission_rule_spec.rb
+++ b/spec/models/submission_rule_spec.rb
@@ -36,27 +36,28 @@ shared_examples 'due_date_calculations' do |assignment_past, section_past, secti
 
   context '#get_collection_time(section)' do
     it "should return #{section_due_date_str}" do
-      expect(assignment.submission_rule.get_collection_time(section)).to eq(section_due_date_due_date)
+      due_date = section_due_date_due_date
+      expect(assignment.submission_rule.get_collection_time(section)).to be_within(1.second).of(due_date)
     end
   end
 
   context '#get_collection_time(nil) (i.e. global due date)' do
     it "should return #{assignment_due_date_str}" do
-      expect(assignment.submission_rule.get_collection_time).to eq(assignment_due_date)
+      expect(assignment.submission_rule.get_collection_time).to be_within(1.second).of(assignment_due_date)
     end
   end
 
   context '#calculate_grouping_collection_time(grouping) with section' do
     it "should return #{section_due_date_str}" do
       time = assignment.submission_rule.calculate_grouping_collection_time(grouping_with_section)
-      expect(time).to eq(section_due_date_due_date)
+      expect(time).to be_within(1.second).of(section_due_date_due_date)
     end
   end
 
   context '#calculate_grouping_collection_time(grouping) w/o section' do
     it "should return #{assignment_due_date_str}" do
       time = assignment.submission_rule.calculate_grouping_collection_time(grouping_without_section)
-      expect(time).to eq(assignment_due_date)
+      expect(time).to be_within(1.second).of(assignment_due_date)
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,6 +2801,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -6144,6 +6149,21 @@ react-keyed-file-browser@^1.5.0:
     react-dnd "^2.1.4"
     react-dnd-html5-backend "^2.1.2"
 
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-modal@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.8.1.tgz#7300f94a6f92a2e17994de0be6ccb61734464c9e"
+  integrity sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
+
 react-table@^6.9.2:
   version "6.9.2"
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.9.2.tgz#6a59adfeb8d5deced288241ed1c7847035b5ec5f"
@@ -7432,6 +7452,13 @@ vm-browserify@0.0.4:
   integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"


### PR DESCRIPTION
Allows instructors to give an individual grouping an extension. This affects the collection time calculation and the submission rule/penalty calculation. However it does not affect the remark request time which stays the same for everyone in the given assignment regardless of their extension. 

If an extension is in place for a grouping, only the instructor may modify that grouping's membership. This means that if there are any pending invitations when an extension is created, those pending invitations are deleted. 

On the submissions table you can now filter uncollected submissions based on whether the due date has passed for the given grouping. 

On the groups table you can now add, update or remove and extension. You can also indicate whether any submission rules/penalties should apply for this grouping and add an optional note. 

This PR also introduces a modal component using react-modal.

#### TODO:
- [x] update rspec tests
- [x] add docstrings to new classes and methods
- [x] flash messages on un/successful creation/update/deletion of an extension
- [x] add ability to filter on and/or sort by extension on the groups table

Closes #3713 and closes #1926