### PR TITLE
Manage subdirectories in submissions file manager

### DIFF
--- a/app/assets/javascripts/Components/Modals/extension_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/extension_modal.jsx
@@ -92,8 +92,8 @@ class ExtensionModal extends React.Component {
       >
         <h2>{I18n.t("activerecord.models.extensions.one")}</h2>
         <form onSubmit={this.submitForm}>
-          <div className={'extension-container-vertical'}>
-            <div className={'extension-container'}>
+          <div className={'modal-container-vertical'}>
+            <div className={'modal-container'}>
               <label>
                 <input
                   type="number"
@@ -148,7 +148,7 @@ class ExtensionModal extends React.Component {
                 />
               </label>
             </div>
-            <div className={"extension-container"}>
+            <div className={"modal-container"}>
               <input type="submit" value={I18n.t("save")} />
               <button
                 onClick={this.deleteExtension}

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+class SubmissionFileUploadModal extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newfiles: []
+    }
+  }
+
+  componentDidMount() {
+    Modal.setAppElement('body');
+  }
+
+  onSubmit = (event) => {
+    event.preventDefault();
+    this.props.onSubmit(this.state.newfiles);
+  };
+
+  handleFileUpload = (event) => {
+    this.setState({newfiles: event.target.files})
+  };
+
+  render() {
+    return (
+      <Modal
+        className="react-modal"
+        isOpen={this.props.isOpen}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <h2>{I18n.t('add_new')}</h2>
+        <form onSubmit={this.onSubmit}>
+          <div className={'modal-container-vertical'}>
+            <div className={'modal-container'}>
+              <input type={'file'} name={'newfiles'} multiple={true} onChange={this.handleFileUpload}/>
+            </div>
+            <div className={'modal-container'}>
+              <input type='submit' value={I18n.t('save')} />
+            </div>
+          </div>
+        </form>
+      </Modal>
+    )
+  }
+}
+
+export default SubmissionFileUploadModal;

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -6,8 +6,8 @@ class SubmissionFileUploadModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      newfiles: []
-    }
+      newFiles: []
+    };
   }
 
   componentDidMount() {
@@ -16,11 +16,11 @@ class SubmissionFileUploadModal extends React.Component {
 
   onSubmit = (event) => {
     event.preventDefault();
-    this.props.onSubmit(this.state.newfiles);
+    this.props.onSubmit(this.state.newFiles);
   };
 
   handleFileUpload = (event) => {
-    this.setState({newfiles: event.target.files})
+    this.setState({newFiles: event.target.files})
   };
 
   render() {
@@ -30,11 +30,11 @@ class SubmissionFileUploadModal extends React.Component {
         isOpen={this.props.isOpen}
         onRequestClose={this.props.onRequestClose}
       >
-        <h2>{I18n.t('add_new')}</h2>
+        <h2>{I18n.t('upload')}</h2>
         <form onSubmit={this.onSubmit}>
           <div className={'modal-container-vertical'}>
             <div className={'modal-container'}>
-              <input type={'file'} name={'newfiles'} multiple={true} onChange={this.handleFileUpload}/>
+              <input type={'file'} name={'new_files'} multiple={true} onChange={this.handleFileUpload}/>
             </div>
             <div className={'modal-container'}>
               <input type='submit' value={I18n.t('save')} />

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -95,7 +95,7 @@ class RawFileManager extends RawFileBrowser {
                 role="button"
               >
                 <i className="fa fa-folder-o" aria-hidden="true"/>
-                &nbsp;{target ? "Add Subolder" : "Add Folder"}
+                &nbsp;{I18n.t('add_folder')}
               </a>
             </li>
           );
@@ -115,7 +115,7 @@ class RawFileManager extends RawFileBrowser {
                 role="button"
               >
                 <i className="fa fa-i-cursor" aria-hidden="true"/>
-                &nbsp;Rename
+                &nbsp;{I18n.t('rename')}
               </a>
             </li>
           );
@@ -173,7 +173,7 @@ class RawFileManager extends RawFileBrowser {
               role="button"
             >
               <i className="fa fa-folder-o" aria-hidden="true"/>
-              &nbsp;Add Folder
+              &nbsp;{I18n.t('add_folder')}
             </a>
           </li>
         )

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -10,13 +10,21 @@ import { RawFileBrowser, Headers, FileRenderers, BaseFileConnectors } from 'reac
 
 
 class RawFileManager extends RawFileBrowser {
-  handleActionBarAddFileClick = (event) => {
+  handleActionBarAddFileClick = (event, selected) => {
     event.preventDefault();
-    window.modal_addnew.open();
+    let uploadTarget = '';
+    if (selected) {
+      if (selected.children) {
+        uploadTarget = selected.relativeKey;
+      } else {
+        uploadTarget = selected.relativeKey.substring(0, selected.relativeKey.lastIndexOf(selected.name));
+      }
+    }
+    this.props.onActionBarAddFileClick(uploadTarget)
   };
 
   renderActionBar(selectedItem) {
-    const selectionIsFolder = selectedItem && !selectedItem.size;
+    const selectionIsFolder = selectedItem && selectedItem.children;
     let filter;
     if (this.props.canFilter) {
       filter = (
@@ -116,7 +124,7 @@ class RawFileManager extends RawFileBrowser {
         actions.unshift(
           <li key="action-add-file>">
             <a
-              onClick={this.handleActionBarAddFileClick}
+              onClick={(event) => this.handleActionBarAddFileClick(event, selectedItem)}
               href="#"
               role="button"
             >
@@ -150,7 +158,7 @@ class RawFileManager extends RawFileBrowser {
       actions.unshift(
         <li key="action-add-file>">
           <a
-            onClick={this.handleActionBarAddFileClick}
+            onClick={(event) => this.handleActionBarAddFileClick(event, selectedItem)}
             href="#"
             role="button"
           >

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -82,6 +82,7 @@ class RawFileManager extends RawFileBrowser {
       else {
         if (
           selectedItem &&
+          !this.props.disableActions.addFolder &&
           typeof this.props.onCreateFolder === 'function' &&
           !this.state.nameFilter
         ) {
@@ -100,7 +101,8 @@ class RawFileManager extends RawFileBrowser {
           );
         }
         if (
-          selectedItem.keyDerived && !this.props.disableActions.rename && (
+          selectedItem.keyDerived &&
+          !this.props.disableActions.rename && (
             (selectionIsFolder && typeof this.props.onRenameFolder === 'function') ||
             (!selectionIsFolder && typeof this.props.onRenameFile === 'function')
           )
@@ -120,8 +122,12 @@ class RawFileManager extends RawFileBrowser {
         }
         if (
           selectedItem.keyDerived && (
-            (!selectionIsFolder && typeof this.props.onDeleteFile === 'function') ||
-            (selectionIsFolder && typeof this.props.onDeleteFolder === 'function')
+            (!selectionIsFolder &&
+              typeof this.props.onDeleteFile === 'function' &&
+              !this.props.disableActions.deleteFile) ||
+            (selectionIsFolder &&
+              typeof this.props.onDeleteFolder === 'function' &&
+              !this.props.disableActions.deleteFolder)
           )
         ) {
           actions.push(
@@ -155,6 +161,7 @@ class RawFileManager extends RawFileBrowser {
     else if (!this.props.readOnly) {
       // Nothing selected.
       if (
+        !this.props.disableActions.addFolder &&
         typeof this.props.onCreateFolder === 'function' &&
         !this.state.nameFilter
       ) {
@@ -186,7 +193,7 @@ class RawFileManager extends RawFileBrowser {
       );
     }
 
-    if (this.props.downloadAllURL) {
+    if (this.props.downloadAllURL && !this.props.disableActions.downloadAll) {
       actions.unshift(
         <li key="action-download-all">
           <a

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -23,6 +23,22 @@ class RawFileManager extends RawFileBrowser {
     this.props.onActionBarAddFileClick(uploadTarget);
   };
 
+  handleActionBarAddFolderClickSetSelection = (event, target) => {
+    event.persist();
+    this.select(target, "folder");
+    this.handleActionBarAddFolderClick(event)
+  };
+
+  folderTarget = (selectedItem) => {
+    const selectionIsFolder = selectedItem && selectedItem.relativeKey.endsWith('/');
+    if (selectionIsFolder) {
+      return selectedItem.relativeKey;
+    } else  {
+      const key = selectedItem ? selectedItem.relativeKey : '';
+      return key.substring(0, key.lastIndexOf("/") + 1)
+    }
+  };
+
   renderActionBar(selectedItem) {
     const selectionIsFolder = selectedItem && selectedItem.relativeKey.endsWith('/');
     let filter;
@@ -65,27 +81,28 @@ class RawFileManager extends RawFileBrowser {
       }
       else {
         if (
-          selectionIsFolder &&
+          selectedItem &&
           typeof this.props.onCreateFolder === 'function' &&
           !this.state.nameFilter
         ) {
+          let target = this.folderTarget(selectedItem);
           actions.push(
             <li key="action-add-folder">
               <a
-                onClick={this.handleActionBarAddFolderClick}
+                onClick={(event) => this.handleActionBarAddFolderClickSetSelection(event, target)}
                 href="#"
                 role="button"
               >
                 <i className="fa fa-folder-o" aria-hidden="true"/>
-                &nbsp;Add Subfolder
+                &nbsp;{target ? "Add Subolder" : "Add Folder"}
               </a>
             </li>
           );
         }
         if (
-          selectedItem.keyDerived && (
-            (selectionIsFolder && typeof this.props.onRenameFile === 'function') ||
-            (!selectionIsFolder && typeof this.props.onRenameFolder === 'function')
+          selectedItem.keyDerived && !this.props.disableActions.rename && (
+            (selectionIsFolder && typeof this.props.onRenameFolder === 'function') ||
+            (!selectionIsFolder && typeof this.props.onRenameFile === 'function')
           )
         ) {
           actions.push(
@@ -354,7 +371,8 @@ FileManager.defaultProps = {
     FolderOpen: <i className="fa fa-folder-open-o" aria-hidden="true" />,
     Delete: <i className="fa fa-trash-o" aria-hidden="true" />,
     Loading: <i className="fa fa-circle-o-notch fa-spin" aria-hidden="true" />,
-  }
+  },
+  disableActions: {}
 };
 
 

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -14,17 +14,17 @@ class RawFileManager extends RawFileBrowser {
     event.preventDefault();
     let uploadTarget = '';
     if (selected) {
-      if (selected.children) {
+      if (selected.relativeKey.endsWith('/')) {
         uploadTarget = selected.relativeKey;
       } else {
         uploadTarget = selected.relativeKey.substring(0, selected.relativeKey.lastIndexOf(selected.name));
       }
     }
-    this.props.onActionBarAddFileClick(uploadTarget)
+    this.props.onActionBarAddFileClick(uploadTarget);
   };
 
   renderActionBar(selectedItem) {
-    const selectionIsFolder = selectedItem && selectedItem.children;
+    const selectionIsFolder = selectedItem && selectedItem.relativeKey.endsWith('/');
     let filter;
     if (this.props.canFilter) {
       filter = (

--- a/app/assets/javascripts/Components/repo_browser.jsx
+++ b/app/assets/javascripts/Components/repo_browser.jsx
@@ -94,6 +94,11 @@ class RepoBrowser extends React.Component {
 
 
 class ManualCollectionForm extends React.Component {
+
+  static defaultProps = {
+    revision_identifier: '' //set initial value so that the input (in render) remains controlled
+  };
+
   render() {
     const action = Routes.manually_collect_and_begin_grading_assignment_submission_path(
       this.props.assignment_id,

--- a/app/assets/javascripts/Components/repo_browser.jsx
+++ b/app/assets/javascripts/Components/repo_browser.jsx
@@ -81,6 +81,7 @@ class RepoBrowser extends React.Component {
           revision_identifier={this.state.revision_identifier}
           onChange={this.fetchRevisions}
           fetchOnMount={false}
+          enableSubdirs={this.props.enableSubdirs}
         />
         <ManualCollectionForm
           assignment_id={this.props.assignment_id}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -154,7 +154,7 @@ class SubmissionFileManager extends React.Component {
           onDeleteFolder={this.props.readOnly ? undefined : this.handleDeleteFolder}
           downloadAllURL={this.getDownloadAllURL()}
           onActionBarAddFileClick={this.props.readOnly ? undefined : this.openUploadModal}
-          disableActions={{rename: true}}
+          disableActions={{rename: true, addFolder: !this.props.enableSubdirs, deleteFolder: !this.props.enableSubdirs}}
         />
         <SubmissionFileUploadModal
           isOpen={this.state.showModal}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -154,6 +154,7 @@ class SubmissionFileManager extends React.Component {
           onDeleteFolder={this.props.readOnly ? undefined : this.handleDeleteFolder}
           downloadAllURL={this.getDownloadAllURL()}
           onActionBarAddFileClick={this.props.readOnly ? undefined : this.openUploadModal}
+          disableActions={{rename: true}}
         />
         <SubmissionFileUploadModal
           isOpen={this.state.showModal}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -79,7 +79,7 @@ class SubmissionFileManager extends React.Component {
 
     let file = deleteFiles[0];
     let file_revisions = {};
-    file_revisions[file.key] = file.last_modified_revision;
+    file_revisions[file.key] = this.props.revision_identifier;
     $.post({
       url: Routes.update_files_assignment_submissions_path(this.props.assignment_id),
       data: {
@@ -95,7 +95,7 @@ class SubmissionFileManager extends React.Component {
     $.post({
       url: Routes.update_files_assignment_submissions_path(this.props.assignment_id),
       data: {
-        delete_folders: [folderKey],
+        new_folders: [folderKey],
         grouping_id: this.props.grouping_id
       }
     }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData)
@@ -103,7 +103,17 @@ class SubmissionFileManager extends React.Component {
   };
 
   handleDeleteFolder = (folderKey) => {
-
+    let folder_revisions = {};
+    folder_revisions[folderKey] = this.props.revision_identifier
+    $.post({
+      url: Routes.update_files_assignment_submissions_path(this.props.assignment_id),
+      data: {
+        delete_folders: [folderKey],
+        folder_revisions: folder_revisions,
+        grouping_id: this.props.grouping_id
+      }
+    }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData)
+      .then(this.endAction);
   };
 
   handleActionBarDeleteClick = (event) => {
@@ -130,6 +140,7 @@ class SubmissionFileManager extends React.Component {
         onDeleteFile={this.props.readOnly ? undefined : this.handleDeleteFile}
         onCreateFiles={this.props.readOnly ? undefined : this.handleCreateFiles}
         onCreateFolder={this.props.readOnly ? undefined : this.handleCreateFolder}
+        onRenameFolder={() => {}}
         onDeleteFolder={this.props.readOnly ? undefined : this.handleDeleteFolder}
         downloadAllURL={this.getDownloadAllURL()}
       />

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -91,6 +91,21 @@ class SubmissionFileManager extends React.Component {
       .then(this.endAction);
   };
 
+  handleCreateFolder = (folderKey) => {
+    $.post({
+      url: Routes.update_files_assignment_submissions_path(this.props.assignment_id),
+      data: {
+        delete_folders: [folderKey],
+        grouping_id: this.props.grouping_id
+      }
+    }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData)
+      .then(this.endAction);
+  };
+
+  handleDeleteFolder = (folderKey) => {
+
+  };
+
   handleActionBarDeleteClick = (event) => {
     event.preventDefault();
     if (this.state.selection) {
@@ -114,6 +129,8 @@ class SubmissionFileManager extends React.Component {
         readOnly={this.props.readOnly}
         onDeleteFile={this.props.readOnly ? undefined : this.handleDeleteFile}
         onCreateFiles={this.props.readOnly ? undefined : this.handleCreateFiles}
+        onCreateFolder={this.props.readOnly ? undefined : this.handleCreateFolder}
+        onDeleteFolder={this.props.readOnly ? undefined : this.handleDeleteFolder}
         downloadAllURL={this.getDownloadAllURL()}
       />
     );

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -10,7 +10,8 @@ class SubmissionFileManager extends React.Component {
     super(props);
     this.state = {
       files: [],
-      showModal: false
+      showModal: false,
+      uploadTarget: undefined
     };
   }
 
@@ -134,7 +135,7 @@ class SubmissionFileManager extends React.Component {
     });
   };
 
-  uploadFiles = (uploadTarget) => {
+  openUploadModal = (uploadTarget) => {
     this.setState({showModal: true, uploadTarget: uploadTarget})
   };
 
@@ -152,7 +153,7 @@ class SubmissionFileManager extends React.Component {
           onRenameFolder={!this.props.readOnly && typeof this.handleCreateFolder === 'function' ? () => {} : undefined}
           onDeleteFolder={this.props.readOnly ? undefined : this.handleDeleteFolder}
           downloadAllURL={this.getDownloadAllURL()}
-          onActionBarAddFileClick={this.props.readOnly ? undefined : this.uploadFiles}
+          onActionBarAddFileClick={this.props.readOnly ? undefined : this.openUploadModal}
         />
         <SubmissionFileUploadModal
           isOpen={this.state.showModal}

--- a/app/assets/stylesheets/common/_modals.scss
+++ b/app/assets/stylesheets/common/_modals.scss
@@ -11,3 +11,19 @@
   top: 50%;
   transform: translate(-50%, -50%);
 }
+
+.modal-container {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.modal-container-vertical {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  padding: 5px;
+
+  > * {
+    margin: 5px;
+  }
+}

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -123,22 +123,6 @@
   height: 250px;
 }
 
-.extension-container {
-  display: flex;
-  justify-content: space-evenly;
-}
-
-.extension-container-vertical {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-  padding: 5px;
-
-  > * {
-    margin: 5px;
-  }
-}
-
 .extension-note {
   width: 100%;
 }

--- a/app/assets/stylesheets/submissions.scss
+++ b/app/assets/stylesheets/submissions.scss
@@ -1,6 +1,7 @@
 @import 'common/core';
 @import 'common/tags';
 @import 'common/assignment_dropdown';
+@import 'common/modals';
 
 #disable {
   color: $grey !important;

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -716,7 +716,7 @@ class SubmissionsController < ApplicationController
         data[:modified] = data[:last_revised_date]
         data
       else
-        {key: "#{file_name}/"}
+        { key: "#{file_name}/" }
       end
     end.compact
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -341,7 +341,13 @@ class SubmissionsController < ApplicationController
       # The files that will be added
       new_files = params[:new_files].nil? ? {} : params[:new_files]
 
-      if delete_files.empty? && new_files.empty?
+      # The folders that will be added
+      new_folders = params[:new_folders].nil? ? [] : params[:new_folders]
+
+      # The folders that will be deleted
+      delete_folders = params[:delete_folders].nil? ? [] : params[:delete_folders]
+
+      if delete_files.empty? && new_files.empty? && new_folders.empty? && delete_folders.empty?
         flash_message(:warning, I18n.t('student.submission.no_action_detected'))
       else
         messages = []
@@ -362,6 +368,12 @@ class SubmissionsController < ApplicationController
                                       path: path, txn: txn, check_size: true, required_files: required_files)
             should_commit &&= success
             messages.concat msgs
+          end
+          if new_folders.present?
+            success, msgs = @grouping.add_folders(new_folders, current_user,
+                                                  path: @path, repo: repo, txn: txn)
+            should_commit &&= success
+            messages = messages.concat msgs
           end
           if should_commit
             commit_success, commit_msg = commit_transaction(repo, txn)

--- a/app/helpers/repository_helper.rb
+++ b/app/helpers/repository_helper.rb
@@ -178,12 +178,15 @@ module RepositoryHelper
       dirs[folder_path] = revision
     end
 
-    success, file_messages = remove_files(files, user, repo, path: '')
+    success, file_messages = remove_files(files, user, repo, path: '', txn: txn)
 
     return [success, file_messages] unless success
 
-    dirs.each do |dir, revision|
-      txn.remove(dir, revision)
+    # folders are removed in git if their contents are removed
+    unless repo.is_a? GitRepository
+      dirs.each do |dir, revision|
+        txn.remove(dir, revision)
+      end
     end
 
     if commit_txn

--- a/app/helpers/repository_helper.rb
+++ b/app/helpers/repository_helper.rb
@@ -122,6 +122,78 @@ module RepositoryHelper
     end
   end
 
+  def add_folders(new_folders, user, repo, path: '/', txn: nil)
+    messages = []
+
+    if txn.nil?
+      txn = repo.get_transaction(user.user_name)
+      commit_txn = true
+    else
+      commit_txn = false
+    end
+
+    current_path = Pathname.new path
+
+    new_folders.each do |folder_path|
+      txn.add_path(current_path.join(folder_path))
+    end
+
+    if commit_txn
+      success, txn_messages = commit_transaction repo, txn
+      [success, messages + txn_messages]
+    else
+      [true, messages]
+    end
+  end
+
+  def remove_folders(folder_revisions, user, repo, path: '/', txn: nil)
+    messages = []
+
+    if txn.nil?
+      txn = repo.get_transaction(user.user_name)
+      commit_txn = true
+    else
+      commit_txn = false
+    end
+
+    current_path = Pathname.new path
+
+    current_revision = repo.get_latest_revision.revision_identifier
+
+    dirs = {}
+    files = {}
+    folder_revisions.each do |folder_path, revision|
+      folder_path = current_path.join(folder_path).to_s
+      next if dirs.include? folder_path
+
+      revision ||= current_revision
+      repo.get_revision(revision).tree_at_path(folder_path, with_attrs: false).each do |_, obj|
+        path = File.join obj.path, obj.name
+        if obj.is_a? Repository::RevisionFile
+          files[path] = revision
+        else
+          dirs[path] = revision
+        end
+      end
+      dirs[folder_path] = revision
+    end
+
+    success, file_messages = remove_files(files, user, repo, path: '')
+
+    return [success, file_messages] unless success
+
+    dirs.each do |dir, revision|
+      txn.remove(dir, revision)
+    end
+
+    if commit_txn
+      success, txn_messages = commit_transaction repo, txn
+      [success, messages + txn_messages]
+    else
+      [true, messages]
+    end
+  end
+
   # Helper method that commits a transaction +txn+ in repo +repo+. Returns a boolean and an array
   # where the boolean indicates whether the transaction was commited successfully and an array
   # containing any error or warning messages.

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -4,6 +4,10 @@ class SubmissionPolicy < ApplicationPolicy
     check?(:not_a_student?) && check?(:run_tests?, record.assignment) && check?(:before_release?)
   end
 
+  def manage_subdirectories?
+    check?(:not_a_student?)
+  end
+
   def not_a_student?
     !user.student?
   end

--- a/app/views/submissions/file_manager.html.erb
+++ b/app/views/submissions/file_manager.html.erb
@@ -9,7 +9,8 @@
         {
           assignment_id: <%= @assignment.id %>,
           grouping_id: <%= @grouping.id %>,
-          readOnly: <%= !@assignment.allow_web_submits %>
+          readOnly: <%= !@assignment.allow_web_submits %>,
+          enableSubdirs: <%= allowed_to? :manage_subdirectories? %>
         });
 
       window.setInterval(() => {

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -17,22 +17,3 @@
 <% end %>
 
 <div id='file_manager'></div>
-
-<aside class='dialog' id='addnew_dialog'>
-  <h2><%= t('add_new') %></h2>
-
-  <%= form_tag update_files_assignment_submissions_path(@grouping.assignment_id),
-               { multipart: true, id: 'file_form' } do %>
-    <%= file_field_tag :new_files, name: 'new_files[]', multiple: true %>
-    <%= hidden_field_tag :path, @path %>
-    <%= hidden_field_tag :grouping_id, @grouping.id %>
-
-    <section class='dialog-actions'>
-      <%= submit_tag t(:upload) %>
-      <%= button_tag t(:cancel),
-                     type: 'button',
-                     onclick: 'modal_addnew.close(); return false;'
-      %>
-    </section>
-  <% end %>
-</aside>

--- a/app/views/submissions/repo_browser.html.erb
+++ b/app/views/submissions/repo_browser.html.erb
@@ -5,7 +5,8 @@
         {
           assignment_id: <%= @grouping.assignment_id %>,
           grouping_id: <%= @grouping.id %>,
-          collected_revision_id: '<%= @collected_revision&.revision_identifier %>'
+          collected_revision_id: '<%= @collected_revision&.revision_identifier %>',
+          enableSubdirs: <%= allowed_to? :manage_subdirectories? %>
         });
     });
   </script>

--- a/config/locales/defaults/download_upload/en.yml
+++ b/config/locales/defaults/download_upload/en.yml
@@ -24,3 +24,5 @@ en:
   upload_success:
     one: "%{count} object successfully uploaded."
     other: "%{count} objects successfully uploaded."
+  add_folder: "Add Folder"
+  rename: "Rename"

--- a/config/locales/defaults/download_upload/es.yml
+++ b/config/locales/defaults/download_upload/es.yml
@@ -21,3 +21,5 @@ es:
   upload_success:
     one: "%{count} objeto han sido subido exitosamente."
     other: "%{count} objetos han sido subidos exitosamente."
+  add_folder: "UPDATE ME"
+  rename: "UPDATE ME"

--- a/config/locales/defaults/download_upload/fr.yml
+++ b/config/locales/defaults/download_upload/fr.yml
@@ -20,3 +20,5 @@ fr:
   upload_success:
     one: "%{count} objet été envoyé."
     other: "%{count} objets été envoyés."
+  add_folder: "Nouveau dossier"
+  rename: "Renommer"

--- a/config/locales/defaults/download_upload/pt.yml
+++ b/config/locales/defaults/download_upload/pt.yml
@@ -20,3 +20,5 @@ pt:
   upload_success:
     one: "%{count} objeto carregado com sucesso."
     other: "%{count} objeto carregado com sucesso."
+  add_folder: "UPDATE ME"
+  rename: "UPDATE ME"

--- a/config/locales/policies/en.yml
+++ b/config/locales/policies/en.yml
@@ -24,3 +24,4 @@ en:
       submission:
         before_release?: "You cannot run tests because the marks have been released."
         not_a_student?: "You cannot run tests because students are not allowed to."
+        manage_subdirectories?: "You are not allowed to create, delete or change subdirectories."

--- a/config/locales/policies/es.yml
+++ b/config/locales/policies/es.yml
@@ -23,3 +23,4 @@ es:
       submission:
         before_release?: "UPDATE ME."
         not_a_student?: "UPDATE ME."
+        manage_subdirectories?: "UPDATE ME."

--- a/config/locales/policies/fr.yml
+++ b/config/locales/policies/fr.yml
@@ -23,3 +23,4 @@ fr:
       submission:
         before_release?: "Les notes pour ce test sont déjà montré aux étudiants."
         not_a_student?: "UPDATE ME."
+        manage_subdirectories?: "Vous n'êtes pas autorisé à créer, supprimer ou modifier des dossiers."

--- a/config/locales/policies/pt.yml
+++ b/config/locales/policies/pt.yml
@@ -23,3 +23,4 @@ pt:
       submission:
         before_release?: "UPDATE ME."
         not_a_student?: "UPDATE ME."
+        manage_subdirectories?: "UPDATE ME."


### PR DESCRIPTION
- enables creation and deletion of subdirectories
- enables uploading files to subdirectories
- only enabled for the submission_file_manager (others will come in a future PR)
- introduces a new react modal for uploading files
- introduces a new policy to check whether a user can create, remove or change subdirectories
- introduces new props to the raw file manager component that selectively prevents certain action bar elements from being created