### PR TITLE
Send request to download submissions as a post request

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -377,8 +377,9 @@ class SubmissionsActionBox extends React.Component {
     }
 
     let downloadGroupingFilesButton = (
-      <form action={Routes.download_groupings_files_assignment_submissions_path(this.props.assignment_id)}
+      <form action={Routes.download_groupings_files_assignment_submissions_url(this.props.assignment_id)}
             onSubmit={this.props.downloadGroupingFiles}
+            method="post"
       >
         {this.props.selection.map(selection => {
           return (

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -11,7 +11,7 @@
           can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
           max_mark: <%= @assignment.max_mark %>,
           authenticity_token: '<%= form_authenticity_token(
-                         form_options: {action: download_groupings_files_assignment_submissions_url, method: 'get'}) %>'
+                         form_options: {action: download_groupings_files_assignment_submissions_url}) %>'
         }
       );
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,7 @@ Rails.application.routes.draw do
           post 'update_files'
           get 'server_time'
           get 'download'
-          get 'download_groupings_files'
+          post 'download_groupings_files'
           get 'check_collect_status'
         end
 


### PR DESCRIPTION
This ensures that grouping info will be sent in the body of the request not in the URL (which has a character limit)

This builds on #4022 