### PR TITLE
result: Only hide file selector on blur.

### DIFF
--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -260,7 +260,8 @@ export class FileSelector extends React.Component {
             e.stopPropagation();
             this.expandFileSelector(expand);
           }}
-          onMouseLeave={() => this.expandFileSelector(null)}
+          onBlur={() => this.expandFileSelector(null)}
+          tabIndex={-1}
         >
           <a>{selectorLabel}</a>
           {arrow}

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -656,7 +656,7 @@ nav {
     display: none;
     left: -1px;
     margin: 0;
-    min-width: 200px;
+    min-width: 16ch;
     padding: 0;
     position: absolute;
     text-align: left;


### PR DESCRIPTION
Previous behaviour was to hide the file selector on mouse leave, which
prevented the ability to scroll horizontally when there were many
nested subdirectories. Fixes #4199.

Also updated the CSS to make each directory level narrower.