### PR TITLE
Create from csv

### DIFF
--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -4,7 +4,7 @@ class Level < ApplicationRecord
 
   validates :name, presence: true
   validates :number, presence: true
-  validates :description, presence: true
+  validates :description, presence: false
   validates :mark, presence: true
 
   validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -4,7 +4,7 @@ class Level < ApplicationRecord
 
   validates :name, presence: true
   validates :number, presence: true
-  validates :description, presence: false
+  validates :description, presence: true
   validates :mark, presence: true
 
   validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -70,10 +70,9 @@ class RubricCriterion < Criterion
   # ===Params:
   #
   # row::         An array representing one CSV file row. Should be in the following
-  #               format: [name, weight, _names_, _descriptions_] where the _names_ part
-  #               must contain RUBRIC_LEVELS elements representing the name of each
-  #               level and the _descriptions_ part (optional) can contain up to
-  #               RUBRIC_LEVELS description (one for each level).
+  #               format: [name, weight, _levels_ ] where the _levels part contains
+  #               the following information about each level in the following order:
+  #               name, number, description, mark.
   # assignment::  The assignment to which the newly created criterion should belong.
   #
   # ===Raises:
@@ -85,7 +84,6 @@ class RubricCriterion < Criterion
     if row.length < RUBRIC_LEVELS + 2
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
-    # byebug
 
     working_row = row.clone
     name = working_row.shift
@@ -102,31 +100,15 @@ class RubricCriterion < Criterion
     if criterion.new_record?
       criterion.position = assignment.next_criterion_position
     end
-    level_names = []
-    level_descriptions = []
-    # next comes the level names.
+
+    # create the levels
     (0..RUBRIC_LEVELS - 1).each do |i|
-      level_names.push(working_row.shift)
+      name = working_row.shift
+      number = working_row.shift
+      description = working_row.shift
+      mark = working_row.shift
+      self.levels.create(name: name, number: number, description: description, mark: mark)
     end
-    # the rest of the values are level descriptions.
-    (0..RUBRIC_LEVELS - 1).each do |i|
-      level_descriptions.push(working_row.shift)
-    end
-    # raises an error if the number of name entries is not the same as the number of description entries
-    if level_names.length != level_descriptions.length
-      raise CsvInvalidLineError, "Number of name entries do not match number of description entries"
-    end
-
-    # byebug
-
-    (0..level_names.length).each do |index|
-      self.levels.create(name: level_names[index], number: index,
-                         description: level_descriptions[index], mark: index)
-    # end
-
-    # byebug
-
-
 
 
     # (0..RUBRIC_LEVELS-1).each do |i|

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -101,9 +101,8 @@ class RubricCriterion < Criterion
       criterion.position = assignment.next_criterion_position
     end
 
-    # create the levels
-    # Right now neither upsert nor save works :(
-    (0..RUBRIC_LEVELS - 1).each do |i|
+    # create/update the levels
+    (0..RUBRIC_LEVELS - 1).each do
       name = working_row.shift
       number = working_row.shift
       description = working_row.shift
@@ -111,19 +110,12 @@ class RubricCriterion < Criterion
       # if level name exists we will update the level
       if criterion.levels.exists?(name: name)
         level = criterion.levels.find_by(name: name)
-        # check out find and create by and find or initialize by
-        criterion.levels.upsert(id: level.id, rubric_criterion_id: level.rubric_criterion_id, name: name, number: number,
-                           description: description, mark: level.mark, created_at: level.created_at, updated_at: level.updated_at)
-        # byebug
-        # level.name = name
-        # level.number = number
-        # level.description = description
-        # level.mark = mark
-        # level.save
-        # byebug
+        criterion.levels.upsert(id: level.id, rubric_criterion_id: level.rubric_criterion_id, name: name,
+                                number: number, description: description, mark: level.mark,
+                                created_at: level.created_at, updated_at: level.updated_at)
       # Otherwise, we create a new level
       else
-        self.levels.create(name: name, number: number, description: description, mark: mark)
+        criterion.levels.create(name: name, number: number, description: description, mark: mark)
       end
       unless criterion.save
         raise CsvInvalidLineError

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -85,6 +85,7 @@ class RubricCriterion < Criterion
     if row.length < RUBRIC_LEVELS + 2
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
+    # byebug
 
     working_row = row.clone
     name = working_row.shift
@@ -101,14 +102,40 @@ class RubricCriterion < Criterion
     if criterion.new_record?
       criterion.position = assignment.next_criterion_position
     end
+    level_names = []
+    level_descriptions = []
     # next comes the level names.
     (0..RUBRIC_LEVELS - 1).each do |i|
-      criterion['level_' + i.to_s + '_name'] = working_row.shift
+      level_names.push(working_row.shift)
     end
     # the rest of the values are level descriptions.
     (0..RUBRIC_LEVELS - 1).each do |i|
-      criterion['level_' + i.to_s + '_description'] = working_row.shift
+      level_descriptions.push(working_row.shift)
     end
+    # raises an error if the number of name entries is not the same as the number of description entries
+    if level_names.length != level_descriptions.length
+      raise CsvInvalidLineError, "Number of name entries do not match number of description entries"
+    end
+
+    # byebug
+
+    (0..level_names.length).each do |index|
+      self.levels.create(name: level_names[index], number: index,
+                         description: level_descriptions[index], mark: index)
+    # end
+
+    # byebug
+
+
+
+
+    # (0..RUBRIC_LEVELS-1).each do |i|
+    #   criterion['level_' + i.to_s + '_name'] = working_row.shift
+    # end
+    #
+    # (0..RUBRIC_LEVELS-1).each do |i|
+    #   criterion['level_' + i.to_s + '_description'] = working_row.shift
+    # end
     unless criterion.save
       raise CsvInvalidLineError
     end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -101,8 +101,11 @@ class RubricCriterion < Criterion
       criterion.position = assignment.next_criterion_position
     end
 
+    # there are 5 fields for each level
+    num_levels = working_row.length/5
+
     # create/update the levels
-    (0..RUBRIC_LEVELS - 1).each do
+    (0..num_levels).each do
       name = working_row.shift
       number = working_row.shift
       description = working_row.shift
@@ -214,7 +217,7 @@ class RubricCriterion < Criterion
     ta_array.each do |ta|
       # & is the mathematical set intersection operator between two arrays
       assoc_to_remove = (ta.criterion_ta_associations & associations_for_criteria)
-      unless assoc_to_remove.size.empty?
+      unless assoc_to_remove.empty?
         criterion_ta_associations.delete(assoc_to_remove)
         assoc_to_remove.first.destroy
       end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -102,7 +102,7 @@ class RubricCriterion < Criterion
     end
 
     # there are 5 fields for each level
-    num_levels = working_row.length/5
+    num_levels = working_row.length / 5
 
     # create/update the levels
     (0..num_levels).each do

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -80,7 +80,7 @@ class RubricCriterion < Criterion
   # CsvInvalidLineError  If the row does not contain enough information, if the weight
   #                      does not evaluate to a float, or if the criterion is not
   #                      successfully saved.
-  def self.create_or_update_from_csv_row(row, assignment)
+  def create_or_update_from_csv_row(row, assignment)
     if row.length < RUBRIC_LEVELS + 2
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -214,7 +214,7 @@ class RubricCriterion < Criterion
     ta_array.each do |ta|
       # & is the mathematical set intersection operator between two arrays
       assoc_to_remove = (ta.criterion_ta_associations & associations_for_criteria)
-      unless assoc_to_remove.empty?
+      if assoc_to_remove.size > 0
         criterion_ta_associations.delete(assoc_to_remove)
         assoc_to_remove.first.destroy
       end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -214,7 +214,7 @@ class RubricCriterion < Criterion
     ta_array.each do |ta|
       # & is the mathematical set intersection operator between two arrays
       assoc_to_remove = (ta.criterion_ta_associations & associations_for_criteria)
-      if assoc_to_remove.size > 0
+      unless assoc_to_remove.size.empty?
         criterion_ta_associations.delete(assoc_to_remove)
         assoc_to_remove.first.destroy
       end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -206,7 +206,6 @@ describe RubricCriterion do
 
         context 'allow a criterion with the same name to overwrite' do
           it 'not raise error' do
-
             names = ['Very Poor', 'Weak', 'Passable', 'Good', 'Excellent']
             row = ['criterion 5', '1.0']
             # order is name, number, description, mark
@@ -233,12 +232,11 @@ describe RubricCriterion do
           it 'not raise error' do
             RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
             levels = @criterion.levels
-            expect(levels[0].name).to eq("Very Poor")
+            expect(levels[0].name).to eq('Very Poor')
             expect(levels[0].mark).to eq(0.0)
             expect(levels.length).to eq(10)
           end
         end
-
       end
     end
   end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -189,61 +189,56 @@ describe RubricCriterion do
         @csv_base_row = row
       end
 
-      # WIP NEXT STEP IS TO GET THIS TEST TO RUN CORRECTLY, MAYBE HAVE TO CHANGE CSV BASE ROW BEING PASSED IN
-      #
-      it 'be able to create a new instance without level descriptions' do
-        rubric = create(:rubric_criterion, assignment: @assignment)
-        criterion = rubric.create_or_update_from_csv_row(@csv_base_row, @assignment)
-        expect(criterion).not_to be_nil
-        expect(criterion).to be_an_instance_of(RubricCriterion)
-        expect(criterion.assignment).to eq(@assignment)
-        levels = rubric.levels
-        (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-          level = levels[i]
-          expect('name' + i.to_s).to eq(level.name)
-        end
-      end
-
       context 'and there is an existing rubric criterion with the same name' do
-        setup do
-          criterion = create(:rubric_criterion, assignment: @assignment)
-          criterion.set_default_levels
+        before(:each) do
+          @criterion = create(:rubric_criterion, assignment: @assignment)
+          @criterion.set_default_levels
           # 'criterion 5' is the name used in the criterion held
           # in @csv_base_row - but they use different level names/descriptions.
           # I'll use the defaults here, and see if I can overwrite with
           # @csv_base_row.
-          criterion.name = 'criterion 5'
-          criterion.assignment = @assignment
-          criterion.position = @assignment.next_criterion_position
-          criterion.max_mark = 5.0
-          expect(criterion.save)
+          @criterion.name = 'criterion 5'
+          @criterion.assignment = @assignment
+          @criterion.position = @assignment.next_criterion_position
+          @criterion.max_mark = 5.0
+          expect(@criterion.save)
         end
 
         context 'allow a criterion with the same name to overwrite' do
           it 'not raise error' do
-            criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
-            (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-              expect('name' + i.to_s).to eq(criterion['level_' + i.to_s + '_name'])
-              expect(4.0).to eq(criterion.max_mark)
+
+            names = ['Very Poor', 'Weak', 'Passable', 'Good', 'Excellent']
+            row = ['criterion 5', '1.0']
+            # order is name, number, description, mark
+            (0..@criterion.levels.length - 1).each do |i|
+              row << names[i]
+              row << i
+              # ...containing commas and quotes in the descriptions
+              row << 'new description number ' + i.to_s
+              row << i
+            end
+
+            RubricCriterion.create_or_update_from_csv_row(row, @assignment)
+            @criterion.reload
+            levels = @criterion.levels
+            expect(levels.length).to eq(5)
+            (0..levels.length - 1).each do |i|
+              expect(names[i]).to eq(levels[i].name)
+              expect('new description number ' + i.to_s).to eq(levels[i].description)
             end
           end
         end
 
-        context 'be able to create a new instance with level descriptions' do
+        context 'allow a criterion with the same name to add levels' do
           it 'not raise error' do
-            criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
-            expect(criterion).not_to be_nil
-            expect(criterion).to be_an_instance_of(RubricCriterion)
-            expect(criterion.assignment).to eq(@assignment)
-            (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-              assert_equal 'name' + i.to_s, criterion['level_' + i.to_s + '_name']
-              expect('name' + i.to_s).to eq(criterion['level_' + i.to_s + '_name'])
-              expect(
-                'description' + i.to_s + ' with comma (,) and ""quotes""'
-              ).to eq(criterion['level_' + i.to_s + '_description'])
-            end
+            RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
+            levels = @criterion.levels
+            expect(levels[0].name).to eq("Very Poor")
+            expect(levels[0].mark).to eq(0.0)
+            expect(levels.length).to eq(10)
           end
         end
+
       end
     end
   end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -178,24 +178,23 @@ describe RubricCriterion do
         # we'll need a valid assignment for those cases.
         @assignment = create(:assignment)
         row = ['criterion 5', '1.0']
+        # order is name, number, description, mark
         (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
           row << 'name' + i.to_s
-        end
-        # ...containing commas and quotes in the descriptions
-        (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
+          row << i
+          # ...containing commas and quotes in the descriptions
           row << 'description' + i.to_s + ' with comma (,) and ""quotes""'
+          row << i
         end
         @csv_base_row = row
       end
 
       it 'be able to create a new instance without level descriptions' do
-        byebug
         criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
         expect(criterion).not_to be_nil
         expect(criterion).to be_an_instance_of(RubricCriterion)
         expect(criterion.assignment).to eq(@assignment)
         criterion_levels = criterion.levels
-        byebug
         (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
           expect('name' + i.to_s).to eq(criterion['level_' + i.to_s + '_name'])
         end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -232,7 +232,6 @@ describe RubricCriterion do
           it 'not raise error' do
             RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
             levels = @criterion.levels
-            expect(levels[0].name).to eq('Very Poor')
             expect(levels[0].mark).to eq(0.0)
             expect(levels.length).to eq(10)
           end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -189,20 +189,24 @@ describe RubricCriterion do
         @csv_base_row = row
       end
 
+      # WIP NEXT STEP IS TO GET THIS TEST TO RUN CORRECTLY, MAYBE HAVE TO CHANGE CSV BASE ROW BEING PASSED IN
+      #
       it 'be able to create a new instance without level descriptions' do
-        criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
+        rubric = create(:rubric_criterion, assignment: @assignment)
+        criterion = rubric.create_or_update_from_csv_row(@csv_base_row, @assignment)
         expect(criterion).not_to be_nil
         expect(criterion).to be_an_instance_of(RubricCriterion)
         expect(criterion.assignment).to eq(@assignment)
-        criterion_levels = criterion.levels
+        levels = rubric.levels
         (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-          expect('name' + i.to_s).to eq(criterion['level_' + i.to_s + '_name'])
+          level = levels[i]
+          expect('name' + i.to_s).to eq(level.name)
         end
       end
 
       context 'and there is an existing rubric criterion with the same name' do
         setup do
-          criterion = RubricCriterion.new
+          criterion = create(:rubric_criterion, assignment: @assignment)
           criterion.set_default_levels
           # 'criterion 5' is the name used in the criterion held
           # in @csv_base_row - but they use different level names/descriptions.

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -189,10 +189,13 @@ describe RubricCriterion do
       end
 
       it 'be able to create a new instance without level descriptions' do
+        byebug
         criterion = RubricCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
         expect(criterion).not_to be_nil
         expect(criterion).to be_an_instance_of(RubricCriterion)
         expect(criterion.assignment).to eq(@assignment)
+        criterion_levels = criterion.levels
+        byebug
         (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
           expect('name' + i.to_s).to eq(criterion['level_' + i.to_s + '_name'])
         end


### PR DESCRIPTION
Updated create_from_csv_row method, such that it utilizes the newly implemented level association between the Level model and the RubricCriterion model. Furthermore, I created/edited the existing tests so that they function properly with the new method. For example, the csv rows that are used in the rspec tests have name, number, description, and mark to match the required fields of level.
Notes and possible shortcomings: 
- we are still using the constants RUBRIC_LEVELS, DEFAULT_MAX_MARK, and MAX_LEVEL. I will remove these and update their respective tests in my next PR.
- I have added an add level test and an edit level test. I believe these would cover the only cases for the update_csv_row method, but if there are edge cases I should test that I have not thought about, I will create more tests to satisfy those cases.