### PR TITLE
Enable error messages and progress messages for all jobs

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -525,8 +525,9 @@ class AssignmentsController < ApplicationController
 
         if should_commit && commit_success
           if new_files.present?
-            UpdateStarterCodeJob.perform_later(@assignment.id, params.fetch(:overwrite, 'false') == 'true')
-            flash_message(:success, t('assignments.starter_code.enqueued'))
+            @current_job = UpdateStarterCodeJob.perform_later(@assignment.id,
+                                                              params.fetch(:overwrite, 'false') == 'true')
+            session[:job_id] = @current_job.job_id
             redirect_back(fallback_location: root_path)
           else
             head :ok

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -330,13 +330,15 @@ class AssignmentsController < ApplicationController
 
   def stop_test
     test_id = params[:test_run_id].to_i
-    AutotestCancelJob.perform_later(request.protocol + request.host_with_port, [test_id])
+    @current_job = AutotestCancelJob.perform_later(request.protocol + request.host_with_port, [test_id])
+    session[:job_id] = @current_job.job_id
     redirect_back(fallback_location: root_path)
   end
 
   def stop_batch_tests
     test_runs = TestRun.where(test_batch_id: params[:test_batch_id]).pluck(:id)
-    AutotestCancelJob.perform_later(request.protocol + request.host_with_port, test_runs)
+    @current_job = AutotestCancelJob.perform_later(request.protocol + request.host_with_port, test_runs)
+    session[:job_id] = @current_job.job_id
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -246,7 +246,8 @@ class AssignmentsController < ApplicationController
       end
       if new_required_files && !MarkusConfigurator.markus_config_repository_hooks.empty?
         # update list of required files in all repos only if there is a hook that will use that list
-        UpdateRepoRequiredFilesJob.perform_later(@assignment.id, current_user.user_name)
+        @current_job = UpdateRepoRequiredFilesJob.perform_later(@assignment.id, current_user.user_name)
+        session[:job_id] = @current_job.job_id
       end
     rescue
     end
@@ -308,7 +309,8 @@ class AssignmentsController < ApplicationController
       end
       if new_required_files && !MarkusConfigurator.markus_config_repository_hooks.empty?
         # update list of required files in all repos only if there is a hook that will use that list
-        UpdateRepoRequiredFilesJob.perform_later(@assignment.id, current_user.user_name)
+        @current_job = UpdateRepoRequiredFilesJob.perform_later(@assignment.id, current_user.user_name)
+        session[:job_id] = @current_job.job_id
       end
     end
     respond_with @assignment, location: -> { edit_assignment_path(@assignment) }

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -66,7 +66,9 @@ class AutomatedTestsController < ApplicationController
       authorize! grouping, to: :run_tests?
       grouping.decrease_test_tokens
       test_run = grouping.create_test_run!(user: current_user)
-      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                                  current_user.id,
+                                                  [{ id: test_run.id }])
       session[:job_id] = @current_job.job_id
       flash_message(:notice, I18n.t('automated_tests.tests_running'))
     rescue StandardError => e

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -13,7 +13,8 @@ class AutomatedTestsController < ApplicationController
     Assignment.transaction do
       assignment.update! assignment_params
       update_test_groups_from_specs(assignment, test_specs)
-      AutotestSpecsJob.perform_later(request.protocol + request.host_with_port, assignment)
+      @current_job = AutotestSpecsJob.perform_later(request.protocol + request.host_with_port, assignment)
+      session[:job_id] = @current_job.job_id
       flash_message(:success, t('flash.actions.update.success', resource_name: Assignment.model_name.human))
     rescue StandardError => e
       flash_message(:error, e.message)
@@ -65,7 +66,8 @@ class AutomatedTestsController < ApplicationController
       authorize! grouping, to: :run_tests?
       grouping.decrease_test_tokens
       test_run = grouping.create_test_run!(user: current_user)
-      AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      session[:job_id] = @current_job.job_id
       flash_message(:notice, I18n.t('automated_tests.tests_running'))
     rescue StandardError => e
       message = e.is_a?(ActionPolicy::Unauthorized) ? e.result.reasons.full_messages.join(' ') : e.message
@@ -82,7 +84,8 @@ class AutomatedTestsController < ApplicationController
 
   # TODO: use authorizations from here on
   def fetch_testers
-    AutotestTestersJob.perform_later
+    @current_job = AutotestTestersJob.perform_later
+    session[:job_id] = @current_job.job_id
     head :no_content
   end
 
@@ -105,7 +108,8 @@ class AutomatedTestsController < ApplicationController
       fill_in_schema_data!(schema_data, file_keys, assignment)
     else
       flash_now(:notice, I18n.t('automated_tests.loading_specs'))
-      AutotestTestersJob.perform_later
+      @current_job = AutotestTestersJob.perform_later
+      session[:job_id] = @current_job.job_id
       schema_data = {}
     end
     test_specs_path = assignment.autotest_settings_file

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -81,8 +81,6 @@ class ExamTemplatesController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find(params[:id])
 
-    flash_message(:success, t('exam_templates.generate.generate_job_started',
-                              exam_name: exam_template.assignment.short_identifier))
     current_job = exam_template.generate_copies(copies, index)
     current_job.status.update(file_name: "#{exam_template.name}-#{index}-#{index + copies - 1}.pdf")
     current_job.status.update(exam_id: exam_template.id)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -253,7 +253,7 @@ class GroupsController < ApplicationController
         group_rows << row.take_while { |x| !x.blank? } unless row.blank?
       end
       if result[:invalid_lines].empty?
-        if true#validate_csv_upload_file(assignment, group_rows)
+        if validate_csv_upload_file(assignment, group_rows)
           @current_job = CreateGroupsJob.perform_later assignment, group_rows
           session[:job_id] = @current_job.job_id
         end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -253,7 +253,7 @@ class GroupsController < ApplicationController
         group_rows << row.take_while { |x| !x.blank? } unless row.blank?
       end
       if result[:invalid_lines].empty?
-        if validate_csv_upload_file(assignment, group_rows)
+        if true#validate_csv_upload_file(assignment, group_rows)
           @current_job = CreateGroupsJob.perform_later assignment, group_rows
           session[:job_id] = @current_job.job_id
         end

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -14,9 +14,9 @@ class JobMessagesController < ApplicationController
       flash_message(:notice, t('poll_job.queued'))
     elsif status.working?
       flash_progress_message(status)
-    elsif status[:job_class]&.show_error_message(status).present?
+    elsif status[:error_message].present?
       flash_progress_message(status)
-      flash_message(:error, status[:job_class].show_error_message(status))
+      flash_message(:error, status[:error_message])
     elsif status.completed?
       status[:progress] = status[:total]
       flash_progress_message(status)
@@ -33,10 +33,6 @@ class JobMessagesController < ApplicationController
   private
 
   def flash_progress_message(status)
-    if status[:job_class]
-      flash_message(:notice, status[:job_class].show_status(status))
-    else # default x out of y message
-      flash_message(:notice, t('poll_job.working_message', progress: status[:progress], total: status[:total]))
-    end
+    flash_message(:notice, status[:job_class].show_status(status))
   end
 end

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -33,6 +33,7 @@ class JobMessagesController < ApplicationController
   private
 
   def flash_progress_message(status)
-    flash_message(:notice, status[:job_class].show_status(status))
+    current_status = status[:job_class].show_status(status)
+    flash_message(:notice, current_status) unless current_status.nil?
   end
 end

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -1,39 +1,32 @@
 class JobMessagesController < ApplicationController
   before_action :authorize_only_for_admin
 
-  def show
-   @job_message = Rails.cache.fetch(params[:job_id])
-   respond_to do |format|
-     format.json { render 'job_messages/show'}
-   end
-  end
-
   def get
     status = ActiveJob::Status.get(params[:job_id])
-    if status.queued?
-      flash_message(:notice, t('poll_job.queued'))
-    elsif status.working?
-      flash_progress_message(status)
-    elsif status[:error_message].present?
-      flash_progress_message(status)
-      flash_message(:error, status[:error_message])
+    if status.failed?
+      flash_message(:error, t('poll_job.failed')) unless status[:error_message].present?
+      session[:job_id] = nil
     elsif status.completed?
       status[:progress] = status[:total]
-      flash_progress_message(status)
       flash_message(:success, t('poll_job.completed'))
-    else
-      flash_message(:error, t('poll_job.failed'))
-    end
-    if status.completed? || status.failed?
       session[:job_id] = nil
+    elsif status.read.empty?
+      flash_message(:error, t('poll_job.failed'))
+      session[:job_id] = nil
+      render 'shared/http_status', locals: { code: '404', message: 'No background job was enqueued' }, status: 404
+      return
     end
+    flash_job_messages(status)
     render json: status.read
   end
 
   private
 
-  def flash_progress_message(status)
-    current_status = status[:job_class].show_status(status)
-    flash_message(:notice, current_status) unless current_status.nil?
+  def flash_job_messages(status)
+    flash_message(:error, status[:error_message]) if status[:error_message].present?
+    current_status = status[:job_class]&.show_status(status)
+    return if current_status.nil?
+
+    status.queued? ? flash_message(:notice, t('poll_job.queued')) : flash_message(:notice, current_status)
   end
 end

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -13,7 +13,7 @@ class JobMessagesController < ApplicationController
     elsif status.read.empty?
       flash_message(:error, t('poll_job.failed'))
       session[:job_id] = nil
-      render 'shared/http_status', locals: { code: '404', message: 'No background job was enqueued' }, status: 404
+      render 'shared/http_status', locals: { code: '404', message: t('poll_job.not_enqueued') }, status: 404
       return
     end
     flash_job_messages(status)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -272,7 +272,8 @@ class ResultsController < ApplicationController
       authorize! assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
       authorize! submission, to: :run_tests?
       test_run = submission.create_test_run!(user: current_user)
-      AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      session[:job_id] = @current_job.job_id
       flash_message(:notice, I18n.t('automated_tests.tests_running'))
     rescue StandardError => e
       message = e.is_a?(ActionPolicy::Unauthorized) ? e.result.reasons.full_messages.join(' ') : e.message
@@ -283,7 +284,8 @@ class ResultsController < ApplicationController
 
   def stop_test
     test_id = params[:test_run_id].to_i
-    AutotestCancelJob.perform_later(request.protocol + request.host_with_port, [test_id])
+    @current_job = AutotestCancelJob.perform_later(request.protocol + request.host_with_port, [test_id])
+    session[:job_id] = @current_job.job_id
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -272,7 +272,9 @@ class ResultsController < ApplicationController
       authorize! assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
       authorize! submission, to: :run_tests?
       test_run = submission.create_test_run!(user: current_user)
-      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, [{ id: test_run.id }])
+      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                                  current_user.id,
+                                                  [{ id: test_run.id }])
       session[:job_id] = @current_job.job_id
       flash_message(:notice, I18n.t('automated_tests.tests_running'))
     rescue StandardError => e

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -216,9 +216,9 @@ class SubmissionsController < ApplicationController
     end
     success = ''
     if collectable.count > 0
-      current_job = SubmissionsJob.perform_later(collectable,
+      @current_job = SubmissionsJob.perform_later(collectable,
                                                  collection_dates: collection_dates.transform_keys(&:to_s))
-      session[:job_id] = current_job.job_id
+      session[:job_id] = @current_job.job_id
     end
     if some_before_due
       error = I18n.t('submissions.collect.could_not_collect_some_due',
@@ -250,7 +250,8 @@ class SubmissionsController < ApplicationController
     begin
       if !test_runs.empty?
         authorize! assignment, to: :run_tests?
-        AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, test_runs)
+        @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, test_runs)
+        session[:job_id] = @current_job.job_id
         success = I18n.t('automated_tests.tests_running', assignment_identifier: assignment.short_identifier)
       else
         error = I18n.t('automated_tests.need_submission')

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -218,10 +218,7 @@ class SubmissionsController < ApplicationController
     if collectable.count > 0
       current_job = SubmissionsJob.perform_later(collectable,
                                                  collection_dates: collection_dates.transform_keys(&:to_s))
-      # TODO: Re-enable this after investigating activejob-status behaviour.
-      # session[:job_id] = current_job.job_id
-      success = I18n.t('submissions.collect.collection_job_started_for_groups',
-                       assignment_identifier: assignment.short_identifier)
+      session[:job_id] = current_job.job_id
     end
     if some_before_due
       error = I18n.t('submissions.collect.could_not_collect_some_due',

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -248,7 +248,9 @@ class SubmissionsController < ApplicationController
     begin
       if !test_runs.empty?
         authorize! assignment, to: :run_tests?
-        @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port, current_user.id, test_runs)
+        @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                                    current_user.id,
+                                                    test_runs)
         session[:job_id] = @current_job.job_id
         success = I18n.t('automated_tests.tests_running', assignment_identifier: assignment.short_identifier)
       else

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -214,7 +214,6 @@ class SubmissionsController < ApplicationController
 
       collectable << grouping
     end
-    success = ''
     if collectable.count > 0
       @current_job = SubmissionsJob.perform_later(collectable,
                                                  collection_dates: collection_dates.transform_keys(&:to_s))
@@ -230,7 +229,6 @@ class SubmissionsController < ApplicationController
                      assignment_identifier: assignment.short_identifier)
       flash_now(:error, error)
     end
-    flash_now(:success, success) unless success.empty?
     render 'shared/_poll_job.js.erb'
   end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -50,36 +50,29 @@ module GroupsHelper
   # Display flash message based errors contained in the +errors+ hash
   def flash_csv_upload_file_validation_errors(errors)
     unless errors[:bad_cell].empty?
-      flash_now :error, I18n.t('csv.bad_cell',
-                               bad_cells: errors[:bad_cell].map { |c| "'#{c}'" }.join(', '))
+      flash_message :error, I18n.t('csv.bad_cell', bad_cells: errors[:bad_cell].map { |c| "'#{c}'" }.join(', '))
     end
     unless errors[:dup_groups].empty?
-      flash_now :error, I18n.t('csv.duplicate_group_name',
-                               group_names: errors[:dup_groups].join(', '))
+      flash_message :error, I18n.t('csv.duplicate_group_name', group_names: errors[:dup_groups].join(', '))
     end
     unless errors[:dup_repos].empty?
-      flash_now :error, I18n.t('csv.duplicate_repo_name',
-                               repo_names: errors[:dup_repos].join(', '))
+      flash_message :error, I18n.t('csv.duplicate_repo_name', repo_names: errors[:dup_repos].join(', '))
     end
     unless errors[:dup_members].empty?
-      flash_now :error, I18n.t('csv.duplicate_membership_name',
-                               member_names: errors[:dup_members].join(', '))
+      flash_message :error, I18n.t('csv.duplicate_membership_name', member_names: errors[:dup_members].join(', '))
     end
     unless errors[:bad_repo].empty?
-      flash_now :error, I18n.t('csv.bad_repo_warning',
-                               group_names: errors[:bad_repo].join(', '))
+      flash_message :error, I18n.t('csv.bad_repo_warning', group_names: errors[:bad_repo].join(', '))
     end
     unless errors[:inconsistent_group_memberships].empty?
-      flash_now :error, I18n.t('csv.bad_membership_warning',
-                               group_names: errors[:inconsistent_group_memberships].join(', '))
+      flash_message :error, I18n.t('csv.bad_membership_warning',
+                                   group_names: errors[:inconsistent_group_memberships].join(', '))
     end
     unless errors[:bad_students].empty?
-      flash_now :error, I18n.t('csv.bad_students',
-                               student_names: errors[:bad_students].join(', '))
+      flash_message :error, I18n.t('csv.bad_students', student_names: errors[:bad_students].join(', '))
     end
     unless errors[:membership_exists].empty?
-      flash_now :error, I18n.t('csv.memberships_exist',
-                               student_names: errors[:membership_exists].join(', '))
+      flash_message :error, I18n.t('csv.memberships_exist', student_names: errors[:membership_exists].join(', '))
     end
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,15 @@
 class ApplicationJob < ActiveJob::Base
   include ActiveJob::Status
 
+  def self.on_complete_js(_status)
+    '() => {}'
+  end
+
+  def self.show_status(status)
+    I18n.t('poll_job.working_message', progress: status[:progress], total: status[:total])
+  end
+
+  before_enqueue do |_job|
+    self.status.update(job_class: self.class)
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,7 +9,13 @@ class ApplicationJob < ActiveJob::Base
     I18n.t('poll_job.working_message', progress: status[:progress], total: status[:total])
   end
 
-  before_enqueue do |_job|
-    self.status.update(job_class: self.class)
+  before_enqueue do |job|
+    self.status.update(job_class: job.class)
+  end
+
+  rescue_from(StandardError) do |e|
+    self.status.update(error_message: e.to_s)
+    self.status.update(status: :failed)
+    raise
   end
 end

--- a/app/jobs/autotest_cancel_job.rb
+++ b/app/jobs/autotest_cancel_job.rb
@@ -1,6 +1,12 @@
 class AutotestCancelJob < ApplicationJob
   queue_as MarkusConfigurator.autotest_cancel_queue
 
+  def self.on_complete_js(_status)
+    'window.BatchTestRunTable.fetchData'
+  end
+
+  def self.show_status(_status); end
+
   def perform(host_with_port, test_run_ids)
     if Rails.application.config.action_controller.relative_url_root.nil?
       markus_address = host_with_port
@@ -11,30 +17,27 @@ class AutotestCancelJob < ApplicationJob
     server_command = MarkusConfigurator.autotest_server_command
     server_params = { markus_address: markus_address, run_ids: test_run_ids }
 
-    begin
-      if server_username.nil?
-        # local cancellation with no authentication
-        cancel_command = [server_command, 'cancel', '-j', JSON.generate(server_params)]
-        output, status = Open3.capture2e(*cancel_command)
-        if status.exitstatus != 0
+    if server_username.nil?
+      # local cancellation with no authentication
+      cancel_command = [server_command, 'cancel', '-j', JSON.generate(server_params)]
+      output, status = Open3.capture2e(*cancel_command)
+      if status.exitstatus != 0
+        raise output
+      end
+    else
+      # local or remote cancellation with authentication
+      server_host = MarkusConfigurator.autotest_server_host
+      Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
+        cancel_command = "#{server_command} cancel -j '#{JSON.generate(server_params)}'"
+        output = ssh.exec!(cancel_command)
+        if output.exitstatus != 0
           raise output
         end
-      else
-        # local or remote cancellation with authentication
-        server_host = MarkusConfigurator.autotest_server_host
-        Net::SSH.start(server_host, server_username, auth_methods: ['publickey']) do |ssh|
-          cancel_command = "#{server_command} cancel -j '#{JSON.generate(server_params)}'"
-          output = ssh.exec!(cancel_command)
-          if output.exitstatus != 0
-            raise output
-          end
-        end
       end
-      # TODO: Use output for something?
-    rescue StandardError => e
-      # TODO: Where to show failure? (when there is a way to show failure, the following code should not be ensured)
-    ensure
-      TestRun.find(test_run_ids).each { |test_run| test_run.update(time_to_service: -1) }
     end
+    TestRun.find(test_run_ids).each { |test_run| test_run.update(time_to_service: -1) }
+    # TODO: Use output for something?
+  rescue StandardError => e
+    self.status[:error_message] = e.message
   end
 end

--- a/app/jobs/autotest_cancel_job.rb
+++ b/app/jobs/autotest_cancel_job.rb
@@ -37,7 +37,5 @@ class AutotestCancelJob < ApplicationJob
     end
     TestRun.find(test_run_ids).each { |test_run| test_run.update(time_to_service: -1) }
     # TODO: Use output for something?
-  rescue StandardError => e
-    self.status[:error_message] = e.message
   end
 end

--- a/app/jobs/autotest_specs_job.rb
+++ b/app/jobs/autotest_specs_job.rb
@@ -55,8 +55,6 @@ class AutotestSpecsJob < ApplicationJob
         end
       end
       # TODO: Use output for something?
-    rescue StandardError => e
-      self.status[:error_message] = e.message
     end
   end
 end

--- a/app/jobs/autotest_specs_job.rb
+++ b/app/jobs/autotest_specs_job.rb
@@ -2,6 +2,8 @@ class AutotestSpecsJob < ApplicationJob
   include AutomatedTestsHelper
   queue_as MarkusConfigurator.autotest_specs_queue
 
+  def self.show_status(_status); end
+
   def perform(host_with_port, assignment)
     assignment_tests_path = assignment.autotest_files_dir
     if Rails.application.config.action_controller.relative_url_root.nil?
@@ -54,7 +56,7 @@ class AutotestSpecsJob < ApplicationJob
       end
       # TODO: Use output for something?
     rescue StandardError => e
-      # TODO: Where to show failure?
+      self.status[:error_message] = e.message
     end
   end
 end

--- a/app/jobs/autotest_testers_job.rb
+++ b/app/jobs/autotest_testers_job.rb
@@ -1,6 +1,8 @@
 class AutotestTestersJob < ApplicationJob
   queue_as MarkusConfigurator.autotest_testers_queue
 
+  def self.show_status(_status); end
+
   def perform
     server_username = MarkusConfigurator.autotest_server_username
     server_command = MarkusConfigurator.autotest_server_command
@@ -27,7 +29,7 @@ class AutotestTestersJob < ApplicationJob
       testers_path = File.join(MarkusConfigurator.autotest_client_dir, 'testers.json')
       File.open(testers_path, 'w') { |f| f.write(output) }
     rescue StandardError => e
-      # TODO: Where to show failure?
+      self.status[:error_message] = e.message
     end
   end
 end

--- a/app/jobs/autotest_testers_job.rb
+++ b/app/jobs/autotest_testers_job.rb
@@ -28,8 +28,6 @@ class AutotestTestersJob < ApplicationJob
       end
       testers_path = File.join(MarkusConfigurator.autotest_client_dir, 'testers.json')
       File.open(testers_path, 'w') { |f| f.write(output) }
-    rescue StandardError => e
-      self.status[:error_message] = e.message
     end
   end
 end

--- a/app/jobs/create_groups_job.rb
+++ b/app/jobs/create_groups_job.rb
@@ -3,7 +3,7 @@ class CreateGroupsJob < ApplicationJob
   queue_as MarkusConfigurator.markus_job_create_groups_queue_name
 
   def self.on_complete_js(_status)
-    '() => {window.groupsManager && window.groupsManager.fetchData}'
+    '() => {window.groupsManager && window.groupsManager.fetchData()}'
   end
 
   def self.show_status(status)

--- a/app/jobs/create_groups_job.rb
+++ b/app/jobs/create_groups_job.rb
@@ -88,11 +88,7 @@ class CreateGroupsJob < ApplicationJob
           raise
         end
       end
-    rescue StandardError => e
-      status.update(error_message: e.to_s)
-      return
     end
-
     m_logger = MarkusLogger.instance
     m_logger.log('Creating all individual groups completed',
                  MarkusLogger::INFO)

--- a/app/jobs/create_groups_job.rb
+++ b/app/jobs/create_groups_job.rb
@@ -82,9 +82,9 @@ class CreateGroupsJob < ApplicationJob
           progress.increment
         rescue ActiveRecord::Rollback
           status[:error_message] = "#{status[:error_message]};#{I18n.t('poll_job.create_groups_job_extra_info',
-                                                                        group_name: group_name,
-                                                                        repo_name: repo_name,
-                                                                        members: members)}"
+                                                                       group_name: group_name,
+                                                                       repo_name: repo_name,
+                                                                       members: members)}"
           raise
         end
       end

--- a/app/jobs/create_groups_job.rb
+++ b/app/jobs/create_groups_job.rb
@@ -10,14 +10,6 @@ class CreateGroupsJob < ApplicationJob
     I18n.t('poll_job.create_groups_job', progress: status[:progress], total: status[:total])
   end
 
-  def self.show_error_message(status)
-    return status[:error_message] unless status[:error_message].blank?
-  end
-
-  before_enqueue do |_job|
-    status.update(job_class: self.class)
-  end
-
   def log_creation
     begin
       obj = yield
@@ -36,72 +28,69 @@ class CreateGroupsJob < ApplicationJob
 
   def perform(assignment, data)
     progress.total = data.length
-    begin
-      Repository.get_class.update_permissions_after(only_on_request: true) do
-        ApplicationRecord.transaction do
-          data.each do |group_name, repo_name, *members|
-            group = log_creation { Group.find_or_create_by(group_name: group_name, repo_name: repo_name) }
-            member_hash = StudentMembership.joins(:grouping)
-                                           .joins(:user)
-                                           .where('groupings.group_id': group.id)
-                                           .where(membership_status: [:inviter, :accepted])
-                                           .pluck('groupings.assignment_id', 'users.user_name')
-                                           .group_by(&:first)
-                                           .transform_values { |g| Set.new g.map(&:second) }
+    Repository.get_class.update_permissions_after(only_on_request: true) do
+      ApplicationRecord.transaction do
+        data.each do |group_name, repo_name, *members|
+          group = log_creation { Group.find_or_create_by(group_name: group_name, repo_name: repo_name) }
+          member_hash = StudentMembership.joins(:grouping)
+                                         .joins(:user)
+                                         .where('groupings.group_id': group.id)
+                                         .where(membership_status: [:inviter, :accepted])
+                                         .pluck('groupings.assignment_id', 'users.user_name')
+                                         .group_by(&:first)
+                                         .transform_values { |g| Set.new g.map(&:second) }
 
-            if member_hash.empty? || Set.new(members) == member_hash.values.first
-              # The set of members does not conflict with other members associated with other
-              # groupings for this group
-              unless member_hash.include? assignment.id
-                grouping = log_creation { Grouping.find_or_create_by(group: group, assignment: assignment) }
-                user_count = 0
-                User.where(user_name: members).find_each.with_index do |student, i|
-                  user_count += 1
-                  if i.zero?
-                    member_status = StudentMembership::STATUSES[:inviter]
-                  else
-                    member_status = StudentMembership::STATUSES[:accepted]
-                  end
-                  log_creation do
-                    StudentMembership.find_or_create_by(user: student,
-                                                        membership_status: member_status,
-                                                        grouping: grouping)
-                  end
+          if member_hash.empty? || Set.new(members) == member_hash.values.first
+            # The set of members does not conflict with other members associated with other
+            # groupings for this group
+            unless member_hash.include? assignment.id
+              grouping = log_creation { Grouping.find_or_create_by(group: group, assignment: assignment) }
+              user_count = 0
+              User.where(user_name: members).find_each.with_index do |student, i|
+                user_count += 1
+                if i.zero?
+                  member_status = StudentMembership::STATUSES[:inviter]
+                else
+                  member_status = StudentMembership::STATUSES[:accepted]
                 end
-                if user_count != members.length
-                  # A member in the members list is not a User in the database
-                  all_users = Set.new User.where(user_name: members).pluck(:user_name)
-                  bad_names = (Set.new(members) - all_users).to_a.join(', ')
-                  msg = I18n.t('csv.member_does_not_exist', group_name: group_name, student_user_name: bad_names)
-                  status.update(error_message: msg)
-                  Rails.logger.error msg
-                  raise ActiveRecord::Rollback
+                log_creation do
+                  StudentMembership.find_or_create_by(user: student,
+                                                      membership_status: member_status,
+                                                      grouping: grouping)
                 end
               end
-            else
-              if member_hash.include? assignment.id
-                msg = I18n.t('csv.group_with_different_membership_current_assignment', group_name: group_name)
-              else
-                msg = I18n.t('csv.group_with_different_membership_different_assignment', group_name: group_name)
+              if user_count != members.length
+                # A member in the members list is not a User in the database
+                all_users = Set.new User.where(user_name: members).pluck(:user_name)
+                bad_names = (Set.new(members) - all_users).to_a.join(', ')
+                msg = I18n.t('csv.member_does_not_exist', group_name: group_name, student_user_name: bad_names)
+                status.update(error_message: msg)
+                Rails.logger.error msg
+                raise ActiveRecord::Rollback
               end
-              status.update(error_message: msg)
-              Rails.logger.error msg
-              raise ActiveRecord::Rollback
             end
-            progress.increment
-          rescue ActiveRecord::Rollback
-            status[:error_message] = "#{status[:error_message]}\n#{I18n.t('poll_job.create_groups_job_extra_info',
-                                                                          group_name: group_name,
-                                                                          repo_name: repo_name,
-                                                                          members: members)}"
-            raise
+          else
+            if member_hash.include? assignment.id
+              msg = I18n.t('csv.group_with_different_membership_current_assignment', group_name: group_name)
+            else
+              msg = I18n.t('csv.group_with_different_membership_different_assignment', group_name: group_name)
+            end
+            status.update(error_message: msg)
+            Rails.logger.error msg
+            raise ActiveRecord::Rollback
           end
+          progress.increment
+        rescue ActiveRecord::Rollback
+          status[:error_message] = "#{status[:error_message]};#{I18n.t('poll_job.create_groups_job_extra_info',
+                                                                        group_name: group_name,
+                                                                        repo_name: repo_name,
+                                                                        members: members)}"
+          raise
         end
       end
     rescue StandardError => e
-      status.update(error_message: e.message)
-      Rails.logger.error e.message
-      raise
+      status.update(error_message: e.to_s)
+      return
     end
 
     m_logger = MarkusLogger.instance

--- a/app/jobs/generate_job.rb
+++ b/app/jobs/generate_job.rb
@@ -49,9 +49,6 @@ class GenerateJob < ApplicationJob
         generated_pdf << (qr_page << template_page)
       end
       progress.increment
-    rescue StandardError => e
-      status.update(error_message: e.to_s)
-      raise
     end
 
     generated_pdf.save File.join(

--- a/app/jobs/generate_job.rb
+++ b/app/jobs/generate_job.rb
@@ -3,61 +3,61 @@ class GenerateJob < ApplicationJob
   queue_as MarkusConfigurator.markus_job_generate_queue_name
 
   def self.on_complete_js(status)
-    path = Rails.application.routes.url_helpers.download_generate_assignment_exam_template_path(assignment_id: status[:id],
-                                                                                                id: status[:exam_id])
-    "function(){window.location='#{path}?file_name=#{status[:file_name]}'}"
+    path = Rails.application.routes.url_helpers.download_generate_assignment_exam_template_path(
+      assignment_id: status[:id],
+      id: status[:exam_id]
+    )
+    "(data) => {
+      if (!data.error_message) {
+        window.location = '#{path}?file_name=#{status[:file_name]}'
+      }
+    }"
   end
 
   def self.show_status(status)
-    I18n.t('poll_job.generate_job', progress: status[:progress],
-           total: status[:total],
-           exam_name: status[:exam_name])
+    I18n.t('poll_job.generate_job', progress: status[:progress], total: status[:total], exam_name: status[:exam_name])
   end
 
   before_enqueue do |job|
-    status.update(job_class: self.class)
     status.update(exam_name: job.arguments[0].name)
   end
 
   def perform(exam_template, num_copies, start)
     m_logger = MarkusLogger.instance
-    begin
-      progress.total = num_copies
-      template_path = File.join(
-        exam_template.base_path,
-        exam_template.filename
-      )
-      template_pdf = CombinePDF.load template_path
-      generated_pdf = CombinePDF.new
-      (start..start + num_copies - 1).each do |exam_num|
-        m_logger.log("Now generating: #{exam_num}")
-        pdf = Prawn::Document::new(margin: 15) do
-          exam_template.num_pages.times do |page_num|
-            qrcode_content = "#{exam_template.name}-#{exam_num}-#{page_num + 1}"
-            qrcode = RQRCode::QRCode.new qrcode_content, level: :l, size: 2
-            alignment = page_num % 2 == 0 ? :right : :left
-            render_qr_code(qrcode, align: alignment, dot: 4.0, stroke: false)
-            draw_text(qrcode_content,
-                 at: [alignment == :left ? 140 : bounds.width - 140 - qrcode_content.length * 6,
-                      bounds.height - 30])
-            start_new_page
-          end
+    progress.total = num_copies
+    template_path = File.join(
+      exam_template.base_path,
+      exam_template.filename
+    )
+    template_pdf = CombinePDF.load template_path
+    generated_pdf = CombinePDF.new
+    (start..start + num_copies - 1).each do |exam_num|
+      m_logger.log("Now generating: #{exam_num}")
+      pdf = Prawn::Document.new(margin: 15) do
+        exam_template.num_pages.times do |page_num|
+          qrcode_content = "#{exam_template.name}-#{exam_num}-#{page_num + 1}"
+          qrcode = RQRCode::QRCode.new qrcode_content, level: :l, size: 2
+          alignment = page_num.even? ? :right : :left
+          render_qr_code(qrcode, align: alignment, dot: 4.0, stroke: false)
+          draw_text(qrcode_content,
+                    at: [alignment == :left ? 140 : bounds.width - 140 - qrcode_content.length * 6, bounds.height - 30])
+          start_new_page
         end
-        combine_pdf_qr = CombinePDF.parse(pdf.render)
-        template_pdf.pages.zip(combine_pdf_qr.pages) do |template_page, qr_page|
-          generated_pdf << (qr_page << template_page)
-        end
-        progress.increment
       end
-
-      generated_pdf.save File.join(
-        exam_template.base_path,
-        "#{exam_template.name}-#{start}-#{start + num_copies - 1}.pdf"
-      )
-     end
-     m_logger.log('Generate pdf copies process done')
-    rescue => e
-      Rails.logger.error e.message
-      raise e
+      combine_pdf_qr = CombinePDF.parse(pdf.render)
+      template_pdf.pages.zip(combine_pdf_qr.pages) do |template_page, qr_page|
+        generated_pdf << (qr_page << template_page)
+      end
+      progress.increment
+    rescue StandardError => e
+      status.update(error_message: e.to_s)
+      return
     end
+
+    generated_pdf.save File.join(
+      exam_template.base_path,
+      "#{exam_template.name}-#{start}-#{start + num_copies - 1}.pdf"
+    )
+    m_logger.log('Generate pdf copies process done')
   end
+end

--- a/app/jobs/generate_job.rb
+++ b/app/jobs/generate_job.rb
@@ -51,7 +51,7 @@ class GenerateJob < ApplicationJob
       progress.increment
     rescue StandardError => e
       status.update(error_message: e.to_s)
-      return
+      raise
     end
 
     generated_pdf.save File.join(

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -19,7 +19,6 @@ class SplitPdfJob < ApplicationJob
   def perform(exam_template, _path, split_pdf_log, _original_filename = nil, _current_user = nil)
     m_logger = MarkusLogger.instance
     begin
-      raise StandardError, 'e'
       # Create directory for files whose QR code couldn't be parsed
       error_dir = File.join(exam_template.base_path, 'error')
       raw_dir = File.join(exam_template.base_path, 'raw')
@@ -110,10 +109,9 @@ class SplitPdfJob < ApplicationJob
       m_logger.log('Split pdf process done')
       return split_pdf_log
     rescue StandardError => e
-      status.update(error_message: e.message)
-      Rails.logger.error e.message
       # Clean tmp folder
       Dir.glob('/tmp/magick-*').each { |file| File.delete(file) }
+      raise e
     end
   end
 

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -13,13 +13,13 @@ class SplitPdfJob < ApplicationJob
   end
 
   before_enqueue do |job|
-    status.update(job_class: self.class)
     status.update(exam_name: "#{job.arguments[0].name} (#{job.arguments[3]})")
   end
 
   def perform(exam_template, _path, split_pdf_log, _original_filename = nil, _current_user = nil)
     m_logger = MarkusLogger.instance
     begin
+      raise StandardError, 'e'
       # Create directory for files whose QR code couldn't be parsed
       error_dir = File.join(exam_template.base_path, 'error')
       raw_dir = File.join(exam_template.base_path, 'raw')
@@ -109,11 +109,11 @@ class SplitPdfJob < ApplicationJob
 
       m_logger.log('Split pdf process done')
       return split_pdf_log
-    rescue => e
+    rescue StandardError => e
+      status.update(error_message: e.message)
       Rails.logger.error e.message
       # Clean tmp folder
       Dir.glob('/tmp/magick-*').each { |file| File.delete(file) }
-      raise e
     end
   end
 

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -52,8 +52,6 @@ class SubmissionsJob < ApplicationJob
         add_error_messages([e.message])
       end
     end
-  rescue StandardError => e
-    add_error_messages([e.message])
   ensure
     m_logger.log('Submission collection process done')
   end

--- a/app/jobs/uncollect_submissions.rb
+++ b/app/jobs/uncollect_submissions.rb
@@ -12,7 +12,5 @@ class UncollectSubmissions < ApplicationJob
 
   def perform(assignment)
     # TODO: implement this.
-  rescue StandardError => e
-    status[:error_message] = e.message
   end
 end

--- a/app/jobs/uncollect_submissions.rb
+++ b/app/jobs/uncollect_submissions.rb
@@ -10,11 +10,9 @@ class UncollectSubmissions < ApplicationJob
     I18n.t('poll_job.uncollect_submissions_job')
   end
 
-  before_enqueue do |job|
-    status.update(job_class: self.class)
-  end
-
   def perform(assignment)
     # TODO: implement this.
+  rescue StandardError => e
+    status[:error_message] = e.message
   end
 end

--- a/app/jobs/update_repo_required_files_job.rb
+++ b/app/jobs/update_repo_required_files_job.rb
@@ -17,7 +17,5 @@ class UpdateRepoRequiredFilesJob < ApplicationJob
       repo.commit(txn)
       progress.increment
     end
-  rescue StandardError => e
-    status[:error_message] = e.message
   end
 end

--- a/app/jobs/update_repo_required_files_job.rb
+++ b/app/jobs/update_repo_required_files_job.rb
@@ -2,14 +2,22 @@ class UpdateRepoRequiredFilesJob < ApplicationJob
 
   queue_as MarkusConfigurator.markus_job_update_repo_required_files_queue_name
 
+  def self.show_status(status)
+    I18n.t('poll_job.update_repo_required_files_job', progress: status[:progress], total: status[:total])
+  end
+
   def perform(assignment_id, user_name)
     assignment = Assignment.includes(groupings: :group).find(assignment_id)
     required_files = Assignment.get_required_files.to_json
+    progress.total = assignment.groupings.count
     assignment.each_group_repo do |repo|
       txn = repo.get_transaction(user_name, I18n.t('repo.commits.required_files',
                                                    assignment: assignment.short_identifier))
       txn.replace('.required.json', required_files, 'application/json', repo.get_latest_revision.revision_identifier)
       repo.commit(txn)
+      progress.increment
     end
+  rescue StandardError => e
+    status[:error_message] = e.message
   end
 end

--- a/app/jobs/update_starter_code_job.rb
+++ b/app/jobs/update_starter_code_job.rb
@@ -27,7 +27,5 @@ class UpdateStarterCodeJob < ApplicationJob
         progress.increment
       end
     end
-  rescue StandardError => e
-    status[:error_message] = e.message
   end
 end

--- a/app/jobs/update_starter_code_job.rb
+++ b/app/jobs/update_starter_code_job.rb
@@ -2,22 +2,32 @@ class UpdateStarterCodeJob < ApplicationJob
 
   queue_as MarkusConfigurator.markus_job_update_starter_code_queue
 
+  def self.show_status(status)
+    I18n.t('poll_job.update_starter_code_job', progress: status[:progress], total: status[:total])
+  end
+
   def perform(assignment_id, overwrite)
     assignment = Assignment.includes(groupings: :group).find(assignment_id)
     return unless Repository.get_class.repository_exists?(assignment.starter_code_repo_path)
+
     assignment_folder = assignment.repository_folder
     assignment.access_starter_code_repo do |starter_repo|
       starter_revision = starter_repo.get_latest_revision
       next unless starter_revision.path_exists?(assignment_folder)
+
       starter_tree = starter_revision.tree_at_path(assignment_folder, with_attrs: false)
       starter_files = {} # cache of starter code files
+      progress.total = assignment.groupings.count
       assignment.each_group_repo do |group_repo|
         txn = assignment.update_starter_code_files(group_repo, starter_repo, starter_tree, overwrite: overwrite,
                                                    starter_files: starter_files)
         if txn.has_jobs?
           group_repo.commit(txn)
         end
+        progress.increment
       end
     end
+  rescue StandardError => e
+    status[:error_message] = e.message
   end
 end

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -80,8 +80,7 @@ class ExamTemplate < ApplicationRecord
 
   # Generate copies of the given exam template, with the given start number.
   def generate_copies(num_copies, start=1)
-    @current_job = GenerateJob.perform_later(self, num_copies, start)
-    session[:job_id] = @current_job.job_id
+    GenerateJob.perform_later(self, num_copies, start)
   end
 
   # Split up PDF file based on this exam template.
@@ -106,8 +105,7 @@ class ExamTemplate < ApplicationRecord
     FileUtils.mkdir_p raw_dir
     FileUtils.cp path, File.join(raw_dir, "raw_upload_#{split_pdf_log.id}.pdf")
 
-    @current_job = SplitPdfJob.perform_later(self, path, split_pdf_log, original_filename, current_user)
-    session[:job_id] = @current_job.job_id
+    SplitPdfJob.perform_later(self, path, split_pdf_log, original_filename, current_user)
   end
 
   def fix_error(filename, exam_num, page_num, upside_down)

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -80,7 +80,8 @@ class ExamTemplate < ApplicationRecord
 
   # Generate copies of the given exam template, with the given start number.
   def generate_copies(num_copies, start=1)
-    GenerateJob.perform_later(self, num_copies, start)
+    @current_job = GenerateJob.perform_later(self, num_copies, start)
+    session[:job_id] = @current_job.job_id
   end
 
   # Split up PDF file based on this exam template.
@@ -105,7 +106,8 @@ class ExamTemplate < ApplicationRecord
     FileUtils.mkdir_p raw_dir
     FileUtils.cp path, File.join(raw_dir, "raw_upload_#{split_pdf_log.id}.pdf")
 
-    SplitPdfJob.perform_later(self, path, split_pdf_log, original_filename, current_user)
+    @current_job = SplitPdfJob.perform_later(self, path, split_pdf_log, original_filename, current_user)
+    session[:job_id] = @current_job.job_id
   end
 
   def fix_error(filename, exam_num, page_num, upside_down)

--- a/app/views/assignments/batch_runs.html.erb
+++ b/app/views/assignments/batch_runs.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :head do %>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      makeBatchTestRunTable(document.getElementById('batch_test_run_table'), {
+      window.BatchTestRunTable = makeBatchTestRunTable(document.getElementById('batch_test_run_table'), {
         assignment_id: <%= @assignment.id %>,
         detailed: <%= @current_user.admin? || @current_user.ta? ||
                       @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) %>

--- a/app/views/job_messages/show.json.jbuilder
+++ b/app/views/job_messages/show.json.jbuilder
@@ -1,2 +1,0 @@
-json.status @job_message.status
-json.message @job_message.message

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,18 +18,7 @@ Markus::Application.configure do
   # Print deprecation notices to stderr.
   config.active_support.deprecation = :stderr
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-    config.cache_store = :null_store
-  end
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/1' } }
 
   # Show where SQL queries were generated from.
   config.active_record.verbose_query_logs = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       create_groups_job_extra_info: "failed for group: %{group_name}, repo: %{repo_name}, members: %{members}"
       uncollect_submissions_job: "Uncollecting assignments ... "
       submissions_job: "%{progress}/%{total} Submissions collected"
+      update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
     repo:
       commits:
         assignment_folder: "Create assignment folder for %{assignment}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
       uncollect_submissions_job: "Uncollecting assignments ... "
       submissions_job: "%{progress}/%{total} Submissions collected"
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
+      update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"
     repo:
       commits:
         assignment_folder: "Create assignment folder for %{assignment}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     poll_job:
       working_message: "%{progress} out of %{total}"
       queued: "Queued"
+      not_enqueued: "No job was enqueued"
       completed: "Completed"
       failed: "Failed"
       split_pdf_job: "Processing page %{progress} out of %{total} for %{exam_name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,8 @@ en:
       submissions_job: "%{progress}/%{total} Submissions collected"
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
       update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"
+      autotest_run_job: "%{progress}/%{total} Test runs started"
+      autotest_run_job_failed_count: "%{failed} Test runs failed. See results pages for details."
     repo:
       commits:
         assignment_folder: "Create assignment folder for %{assignment}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,6 +58,7 @@ es:
     poll_job:
       working_message: "%{progress} fuera de %{total}"
       queued: "En cola"
+      not_enqueued: "No en cola"
       completed: "Terminado"
       failed: "Ha fallado"
       split_pdf_job: "Procesamiento página %{progress} fuera de %{total} para %{exam_name}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -67,6 +67,7 @@ es:
       uncollect_submissions_job: "Asignaciones incumplidas... "
       submissions_job: "%{progress}/%{total} Envíos recibidos"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
+      update_starter_code_job: "%{progress}/%{total} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,7 @@ es:
       create_groups_job_extra_info: "Ha fallado: %{group_name}, %{repo_name}, %{members}"
       uncollect_submissions_job: "Asignaciones incumplidas... "
       submissions_job: "%{progress}/%{total} Envíos recibidos"
+      update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -68,6 +68,8 @@ es:
       submissions_job: "%{progress}/%{total} Envíos recibidos"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
+      autotest_run_job: "%{progress}/%{total} UPDATE ME"
+      autotest_run_job_failed_count: "%{failed} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -58,6 +58,8 @@ fr:
       submissions_job: "%{progress}/%{total} Soumissions collectées"
       update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
       update_starter_code_job: "%{progress}/%{total} repos modifiés"
+      autotest_run_job: "%{progress}/%{total} Tests commencés"
+      autotest_run_job_failed_count: "%{failed} Tests échoués"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -56,6 +56,7 @@ fr:
       create_groups_job_extra_info: "Échoué pour: groupe: %{group_name}, repo: %{repo_name}, membres: %{members}"
       uncollect_submissions_job: "Tâches de décollement... "
       submissions_job: "%{progress}/%{total} Soumissions collectées"
+      update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -57,6 +57,7 @@ fr:
       uncollect_submissions_job: "Tâches de décollement... "
       submissions_job: "%{progress}/%{total} Soumissions collectées"
       update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
+      update_starter_code_job: "%{progress}/%{total} repos modifiés"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -48,6 +48,7 @@ fr:
     poll_job:
       working_message: "%{progress} hors de %{total}"
       queued: "Mis en file d'attente"
+      not_enqueued: "Aucun tâches mis en file"
       completed: "Terminé"
       failed: "échoué"
       split_pdf_job: "Traitement page %{progress} sur %{total} pour %{exam_name}"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -53,6 +53,8 @@ pt:
       submissions_job: "%{progress}/%{total} Submissões coletadas"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
+      autotest_run_job: "%{progress}/%{total} UPDATE ME"
+      autotest_run_job_failed_count: "%{failed} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -51,6 +51,7 @@ pt:
       create_groups_job_extra_info: "Falhou: %{group_name}, %{repo_name}, %{members}"
       uncollect_submissions_job: "Tarefas não coletadas ... "
       submissions_job: "%{progress}/%{total} Submissões coletadas"
+      update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -52,6 +52,7 @@ pt:
       uncollect_submissions_job: "Tarefas não coletadas ... "
       submissions_job: "%{progress}/%{total} Submissões coletadas"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
+      update_starter_code_job: "%{progress}/%{total} UPDATE ME"
     repo:
       commits:
         assignment_folder: "UPDATE ME %{assignment}"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -43,6 +43,7 @@ pt:
     poll_job:
       working_message: "%{progress} fora de %{total}"
       queued: "Enfileiradas"
+      not_enqueued: "Não enfileiradas"
       completed: "Completado"
       failed: "Falhou"
       split_pdf_job: "Processando a página %{progress} em %{total} para %{exam_name}"

--- a/config/locales/views/assignments/en.yml
+++ b/config/locales/views/assignments/en.yml
@@ -25,7 +25,6 @@ en:
       under_review: "This exam is still under review."
     starter_code:
       description: "Starter code files you upload will be automatically added to every new group's repositories."
-      enqueued: "Starter code files will be uploaded to existing group repositories in the background."
       overwrite: "Overwrite group files"
       title: "Starter Code"
 

--- a/config/locales/views/assignments/es.yml
+++ b/config/locales/views/assignments/es.yml
@@ -65,7 +65,6 @@ es:
       under_review: "Este examen todavía está en revisión"
     starter_code:
       description: "UPDATE ME."
-      enqueued: "UPDATE ME."
       overwrite: "UPDATE ME"
       title: "Código Inicial"
 

--- a/config/locales/views/assignments/fr.yml
+++ b/config/locales/views/assignments/fr.yml
@@ -26,7 +26,6 @@ fr:
       under_review: "Cet examen est marqué"
     starter_code:
       description: "UPDATE ME."
-      enqueued: "UPDATE ME."
       overwrite: "UPDATE ME"
       title: "UPDATE ME"
 

--- a/config/locales/views/assignments/pt.yml
+++ b/config/locales/views/assignments/pt.yml
@@ -25,7 +25,6 @@ pt:
       under_review: "Este exame está sendo marcado"
     starter_code:
       description: "UPDATE ME."
-      enqueued: "UPDATE ME."
       overwrite: "UPDATE ME"
       title: "UPDATE ME"
 

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -2,7 +2,6 @@ en:
   submissions:
     collect:
       apply_late_penalty: "Apply late penalty/Deduct grace tokens (Leaving this box unchecked means the submission will not be penalized, regardless of submission time.)"
-      collection_job_started_for_groups: "Submission collection for selected groupings for assignment %{assignment_identifier} has begun. The complete process may take some time, but you can access submissions as they become available."
       could_not_collect_some_due: "Could not collect submissions for some groupings and assignment %{assignment_identifier} - the collection date has not been reached for these groupings."
       could_not_collect_some_released: "Could not collect submissions for some groupings and assignment %{assignment_identifier} - the submission has already been released."
       manual_collection: "Manual Collection"

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -4,9 +4,6 @@ es:
       apply_late_penalty: "Aplicar penalidad por demora/Deducir aplazamiento de gracia (Si esta opción no
                            es seleccionada, las entregas no serán penalizadas, sin importar la hora o
                            fecha de la entrega.)"
-      collection_job_started_for_groups: "La recolección de las entregas para las agrupaciones seleccionadas del
-                                          proyecto %{assignment_identifier} ha iniciado. El proceso puede demorar,
-                                          pero usted puede acceder las entregas tan pronto como se vuelvan disponibles."
       could_not_collect_some_due: "No se pudo recolectar las entregas para algunas agrupaciones del proyecto
                                %{assignment_identifier} -  la fecha de recolección para estas
                                agrupaciones no ha llegado."

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -2,7 +2,6 @@ fr:
   submissions:
     collect:
       apply_late_penalty: "Appliquer pénalité de retard / Déduire jetons de grâce ( Laissant cette case cochée signifie la soumission ne sera pas pénalisé , indépendamment du moment de la soumission . )"
-      collection_job_started_for_groups: "La récupération des envois pour les groupements sélectionnés pour le projet %{assignment_identifier} a débuté. Cela peut prendre du temps, mais vous avez accès aux envois dès qu'ils sont disponibles."
       could_not_collect_some_due: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier} - la date de collecte n'a pas été atteint pour ces groupes."
       could_not_collect_some_released: "Impossible de recueillir des soumissions pour certains groupements et projet %{assignment_identifier}."
       overwrite_warning: "Récupérer et noter cette révision effacera les précédentes récupération et évaluations de ce groupe sur ce projet. Êtes-vous sûr de vouloir faire cela ?"

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -4,7 +4,6 @@ pt:
       apply_late_penalty: "Aplicar pênalti no final / Deduzir fichas de carência
                            ( Deixando esta caixa desmarcada , a apresentação não
                            será penalizado , independentemente do tempo de apresentação . )"
-      collection_job_started_for_groups: "Coleta das submissões para grupos selecionados para o projeto %{assignment_identifier} começou. O processo pode demorar, você poderá acessar as submissões assim que elas tornarem-se disponíveis."
       could_not_collect_some_due: "Não foi possível recolher inscrições para alguns grupos e projecto %{assignment_identifier} - a data de coleta não foi alcançado por estes agrupamentos."
       could_not_collect_some_released: "Não foi possível recolher inscrições para alguns grupos e projecto %{assignment_identifier}."
       overwrite_warning: "Coletando e avaliando essa revisão irá sobrescrever coletas/avalições anteriores feitas para esse grupo no projeto. Tem certeza que quer fazer isso?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -415,7 +415,7 @@ Rails.application.routes.draw do
     resources :extensions
   end
 
-  resources :job_messages, only: %w(show), param: :job_id do
+  resources :job_messages, param: :job_id do
     member do
       get 'get'
     end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -387,8 +387,7 @@ describe SubmissionsController do
             @section_due_date.update!(due_date: Time.current - 1.week)
             allow(Assignment).to receive_message_chain(
               :includes, :find) { @assignment }
-            expect_any_instance_of(SubmissionsController).to receive(:flash_now).with(:success, anything)
-            expect(@assignment).to receive(:short_identifier) { 'a1' }
+            expect_any_instance_of(SubmissionsController).not_to receive(:flash_now).with(:error, anything)
             allow(SubmissionsJob).to receive(:perform_later) { Struct.new(:job_id).new('1') }
 
             post_as @admin,
@@ -424,8 +423,7 @@ describe SubmissionsController do
             @assignment.update!(due_date: Time.current - 1.week)
             allow(Assignment).to receive_message_chain(
               :includes, :find) { @assignment }
-            expect_any_instance_of(SubmissionsController).to receive(:flash_now).with(:success, anything)
-            expect(@assignment).to receive(:short_identifier) { 'a1' }
+            expect_any_instance_of(SubmissionsController).not_to receive(:flash_now).with(:error, anything)
             allow(SubmissionsJob).to receive(:perform_later) { Struct.new(:job_id).new('1') }
 
             post_as @admin,


### PR DESCRIPTION
- added new message strings for reporting errors and progress messages for jobs
- moved default job status methods into the `ApplicationJob` class so that they can be inherited by subclasses
- added job status methods to all jobs classes that should override the defaults
- report error messages by capturing `StandardError` for all `perform` messages
- change the logic (order of `if` statements) in `JobMessagesController.get` in order to make sure that the correct message is displayed throughout the lifecycle of the job
- use the `:error_message` status key to indicate whether an error occurred during the job lifecycle
     - the `:failed` key should get set when `ActiveJob::Status` catches an `Exception` however this does not appear to happen consistently (unsure why)