### PR TITLE
Default levels

### DIFF
--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,5 +1,7 @@
 # Level represent a level within a Rubric Criterion
 class Level < ApplicationRecord
+  belongs_to :rubric_criterion
+
   validates :name, presence: true
   validates :number, presence: true
   validates :description, presence: true

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,7 +1,5 @@
 # Level represent a level within a Rubric Criterion
 class Level < ApplicationRecord
-  belongs_to :rubric_criterion
-
   validates :name, presence: true
   validates :number, presence: true
   validates :description, presence: true
@@ -9,5 +7,4 @@ class Level < ApplicationRecord
 
   validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
   validates_numericality_of :mark, greater_than_or_equal_to: 0
-
 end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -36,13 +36,23 @@ class RubricCriterion < Criterion
     self.assigned_groups_count = result.uniq.length
   end
 
-  @max_mark = 0
-  @rubric_levels = 0
-  @max_levels = 0
   LEVELS = []
 
   def mark_for(result_id)
     marks.where(result_id: result_id).first
+  end
+
+  def get_max_mark
+    max_level = Level.find(LEVELS[LEVELS.length - 1].id)
+    max_level.mark
+  end
+
+  def get_num_levels
+
+  end
+
+  def get_max_levels
+    LEVELS.length
   end
 
   def set_default_levels
@@ -63,9 +73,6 @@ class RubricCriterion < Criterion
       new_level = Level(level['name'], level['description'], index)
       LEVELS.push(new_level)
     end
-    @max_mark = 4
-    @rubric_levels = LEVELS.length
-    @max_levels = LEVELS.length - 1
   end
 
   # Instantiate a RubricCriterion from a CSV row and attach it to the supplied

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -35,19 +35,19 @@ class RubricCriterion < Criterion
     end
     self.assigned_groups_count = result.uniq.length
   end
-  LEVELS = []
+
   RUBRIC_LEVELS = 5
   DEFAULT_MAX_MARKS = 4
   MAX_LEVELS = RUBRIC_LEVELS - 1
+
+  def get_levels
+    self.levels
+  end
 
   def mark_for(result_id)
     marks.where(result_id: result_id).first
   end
 
-  def get_max_mark
-    max_level = Level.find(LEVELS[LEVELS.length - 1].id)
-    max_level.mark
-  end
 
   def set_default_levels
     default_levels = [
@@ -62,10 +62,13 @@ class RubricCriterion < Criterion
       {'name' => I18n.t('rubric_criteria.defaults.level_4'),
        'description' => I18n.t('rubric_criteria.defaults.description_4')}
     ]
-    default.each_with_index do |level, index|
+    default_levels.each_with_index do |level, index|
+      # creates a new level and saves it to database
+      new_level = self.levels.new( :name => level['name'], :number => index, :description => level['description'],
+                                                          :mark => index)
+      new_level.save!
     end
   end
-
 
   # Instantiate a RubricCriterion from a CSV row and attach it to the supplied
   # assignment.

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -40,7 +40,7 @@ class RubricCriterion < Criterion
   DEFAULT_MAX_MARK = 4
   MAX_LEVEL = RUBRIC_LEVELS - 1
 
-  def get_levels
+  def levels
     self.levels
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -35,7 +35,7 @@ class RubricCriterion < Criterion
     end
     self.assigned_groups_count = result.uniq.length
   end
-
+  
   LEVELS = []
 
   def mark_for(result_id)
@@ -70,12 +70,10 @@ class RubricCriterion < Criterion
     ]
     default.each_with_index do |level, index|
 
-      # creates a new level and saves it to database
-      new_level = Level.create( :name => level['name'], :number => index, :description => level['description'],
-                                :mark => index)
-      LEVELS.push(new_level)
-      sort
     end
+    @max_mark = 4
+    @rubric_levels = LEVELS.length
+    @max_levels = LEVELS.length - 1
   end
 
   def sort

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -12,6 +12,8 @@ class RubricCriterion < Criterion
 
   has_many :tas, through: :criterion_ta_associations
 
+  has_many :levels,
+
   belongs_to :assignment, counter_cache: true
 
   validates_presence_of :assigned_groups_count
@@ -34,32 +36,36 @@ class RubricCriterion < Criterion
     self.assigned_groups_count = result.uniq.length
   end
 
-  # Just a small effort here to remove magic numbers...
-  RUBRIC_LEVELS = 5
-  DEFAULT_MAX_MARK = 4
-  MAX_LEVEL = RUBRIC_LEVELS - 1
-  DEFAULT_LEVELS = [
-    {'name' => I18n.t('rubric_criteria.defaults.level_0'),
-     'description' => I18n.t('rubric_criteria.defaults.description_0')},
-    {'name' => I18n.t('rubric_criteria.defaults.level_1'),
-     'description' => I18n.t('rubric_criteria.defaults.description_1')},
-    {'name' => I18n.t('rubric_criteria.defaults.level_2'),
-     'description' => I18n.t('rubric_criteria.defaults.description_2')},
-    {'name' => I18n.t('rubric_criteria.defaults.level_3'),
-     'description' => I18n.t('rubric_criteria.defaults.description_3')},
-    {'name' => I18n.t('rubric_criteria.defaults.level_4'),
-     'description' => I18n.t('rubric_criteria.defaults.description_4')}
-  ]
+  @max_mark = 0
+  @rubric_levels = 0
+  @max_levels = 0
+  LEVELS = []
 
   def mark_for(result_id)
     marks.where(result_id: result_id).first
   end
 
   def set_default_levels
-    DEFAULT_LEVELS.each_with_index do |level, index|
-      self['level_' + index.to_s + '_name'] = level['name']
-      self['level_' + index.to_s + '_description'] = level['description']
+    default_levels = [
+      {'name' => I18n.t('rubric_criteria.defaults.level_0'),
+       'description' => I18n.t('rubric_criteria.defaults.description_0')},
+      {'name' => I18n.t('rubric_criteria.defaults.level_1'),
+       'description' => I18n.t('rubric_criteria.defaults.description_1')},
+      {'name' => I18n.t('rubric_criteria.defaults.level_2'),
+       'description' => I18n.t('rubric_criteria.defaults.description_2')},
+      {'name' => I18n.t('rubric_criteria.defaults.level_3'),
+       'description' => I18n.t('rubric_criteria.defaults.description_3')},
+      {'name' => I18n.t('rubric_criteria.defaults.level_4'),
+       'description' => I18n.t('rubric_criteria.defaults.description_4')}
+    ]
+    default.each_with_index do |level, index|
+      # Level(name: something ...)
+      new_level = Level(level['name'], level['description'], index)
+      LEVELS.push(new_level)
     end
+    @max_mark = 4
+    @rubric_levels = LEVELS.length
+    @max_levels = LEVELS.length - 1
   end
 
   # Instantiate a RubricCriterion from a CSV row and attach it to the supplied

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -35,7 +35,6 @@ class RubricCriterion < Criterion
     end
     self.assigned_groups_count = result.uniq.length
   end
-  
   LEVELS = []
 
   def mark_for(result_id)
@@ -45,14 +44,6 @@ class RubricCriterion < Criterion
   def get_max_mark
     max_level = Level.find(LEVELS[LEVELS.length - 1].id)
     max_level.mark
-  end
-
-  def get_num_levels
-    LEVELS.length
-  end
-
-  def get_max_levels
-    LEVELS.length - 1
   end
 
   def set_default_levels
@@ -71,9 +62,6 @@ class RubricCriterion < Criterion
     default.each_with_index do |level, index|
 
     end
-    @max_mark = 4
-    @rubric_levels = LEVELS.length
-    @max_levels = LEVELS.length - 1
   end
 
   def sort

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -12,7 +12,7 @@ class RubricCriterion < Criterion
 
   has_many :tas, through: :criterion_ta_associations
 
-  has_many :levels
+  has_many :levels, -> { order(:mark) }
 
   belongs_to :assignment, counter_cache: true
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -45,7 +45,7 @@ class RubricCriterion < Criterion
     max_level = Level.find(LEVELS[LEVELS.length - 1].id)
     max_level.mark
   end
-
+  
   def set_default_levels
     default_levels = [
       {'name' => I18n.t('rubric_criteria.defaults.level_0'),
@@ -64,11 +64,6 @@ class RubricCriterion < Criterion
     end
   end
 
-  def sort
-    LEVELS.sort{|a,b|
-      Level.find(a.id).mark <=> Level.find(b.id).mark
-    }
-  end
 
   # Instantiate a RubricCriterion from a CSV row and attach it to the supplied
   # assignment.

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -48,11 +48,11 @@ class RubricCriterion < Criterion
   end
 
   def get_num_levels
-
+    LEVELS.length
   end
 
   def get_max_levels
-    LEVELS.length
+    LEVELS.length - 1
   end
 
   def set_default_levels
@@ -69,10 +69,19 @@ class RubricCriterion < Criterion
        'description' => I18n.t('rubric_criteria.defaults.description_4')}
     ]
     default.each_with_index do |level, index|
-      # Level(name: something ...)
-      new_level = Level(level['name'], level['description'], index)
+
+      # creates a new level and saves it to database
+      new_level = Level.create( :name => level['name'], :number => index, :description => level['description'],
+                                :mark => index)
       LEVELS.push(new_level)
+      sort
     end
+  end
+
+  def sort
+    LEVELS.sort{|a,b|
+      Level.find(a.id).mark <=> Level.find(b.id).mark
+    }
   end
 
   # Instantiate a RubricCriterion from a CSV row and attach it to the supplied

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -12,7 +12,7 @@ class RubricCriterion < Criterion
 
   has_many :tas, through: :criterion_ta_associations
 
-  has_many :levels,
+  has_many :levels
 
   belongs_to :assignment, counter_cache: true
 
@@ -36,6 +36,9 @@ class RubricCriterion < Criterion
     self.assigned_groups_count = result.uniq.length
   end
   LEVELS = []
+  RUBRIC_LEVELS = 5
+  DEFAULT_MAX_MARKS = 4
+  MAX_LEVELS = RUBRIC_LEVELS - 1
 
   def mark_for(result_id)
     marks.where(result_id: result_id).first
@@ -45,7 +48,7 @@ class RubricCriterion < Criterion
     max_level = Level.find(LEVELS[LEVELS.length - 1].id)
     max_level.mark
   end
-  
+
   def set_default_levels
     default_levels = [
       {'name' => I18n.t('rubric_criteria.defaults.level_0'),
@@ -60,7 +63,6 @@ class RubricCriterion < Criterion
        'description' => I18n.t('rubric_criteria.defaults.description_4')}
     ]
     default.each_with_index do |level, index|
-
     end
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -40,10 +40,6 @@ class RubricCriterion < Criterion
   DEFAULT_MAX_MARK = 4
   MAX_LEVEL = RUBRIC_LEVELS - 1
 
-  def levels
-    self.levels
-  end
-
   def mark_for(result_id)
     marks.where(result_id: result_id).first
   end
@@ -198,7 +194,7 @@ class RubricCriterion < Criterion
     associations = criterion_ta_associations.where(ta_id: ta_array).to_a
     ta_array.each do |ta|
       # & is the mathematical set intersection operator between two arrays
-      if (ta.criterion_ta_associations & associations).empty?
+      if (ta.criterion_ta_associations & associations).size < 1
         criterion_ta_associations.create(ta: ta, criterion: self, assignment: self.assignment)
       end
     end
@@ -207,8 +203,7 @@ class RubricCriterion < Criterion
   def remove_tas(ta_array)
     ta_array = Array(ta_array)
     associations_for_criteria = criterion_ta_associations.where(
-      ta_id: ta_array
-    ).to_a
+      ta_id: ta_array).to_a
     ta_array.each do |ta|
       # & is the mathematical set intersection operator between two arrays
       assoc_to_remove = (ta.criterion_ta_associations & associations_for_criteria)
@@ -228,6 +223,6 @@ class RubricCriterion < Criterion
       return false
     end
 
-    criterion_ta_associations.where(ta_id: ta.id).first != nil
+    !(criterion_ta_associations.where(ta_id: ta.id).first == nil)
   end
 end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -33,14 +33,16 @@ describe RubricCriterion do
     end
 
     it 'sets default levels' do
-      r = RubricCriterion.new
-      r.set_default_levels
+      assignment = create(:assignment)
+      rubric = create(:rubric_criterion, assignment: assignment)
+      rubric.set_default_levels
+      levels = rubric.get_levels
       byebug
-      expect(r.LEVELS[0]).to eq(I18n.t('rubric_criteria.defaults.level_0'))
-      expect(r.LEVELS[1]).to eq(I18n.t('rubric_criteria.defaults.level_1'))
-      expect(r.LEVELS[2]).to eq(I18n.t('rubric_criteria.defaults.level_2'))
-      expect(r.LEVELS[3]).to eq(I18n.t('rubric_criteria.defaults.level_3'))
-      expect(r.LEVELS[4]).to eq(I18n.t('rubric_criteria.defaults.level_4'))
+      expect(rubric.LEVELS[0]).to eq(I18n.t('rubric_criteria.defaults.level_0'))
+      expect(rubric.LEVELS[1]).to eq(I18n.t('rubric_criteria.defaults.level_1'))
+      expect(rubric.LEVELS[2]).to eq(I18n.t('rubric_criteria.defaults.level_2'))
+      expect(rubric.LEVELS[3]).to eq(I18n.t('rubric_criteria.defaults.level_3'))
+      expect(rubric.LEVELS[4]).to eq(I18n.t('rubric_criteria.defaults.level_4'))
     end
   end
 

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -35,6 +35,7 @@ describe RubricCriterion do
     it 'sets default levels' do
       r = RubricCriterion.new
       r.set_default_levels
+      byebug
       expect(r.LEVELS[0]).to eq(I18n.t('rubric_criteria.defaults.level_0'))
       expect(r.LEVELS[1]).to eq(I18n.t('rubric_criteria.defaults.level_1'))
       expect(r.LEVELS[2]).to eq(I18n.t('rubric_criteria.defaults.level_2'))

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -35,11 +35,11 @@ describe RubricCriterion do
     it 'sets default levels' do
       r = RubricCriterion.new
       r.set_default_levels
-      expect(r.level_0_name).to eq(I18n.t('rubric_criteria.defaults.level_0'))
-      expect(r.level_1_name).to eq(I18n.t('rubric_criteria.defaults.level_1'))
-      expect(r.level_2_name).to eq(I18n.t('rubric_criteria.defaults.level_2'))
-      expect(r.level_3_name).to eq(I18n.t('rubric_criteria.defaults.level_3'))
-      expect(r.level_4_name).to eq(I18n.t('rubric_criteria.defaults.level_4'))
+      expect(r.LEVELS[0]).to eq(I18n.t('rubric_criteria.defaults.level_0'))
+      expect(r.LEVELS[1]).to eq(I18n.t('rubric_criteria.defaults.level_1'))
+      expect(r.LEVELS[2]).to eq(I18n.t('rubric_criteria.defaults.level_2'))
+      expect(r.LEVELS[3]).to eq(I18n.t('rubric_criteria.defaults.level_3'))
+      expect(r.LEVELS[4]).to eq(I18n.t('rubric_criteria.defaults.level_4'))
     end
   end
 

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -37,12 +37,11 @@ describe RubricCriterion do
       rubric = create(:rubric_criterion, assignment: assignment)
       rubric.set_default_levels
       levels = rubric.get_levels
-      byebug
-      expect(rubric.LEVELS[0]).to eq(I18n.t('rubric_criteria.defaults.level_0'))
-      expect(rubric.LEVELS[1]).to eq(I18n.t('rubric_criteria.defaults.level_1'))
-      expect(rubric.LEVELS[2]).to eq(I18n.t('rubric_criteria.defaults.level_2'))
-      expect(rubric.LEVELS[3]).to eq(I18n.t('rubric_criteria.defaults.level_3'))
-      expect(rubric.LEVELS[4]).to eq(I18n.t('rubric_criteria.defaults.level_4'))
+      expect(levels[0].name).to eq(I18n.t('rubric_criteria.defaults.level_0'))
+      expect(levels[1].name).to eq(I18n.t('rubric_criteria.defaults.level_1'))
+      expect(levels[2].name).to eq(I18n.t('rubric_criteria.defaults.level_2'))
+      expect(levels[3].name).to eq(I18n.t('rubric_criteria.defaults.level_3'))
+      expect(levels[4].name).to eq(I18n.t('rubric_criteria.defaults.level_4'))
     end
   end
 
@@ -113,7 +112,7 @@ describe RubricCriterion do
         it 'raises' do
           expect do
             RubricCriterion.create_or_update_from_csv_row([], @assignment)
-              .to raise_error CsvInvalidLineError
+                           .to raise_error CsvInvalidLineError
           end
         end
       end
@@ -226,7 +225,7 @@ describe RubricCriterion do
 
         context 'be able to create a new instance with level descriptions' do
           it 'not raise error' do
-            criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
+            criterion = RubricCriterion.create_or_update_fbyerom_csv_row(@csv_base_row, @assignment)
             expect(criterion).not_to be_nil
             expect(criterion).to be_an_instance_of(RubricCriterion)
             expect(criterion.assignment).to eq(@assignment)

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -36,7 +36,7 @@ describe RubricCriterion do
       assignment = create(:assignment)
       rubric = create(:rubric_criterion, assignment: assignment)
       rubric.set_default_levels
-      levels = rubric.get_levels
+      levels = rubric.levels
       expect(levels[0].name).to eq(I18n.t('rubric_criteria.defaults.level_0'))
       expect(levels[1].name).to eq(I18n.t('rubric_criteria.defaults.level_1'))
       expect(levels[2].name).to eq(I18n.t('rubric_criteria.defaults.level_2'))
@@ -225,7 +225,7 @@ describe RubricCriterion do
 
         context 'be able to create a new instance with level descriptions' do
           it 'not raise error' do
-            criterion = RubricCriterion.create_or_update_fbyerom_csv_row(@csv_base_row, @assignment)
+            criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
             expect(criterion).not_to be_nil
             expect(criterion).to be_an_instance_of(RubricCriterion)
             expect(criterion.assignment).to eq(@assignment)


### PR DESCRIPTION
Created method for 'set_default_levels' where preexisting levels (level 0-4) are created and saved to the data base for the rubric criterion, with default names and descriptions. 
Possible shortcomings: 
- Currently, two of the tests relating to the create_and_update_from_csv_row are failing. I am currently working on that method on a branch that is branched off of this one. We may want to wait until I finish that method so that all the tests work and I can merge that branch into this one and this one into sti-criteria so that all the tests pass?
- I used rubocop -a to lint all three files. However, this resulted in me linting beyond what I worked on. Some of the autolint resulted in changing some lines of code, and I don't know whether these should be changed back or not.