### PR TITLE
Constant refactor

### DIFF
--- a/app/controllers/rubric_criteria_controller.rb
+++ b/app/controllers/rubric_criteria_controller.rb
@@ -6,11 +6,11 @@ class RubricCriteriaController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     file_out = MarkusCsv.generate(@assignment.get_criteria(:all, :rubric)) do |criterion|
       criterion_array = [criterion.name, criterion.max_mark]
-      (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-        criterion_array.push(criterion['level_' + i.to_s + '_name'])
+      (0..criterion.levels.length - 1).each do |i|
+        criterion_array.push(criterion.levels[i].name)
       end
-      (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
-        criterion_array.push(criterion['level_' + i.to_s + '_description'])
+      (0..criterion.levels.length - 1).each do |i|
+        criterion_array.push(criterion.levels[i].description)
       end
       criterion_array
     end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -81,7 +81,9 @@ class RubricCriterion < Criterion
   #                      does not evaluate to a float, or if the criterion is not
   #                      successfully saved.
   def self.create_or_update_from_csv_row(row, assignment)
-    if row.length < RUBRIC_LEVELS + 2
+    # get number of required fields
+    required_fields = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
+    if row.length < required_fields + 2
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
 
@@ -146,8 +148,10 @@ class RubricCriterion < Criterion
     criterion.name = name
     criterion.max_mark = criterion_yml[1]['max_mark']
 
+    # get number of required fields
+    required_fields = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
     # Next comes the level names.
-    (0..RUBRIC_LEVELS - 1).each do |i|
+    (0..required_fields - 1).each do |i|
       if criterion_yml[1]['level_' + i.to_s]
         criterion['level_' + i.to_s + '_name'] =
           criterion_yml[1]['level_' + i.to_s]['name']

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -85,7 +85,6 @@ class RubricCriterion < Criterion
     if row.length < 1
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
-
     working_row = row.clone
     name = working_row.shift
     # If a RubricCriterion of the same name exits, load it up.  Otherwise,
@@ -115,6 +114,7 @@ class RubricCriterion < Criterion
       else
         criterion.levels.create(name: name, number: number, description: description, mark: mark)
       end
+
       unless criterion.save
         raise CsvInvalidLineError
       end
@@ -177,7 +177,7 @@ class RubricCriterion < Criterion
   end
 
   def weight
-    max_mark / MAX_LEVEL
+    self.max_mark / (self.levels.length - 1)
   end
 
   def round_max_mark

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -116,12 +116,10 @@ class RubricCriterion < Criterion
         criterion.levels.create(name: name, number: number, description: description, mark: mark)
       end
       unless criterion.save
-        byebug
         raise CsvInvalidLineError
       end
     end
-    # criterion.update
-    criterion.max_mark = Float(criterion.levels.maximum('mark'))
+    criterion.update(max_mark: Float(criterion.levels.maximum('mark')))
   end
 
   # Instantiate a RubricCriterion from a YML entry

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -121,7 +121,7 @@ class RubricCriterion < Criterion
         raise CsvInvalidLineError
       end
     end
-    criterion.max_mark = Float(criterion.levels.maximum("mark"))
+    criterion.max_mark = Float(criterion.levels.maximum('mark'))
   end
 
   # Instantiate a RubricCriterion from a YML entry

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -82,7 +82,7 @@ class RubricCriterion < Criterion
   #                      successfully saved.
   def self.create_or_update_from_csv_row(row, assignment)
     # we only require the user to upload a single entry, as blank rubric criterion can be uploaded
-    if row.length < 1
+    if row.empty?
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
     working_row = row.clone

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -181,7 +181,6 @@ describe RubricCriterion do
         row = ['criterion 5']
         rubric_levels = 5
         # order is name, number, description, mark
-        # .weight
         (0..rubric_levels - 1).each do |i|
           row << 'name' + i.to_s
           row << i

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -143,7 +143,9 @@ describe RubricCriterion do
     context 'when parsing a CSV file' do
       describe 'raise csv line error on rows with elements without names for every criterion' do
         row = %w[name 1.0]
-        (0..RubricCriterion::RUBRIC_LEVELS - 2).each do |i|
+        # get number of required fields
+        required = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
+        (0..required).each do |i|
           row << 'name' + i.to_s
           it 'raises' do
             expect do
@@ -178,8 +180,10 @@ describe RubricCriterion do
         # we'll need a valid assignment for those cases.
         @assignment = create(:assignment)
         row = ['criterion 5', '1.0']
+        # get number of required fields
+        required_fields = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
         # order is name, number, description, mark
-        (0..RubricCriterion::RUBRIC_LEVELS - 1).each do |i|
+        (0..required_fields - 1).each do |i|
           row << 'name' + i.to_s
           row << i
           # ...containing commas and quotes in the descriptions

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -143,9 +143,8 @@ describe RubricCriterion do
     context 'when parsing a CSV file' do
       describe 'raise csv line error on rows with elements without names for every criterion' do
         row = %w[name 1.0]
-        # get number of required fields
-        required = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
-        (0..required).each do |i|
+        levels = 5
+        (0..levels).each do |i|
           row << 'name' + i.to_s
           it 'raises' do
             expect do
@@ -180,10 +179,10 @@ describe RubricCriterion do
         # we'll need a valid assignment for those cases.
         @assignment = create(:assignment)
         row = ['criterion 5']
-        # get number of required fields
-        required_fields = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
+        rubric_levels = 5
         # order is name, number, description, mark
-        (0..required_fields - 1).each do |i|
+        # .weight
+        (0..rubric_levels - 1).each do |i|
           row << 'name' + i.to_s
           row << i
           # ...containing commas and quotes in the descriptions

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -179,7 +179,7 @@ describe RubricCriterion do
       before(:each) do
         # we'll need a valid assignment for those cases.
         @assignment = create(:assignment)
-        row = ['criterion 5', '1.0']
+        row = ['criterion 5']
         # get number of required fields
         required_fields = Level.validators.grep(ActiveRecord::Validations::PresenceValidator).length
         # order is name, number, description, mark
@@ -211,7 +211,7 @@ describe RubricCriterion do
         context 'allow a criterion with the same name to overwrite' do
           it 'not raise error' do
             names = ['Very Poor', 'Weak', 'Passable', 'Good', 'Excellent']
-            row = ['criterion 5', '1.0']
+            row = ['criterion 5']
             # order is name, number, description, mark
             (0..@criterion.levels.length - 1).each do |i|
               row << names[i]


### PR DESCRIPTION
Removed usages of RUBRIC_LEVEL, MAX_LEVEL, and MAX_MARK constants within rubric_criterion.rb as well as within rubric_criterion_spec.rb. Also edited how csv_rows are inputted as we do not need a 'weight' of marks as we needed before, so I removed the second entry in every csv_row which originally was a weight of 1.0, as levels keep track of marks now. 
Possible shortcomings and additional notes:
- I have kept the constants within the Rubric Criterion class as there are other references to them within Markus to the constants. I will work on removing those next.
- This PR should be merged after create_or_update from_csv PR gets merged as this branch is branched off of that one.