### PR TITLE
Fix download submission bug

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -494,6 +494,8 @@ class SubmissionsController < ApplicationController
         grouping.group.access_repo do |repo|
           revision = repo.get_revision(revision_id)
           repo.send_tree_to_zip(assignment.repository_folder, zip_file, zip_name + group_name, revision)
+        rescue Repository::RevisionDoesNotExist
+          next
         end
       end
     end

--- a/app/lib/git_revision.rb
+++ b/app/lib/git_revision.rb
@@ -4,13 +4,13 @@ class GitRevision < Repository::AbstractRevision
 
   # Constructor; checks if +revision_hash+ is actually present in +repo+.
   def initialize(revision_hash, repo)
+    super(revision_hash)
     @repo = repo.get_repos
     begin
       @commit = @repo.lookup(revision_hash)
     rescue Rugged::OdbError
       raise RevisionDoesNotExist
     end
-    super(revision_hash)
     @revision_identifier_ui = @revision_identifier[0..6]
     @author = @commit.author[:name]
     @timestamp = @commit.time.in_time_zone

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -350,6 +350,8 @@ module Repository
     attr_accessor :server_timestamp
 
     def initialize(revision_identifier)
+      raise RevisionDoesNotExist if revision_identifier.nil?
+
       @revision_identifier = revision_identifier
       @revision_identifier_ui = @revision_identifier
     end

--- a/app/lib/subversion_revision.rb
+++ b/app/lib/subversion_revision.rb
@@ -5,6 +5,7 @@ class SubversionRevision < Repository::AbstractRevision
   # repository
   def initialize(revision_number, repo)
     revision_number = revision_number.to_i # can be passed as string or int
+    super(revision_number)
     @repo = repo
     @revision_identifier_ui = revision_number.to_s
     begin
@@ -18,7 +19,6 @@ class SubversionRevision < Repository::AbstractRevision
       raise RevisionDoesNotExist
     end
     @server_timestamp = @timestamp
-    super(revision_number)
   end
 
   # Return all of the files in this repository at the root directory


### PR DESCRIPTION
When downloading submissions from the "Submissions" page, if one of the selected submissions had a null revision identifier<sup>[1](#footnote1)</sup> then the download was failing for both svn and git repositories. 

However, since the failure was signalled by two different types of errors for each type of repo, the code was not handling both/either case gracefully.

This bug fix unifies the two errors by preemptively raising a `RevisionDoesNotExist` error when the 
revision identifier is null and allows the controller code to catch that single exception type. 


<a name="footnote1"><sub>1</sub></a> <sub>:there were no files submitted before the deadline and the submission was not manually collected</sub>