### PR TITLE
Make relative url root work in bg jobs in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Markus::Application.configure do
   # Show where SQL queries were generated from.
   config.active_record.verbose_query_logs = true
 
+  # Set this if MarkUs is deployed to a subdirectory, e.g. if it is served at https://yourhost.com/instance0
+  config.action_controller.relative_url_root = '/csc108'
+
   ###################################################################
   # MarkUs SPECIFIC CONFIGURATION
   #   - use "/" as path separator no matter what OS server is running

--- a/lib/tasks/autotest.rake
+++ b/lib/tasks/autotest.rake
@@ -145,8 +145,8 @@ class AutotestSetup
   def upload_test_files
     # send files for all hostnames because the
     # autotester uses the names as part of a hash key
-    AutotestSpecsJob.perform_now('http://localhost:3000/csc108', @assignment)
-    AutotestSpecsJob.perform_now('http://127.0.0.1:3000/csc108', @assignment)
-    AutotestSpecsJob.perform_now('http://0.0.0.0:3000/csc108', @assignment)
+    AutotestSpecsJob.perform_now('http://localhost:3000', @assignment)
+    AutotestSpecsJob.perform_now('http://127.0.0.1:3000', @assignment)
+    AutotestSpecsJob.perform_now('http://0.0.0.0:3000', @assignment)
   end
 end


### PR DESCRIPTION
- `config.action_controller.relative_url_root` in configuration file must be set in order for background jobs to be able to access the relative url root setting. 