### PR TITLE
Simplify Submission Files API controller

### DIFF
--- a/app/controllers/api/submission_files_controller.rb
+++ b/app/controllers/api/submission_files_controller.rb
@@ -26,8 +26,7 @@ module Api
         return
       end
 
-      submission = Submission.get_submission_by_group_and_assignment(
-        group[:group_name], assignment[:short_identifier])
+      submission = group.grouping_for_assignment(assignment.id)&.current_submission_used
       if submission.nil?
         # No assignment submission by that group
         render 'shared/http_status', locals: {code: '404', message:
@@ -45,6 +44,7 @@ module Api
       end
 
       zip_name = "#{assignment[:short_identifier]}_#{group[:group_name]}.zip"
+      FileUtils.rm_f "tmp/#{zip_name}"
 
       # If only one file is found, send the file, otherwise loop through and
       # create a zip with all files

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -263,20 +263,6 @@ class Submission < ApplicationRecord
     end
   end
 
-  #=== Description
-  # Helper class method to find a submission by providing a group_name and
-  # and an assignment short identifier.
-  #=== Returns
-  # nil if no such submission exists.
-  def self.get_submission_by_group_and_assignment(group_n, ass_si)
-    assignment = Assignment.where(short_identifier: ass_si).first
-    group = Group.where(group_name: group_n).first
-    if !assignment.nil? && !group.nil?
-      grouping = group.grouping_for_assignment(assignment.id)
-      grouping.current_submission_used if !grouping.nil?
-    end
-  end
-
   def self.get_submission_by_group_id_and_assignment_id(group_id, assignment_id)
     group = Group.find(group_id)
     grouping = group.grouping_for_assignment(assignment_id)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -90,21 +90,6 @@ describe Submission do
   end
 
   describe 'The Submission class' do
-    it 'should be able to find a submission object by group name and assignment short identifier' do
-      assignment = create(:assignment)
-      group = create(:group)
-      grouping = create(:grouping, assignment: assignment, group: group)
-      submission = create(:version_used_submission, grouping: grouping)
-      sub2 = Submission.get_submission_by_group_and_assignment(group.group_name,
-                                                               assignment.short_identifier)
-      expect(sub2).to_not be_nil
-      expect(sub2).to be_a Submission
-      expect(sub2).to eq submission
-      expect(Submission.get_submission_by_group_and_assignment(
-              'group_name_not_there',
-              'A_not_there')).to be_nil
-    end
-
     it 'create a remark result' do
       s = create(:submission)
       s.update(remark_request_timestamp: Time.zone.now)


### PR DESCRIPTION
- reduce number of parameters (don't pass in group name and short identifier since they can be inferred from the required group id and assignment id)
- remove any previous temporary zip files since the `Zip::File::CREATE` mode for `Zip::File.open` does not overwrite a zip file, instead it either creates or appends (if the file exists). 