### PR TITLE
Don't override native text range selection keybindings

### DIFF
--- a/app/assets/javascripts/Results/keybinding.js
+++ b/app/assets/javascripts/Results/keybinding.js
@@ -3,14 +3,23 @@ Mousetrap.bind('?', function() {
   modal_help.open();
 });
 
+function is_text_selected() {
+  return 'getSelection' in window && window.getSelection().type === 'Range';
+}
+
 // Go to the previous submission with <
 Mousetrap.bind('shift+left', function() {
-  $('.button.previous')[0].click();
+  // Don't override range selection keybindings
+  if (!is_text_selected()) {
+    $('.button.previous')[0].click();
+  }
 });
 
 // Go to next submission with >
 Mousetrap.bind('shift+right', function() {
-  $('.button.next')[0].click();
+  if (!is_text_selected()) {
+    $('.button.next')[0].click();
+  }
 });
 
 // Go to the previous criterion with shift + up

--- a/app/assets/javascripts/Results/keybinding.js
+++ b/app/assets/javascripts/Results/keybinding.js
@@ -24,16 +24,20 @@ Mousetrap.bind('shift+right', function() {
 
 // Go to the previous criterion with shift + up
 Mousetrap.bind('shift+up', function(e) {
-  e.preventDefault();
-  prevCriterion();
-  return false;
+  if (!is_text_selected()) {
+    e.preventDefault();
+    prevCriterion();
+    return false;
+  }
 });
 
 // Go to the next criterion with shift + down
 Mousetrap.bind('shift+down', function(e) {
-  e.preventDefault();
-  nextCriterion();
-  return false;
+  if (!is_text_selected()) {
+    e.preventDefault();
+    nextCriterion();
+    return false;
+  }
 });
 
 // When on rubric criterion, use the arrow keys to hover over the next rubric


### PR DESCRIPTION
Oftentimes while marking, I'll select some code to annotate by double-clicking a token, which might select more (or less) text on the right end than I wanted to, at which point I'll instinctively type Shift+Left/Right to adjust my range selection.

Currently, Shift+Left/Right are rebound to go to the previous/next submissions, which is frustrating (muscle memory makes it so that this happens almost every submission, at least once).

This PR proposes disabling the Shift-modifier submission-navigation keybindings if there is currently an active range selection, so that existing workflows are (hopefully) not affected.