### PR TITLE
1.8.0:  Make group members always visible on submission table 

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -47,12 +47,10 @@ class RawSubmissionTable extends React.Component {
       id: 'group_name',
       Cell: row => {
         let members = '';
-        if (this.props.show_members) {
-          if (row.original.members) {
-            members = ` (${row.original.members.join(', ')})`;
-          } else {
-            members = '';
-          }
+        if (row.original.members.length === 1 && row.value === row.original.members[0]) {
+          members = '';
+        } else {
+          members = ` (${row.original.members.join(', ')})`;
         }
         if (row.original.result_id) {
           const result_url = Routes.edit_assignment_submission_result_path(

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -6,7 +6,6 @@
           assignment_id: <%= @assignment.id %>,
           show_grace_tokens: <%= @assignment.submission_rule.type == 'GracePeriodSubmissionRule' %>,
           show_sections: <%= Section.exists? %>,
-          show_members: <%= @assignment.group_max > 1 || @assignment.scanned_exam? %>,
           is_admin: <%= @current_user.admin? %>,
           can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
           max_mark: <%= @assignment.max_mark %>,


### PR DESCRIPTION
Copy of #4178 for the 1.8.0 branch