### PR TITLE
Unify code to download multiple files

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -458,7 +458,6 @@ class SubmissionsController < ApplicationController
     ## a currently downloading file
     short_id = assignment.short_identifier
     zip_name = Pathname.new(short_id + '_' + current_user.user_name + '.zip')
-    ## check if there is a '/' in the file name to replace by '_'
     zip_path = Pathname.new('tmp') + zip_name
 
     ## delete the old file if it exists
@@ -469,7 +468,7 @@ class SubmissionsController < ApplicationController
     Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
       groupings.each do |grouping|
         revision_id = grouping.current_submission_used&.revision_identifier
-        group_name = grouping.group.group_name
+        group_name = grouping.group.repo_name
         grouping.group.access_repo do |repo|
           revision = repo.get_revision(revision_id)
           repo.send_tree_to_zip(assignment.repository_folder, zip_file, zip_name + group_name, revision)

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -319,6 +319,25 @@ module Repository
     end
 
     private_class_method :__update_permissions
+
+    # Given a subdirectory path, and an already created zip_file, fill the subdirectory
+    # within the zip_file with all of its files.
+    #
+    # If a block is passed to this function, The block will receive a Repository::RevisionFile
+    # object as a parameter.
+    # The result of the block will be written to the zip file instead of the file content.
+    #
+    # This can be used to modify the file content before it is written to the zip file.
+    def send_tree_to_zip(subdirectory_path, zip_file, zip_name, revision, &block)
+      revision.tree_at_path(subdirectory_path, with_attrs: false).each do |path, obj|
+        if obj.is_a? Repository::RevisionFile
+          file_contents = block_given? ? block.call(obj) : download_as_string(obj)
+          zip_file.get_output_stream(File.join(zip_name, path)) do |f|
+            f.puts file_contents
+          end
+        end
+      end
+    end
   end
 
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -510,15 +510,14 @@ describe SubmissionsController do
       it 'should be able to download all groups\' submissions' do
         get_as @admin, :download_groupings_files, params: { assignment_id: @assignment.id }
         is_expected.to respond_with(:success)
-        zip_path = "tmp/#{@assignment.short_identifier}_" +
-                   "#{@admin.user_name}.zip"
+        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@admin.user_name}.zip")
+        zip_path = Pathname.new('tmp') + zip_subpath
         Zip::File.open(zip_path) do |zip_file|
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              File.join(
-                "#{instance_variable_get(:"@grouping#{i}").group.repo_name}/",
-                "file#{i}"))
+              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
+            p instance_variable_get(:"@file#{i}_path")
             expect(zip_file.find_entry(
                      instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(
@@ -530,15 +529,13 @@ describe SubmissionsController do
         @ta = create(:ta)
         get_as @ta, :download_groupings_files, params: { assignment_id: @assignment.id }
         is_expected.to respond_with(:success)
-        zip_path = "tmp/#{@assignment.short_identifier}_" +
-                   "#{@ta.user_name}.zip"
+        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@ta.user_name}.zip")
+        zip_path = Pathname.new('tmp') + zip_subpath
         Zip::File.open(zip_path) do |zip_file|
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              File.join(
-                "#{instance_variable_get(:"@grouping#{i}").group.repo_name}/",
-                "file#{i}"))
+              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
             expect(zip_file.find_entry(
                      instance_variable_get(:"@file#{i}_path"))).to be_nil
           end
@@ -551,15 +548,13 @@ describe SubmissionsController do
         end
         get_as @ta, :download_groupings_files, params: { assignment_id: @assignment.id }
         is_expected.to respond_with(:success)
-        zip_path = "tmp/#{@assignment.short_identifier}_" +
-          "#{@ta.user_name}.zip"
+        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@ta.user_name}.zip")
+        zip_path = Pathname.new('tmp') + zip_subpath
         Zip::File.open(zip_path) do |zip_file|
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              File.join(
-                "#{instance_variable_get(:"@grouping#{i}").group.repo_name}/",
-                "file#{i}"))
+              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
             expect(zip_file.find_entry(
               instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(


### PR DESCRIPTION
- creates a single function that sends all files in a tree to a zip file (uses existing methods for iterating over a directory tree)
- fixes bug where files in subdirectories were not downloaded properly.