### PR TITLE
Flatten policies

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -45,7 +45,7 @@ class AutomatedTestsController < ApplicationController
       @grouping.refresh_test_tokens
       # authorization
       begin
-        authorize! @assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
+        authorize! @assignment, to: :run_tests?
         authorize! @grouping, to: :run_tests?
         @authorized = true
       rescue ActionPolicy::Unauthorized => e
@@ -62,7 +62,7 @@ class AutomatedTestsController < ApplicationController
       assignment = Assignment.find(params[:id])
       grouping = current_user.accepted_grouping_for(assignment.id)
       grouping.refresh_test_tokens
-      authorize! assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
+      authorize! assignment, to: :run_tests?
       authorize! grouping, to: :run_tests?
       grouping.decrease_test_tokens
       test_run = grouping.create_test_run!(user: current_user)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -47,6 +47,8 @@ class ResultsController < ApplicationController
             head :forbidden
             return
           end
+        else
+          grouping = submission.grouping
         end
 
         data = {
@@ -84,7 +86,8 @@ class ResultsController < ApplicationController
 
         if assignment.enable_test
           begin
-            authorize! assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
+            authorize! assignment, to: :run_tests?
+            authorize! grouping, to: :run_tests?
             authorize! submission, to: :run_tests?
             authorized = true
           rescue ActionPolicy::Unauthorized
@@ -235,7 +238,8 @@ class ResultsController < ApplicationController
 
     # authorization
     begin
-      authorize! @assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
+      authorize! @assignment, to: :run_tests?
+      authorize! @grouping, to: :run_tests?
       authorize! @submission, to: :run_tests?
       @authorized = true
     rescue ActionPolicy::Unauthorized => e
@@ -269,7 +273,8 @@ class ResultsController < ApplicationController
     begin
       submission = Result.find(params[:id]).submission
       assignment = submission.assignment
-      authorize! assignment, to: :run_tests? # TODO: Remove it when reasons will have the dependent policy details
+      authorize! assignment, to: :run_tests?
+      authorize! submission.grouping, to: :run_tests?
       authorize! submission, to: :run_tests?
       test_run = submission.create_test_run!(user: current_user)
       @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,

--- a/app/policies/grouping_policy.rb
+++ b/app/policies/grouping_policy.rb
@@ -1,13 +1,11 @@
 class GroupingPolicy < ApplicationPolicy
 
   def run_tests?
-    check?(:run_tests?, record.assignment) && (
-      !user.student? || (
-        check?(:member?) &&
-        check?(:not_in_progress?) &&
-        check?(:tokens_available?) &&
-        check?(:before_due_date?)
-      )
+    !user.student? || (
+      check?(:member?) &&
+      check?(:not_in_progress?) &&
+      check?(:tokens_available?) &&
+      check?(:before_due_date?)
     )
   end
 

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -2,7 +2,6 @@ class SubmissionPolicy < ApplicationPolicy
 
   def run_tests?
     check?(:not_a_student?) &&
-    check?(:run_tests?, record.grouping) &&
     check?(:before_release?)
   end
 

--- a/spec/policies/grouping_policy_spec.rb
+++ b/spec/policies/grouping_policy_spec.rb
@@ -7,11 +7,6 @@ describe GroupingPolicy do
     context 'when the user is an admin' do
       let(:user) { build(:admin) }
 
-      context 'if the assignment policy fails' do
-        let(:grouping) { build_stubbed(:grouping) }
-        it { is_expected.not_to pass :run_tests?, because_of: { AssignmentPolicy => :run_tests? } }
-      end
-
       context 'if the assignment policy passes' do
         let(:assignment) { create(:assignment_for_tests) }
         let(:grouping) { build_stubbed(:grouping, assignment: assignment) }
@@ -19,19 +14,8 @@ describe GroupingPolicy do
       end
     end
 
-    context 'when the user is a TA' do
-      let(:user) { build(:ta) }
-      let(:grouping) { build_stubbed(:grouping) }
-      it { is_expected.not_to pass :run_tests?, because_of: { AssignmentPolicy => :run_tests? } }
-    end
-
     context 'when the user is a student' do
       let(:user) { build(:student) }
-
-      context 'if the assignment policy fails' do
-        let(:grouping) { build_stubbed(:grouping) }
-        it { is_expected.not_to pass :run_tests?, because_of: { AssignmentPolicy => :run_tests? } }
-      end
 
       context 'if the assignment policy passes' do
         let(:assignment) { create(:assignment_for_student_tests, unlimited_tokens: false) }

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -7,11 +7,6 @@ describe SubmissionPolicy do
     context 'when the user is an admin' do
       let(:user) { build(:admin) }
 
-      context 'if the assignment policy fails' do
-        let(:submission) { build_stubbed(:submission) }
-        it { is_expected.not_to pass :run_tests?, because_of: { GroupingPolicy => :run_tests? } }
-      end
-
       context 'if the assignment policy passes' do
         let(:assignment) { create(:assignment_for_tests) }
         let(:grouping) { create(:grouping, assignment: assignment) }
@@ -31,12 +26,6 @@ describe SubmissionPolicy do
           it { is_expected.to pass :run_tests? }
         end
       end
-    end
-
-    context 'when the user is a TA' do
-      let(:user) { build(:ta) }
-      let(:submission) { build_stubbed(:submission) }
-      it { is_expected.not_to pass :run_tests?, because_of: { GroupingPolicy => :run_tests? } }
     end
 
     context 'when the user is a student' do


### PR DESCRIPTION
- policies that call `check?` on a policy for another record don't report the correct failure error if one of the checks for the other record fail (https://github.com/palkan/action_policy/issues/50)
- because it doesn't look like this will be changed soon, this changes the way we call policies so that no policy will call any other.