### PR TITLE
Confirm that submissions should be re-collected

### DIFF
--- a/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+class CollectSubmissionsModal extends React.Component {
+
+  static defaultProps = {
+    override: false
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      override: this.props.override
+    };
+  }
+
+  componentDidMount() {
+    Modal.setAppElement('body');
+  }
+
+  onSubmit = (event) => {
+    event.preventDefault();
+    this.props.onSubmit(this.state.override);
+  };
+
+  handleOverrideChange = (event) => {
+    this.setState({override: event.target.checked})
+  };
+
+  render() {
+    return (
+      <Modal
+        className="react-modal"
+        isOpen={this.props.isOpen}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <h2>
+          {I18n.t('submissions.collect.submit')}
+        </h2>
+        <form onSubmit={this.onSubmit}>
+          <div className={'modal-container-vertical'}>
+            <div>
+              {I18n.t('submissions.collect.results_loss_warning')}
+            </div>
+            <div>
+              <label>
+                <input type="checkbox" name="override" onChange={this.handleOverrideChange}/>
+                &nbsp; {I18n.t('submissions.collect.override_existing')}
+              </label>
+            </div>
+            <div className={'modal-container'}>
+                <input type='submit' value={I18n.t('save')} />
+            </div>
+          </div>
+        </form>
+      </Modal>
+    )
+  }
+
+}
+
+export default CollectSubmissionsModal;

--- a/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
@@ -49,14 +49,13 @@ class CollectSubmissionsModal extends React.Component {
               </label>
             </div>
             <div className={'modal-container'}>
-                <input type='submit' value={I18n.t('save')} />
+              <input type='submit' value={I18n.t('save')} />
             </div>
           </div>
         </form>
       </Modal>
     )
   }
-
 }
 
 export default CollectSubmissionsModal;

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -3,6 +3,7 @@ import {render} from 'react-dom';
 
 import {CheckboxTable, withSelection} from './markus_with_selection_hoc'
 import {stringFilter, dateSort} from './Helpers/table_helpers';
+import CollectSubmissionsModal from "./Modals/collect_submissions_modal";
 
 
 class RawSubmissionTable extends React.Component {
@@ -12,6 +13,7 @@ class RawSubmissionTable extends React.Component {
       groupings: [],
       sections: {},
       loading: true,
+      showModal: false
     };
   }
 
@@ -226,14 +228,12 @@ class RawSubmissionTable extends React.Component {
   };
 
   // Submission table actions
-  collectSubmissions = () => {
-    if (!window.confirm(I18n.t('submissions.collect.results_loss_warning'))) {
-      return;
-    }
-
+  collectSubmissions = (override) => {
+    console.log(override);
+    this.setState({showModal: false})
     $.post({
       url: Routes.collect_submissions_assignment_submissions_path(this.props.assignment_id),
-      data: { groupings: this.props.selection },
+      data: { groupings: this.props.selection, override: override },
     });
   };
 
@@ -286,7 +286,7 @@ class RawSubmissionTable extends React.Component {
           assignment_id={this.props.assignment_id}
           can_run_tests={this.props.can_run_tests}
 
-          collectSubmissions={this.collectSubmissions}
+          collectSubmissions={() => {this.setState({showModal: true})}}
           downloadGroupingFiles={this.downloadGroupingFiles}
           selection={this.props.selection}
           runTests={this.runTests}
@@ -311,6 +311,11 @@ class RawSubmissionTable extends React.Component {
           getTrProps={this.getTrProps}
 
           {...this.props.getCheckboxProps()}
+        />
+        <CollectSubmissionsModal
+          isOpen={this.state.showModal}
+          onRequestClose={() => {this.setState({showModal: false})}}
+          onSubmit={this.collectSubmissions}
         />
       </div>
     );

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -229,8 +229,7 @@ class RawSubmissionTable extends React.Component {
 
   // Submission table actions
   collectSubmissions = (override) => {
-    console.log(override);
-    this.setState({showModal: false})
+    this.setState({showModal: false});
     $.post({
       url: Routes.collect_submissions_assignment_submissions_path(this.props.assignment_id),
       data: { groupings: this.props.selection, override: override },

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -205,6 +205,8 @@ class SubmissionsController < ApplicationController
                             .pluck(:id).to_set
     collection_dates = assignment.all_grouping_collection_dates
     groupings.each do |grouping|
+      next unless params[:override] == 'true' || grouping.current_submission_used.nil?
+
       collect_now = collection_dates[grouping.id] <= Time.current
       some_before_due = true unless collect_now
       next if !collect_now || some_released.include?(grouping.id)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -205,7 +205,7 @@ class SubmissionsController < ApplicationController
                             .pluck(:id).to_set
     collection_dates = assignment.all_grouping_collection_dates
     groupings.each do |grouping|
-      next unless params[:override] == 'true' || grouping.current_submission_used.nil?
+      next if params[:override] != 'true' && grouping.is_collected?
 
       collect_now = collection_dates[grouping.id] <= Time.current
       some_before_due = true unless collect_now

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -9,13 +9,13 @@ en:
       overwrite_warning: "Collecting and grading this revision will overwrite any previous collections/grading done for this group on this assignment.  Are you sure you want to do this?"
       progress: "%{count}/%{size} submissions collected"
       results_loss_warning: "This operation:
-                             Identifies the file version for each submission that meets the due date and/or late penalty set for this assignment.
-                             Creates the views for annotating and grading each submission."
+                             Identifies the file version for each selected group that meets the due date and/or late penalty set for this assignment.
+                             Creates the views for annotating and grading each selected group."
       submit: "Collect Submissions"
       this_revision: "Collect and Grade This Revision"
       undo_results_loss_warning: "This operation will undo the previous Collect All Submissions operation. This should only be done if the previous Collect All Submissions operation was done in error.
                                   WARNING: All grading work done since the previous Collect All Submissions operation will be lost."
-      override_existing: "Collect all selected submissions. Warning: any previous grading work will be overwritten."
+      override_existing: "Override previously collected submissions. Warning: any previous grading work will be overwritten."
     errors:
       no_submission: "%{group_name} has no submissions"
       not_complete: "Cannot release result for %{group_name}: the marking is not complete."

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -10,12 +10,12 @@ en:
       progress: "%{count}/%{size} submissions collected"
       results_loss_warning: "This operation:
                              Identifies the file version for each submission that meets the due date and/or late penalty set for this assignment.
-                             Creates the views for annotating and grading each submission.
-                             Warning: If this operation is carried out after grading has begun, this grading work will be overwritten. This work can be recovered using the Undo Collection button."
+                             Creates the views for annotating and grading each submission."
       submit: "Collect Submissions"
       this_revision: "Collect and Grade This Revision"
       undo_results_loss_warning: "This operation will undo the previous Collect All Submissions operation. This should only be done if the previous Collect All Submissions operation was done in error.
                                   WARNING: All grading work done since the previous Collect All Submissions operation will be lost."
+      override_existing: "Collect all selected submissions. Warning: any previous grading work will be overwritten."
     errors:
       no_submission: "%{group_name} has no submissions"
       not_complete: "Cannot release result for %{group_name}: the marking is not complete."

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -19,10 +19,7 @@ es:
       results_loss_warning: "Esta operación:
                              Identifica la versión del archivo para cada entrega que satisface el plazo
                              de entrega y/o la penalidad por demora establecidos para este proyecto.
-                             Crea las páginas web para anotar y calificar cada entrega.
-                             Precaución: Si la operación se lleva a cabo después de que el proceso de
-                             calificación ha iniciado, los datos serán reescritos. Los datos pueden ser
-                             recuperados usando el botón para deshacer la recolección."
+                             Crea las páginas web para anotar y calificar cada entrega."
       submit: "Recolectar entregas"
       this_revision: "Recolectar y Calificar esta revisión"
       undo_results_loss_warning: "Esta operación deshacera las operaciones anteriores del tipo Recolectar
@@ -30,6 +27,7 @@ es:
                                   del mismo tipo fueron realizadas por error. PRECAUCIÓN: Todo el proceso de
                                   calificación realizado desde la anterior operación de tipo Recolectar Todas
                                   las Entregas se perderá."
+      override_existing: "UPDATE ME"
     errors:
       no_submission: "%{group_name} no tiene entregas"
       not_complete: "No puede publicar los resultados para %{group_name}: el proceso de calificación no ha

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -7,9 +7,11 @@ fr:
       could_not_collect_some_released: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier}."
       overwrite_warning: "Récupérer et noter cette révision effacera les précédentes récupération et évaluations de ce groupe sur ce projet. Êtes-vous sûr de vouloir faire cela ?"
       progress: "%{count}/%{size} envois récupérés"
-      results_loss_warning: "Attention : cette action effacera vos annotations et évaluations. Êtes-vous sûr de vouloir continuer ?"
+      results_loss_warning: "Cette action:
+                             Identifier la version des fichiers qui respecte la date d'échéance et/ou des pénalités."
       submit: "Récupérer les envois"
       this_revision: "Récupérer et évaluer cette révision"
+      override_existing: "Recueillir toutes les soumissions. Attention : cette action effacera vos annotations et évaluations "
     errors:
       no_submission: "%{group_name} n'a pas d'envoi"
       not_complete: "La note du groupe %{group_name} ne peut pas être publiée : l'évalutation n'est pas indiquée comme étant terminée."

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -12,6 +12,7 @@ pt:
       results_loss_warning: "Nota: Isso apagará qualquer avaliação e anotações que já foram feitas. Tem certeza que deseja continuar?"
       submit: "Coletar as submissões"
       this_revision: "Coletar e avaliar essa revisão"
+      override_existing: "UPDATE ME"
     errors:
       no_submission: "%{group_name} não tem submissões"
       not_complete: "Não pode liberar resultado para %{group_name}: o estado da avaliação não está completo"


### PR DESCRIPTION
- introduces a modal where the user can choose to override existing submissions (default: don't override) when collecting submissions.

- [x] write rspec test for the new functionality of the collect_submissions method