### PR TITLE
saved criterion before adding levels to avoid parent not saved error

### DIFF
--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -28,7 +28,7 @@ class CriteriaController < ApplicationController
     end
     criterion_class = params[:criterion_type].constantize
     @criterion = criterion_class.new
-    @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
+
     if @criterion.update(name: params[:new_criterion_prompt],
                              assignment_id: @assignment.id,
                              max_mark: params[:max_mark_prompt],
@@ -41,6 +41,8 @@ class CriteriaController < ApplicationController
       end
       head :unprocessable_entity
     end
+    @criterion.save!
+    @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
   end
 
   def edit

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -33,6 +33,8 @@ class CriteriaController < ApplicationController
                              assignment_id: @assignment.id,
                              max_mark: params[:max_mark_prompt],
                              position: @assignment.next_criterion_position)
+      @criterion.save!
+      @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
       flash_now(:success, t('flash.actions.create.success',
                             resource_name: criterion_class.model_name.human))
     else
@@ -41,8 +43,6 @@ class CriteriaController < ApplicationController
       end
       head :unprocessable_entity
     end
-    @criterion.save!
-    @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
   end
 
   def edit

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -33,7 +33,6 @@ class CriteriaController < ApplicationController
                              assignment_id: @assignment.id,
                              max_mark: params[:max_mark_prompt],
                              position: @assignment.next_criterion_position)
-      @criterion.save!
       @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
       flash_now(:success, t('flash.actions.create.success',
                             resource_name: criterion_class.model_name.human))


### PR DESCRIPTION
There was an error trying to save a rubric criteria before hand because we were trying to create and save levels before the rubric criteria itself was saved. I made a small change where we first update the attributes in the criteria and then save it, and set the default levels at the very end so we will not get this error.