### PR TITLE
Recover from inability to access a repository on the first attempt

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -78,7 +78,7 @@ class AssignmentsController < ApplicationController
         rescue RuntimeError => error
           flash_message(:error, error.message)
         end
-        redirect_to action: 'student_interface', id: @assignment.id
+        redirect_to controller: :assignments
       else
         if @assignment.scanned_exam
           flash_now(:notice, t('assignments.scanned_exam.under_review'))

--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -36,10 +36,14 @@ class GitRepository < Repository::AbstractRepository
         rescue Rugged::ReferenceError   # It seems the master branch might not be correctly setup at first.
         end
         @repos.reset('origin/master', :hard) # align to whatever is in origin/master
-      rescue Rugged::Error, Rugged::OSError
+      rescue Rugged::Error, Rugged::OSError => e
+        m_logger = MarkusLogger.instance
+        m_logger.log "Error accessing repository #{@repos_path}: #{e.message}"
         reclone_repo
       end
     else
+      m_logger = MarkusLogger.instance
+      m_logger.log "Error accessing repository #{@repos_path}: repository missing"
       reclone_repo
     end
   end

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -308,7 +308,7 @@ module Repository
       begin
         loop do
           return yield if redis.lrange(resource_id, -1, -1).first&.to_i == Thread.current.object_id
-          raise Timeout::Error(I18n.t('repo.timeout')) if elapsed_time >= timeout
+          raise Timeout::Error, I18n.t('repo.timeout') if elapsed_time >= timeout
 
           sleep(interval / 1000.0) # interval is in milliseconds but sleep arg is in seconds
           elapsed_time += interval

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -286,7 +286,7 @@ module Repository
     # The +namespace+ argument can be given to ensure that two resources with the same resource_id can be treated
     # as separate resources as long as the +namespace+ value is distinct. By default the +namespace+ is the relative
     # root of the current MarkUs instance.
-    def self.redis_exclusive_lock(resource_id, namespace: Rails.root.to_s, timeout: 1000, interval: 100)
+    def self.redis_exclusive_lock(resource_id, namespace: Rails.root.to_s, timeout: 5000, interval: 100)
       redis = Redis::Namespace.new(namespace)
       return yield if redis.lrange(resource_id, -1, -1).first&.to_i == Thread.current.object_id
 
@@ -308,7 +308,7 @@ module Repository
       begin
         loop do
           return yield if redis.lrange(resource_id, -1, -1).first&.to_i == Thread.current.object_id
-          raise Timeout::Error("waited #{timeout} ms to access resource: #{resource_id}") if elapsed_time >= timeout
+          raise Timeout::Error(I18n.t('repo.timeout')) if elapsed_time >= timeout
 
           sleep(interval / 1000.0) # interval is in milliseconds but sleep arg is in seconds
           elapsed_time += interval

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -5,7 +5,7 @@ class Grouping < ApplicationRecord
   include ActiveRecordCreator
   include SubmissionsHelper
 
-  after_create_commit :create_grouping_repository_folder
+  after_create :create_grouping_repository_folder
   after_commit :update_repo_permissions_after_save, on: [:create, :update]
 
   has_many :memberships, dependent: :destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,3 +69,4 @@ en:
         default: "Update files"
         required_files: "Update the list of required files for assignment %{assignment}"
         starter_code: "Update starter code files for assignment %{assignment}"
+      timeout: 'Waited %{ms} milliseconds to access this repository. Please wait a few seconds and try again.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -78,3 +78,4 @@ es:
         default: "UPDATE ME"
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
+      timeout: 'UPDATE ME %{ms}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,3 +68,4 @@ fr:
         default: "UPDATE ME"
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
+      timeout: 'Attendu %{ms} millisecondes pour accéder à ce repo. Veuillez patienter quelques secondes et réessayer.'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -63,3 +63,4 @@ pt:
         default: "UPDATE ME"
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
+      timeout: 'UPDATE ME %{ms}'


### PR DESCRIPTION
- if there is an error accessing a repo from the student view, redirect back to the `assignments` view instead of trying to (repeatedly) reload the `student_interface` view (which hits the same error, reloads again, etc.)
- some code cleanup (guard clauses and remove unnecessary `begin` blocks)
- log the reason why a repo becomes corrupted (as much as possible)
- Internationalize timeout error message
- create grouping repository folder as an `after_create` callback instead of `after_create_commit` so that an error accessing the repository will prevent the grouping from being created entirely