### PR TITLE
Fix spreadsheet render error

### DIFF
--- a/app/assets/javascripts/Components/marks_spreadsheet.jsx
+++ b/app/assets/javascripts/Components/marks_spreadsheet.jsx
@@ -103,7 +103,7 @@ class RawMarksSpreadsheet extends React.Component {
       show: this.props.show_sections || false,
       minWidth: 70,
       Cell: ({ value }) => {
-        return value === null ? '' : this.state.sections[value]
+        return this.state.sections[value] || ''
       },
       filterMethod: (filter, row) => {
         if (filter.value === 'all') {


### PR DESCRIPTION
Fix bug that stopped spreadsheet table from rendering if a section is not null and not in the sections hash.