### PR TITLE
Change `load_from_yml` in `rubric_criterion.rb`

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -137,17 +137,28 @@ class RubricCriterion < Criterion
     criterion.max_mark = criterion_yml[1]['max_mark']
 
     # Next comes the level names.
+    # (0..RUBRIC_LEVELS - 1).each do |i|
+    #   if criterion_yml[1]['level_' + i.to_s]
+    #     criterion['level_' + i.to_s + '_name'] =
+    #       criterion_yml[1]['level_' + i.to_s]['name']
+    #     criterion['level_' + i.to_s + '_description'] =
+    #       criterion_yml[1]['level_' + i.to_s]['description']
+    #   end
+    # end
+
     (0..RUBRIC_LEVELS - 1).each do |i|
       if criterion_yml[1]['level_' + i.to_s]
-        criterion['level_' + i.to_s + '_name'] =
-          criterion_yml[1]['level_' + i.to_s]['name']
-        criterion['level_' + i.to_s + '_description'] =
-          criterion_yml[1]['level_' + i.to_s]['description']
+        criterion.levels.build(:rubric_criterion => criterion,
+                               :name => criterion_yml[1]['level_' + i.to_s]['name'],
+                               :number => i,
+                               :description => criterion['level_' + i.to_s + '_description'],
+                               :mark => criterion['level_' + i.to_s + '_mark'])
       end
     end
     # Visibility options
     criterion.ta_visible = criterion_yml[1]['ta_visible'] unless criterion_yml[1]['ta_visible'].nil?
     criterion.peer_visible = criterion_yml[1]['peer_visible'] unless criterion_yml[1]['peer_visible'].nil?
+    criterion.save
     criterion
   end
 

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -935,6 +935,20 @@ describe CriteriaController do
         expect(cr1.peer_visible).to be false
       end
 
+      it ' creates a rubric criterion with levels properly ' do
+        @yaml_file = fixture_file_upload('spec/fixtures/files/rubric_criteria/rubric_criterion_test.yaml')
+
+        post_as @admin, :upload, params: { assignment_id: @assignment.id, upload_file: @yaml_file }
+
+        expect(@assignment.get_criteria(:all, :rubric).pluck(:name)).to contain_exactly('Grammar usage')
+        test_rubric_criterion = @assignment.get_criteria(:all, :rubric).find_by('Grammar usage')
+
+        expect(test_rubric_criterion.levels).not_to be_nil
+        (0..test_rubric_criterion.size - 1).each do |i|
+          expect(test_rubric_criterion.levels[i].name == "level_" + i.to_s )
+        end
+      end
+
       it 'creates criteria being case insensitive with the type given' do
         post_as @admin, :upload, params: { assignment_id: @assignment.id, upload_file: @uploaded_file }
 

--- a/spec/fixtures/files/rubric_criteria/rubric_criterion_test.yaml
+++ b/spec/fixtures/files/rubric_criteria/rubric_criterion_test.yaml
@@ -1,0 +1,25 @@
+Grammar usage:
+    type: rubric
+    max_mark: 16.0
+    level_0:
+      name: Beginner
+      description: There are more than 5 grammar mistakes in this entire essay.
+      mark: 0
+    level_1:
+      name: Intermediate
+      description: Intermediate.
+      mark: 2
+    level_2:
+      name: Accomplished
+      description: Accomplished.
+      mark: 3
+    level_3:
+      name: level 3 criterion
+      description: level 3 description
+      mark: 5
+    level_4:
+      name: level 4 criterion
+      description: level 4 description
+      mark: 6
+    ta_visible: true
+    peer_visible: false


### PR DESCRIPTION
I made changes in `rubric_criterion.load_from_yml` so that every time a user uploads a YML file that contains information for rubric_criteria, `load_from_yml` will create rubric_criteria with levels by the given information of a user and store these levels into the table 'levels' in the database. 

I also write corresponding tests for this method in `criteria_controller.rb` but it reports that `load_from_yml` does not create a rubric criterion properly and it cannot save a rubric criterion with associated levels into the database yet.