### PR TITLE
Use keyword arguments for all faker methods

### DIFF
--- a/spec/controllers/api/submission_files_controller_spec.rb
+++ b/spec/controllers/api/submission_files_controller_spec.rb
@@ -36,7 +36,7 @@ describe Api::SubmissionFilesController do
     let(:grouping) { create :grouping_with_inviter, assignment: assignment }
     let(:group) { grouping.group }
     let(:file_content) { Array.new(2) { Faker::TvShows::HeyArnold.quote } }
-    let(:file_names) { Array.new(2) { Faker::File.file_name('') } }
+    let(:file_names) { Array.new(2) { Faker::File.file_name(dir: '') } }
     before :each do
       admin = create :admin
       admin.reset_api_key

--- a/spec/factories/test_group_results.rb
+++ b/spec/factories/test_group_results.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     association :test_run
     marks_earned { 1 }
     marks_total { 1 }
-    time { Faker::Number.number(4) }
+    time { Faker::Number.number(digits: 4) }
   end
 end

--- a/spec/factories/test_runs.rb
+++ b/spec/factories/test_runs.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :test_run do
     association :grouping
     association :user
-    revision_identifier { Faker::Number.hexadecimal(40) }
+    revision_identifier { Faker::Number.hexadecimal(digits: 40) }
   end
 end


### PR DESCRIPTION
- this is a continuation of #4186 but with the rest of the methods that are now deprecated in Faker version 2.6.0 