### PR TITLE
Code-viewer and annotation bugfixes

### DIFF
--- a/app/assets/javascripts/Components/Result/annotation_panel.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_panel.jsx
@@ -25,6 +25,12 @@ export class AnnotationPanel extends React.Component {
     MathJax.Hub.Queue(['Typeset', MathJax.Hub, target_id]);
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.overallComment !== this.props.overallComment) {
+      this.setState({overallComment: this.props.overallComment});
+    }
+  }
+
   updateOverallComment = (event) => {
     const comment = event.target.value;
     this.setState({overallComment: comment, unsavedChanges: true});

--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -23,7 +23,6 @@ export class SubmissionFilePanel extends React.Component {
     this.modalDownload = new ModalMarkus('#download_dialog');
     if (localStorage.getItem('assignment_id') !== String(this.props.assignment_id)) {
       localStorage.removeItem('file');
-      localStorage.removeItem('file_id');
     }
     localStorage.setItem('assignment_id', this.props.assignment_id);
 
@@ -39,6 +38,8 @@ export class SubmissionFilePanel extends React.Component {
         document.getElementById('download_dialog_body')
       );
     }
+    const selectedFile = this.getFirstFile(this.props.fileData);
+    this.setState({selectedFile});
   }
 
   componentDidUpdate(prevProps) {
@@ -60,19 +61,26 @@ export class SubmissionFilePanel extends React.Component {
     }
   }
 
-  getFirstFile = (fileData) => {
+  getFirstFile = (fileData, filename) => {
     if (!this.state.student_view &&
         localStorage.getItem('assignment_id') === this.props.assignment_id.toString() &&
-        localStorage.getItem('file')) {
-      return [localStorage.getItem('file'), parseInt(localStorage.getItem('file_id'), 10)];
+        localStorage.getItem('file') && !filename) {
+        return this.getFirstFile(fileData, localStorage.getItem('file'))
     }
-
     if (fileData.files.length > 0) {
-      return fileData.files[0];
+      if (filename) {
+        for (let file_data of fileData.files) {
+          if (file_data[0] === filename) {
+            return file_data;
+          }
+        }
+      } else {
+        return fileData.files[0];
+      }
     }
     for (let dir in fileData.directories) {
       if (fileData.directories.hasOwnProperty(dir)) {
-        let f = this.getFirstFile(dir);
+        let f = this.getFirstFile(fileData.directories[dir], filename);
         if (f !== null) {
           return f;
         }
@@ -84,7 +92,6 @@ export class SubmissionFilePanel extends React.Component {
   selectFile = (file, id, focusLine) => {
     this.setState({selectedFile: [file, id], focusLine: focusLine});
     localStorage.setItem('file', file);
-    localStorage.setItem('file_id', id)
   };
 
   // Download the currently-selected file.

--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -56,14 +56,15 @@ export class SubmissionFilePanel extends React.Component {
     }
 
     if (prevProps.loading && !this.props.loading) {
-      let selectedFile;
+      let selectedFile = [];
       const stored_file = localStorage.getItem('file');
       const stored_assignment = localStorage.getItem('assignment_id');
       if (!this.state.student_view && stored_assignment === this.props.assignment_id.toString() && stored_file) {
         let filepath = stored_file.split('/');
-        selectedFile = [stored_file, this.getNamedFileId(this.props.fileData, filepath, filepath.pop())];
+        let filename = filepath.pop();
+        selectedFile = [stored_file, this.getNamedFileId(this.props.fileData, filepath, filename)];
       }
-      if (!selectedFile) {
+      if (!selectedFile[1]) {
         localStorage.removeItem('file');
         selectedFile = this.getFirstFile(this.props.fileData);
       }


### PR DESCRIPTION
Bugs:

- caching the submission file id in `localStorage` meant that a pdf or image file from a previous student was being displayed when changing between student submissions in the results page. 
- the `annotationPanel` component stores the current overall comment as both a prop and in the component state. This state was not being updated after the initial render which meant that a previously saved overall comment was never visible. 

Fixes:

- only cache the file name in `localStorage` and update the `getFirstFile` function to find either the first visible file or the first file with the cached filename. 
- add a `componentDidUpdate` method to the `annotationPanel` that makes sure the state updates to reflect the props when the props change (ie. when new data is sent from the server). 