### PR TITLE
Don't consider due dates when collecting scanned exams

### DIFF
--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -323,6 +323,7 @@ class RawGroupsTable extends React.Component {
     {
       Header: I18n.t('groups.extension'),
       accessor: 'extension',
+      show: !this.props.scanned_exam,
       Cell: row => {
         let extension = ['weeks', 'days', 'hours'].map(
           (key) => {

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -214,10 +214,12 @@ class AssignmentsController < ApplicationController
     @assignments = Assignment.all
     @sections = Section.all
 
-    if @assignment.past_collection_date?
-      flash_now(:notice, t('assignments.due_date.final_due_date_passed'))
-    elsif !past_date.blank?
-      flash_now(:notice, t('assignments.due_date.past_due_date_notice') + past_date.join(', '))
+    unless @assignment.scanned_exam
+      if @assignment.past_collection_date?
+        flash_now(:notice, t('assignments.due_date.final_due_date_passed'))
+      elsif !past_date.blank?
+        flash_now(:notice, t('assignments.due_date.past_due_date_notice') + past_date.join(', '))
+      end
     end
 
     # build section_due_dates for each section that doesn't already have a due date

--- a/app/views/assignments/student_interface.html.erb
+++ b/app/views/assignments/student_interface.html.erb
@@ -65,7 +65,7 @@
            if @grouping.nil? %>
           <p class='notice'>
             <%= t('groups.student_interface.no_group_yet') %>
-            <% if @assignment.past_collection_date?(@student.section) %>
+            <% if !@assignment.scanned_exam && @assignment.past_collection_date?(@student.section) %>
               <%= t('assignments.due_date.final_due_date_passed') %>
             <% end %>
           </p>


### PR DESCRIPTION
- remove extensions column from graders table for scanned exams
- don't check due date on collection for scanned exams
- don't show flash messages about due dates for scanned exams on:
     - submissions page
     - assignment update page
     - student view page