### PR TITLE
1.8.0: Use multiple count for I18n string properly

### DIFF
--- a/config/locales/views/statistics/en.yml
+++ b/config/locales/views/statistics/en.yml
@@ -10,7 +10,7 @@ en:
   num_zeros: "Number of zeros"
   outstanding_remark_request:
     one: "%{count} outstanding remark request"
-    other: "%{request_count} outstanding remark requests"
+    other: "%{count} outstanding remark requests"
   refresh_graph: "Refresh the graph"
 
   # app/views/main/_grader_summary.erb


### PR DESCRIPTION
Be consistent with interpolated variables in I18n strings

This prevents the dashboard (admin landing page) from loading at all if:

- default language is English
- there at least two remark requests for the "featured assignment" (`Assignment.get_current_assignment`)
 