### PR TITLE
Remove unnecessary parameter from recursive call

### DIFF
--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -94,7 +94,7 @@ export class SubmissionFilePanel extends React.Component {
     }
     for (let dir in fileData.directories) {
       if (fileData.directories.hasOwnProperty(dir)) {
-        let f = this.getFirstFile(fileData.directories[dir], filename);
+        let f = this.getFirstFile(fileData.directories[dir]);
         if (f !== null) {
           f[0] = `${dir}/${f[0]}`;
           return f;


### PR DESCRIPTION
- this is fixed on master but didn't make in to 1.8.0 for some reason