### PR TITLE
Update travis distribution version and postgres version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 rvm:
   - 2.5.3
-dist: trusty
+dist: bionic
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
+  apt:
+    packages:
+      - postgresql-10
+      - postgresql-client-10
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
- Update travis distribution from ubuntu trusty (14.04) to bionic (18.04)
- Update postgres version from 9.6 to 10.1
- both of these are what are currently used both in production and development environements