### PR TITLE
Remove unused code

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -288,6 +288,7 @@ class RawSubmissionTable extends React.Component {
 
           collectSubmissions={this.collectSubmissions}
           downloadGroupingFiles={this.downloadGroupingFiles}
+          selection={this.props.selection}
           runTests={this.runTests}
           releaseMarks={() => this.toggleRelease(true)}
           unreleaseMarks={() => this.toggleRelease(false)}
@@ -376,11 +377,13 @@ class SubmissionsActionBox extends React.Component {
     }
 
     let downloadGroupingFilesButton = (
-      <a
-        href={Routes.download_groupings_files_assignment_submissions_path(this.props.assignment_id)}
+      <a href={
+          Routes.download_groupings_files_assignment_submissions_path(this.props.assignment_id) +
+            '?groupings=' + this.props.selection.join()
+        }
         onClick={this.props.downloadGroupingFiles}
         download
-        className="button"
+        className={"button" + (this.props.disabled ? " disabled" : "")}
       >
         {I18n.t('download_the', {item: I18n.t('activerecord.models.submission.other')})}
       </a>

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -292,6 +292,7 @@ class RawSubmissionTable extends React.Component {
           runTests={this.runTests}
           releaseMarks={() => this.toggleRelease(true)}
           unreleaseMarks={() => this.toggleRelease(false)}
+          authenticity_token={this.props.authenticity_token}
         />
         <CheckboxTable
           ref={(r) => this.checkboxTable = r}
@@ -322,7 +323,6 @@ SubmissionTable.defaultProps = {
   is_admin: false,
   can_run_tests: false
 };
-
 
 class SubmissionsActionBox extends React.Component {
   constructor(props) {
@@ -377,16 +377,19 @@ class SubmissionsActionBox extends React.Component {
     }
 
     let downloadGroupingFilesButton = (
-      <a href={
-          Routes.download_groupings_files_assignment_submissions_path(this.props.assignment_id) +
-            '?groupings=' + this.props.selection.join()
-        }
-        onClick={this.props.downloadGroupingFiles}
-        download
-        className={"button" + (this.props.disabled ? " disabled" : "")}
+      <form action={Routes.download_groupings_files_assignment_submissions_path(this.props.assignment_id)}
+            onSubmit={this.props.downloadGroupingFiles}
       >
-        {I18n.t('download_the', {item: I18n.t('activerecord.models.submission.other')})}
-      </a>
+        {this.props.selection.map(selection => {
+          return (
+            <input type="number" name="groupings[]" defaultValue={selection} key={selection} hidden={true}/>
+          )
+        })}
+        <input type="hidden" name="authenticity_token" value={this.props.authenticity_token} />
+        <button type={'submit'} disabled={this.props.disabled}>
+          {I18n.t('download_the', {item: I18n.t('activerecord.models.submission.other')})}
+        </button>
+      </form>
     );
 
     return (

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,7 +14,6 @@ class SubmissionsController < ApplicationController
                          :download,
                          :downloads,
                          :download_groupings_files,
-                         :check_collect_status,
                          :manually_collect_and_begin_grading,
                          :repo_browser,
                          :update_submissions,
@@ -27,7 +26,6 @@ class SubmissionsController < ApplicationController
                        :revisions,
                        :repo_browser,
                        :download_groupings_files,
-                       :check_collect_status,
                        :update_submissions]
   before_action :authorize_for_student,
                 only: [:file_manager]
@@ -504,19 +502,6 @@ class SubmissionsController < ApplicationController
 
     ## Send the Zip file
     send_file zip_path, disposition: 'inline', filename: zip_name
-  end
-
-  ##
-  # Check the status of collection for all groupings
-  ##
-  def check_collect_status
-    assignment = Assignment.find(params[:assignment_id])
-    groupings = Grouping.get_groupings_for_assignment(assignment,
-                                                      current_user)
-
-    ## check collection is completed for all groupings
-    all_groupings_collected = groupings.all?(&:is_collected?)
-    render json: { collect_status: all_groupings_collected }
   end
 
   ##

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -475,8 +475,7 @@ class SubmissionsController < ApplicationController
   ##
   def download_groupings_files
     assignment = Assignment.find(params[:assignment_id])
-    groupings = params[:groupings].respond_to?(:map) ? params[:groupings] : params[:groupings].split(',')
-    groupings = Set.new groupings.map(&:to_i)
+    groupings = Set.new params[:groupings]&.map(&:to_i)
 
     ## create the zip name with the user name to have less chance to delete
     ## a currently downloading file

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -4,15 +4,14 @@
       window.submissionTable = makeSubmissionTable(document.getElementById('submission-table'),
         {
           assignment_id: <%= @assignment.id %>,
-          show_grace_tokens:
-            <%= @assignment.submission_rule.type == 'GracePeriodSubmissionRule' %>,
-          show_sections:
-            <%= Section.exists? %>,
-          show_members:
-            <%= @assignment.group_max > 1 || @assignment.scanned_exam? %>,
+          show_grace_tokens: <%= @assignment.submission_rule.type == 'GracePeriodSubmissionRule' %>,
+          show_sections: <%= Section.exists? %>,
+          show_members: <%= @assignment.group_max > 1 || @assignment.scanned_exam? %>,
           is_admin: <%= @current_user.admin? %>,
           can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
           max_mark: <%= @assignment.max_mark %>,
+          authenticity_token: '<%= form_authenticity_token(
+                         form_options: {action: download_groupings_files_assignment_submissions_url, method: 'get'}) %>'
         }
       );
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,6 @@ Rails.application.routes.draw do
           get 'server_time'
           get 'download'
           get 'download_groupings_files'
-          get 'check_collect_status'
         end
 
         member do

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -518,7 +518,7 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
             expect(zip_file.find_entry(
                      instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(
@@ -537,11 +537,9 @@ describe SubmissionsController do
           (1..2).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
-            expect(zip_file.find_entry(
-              instance_variable_get(:"@file#{i}_path"))).to_not be_nil
-            expect("file#{i}'s content\n").to eq(
-                                                zip_file.read(instance_variable_get(:"@file#{i}_path")))
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
+            expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
           end
         end
       end
@@ -556,9 +554,8 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
-            expect(zip_file.find_entry(
-                     instance_variable_get(:"@file#{i}_path"))).to be_nil
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to be_nil
           end
         end
       end
@@ -575,11 +572,9 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + "#{instance_variable_get(:"@grouping#{i}").group.repo_name}" + "file#{i}")
-            expect(zip_file.find_entry(
-              instance_variable_get(:"@file#{i}_path"))).to_not be_nil
-            expect("file#{i}'s content\n").to eq(
-              zip_file.read(instance_variable_get(:"@file#{i}_path")))
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
+            expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
           end
         end
       end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -503,7 +503,8 @@ describe SubmissionsController do
                                user: instance_variable_get(:"@student#{i}"),
                                membership_status: 'inviter',
                                grouping: instance_variable_get(
-                                 :"@grouping#{i}"))
+                                 :"@grouping#{i}"
+                               ))
           submit_file(@assignment, instance_variable_get(:"@grouping#{i}"),
                       "file#{i}", "file#{i}'s content\n")
         end
@@ -518,7 +519,8 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
+            )
             expect(zip_file.find_entry(
                      instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(
@@ -537,7 +539,8 @@ describe SubmissionsController do
           (1..2).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
+            )
             expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
           end
@@ -554,7 +557,8 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
+            )
             expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to be_nil
           end
         end
@@ -572,7 +576,8 @@ describe SubmissionsController do
           (1..3).to_a.each do |i|
             instance_variable_set(
               :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}")
+              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
+            )
             expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
             expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
           end


### PR DESCRIPTION
Remove the `SubmissionController#check_collect_status` and `Grouping#get_groupings_for_assignment` functions which are no longer used.

Pull this in only after #4022 has been pulled in and this PR has been rebased. 