### PR TITLE
Be consistent with in I18n definitions: group

### DIFF
--- a/config/locales/models/groups/es.yml
+++ b/config/locales/models/groups/es.yml
@@ -1,7 +1,7 @@
 es:
   activerecord:
     models:
-      groups:
+      group:
         one: "Grupo"
     attributes:
       group:

--- a/config/locales/models/groups/fr.yml
+++ b/config/locales/models/groups/fr.yml
@@ -1,7 +1,7 @@
 fr:
   activerecord:
     models:
-      groups:
+      group:
         one: "Groupe"
     attributes:
       group:

--- a/config/locales/models/groups/pt.yml
+++ b/config/locales/models/groups/pt.yml
@@ -1,7 +1,7 @@
 pt:
   activerecord:
     models:
-      groups:
+      group:
         one: "Grupo"
     attributes:
       group:


### PR DESCRIPTION
- the string is "group" in English and so should be the same everywhere