### PR TITLE
New api routes for grade entry form controller

### DIFF
--- a/app/controllers/api/grade_entry_forms_controller.rb
+++ b/app/controllers/api/grade_entry_forms_controller.rb
@@ -20,7 +20,7 @@ module Api
     def index
       grade_entry_forms = get_collection(GradeEntryForm.includes(:grade_entry_items)) || return
 
-      include_args = { only: DEFAULT_FIELDS, include: { grade_entry_items: { only: [:name, :out_of] } } }
+      include_args = { only: DEFAULT_FIELDS, include: { grade_entry_items: { only: [:id, :name, :out_of] } } }
 
       respond_to do |format|
         format.xml do
@@ -28,6 +28,95 @@ module Api
           render xml: xml
         end
         format.json { render json: grade_entry_forms.to_json(include_args) }
+      end
+    end
+
+    # create a new grade entry form
+    # Requires:
+    #   :short_identifier
+    # Optional:
+    #   :description, :date, :is_hidden
+    #   grade_entry_items:
+    #     :name, :out_of, :bonus
+    def create
+      if has_missing_params?([:short_identifier])
+        # incomplete/invalid HTTP params
+        render 'shared/http_status', locals: { code: '422', message:
+          HttpStatusHelper::ERROR_CODE['message']['422'] }, status: 422
+        return
+      end
+
+      # check if there is an existing assignment
+      form = GradeEntryForm.find_by_short_identifier(params[:short_identifier])
+      unless form.nil?
+        render 'shared/http_status', locals: { code: '409', message:
+          'Grade Entry Form already exists' }, status: 409
+        return
+      end
+
+      ApplicationRecord.transaction do
+        create_params = params.permit(*DEFAULT_FIELDS, :show_total)
+        create_params[:is_hidden] ||= false
+        create_params[:description] ||= ''
+        new_form = GradeEntryForm.new(create_params)
+        unless new_form.save
+          render 'shared/http_status', locals: { code: '500', message:
+            new_form.errors.full_messages.first }, status: 500
+          raise ActiveRecord::Rollback
+        end
+
+        params[:grade_entry_items]&.each&.with_index do |column_params, i|
+          column_params = column_params.permit(:name, :out_of, :bonus).to_h.symbolize_keys
+          grade_item = GradeEntryItem.new(**column_params, grade_entry_form_id: new_form.id, position: i + 1)
+          unless grade_item.save
+            render 'shared/http_status', locals: { code: '500', message:
+              new_form.errors.full_messages.first }, status: 500
+            raise ActiveRecord::Rollback
+          end
+        end
+        render 'shared/http_status', locals: { code: '200', message:
+          HttpStatusHelper::ERROR_CODE['message']['200'] }, status: 200
+      end
+    end
+
+    # create a new grade entry form
+    # params:
+    #   :short_identifier, :description, :date, :is_hidden
+    #   grade_entry_items:
+    #     :id, :name, :out_of, :bonus
+    def update
+      # check if there is an existing assignment
+      form = GradeEntryForm.find(params[:id])
+      if form.nil?
+        render 'shared/http_status', locals: { code: '404', message:
+          'Grade Entry Form not found' }, status: 404
+        return
+      end
+
+      ApplicationRecord.transaction do
+        update_params = params.permit(*DEFAULT_FIELDS, :show_total)
+        unless form.update(update_params)
+          render 'shared/http_status', locals: { code: '500', message:
+            form.errors.full_messages.first }, status: 500
+          raise ActiveRecord::Rollback
+        end
+
+        params[:grade_entry_items]&.each do |column_params|
+          grade_item = GradeEntryItem.find_by_id(column_params[:id])
+          if grade_item.nil?
+            render 'shared/http_status', locals: { code: '404', message:
+              "Grade Entry Item with id=#{column_params[:id]} not found" }, status: 404
+            raise ActiveRecord::Rollback
+          end
+          column_params = column_params.permit(:name, :out_of, :bonus).to_h.symbolize_keys
+          unless grade_item.update(column_params)
+            render 'shared/http_status', locals: { code: '500', message:
+              grade_item.errors.full_messages.first }, status: 500
+            raise ActiveRecord::Rollback
+          end
+        end
+        render 'shared/http_status', locals: { code: '200', message:
+          HttpStatusHelper::ERROR_CODE['message']['200'] }, status: 200
       end
     end
 

--- a/app/controllers/api/grade_entry_forms_controller.rb
+++ b/app/controllers/api/grade_entry_forms_controller.rb
@@ -67,7 +67,7 @@ module Api
 
         params[:grade_entry_items]&.each&.with_index do |column_params, i|
           column_params = column_params.permit(:name, :out_of, :bonus).to_h.symbolize_keys
-          grade_item = GradeEntryItem.new(**column_params, grade_entry_form_id: new_form.id, position: i + 1)
+          grade_item = new_form.grade_entry_items.build(**column_params, position: i + 1)
           unless grade_item.save
             render 'shared/http_status', locals: { code: '500', message:
               grade_item.errors.full_messages.first }, status: 500
@@ -104,11 +104,11 @@ module Api
           raise ActiveRecord::Rollback
         end
 
+        position = form.grade_entry_items.count
         params[:grade_entry_items]&.each do |column_params|
           if column_params[:id].nil?
             column_params = column_params.permit(:name, :out_of, :bonus).to_h.symbolize_keys
-            position = form.grade_entry_items.count + 1
-            grade_item = GradeEntryItem.new(**column_params, grade_entry_form_id: form.id, position: position)
+            grade_item = form.build(**column_params, position: position += 1)
             unless grade_item.save
               render 'shared/http_status', locals: { code: '500', message:
                 grade_item.errors.full_messages.first }, status: 500

--- a/app/controllers/api/grade_entry_forms_controller.rb
+++ b/app/controllers/api/grade_entry_forms_controller.rb
@@ -2,7 +2,7 @@ module Api
 
   class GradeEntryFormsController < MainApiController
 
-    DEFAULT_FIELDS = [:id, :short_identifier, :description, :date, :is_hidden].freeze
+    DEFAULT_FIELDS = [:id, :short_identifier, :description, :date, :is_hidden, :show_total].freeze
 
     # Sends the contents of the specified grade entry form
     # Requires: id
@@ -55,7 +55,7 @@ module Api
       end
 
       ApplicationRecord.transaction do
-        create_params = params.permit(*DEFAULT_FIELDS, :show_total)
+        create_params = params.permit(*DEFAULT_FIELDS)
         create_params[:is_hidden] ||= false
         create_params[:description] ||= ''
         new_form = GradeEntryForm.new(create_params)
@@ -97,7 +97,7 @@ module Api
       end
 
       ApplicationRecord.transaction do
-        update_params = params.permit(*DEFAULT_FIELDS, :show_total)
+        update_params = params.permit(*DEFAULT_FIELDS)
         unless form.update(update_params)
           render 'shared/http_status', locals: { code: '500', message:
             form.errors.full_messages.first }, status: 500

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
           put 'update_by_username'
         end
       end
-      resources :grade_entry_forms, only: [:show, :index] do
+      resources :grade_entry_forms, only: [:show, :index, :create, :update] do
         member do
           put 'update_grades'
         end


### PR DESCRIPTION
- `grade_entry_forms_controller.create` : create a new grade entry form with optional columns
- `grade_entry_forms_controller.update` : update an existing grade entry form and update existing columns (or create new ones)
- these are required for the markus/quercus integration