### PR TITLE
Fix spreadsheet total column update bug

### DIFF
--- a/app/assets/javascripts/Components/marks_spreadsheet.jsx
+++ b/app/assets/javascripts/Components/marks_spreadsheet.jsx
@@ -48,11 +48,6 @@ class RawMarksSpreadsheet extends React.Component {
     }).then(response => {
       this.props.resetSelection();
 
-      if (this.props.show_total) {
-        response.data.forEach(row => {
-          this[`total-${row.id}`] |= React.createRef();
-        });
-      }
       this.setState({
         data: response.data,
         loading: false,
@@ -144,7 +139,7 @@ class RawMarksSpreadsheet extends React.Component {
       student_id={row.original._id}
       default_value={row.value}
       updateTotal={(gradeEntryItemId, newGrade, newTotal) =>
-                    this.updateTotal(row.index, row.original.id, gradeEntryItemId, newGrade, newTotal)}
+                    this.updateTotal(row.index, row.original._id, gradeEntryItemId, newGrade, newTotal)}
     />;
   };
 
@@ -154,7 +149,7 @@ class RawMarksSpreadsheet extends React.Component {
     minWidth: 50,
     className: 'grade-total',
     Cell: row => {
-      return <GradeEntryTotal initial_value={row.value} ref={node => this[`total-${row.original.id}`] = node} />;
+      return <GradeEntryTotal initial_value={row.value} ref={node => this[`total-${row.original._id}`] = node} />;
     },
     defaultSortDesc: true,
     sortMethod: (a, b, desc) => {

--- a/spec/models/penalty_decay_period_submission_rule_spec.rb
+++ b/spec/models/penalty_decay_period_submission_rule_spec.rb
@@ -41,7 +41,7 @@ describe PenaltyDecayPeriodSubmissionRule do
 
     it 'be able to calculate collection time for a grouping' do
       expect(Time.now).to be < @assignment.due_date
-      due_date_plus_period = @assignment.due_date + 2.days
+      due_date_plus_period = @assignment.due_date + 48.hours
       expect(due_date_plus_period.to_a).to eq @rule.calculate_grouping_collection_time(@membership.grouping).to_a
     end
 


### PR DESCRIPTION
Fixes a bug where the total column was not updated as row values were edited. 

- caused by a confusion between the `id` and `_id` keys
- also removed unnecessary calls to `React.createRef()` since we are overwriting the reference to the `GradeEntryTotal` components when the `Cell` is rendered anyway (see: https://reactjs.org/docs/refs-and-the-dom.html#callback-refs)