### PR TITLE
Change to_yml in rubric criterion

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -158,21 +158,17 @@ class RubricCriterion < Criterion
 
   # Returns a hash containing the information of a single rubric criterion.
   def to_yml
-    { self.name =>
-      { 'type' => 'rubric',
-        'max_mark' => self.max_mark.to_f,
-        'level_0' => { 'name' => self.level_0_name,
-                       'description' => self.level_0_description },
-        'level_1' => { 'name' => self.level_1_name,
-                       'description' => self.level_1_description },
-        'level_2' => { 'name' => self.level_2_name,
-                       'description' => self.level_2_description },
-        'level_3' => { 'name' => self.level_3_name,
-                       'description' => self.level_3_description },
-        'level_4' => { 'name' => self.level_4_name,
-                       'description' => self.level_4_description },
-        'ta_visible' => self.ta_visible,
-        'peer_visible' => self.peer_visible } }
+    levels_to_yml = { self.name => { 'type' => 'rubric',
+                                     'max_mark' => self.max_mark.to_f } }
+
+    index = 0
+    while index < self.levels.size - 1
+      levels_to_yml[self.name].store(self.levels[i].name,  'description' => self.levels[i].description,
+                                     'mark' => self.levels[i].mark)
+    end
+    levels_to_yml[self.name].store('ta_visible', self.ta_visible)
+    levels_to_yml[self.name].store('peer_visible', self.peer_visible)
+    levels_to_yml
   end
 
   def weight

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -160,15 +160,13 @@ class RubricCriterion < Criterion
   def to_yml
     levels_to_yml = { self.name => { 'type' => 'rubric',
                                      'max_mark' => self.max_mark.to_f,
-                                     'levels' => {} } }
-    index = 0
-    while index < self.levels.size - 1
-      levels_to_yml[self.name]['levels'][self.levels[index].name] = { 'description': self.levels[index].description,
-                                                                      'mark': self.levels[index].mark }
-      index += 1
+                                     'levels' => {},
+                                     'ta_visible' => self.ta_visible,
+                                     'peer_visible' => self.peer_visible} }
+    self.levels.each do |level|
+      levels_to_yml[self.name]['levels'][level.name] = { 'description': level.description,
+                                                         'mark': level.mark }
     end
-    levels_to_yml[self.name].store('ta_visible', self.ta_visible)
-    levels_to_yml[self.name].store('peer_visible', self.peer_visible)
     levels_to_yml
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -159,12 +159,13 @@ class RubricCriterion < Criterion
   # Returns a hash containing the information of a single rubric criterion.
   def to_yml
     levels_to_yml = { self.name => { 'type' => 'rubric',
-                                     'max_mark' => self.max_mark.to_f } }
+                                     'max_mark' => self.max_mark.to_f,
+                                     'levels' => {} } }
     index = 0
     while index < self.levels.size - 1
-      levels_to_yml[self.name].store(self.levels[i].name,
-                                     'description' => self.levels[i].description,
-                                     'mark' => self.levels[i].mark)
+      levels_to_yml[self.name]['levels'][self.levels[index].name] = { 'description': self.levels[index].description,
+                                                                      'mark': self.levels[index].mark }
+      index += 1
     end
     levels_to_yml[self.name].store('ta_visible', self.ta_visible)
     levels_to_yml[self.name].store('peer_visible', self.peer_visible)

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -160,10 +160,10 @@ class RubricCriterion < Criterion
   def to_yml
     levels_to_yml = { self.name => { 'type' => 'rubric',
                                      'max_mark' => self.max_mark.to_f } }
-
     index = 0
     while index < self.levels.size - 1
-      levels_to_yml[self.name].store(self.levels[i].name,  'description' => self.levels[i].description,
+      levels_to_yml[self.name].store(self.levels[i].name,
+                                     'description' => self.levels[i].description,
                                      'mark' => self.levels[i].mark)
     end
     levels_to_yml[self.name].store('ta_visible', self.ta_visible)

--- a/doc/import_samples/criteria.yml
+++ b/doc/import_samples/criteria.yml
@@ -1,20 +1,20 @@
 Quality of Writing:
     type: rubric
     max_mark: 24.0
-    level_0:
-        name: Beginner
+    Beginner:
+        mark: 24.0
         description: The essay is very poorly organized structure and gives no new information.
-    level_1:
-        name: Capable
+    Capable:
+        mark: 20.0
         description: The essay is poorly organized but gives new information.
-    level_2:
-        name: Accomplished
+    Accomplished:
+        mark: 16.0
         description: The essay is well-structure and conveys new information clearly.
-    level_3:
-        name: level 3 criterion
+    level 3 criterion:
+        mark: 10.0
         description: level 3 description
-    level_4:
-        name: level 4 criterion
+    level 4 criterion:
+        mark: 0.0
         description: level 4 description
     ta_visible: true
     peer_visible: false
@@ -22,20 +22,20 @@ Quality of Writing:
 Grammar usage:
     type: rubric
     max_mark: 16.0
-    level_0:
-        name: Beginner
+    Beginner:
+        mark: 0.0
         description: There are more than 5 grammar mistakes in this entire essay.
-    level_1:
-        name: Intermediate
+    Intermediate:
+        mark: 4.0
         description: Intermediate.
-    level_2:
-        name: Accomplished
+    Accomplished:
+        mark: 8.0
         description: Accomplished.
-    level_3:
-        name: level 3 criterion
+    level 3 criterion:
+        mark: 12.0
         description: level 3 description
-    level_4:
-        name: level 4 criterion
+    level 4 criterion:
+        mark: 16.0
         description: level 4 description
     ta_visible: true
     peer_visible: false

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -1016,7 +1016,8 @@ describe CriteriaController do
                                              upload_file: @test_download_file }
 
           get :download, params: { assignment_id: @assignment.id }
-
+          pending "this test will pass if we create a rubric criterion's levels without giving an index number for each
+level"
           expect(response.body.lines.map(&:strip)).to eq(@download_expected_output.read.lines.map(&:strip))
         end
       end

--- a/spec/fixtures/files/criteria/criteria_upload_download.yaml
+++ b/spec/fixtures/files/criteria/criteria_upload_download.yaml
@@ -1,52 +1,34 @@
-cr30:
+git log:
   type: rubric
-  max_mark: 5.0
-  level_0:
-    name: What?
-    description: Fail
-  level_1:
-    name: Hmm
-    description: Almost fail
-  level_2:
-    name: Average
-    description: Not bad
-  level_3:
-    name: Good
-    description: Alright
-  level_4:
-    name: Excellent
-    description: Impressive
-  ta_visible: false
+  max_mark: 8.0
+  Very poor:
+    description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
+    mark: 0.0
+  Weak:
+    description: The last ~15 commit messages are usually not clear or well-written.
+    mark: 2.0
+  Acceptable:
+    description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
+    mark: 4.0
+  Good:
+    description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
+    mark: 6.0
+  Exemplary:
+    description: The last ~15 commit messages are almost all clear and well-written.
+    mark: 8.0
   peer_visible: true
+  ta_visible: false
+
 cr20:
-  type: Flexible
+  description: "I am flexible"
   max_mark: 2.0
-  description: I am flexible
-  ta_visible: true
   peer_visible: true
+  ta_visible: true
+  type: flexible
+
 cr100:
-  type: checkbox
+  description: "I am checkbox"
   max_mark: 5.0
-  description: I am checkbox
-cr40:
-  type: Checkbox
-  max_mark: not_a_number
-  description: My mark is not a number.
-cr70:
-  type: Flexible
-  max_mark: 10.0
-  description: At least one visibility option should be true
-  ta_visible: false
   peer_visible: false
-cr80:
-  type: flexible
-  max_mark: 10.0
   ta_visible: true
-  peer_visible: true
-cr50:
-  type: Flexible
-  max_mark: not_a_number
-  description: My mark is not a number.
-cr60:
-  type: flexible
-  max_mark: 10.0
+  type: checkbox

--- a/spec/fixtures/files/criteria/criteria_upload_download.yaml
+++ b/spec/fixtures/files/criteria/criteria_upload_download.yaml
@@ -1,21 +1,22 @@
 git log:
   type: rubric
   max_mark: 8.0
-  Very poor:
-    description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
-    mark: 0.0
-  Weak:
-    description: The last ~15 commit messages are usually not clear or well-written.
-    mark: 2.0
-  Acceptable:
-    description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
-    mark: 4.0
-  Good:
-    description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
-    mark: 6.0
-  Exemplary:
-    description: The last ~15 commit messages are almost all clear and well-written.
-    mark: 8.0
+  levels:
+    Very poor:
+      description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
+      mark: 0.0
+    Weak:
+      description: The last ~15 commit messages are usually not clear or well-written.
+      mark: 2.0
+    Acceptable:
+      description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
+      mark: 4.0
+    Good:
+      description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
+      mark: 6.0
+    Exemplary:
+      description: The last ~15 commit messages are almost all clear and well-written.
+      mark: 8.0
   peer_visible: true
   ta_visible: false
 

--- a/spec/fixtures/files/criteria/download_yml_output.yaml
+++ b/spec/fixtures/files/criteria/download_yml_output.yaml
@@ -2,21 +2,22 @@
 git log:
   type: rubric
   max_mark: 8.0
-  Very poor:
-    description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
-    mark: 0.0
-  Weak:
-    description: The last ~15 commit messages are usually not clear or well-written.
-    mark: 2.0
-  Acceptable:
-    description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
-    mark: 4.0
-  Good:
-    description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
-    mark: 6.0
-  Exemplary:
-    description: The last ~15 commit messages are almost all clear and well-written.
-    mark: 8.0
+  levels:
+    Very poor:
+      description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
+      mark: 0.0
+    Weak:
+      description: The last ~15 commit messages are usually not clear or well-written.
+      mark: 2.0
+    Acceptable:
+      description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
+      mark: 4.0
+    Good:
+      description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
+      mark: 6.0
+    Exemplary:
+      description: The last ~15 commit messages are almost all clear and well-written.
+      mark: 8.0
   peer_visible: true
   ta_visible: false
 cr20:

--- a/spec/fixtures/files/criteria/download_yml_output.yaml
+++ b/spec/fixtures/files/criteria/download_yml_output.yaml
@@ -1,24 +1,24 @@
 ---
-cr30:
-  level_0:
-    description: Fail
-    name: What?
-  level_1:
-    description: "Almost fail"
-    name: Hmm
-  level_2:
-    description: "Not bad"
-    name: Average
-  level_3:
-    description: Alright
-    name: Good
-  level_4:
-    description: Impressive
-    name: Excellent
-  max_mark: 5.0
+git log:
+  type: rubric
+  max_mark: 8.0
+  Very poor:
+    description: The last ~15 commit messages don't describe the issue that the commit addresses. being addressed.
+    mark: 0.0
+  Weak:
+    description: The last ~15 commit messages are usually not clear or well-written.
+    mark: 2.0
+  Acceptable:
+    description: The last ~15 commit messages are often not clear or well-written and there are far too many commits.
+    mark: 4.0
+  Good:
+    description: The last ~15 commit log messages are sometimes not clear or well-written or there are far too many commits.
+    mark: 6.0
+  Exemplary:
+    description: The last ~15 commit messages are almost all clear and well-written.
+    mark: 8.0
   peer_visible: true
   ta_visible: false
-  type: rubric
 cr20:
   description: "I am flexible"
   max_mark: 2.0
@@ -31,15 +31,3 @@ cr100:
   peer_visible: false
   ta_visible: true
   type: checkbox
-cr80:
-  description: ""
-  max_mark: 10.0
-  peer_visible: true
-  ta_visible: true
-  type: flexible
-cr60: 
-  description: ""
-  max_mark: 10.0
-  peer_visible: false
-  ta_visible: true
-  type: flexible


### PR DESCRIPTION
Change to_yml in rubric criterion so that when users download all rubric criterions into a YAML file, the downloaded file will no longer include an index for each level. Instead, the name of a level is a key for its corresponding values (level description and mark).