### PR TITLE
Update for autotest file manager

### DIFF
--- a/app/assets/javascripts/Components/Modals/autotest_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/autotest_file_upload_modal.jsx
@@ -6,8 +6,8 @@ class AutotestFileUploadModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      newfiles: []
-    }
+      newFiles: []
+    };
   }
 
   componentDidMount() {
@@ -16,11 +16,11 @@ class AutotestFileUploadModal extends React.Component {
 
   onSubmit = (event) => {
     event.preventDefault();
-    this.props.onSubmit(this.state.newfiles);
+    this.props.onSubmit(this.state.newFiles);
   };
 
   handleFileUpload = (event) => {
-    this.setState({newfiles: event.target.files})
+    this.setState({newFiles: event.target.files})
   };
 
   render() {
@@ -30,11 +30,11 @@ class AutotestFileUploadModal extends React.Component {
         isOpen={this.props.isOpen}
         onRequestClose={this.props.onRequestClose}
       >
-        <h2>{I18n.t('add_new')}</h2>
+        <h2>{I18n.t('upload')}</h2>
         <form onSubmit={this.onSubmit}>
           <div className={'modal-container-vertical'}>
             <div className={'modal-container'}>
-              <input type={'file'} name={'newfiles'} multiple={true} onChange={this.handleFileUpload}/>
+              <input type={'file'} name={'new_files'} multiple={true} onChange={this.handleFileUpload}/>
             </div>
             <div className={'modal-container'}>
               <input type='submit' value={I18n.t('save')} />

--- a/app/assets/javascripts/Components/Modals/autotest_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/autotest_file_upload_modal.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+class AutotestFileUploadModal extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newfiles: []
+    }
+  }
+
+  componentDidMount() {
+    Modal.setAppElement('body');
+  }
+
+  onSubmit = (event) => {
+    event.preventDefault();
+    this.props.onSubmit(this.state.newfiles);
+  };
+
+  handleFileUpload = (event) => {
+    this.setState({newfiles: event.target.files})
+  };
+
+  render() {
+    return (
+      <Modal
+        className="react-modal"
+        isOpen={this.props.isOpen}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <h2>{I18n.t('add_new')}</h2>
+        <form onSubmit={this.onSubmit}>
+          <div className={'modal-container-vertical'}>
+            <div className={'modal-container'}>
+              <input type={'file'} name={'newfiles'} multiple={true} onChange={this.handleFileUpload}/>
+            </div>
+            <div className={'modal-container'}>
+              <input type='submit' value={I18n.t('save')} />
+            </div>
+          </div>
+        </form>
+      </Modal>
+    )
+  }
+}
+
+export default AutotestFileUploadModal;

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -32,7 +32,8 @@ class AutotestManager extends React.Component {
       non_regenerating_tokens: false,
       unlimited_tokens: false,
       loading: true,
-      showModal: false
+      showModal: false,
+      uploadTarget: undefined
     };
   };
 
@@ -93,7 +94,7 @@ class AutotestManager extends React.Component {
       .then(this.endAction);
   };
 
-  uploadFiles = (uploadTarget) => {
+  openUploadModal = (uploadTarget) => {
     this.setState({showModal: true, uploadTarget: uploadTarget})
   };
 
@@ -265,7 +266,7 @@ class AutotestManager extends React.Component {
             onCreateFolder={this.handleCreateFolder}
             onRenameFolder={typeof this.handleCreateFolder === 'function' ? () => {} : undefined}
             onDeleteFolder={this.handleDeleteFolder}
-            onActionBarAddFileClick={this.uploadFiles}
+            onActionBarAddFileClick={this.openUploadModal}
           />
         </fieldset>
         <fieldset>

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -267,6 +267,7 @@ class AutotestManager extends React.Component {
             onRenameFolder={typeof this.handleCreateFolder === 'function' ? () => {} : undefined}
             onDeleteFolder={this.handleDeleteFolder}
             onActionBarAddFileClick={this.openUploadModal}
+            disableActions={{rename: true}}
           />
         </fieldset>
         <fieldset>

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import FileManager from './markus_file_manager';
 import Form from 'react-jsonschema-form';
 import Datepicker from './date_picker'
+import AutotestFileUploadModal from './Modals/autotest_file_upload_modal'
 
 class AutotestManager extends React.Component {
   constructor(props) {
@@ -30,12 +31,12 @@ class AutotestManager extends React.Component {
       token_period: 0,
       non_regenerating_tokens: false,
       unlimited_tokens: false,
-      loading: true
+      loading: true,
+      showModal: false
     };
   };
 
   componentDidMount() {
-    window.modal_addnew = new ModalMarkus('#addnew_dialog');
     this.fetchData();
   }
 
@@ -52,8 +53,11 @@ class AutotestManager extends React.Component {
   };
 
   handleCreateFiles = (files) => {
+    const prefix = this.state.uploadTarget || '';
+    this.setState({showModal: false, uploadTarget: undefined});
     let data = new FormData();
-    files.forEach(f => data.append('new_files[]', f, f.name));
+    Array.from(files).forEach(f => data.append('new_files[]', f, f.name));
+    data.append('path', prefix);
     $.post({
       url: Routes.upload_files_assignment_automated_tests_path(this.props.assignment_id),
       data: data,
@@ -71,6 +75,26 @@ class AutotestManager extends React.Component {
       data: {delete_files: [fileKey]}
     }).then(this.fetchFileDataOnly)
       .then(this.endAction);
+  };
+
+  handleCreateFolder = (folderKey) => {
+    $.post({
+      url: Routes.upload_files_assignment_automated_tests_path(this.props.assignment_id),
+      data: {new_folders: [folderKey]}
+    }).then(this.fetchFileDataOnly)
+      .then(this.endAction);
+  };
+
+  handleDeleteFolder = (folderKey) => {
+    $.post({
+      url: Routes.upload_files_assignment_automated_tests_path(this.props.assignment_id),
+      data: {delete_folders: [folderKey]}
+    }).then(this.fetchFileDataOnly)
+      .then(this.endAction);
+  };
+
+  uploadFiles = (uploadTarget) => {
+    this.setState({showModal: true, uploadTarget: uploadTarget})
   };
 
   handleFormChange = (data) => {
@@ -238,6 +262,10 @@ class AutotestManager extends React.Component {
             readOnly={!this.state.enable_test}
             onDeleteFile={this.handleDeleteFile}
             onCreateFile={this.handleCreateFiles}
+            onCreateFolder={this.handleCreateFolder}
+            onRenameFolder={typeof this.handleCreateFolder === 'function' ? () => {} : undefined}
+            onDeleteFolder={this.handleDeleteFolder}
+            onActionBarAddFileClick={this.uploadFiles}
           />
         </fieldset>
         <fieldset>
@@ -260,6 +288,11 @@ class AutotestManager extends React.Component {
                onClick={this.onSubmit}
         >
         </input>
+        <AutotestFileUploadModal
+          isOpen={this.state.showModal}
+          onRequestClose={() => this.setState({showModal: false, uploadTarget: undefined})}
+          onSubmit={this.handleCreateFiles}
+        />
       </div>
     )
   }

--- a/app/assets/stylesheets/automated_tests.scss
+++ b/app/assets/stylesheets/automated_tests.scss
@@ -1,4 +1,5 @@
 @import "assignments";
+@import "common/modals";
 
 .right {
   float: right;

--- a/app/assets/stylesheets/automated_tests.scss
+++ b/app/assets/stylesheets/automated_tests.scss
@@ -1,5 +1,5 @@
-@import "assignments";
-@import "common/modals";
+@import 'assignments';
+@import 'common/modals';
 
 .right {
   float: right;

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1095,9 +1095,14 @@ class Assignment < ApplicationRecord
   end
 
   def autotest_files
-    files_dir = autotest_files_dir
+    files_dir = Pathname.new autotest_files_dir
     return [] unless Dir.exist? files_dir
-    Dir.entries(files_dir) - ['.', '..']
+
+    Dir.glob("#{files_dir}/**/*", File::FNM_DOTMATCH).map do |f|
+      unless %w[.. .].include?(File.basename(f))
+        Pathname.new(f).relative_path_from(files_dir).to_s
+      end
+    end.compact
   end
 
   def autotest_settings_file

--- a/app/views/automated_tests/_form.html.erb
+++ b/app/views/automated_tests/_form.html.erb
@@ -15,18 +15,6 @@
              handlers: [:erb] %>
 <% end %>
 
-<aside class='dialog' id='addnew_dialog'>
-  <h2><%= t('add_new') %></h2>
-  <%= form_with url: upload_files_assignment_automated_tests_path(assignment_id: @assignment.id),
-               multipart: true, id: 'file_form', remote: true do |f| %>
-    <%= f.file_field :new_files, name: 'new_files[]', multiple: true %>
-    <section class='dialog-actions'>
-      <%= f.submit t(:upload), onclick: 'modal_addnew.close();' %>
-      <%= f.button t(:cancel), onclick: 'modal_addnew.close(); return false;' %>
-    </section>
-  <% end %>
-</aside>
-
 <div class="wrapLeft">
   <%= render partial: 'shared/flash_message' %>
 </div>


### PR DESCRIPTION
Applies the same changes made in #4018 but for the file manager on the Test Framework page