### PR TITLE
Don't require test group names to be unique

### DIFF
--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -13,7 +13,12 @@ class AutotestManager extends React.Component {
       uiSchema: {
         testers: {
           items: {
-            classNames: 'tester-item'
+            classNames: 'tester-item',
+            test_data: {
+              items: {
+                'ui:order': ['extra_info', '*']
+              }
+            }
           }
         }
       },

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -5,6 +5,11 @@ module AutomatedTestsHelper
     end.transpose
     { type: :object,
       properties: {
+        name: {
+          type: :string,
+          title: "#{TestGroup.model_name.human} #{TestGroup.human_attribute_name(:name).downcase}",
+          default: TestGroup.model_name.human
+        },
         display_output: {
           type: :string,
           enum: TestGroup.display_outputs.keys,
@@ -35,12 +40,12 @@ module AutomatedTestsHelper
     test_specs['testers'].each do |tester_specs|
       next if tester_specs['test_data'].nil?
 
-      tester_specs['test_data'].each_with_index do |test_group_specs, i|
+      tester_specs['test_data'].each do |test_group_specs|
         test_group_specs['extra_info'] ||= {}
         extra_data_specs = test_group_specs['extra_info']
-        test_group_name = test_group_specs['name'] || "#{tester_specs['tester_type']}: #{i}"
         test_group_id = extra_data_specs['test_group_id']
         display_output = extra_data_specs['display_output'] || TestGroup.display_outputs.keys.first
+        test_group_name = extra_data_specs['name'] || TestGroup.model_name.human
         criterion_id = nil
         criterion_type = nil
         if !extra_data_specs['criterion'].nil? && extra_data_specs['criterion'].include?('_')

--- a/app/models/test_group.rb
+++ b/app/models/test_group.rb
@@ -6,7 +6,7 @@ class TestGroup < ApplicationRecord
   belongs_to :criterion, optional: true, polymorphic: true
   has_many :test_group_results, dependent: :delete_all
 
-  validates :name, presence: true, uniqueness: { scope: :assignment_id }
+  validates :name, presence: true
   validates :display_output, presence: true
 
 end

--- a/db/migrate/20190621203403_remove_index_from_test_groups.rb
+++ b/db/migrate/20190621203403_remove_index_from_test_groups.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromTestGroups < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :test_groups, name: :index_test_groups_on_assignment_id_and_name
+  end
+end

--- a/spec/models/test_group_spec.rb
+++ b/spec/models/test_group_spec.rb
@@ -50,13 +50,6 @@ describe TestGroup do
       end
     end
 
-    context 'test group expected to be invalid when the name already exists in the same assignment' do
-      it 'return false when the file_name already exists' do
-        @invalid_test_group.name = 'valid_test_group'
-        expect(@invalid_test_group).not_to be_valid
-      end
-    end
-
     context 'test group expected to be invalid when the display_output option has an invalid option' do
       it 'raise an ArgumentError when the display_output option has an invalid option' do
         expect { @invalid_test_group.display_output = 'something_else' }.to raise_error(ArgumentError)


### PR DESCRIPTION
This requirement was causing test group creation to fail silently when the test group fields on the Test Framework page were removed and and then replaced.

These were originally intended to be unique for identification purposes but are now only being used for display purposes. Therefore, the uniqueness of test group names is no longer required.  

