### PR TITLE
File viewer and autotest bugfixes

### DIFF
--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -13,7 +13,9 @@ class SubmissionFileManager extends React.Component {
   }
 
   static defaultProps = {
-    fetchOnMount: true
+    fetchOnMount: true,
+    readOnly: false,
+    revision_identifier: undefined
   };
 
   componentDidMount() {
@@ -117,12 +119,6 @@ class SubmissionFileManager extends React.Component {
     );
   }
 }
-
-SubmissionFileManager.defaultProps = {
-  readOnly: false,
-  revision_identifier: undefined
-};
-
 
 export function makeSubmissionFileManager(elem, props) {
   render(<SubmissionFileManager {...props} />, elem);

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -29,6 +29,9 @@ class AutomatedTestsController < ApplicationController
     unless File.exist? @assignment.autotest_path
       FileUtils.mkdir_p @assignment.autotest_path
     end
+    unless File.exist? @assignment.autotest_files_dir
+      FileUtils.mkdir_p @assignment.autotest_files_dir
+    end
     @assignment.test_groups.build
   end
 

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -31,6 +31,8 @@ module AutomatedTestsHelper
     # create/modify test groups based on the autotest specs
     test_group_ids = []
     test_specs['testers'].each do |tester_specs|
+      next if tester_specs['test_data'].nil?
+
       tester_specs['test_data'].each_with_index do |test_group_specs, i|
         test_group_specs['extra_info'] ||= {}
         extra_data_specs = test_group_specs['extra_info']


### PR DESCRIPTION
- put default props in one place only so that the `fetchOnMount` prop is true by default 
- create the `autotest_files_dir ` subdirectory when uploading autotest files for the first time
- handle the case where we may be updating the test framework without updating the test specs (eg. if we set "enable tests" to true without making any other changes)