### PR TITLE
Create a table for levels of rubric criteria, and update the schema

### DIFF
--- a/db/migrate/20190924061752_create_levels.rb
+++ b/db/migrate/20190924061752_create_levels.rb
@@ -1,10 +1,10 @@
 class CreateLevels < ActiveRecord::Migration[6.0]
   def change
     create_table :levels do |t|
-      t.belongs_to :rubric_criterion, foreign_key: true
+      t.belongs_to :rubric_criterion, foreign_key: true, null: false
       t.string :name, null: false
       t.integer :number, null: false
-      t.string :description
+      t.string :description, null: false
       t.float :mark, null: false
       t.timestamps
     end

--- a/db/migrate/20190924061752_create_levels.rb
+++ b/db/migrate/20190924061752_create_levels.rb
@@ -1,0 +1,12 @@
+class CreateLevels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :levels do |t|
+      t.belongs_to :rubric_criterion, foreign_key: true
+      t.string :name, null: false
+      t.integer :number, null: false
+      t.string :description
+      t.float :mark, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,10 +313,10 @@ ActiveRecord::Schema.define(version: 2019_09_24_061752) do
   end
 
   create_table "levels", force: :cascade do |t|
-    t.bigint "rubric_criterion_id"
+    t.bigint "rubric_criterion_id", null: false
     t.string "name", null: false
     t.integer "number", null: false
-    t.string "description"
+    t.string "description", null: false
     t.float "mark", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_183843) do
+ActiveRecord::Schema.define(version: 2019_09_24_061752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -312,6 +312,17 @@ ActiveRecord::Schema.define(version: 2019_07_08_183843) do
     t.datetime "updated_at"
   end
 
+  create_table "levels", force: :cascade do |t|
+    t.bigint "rubric_criterion_id"
+    t.string "name", null: false
+    t.integer "number", null: false
+    t.string "description"
+    t.float "mark", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["rubric_criterion_id"], name: "index_levels_on_rubric_criterion_id"
+  end
+
   create_table "marking_schemes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
@@ -606,6 +617,7 @@ ActiveRecord::Schema.define(version: 2019_07_08_183843) do
   add_foreign_key "feedback_files", "submissions"
   add_foreign_key "groupings", "assignments", name: "fk_groupings_assignments"
   add_foreign_key "groupings", "groups", name: "fk_groupings_groups"
+  add_foreign_key "levels", "rubric_criteria"
   add_foreign_key "marks", "results", name: "fk_marks_results", on_delete: :cascade
   add_foreign_key "memberships", "groupings", name: "fk_memberships_groupings"
   add_foreign_key "memberships", "users", name: "fk_memberships_users"


### PR DESCRIPTION
I did `rails delete migration create_levels` first and then `rake db:rollback`. It just deleted the migration file but there still was the wrong table for levels in the `schema.rb`. So I deleted the entire branch and built the vagrant box again. 

I think the right way to delete a wrong migration file and update the schema is to do `rake db:rollback` first to change the `schema.rb` back to the version without the wrong table and then do `rails delete migration <wrong_migration_name>` to delete the wrong migration file. 