### PR TITLE
Revert to xenial until travis fixes postgres in bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.5.3
-dist: bionic
+dist: xenial
 addons:
   postgresql: "10"
   apt:


### PR DESCRIPTION
It looks like there are some conflicts with the current travis setup for bionic:

https://travis-ci.community/t/postgresql-fails-to-start-unrecognized-operating-system/4558

With bionic, our builds are currently failing with:

```bash
$ travis_setup_postgresql 10
Starting PostgreSQL v10
Job for postgresql@10-main.service failed because the service did not take the steps required by its unit configuration.
See "systemctl status postgresql@10-main.service" and "journalctl -xe" for details.
sudo systemctl start postgresql@10-main
```

which makes us unable to connect to postgres later on:

```bash
$ psql -c 'create database markus_test;' -U postgres
psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
The command "psql -c 'create database markus_test;' -U postgres" failed and exited with 2 during .
```

Attempts to change the port, uninstall other versions, etc. do not seem to work so the suggested fix for now seems to be to revert to xenial until travis can fix the bionic issue (or another workaround presents itself). 