### PR TITLE
Level Model

### DIFF
--- a/app/controllers/rubric_criteria_controller.rb
+++ b/app/controllers/rubric_criteria_controller.rb
@@ -2,7 +2,7 @@ class RubricCriteriaController < ApplicationController
 
   before_action :authorize_only_for_admin
 
-  def csv_download
+  def download_csv
     @assignment = Assignment.find(params[:assignment_id])
     file_out = MarkusCsv.generate(@assignment.get_criteria(:all, :rubric)) do |criterion|
       criterion_array = [criterion.name, criterion.max_mark]

--- a/app/controllers/rubric_criteria_controller.rb
+++ b/app/controllers/rubric_criteria_controller.rb
@@ -2,7 +2,7 @@ class RubricCriteriaController < ApplicationController
 
   before_action :authorize_only_for_admin
 
-  def download_csv
+  def csv_download
     @assignment = Assignment.find(params[:assignment_id])
     file_out = MarkusCsv.generate(@assignment.get_criteria(:all, :rubric)) do |criterion|
       criterion_array = [criterion.name, criterion.max_mark]

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,4 +1,8 @@
 class Level < ApplicationRecord
   belongs_to :rubric_criterion
 
+  validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
+  validates_numericality_of :mark, greater_than_or_equal_to: 0
+
+
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,0 +1,4 @@
+class Level < ApplicationRecord
+  belongs_to :rubric_criterion
+
+end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,8 +1,8 @@
+# Level represent a level within a Rubric Criterion
 class Level < ApplicationRecord
   belongs_to :rubric_criterion
 
   validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
   validates_numericality_of :mark, greater_than_or_equal_to: 0
-
 
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -2,6 +2,11 @@
 class Level < ApplicationRecord
   belongs_to :rubric_criterion
 
+  validates :name, presence: true
+  validates :number, presence: true
+  validates :description, presence: true
+  validates :mark, presence: true
+
   validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
   validates_numericality_of :mark, greater_than_or_equal_to: 0
 

--- a/db/migrate/20190924061752_create_levels.rb
+++ b/db/migrate/20190924061752_create_levels.rb
@@ -4,8 +4,9 @@ class CreateLevels < ActiveRecord::Migration[6.0]
       t.belongs_to :rubric_criterion, foreign_key: true, null: false
       t.string :name, null: false
       t.integer :number, null: false
-      t.string :description, null: false
+      t.text :description, null: false
       t.float :mark, null: false
+
       t.timestamps
     end
   end

--- a/db/migrate/20190924061752_create_levels.rb
+++ b/db/migrate/20190924061752_create_levels.rb
@@ -4,7 +4,7 @@ class CreateLevels < ActiveRecord::Migration[6.0]
       t.belongs_to :rubric_criterion, foreign_key: true, null: false
       t.string :name, null: false
       t.integer :number, null: false
-      t.text :description, null: false
+      t.string :description, null: false
       t.float :mark, null: false
 
       t.timestamps


### PR DESCRIPTION
Created a Level model that belongs to the Rubric Criterion model, as well made small changes to the Rubric Criterion controller and Yolanda's migration file. 
Possible future concern: Should we look to removing the number column in the Levels migration. If we are sorting models in the future by the mark, then the number column may just get in the way. For example, if we create levels 1, 2, 3, 4 and remove level 3 and add level 5, we would have levels 1, 2, 4, 5 in the database. 