### PR TITLE
Make select-all checkbox more clickable

### DIFF
--- a/app/assets/javascripts/Components/marks_spreadsheet.jsx
+++ b/app/assets/javascripts/Components/marks_spreadsheet.jsx
@@ -88,6 +88,7 @@ class RawMarksSpreadsheet extends React.Component {
       },
       className: 'rt-hidden',
       headerClassName: 'rt-hidden',
+      show: false,
       width: 0,
       Filter: () => '',
     },


### PR DESCRIPTION
Setting `show` to false also makes the hidden column non-adjustable. Otherwise there are clickable regions in the header row to allow you to adjust the size of the id column which overlaps with the checkbox column. 