### PR TITLE
autotest: Support non-ASCII encoding in text file upload.

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -139,8 +139,7 @@ class AutomatedTestsController < ApplicationController
       end
       file_path = File.join(assignment.autotest_files_dir, f.original_filename)
       file_content = f.read
-      mode = SubmissionFile.is_binary?(file_content) ? 'wb' : 'w'
-      File.write(file_path, file_content, mode: mode)
+      File.write(file_path, file_content, mode: 'wb')
     end
     delete_files.each do |f|
       file_path = File.join(assignment.autotest_files_dir, f)


### PR DESCRIPTION
The `'wb'` mode can always be used to write the data that's read from `f.read`. We can follow the example at https://guides.rubyonrails.org/form_helpers.html#what-gets-uploaded.