### PR TITLE
i18n: Simplify handling of locale setting.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,23 +62,13 @@ class ApplicationController < ActionController::Base
   # Set locale according to URL parameter. If unknown parameter is
   # requested, fall back to default locale.
   def set_locale
-    @available_locales = AVAILABLE_LANGS if @available_locales.nil?
-    I18n.locale = params[:locale] || I18n.default_locale
-
-    locale_path = File.join(LOCALES_DIRECTORY, "#{I18n.locale}.yml")
-
-    unless I18n.load_path.include? locale_path
-      I18n.load_path << locale_path
-      I18n.backend.send(:init_translations)
+    if params[:locale].nil?
+      I18n.locale = I18n.default_locale
+    elsif I18n.available_locales.include? params[:locale].to_sym
+      I18n.locale = params[:locale]
+    else
+      flash_now(:notice, I18n.t('locale_not_available', locale: params[:locale]))
     end
-
-  # handle unknown locales
-  rescue Exception => err
-    logger.error err
-    flash.now[:notice] = I18n.t('locale_not_available', locale: I18n.locale)
-
-    I18n.load_path -= [locale_path]
-    I18n.locale = I18n.default_locale
   end
 
   def get_file_encodings

--- a/app/lib/markus_configurator.rb
+++ b/app/lib/markus_configurator.rb
@@ -252,14 +252,6 @@ module MarkusConfigurator
     end
   end
 
-  def markus_config_default_language
-    if defined? MARKUS_DEFAULT_LANGUAGE
-      return MARKUS_DEFAULT_LANGUAGE
-    else
-      return 'en'
-    end
-  end
-
   ##########################################
   # Automated Testing Engine Configuration
   ##########################################

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,8 +10,7 @@
         relative_root = Rails.application.config.action_controller.relative_url_root || ''
         curr_path = request.path.gsub(relative_root, "").gsub(Regexp.compile("(?<=/)#{I18n.locale}/"), "")
 
-        select_tag(:locale, options_for_select(@available_locales,
-                   selected: "#{I18n.locale}"),
+        select_tag(:locale, options_for_select(I18n.available_locales, selected: "#{I18n.locale}"),
                    { onchange: "javascript:
                                     window.location.href =
                                          '#{relative_root}/' +

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,12 @@ Markus::Application.configure do
   # Set this if MarkUs is deployed to a subdirectory, e.g. if it is served at https://yourhost.com/instance0
   config.action_controller.relative_url_root = '/csc108'
 
+  # Explicitly whitelist available locales for i18n-js.
+  I18n.available_locales = [:en, :fr, :es, :pt]
+
+  # Set default locale.
+  I18n.default_locale = :en
+
   ###################################################################
   # MarkUs SPECIFIC CONFIGURATION
   #   - use "/" as path separator no matter what OS server is running
@@ -184,13 +190,6 @@ Markus::Application.configure do
   ###################################################################
   # Global flag to enable/disable starter code feature.
   STARTER_CODE_ON = true
-
-  ###################################################################
-  # Set this to the desired default language MarkUs should load if
-  # nothing else tells it otherwise. At the moment valid values are
-  # 'en', 'fr'. Please make sure that proper locale files are present
-  # in config/locales.
-  MARKUS_DEFAULT_LANGUAGE = 'en'
 
   ###################################################################
   # Session Timeouts

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,12 @@ Markus::Application.configure do
   # Set this if MarkUs is deployed to a subdirectory, e.g. if it is served at https://yourhost.com/instance0
   # config.action_controller.relative_url_root = '/instance0'
 
+  # Explicitly whitelist available locales for i18n-js.
+  I18n.available_locales = [:en]
+
+  # Set default locale.
+  I18n.default_locale = :en
+
   ###################################################################
   # MarkUs SPECIFIC CONFIGURATION
   #   - use "/" as path separator no matter what OS server is running
@@ -189,13 +195,6 @@ Markus::Application.configure do
   ###################################################################
   # Global flag to enable/disable starter code feature.
   STARTER_CODE_ON = true
-
-  ###################################################################
-  # Set this to the desired default language MarkUs should load if
-  # nothing else tells it otherwise. At the moment valid values are
-  # 'en', 'fr'. Please make sure that proper locale files are present
-  # in config/locales.
-  MARKUS_DEFAULT_LANGUAGE = 'en'
 
   ###################################################################
   # Session Timeouts

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,6 +24,12 @@ Markus::Application.configure do
   # Disable caching.
   config.action_controller.perform_caching = false
 
+  # Explicitly whitelist available locales for i18n-js.
+  I18n.available_locales = [:en, :fr, :es, :pt]
+
+  # Set default locale.
+  I18n.default_locale = :en
+
   ###################################################################
   # MarkUs SPECIFIC CONFIGURATION
   #   - use "/" as path separator no matter what OS server is running
@@ -181,13 +187,6 @@ Markus::Application.configure do
   ###################################################################
   # Global flag to enable/disable starter code feature.
   STARTER_CODE_ON = true
-
-  ###################################################################
-  # Set this to the desired default language MarkUs should load if
-  # nothing else tells it otherwise. At the moment valid values are
-  # 'en', 'fr'. Please make sure that proper locale files are present
-  # in config/locales.
-  MARKUS_DEFAULT_LANGUAGE = 'en'
 
   ###################################################################
   # Session Timeouts

--- a/config/initializers/02_i18n.rb
+++ b/config/initializers/02_i18n.rb
@@ -1,15 +1,2 @@
 # Add all config/locales subdirs
 I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-
-# Explicitly whitelist available locales for i18n-js
-I18n.available_locales = [:en, :fr, :es, :pt]
-
-# set English as default
-I18n.default_locale = MarkusConfigurator.markus_config_default_language
-I18n.locale = MarkusConfigurator.markus_config_default_language
-
-# location where the language files go
-LOCALES_DIRECTORY = File.join(::Rails.root.to_s, "config", "locales")
-
-language_files = Dir.glob(File.join(LOCALES_DIRECTORY, "*.yml" ))
-AVAILABLE_LANGS = language_files.collect{ |file| File.basename(file).chomp(".yml") }.sort


### PR DESCRIPTION
This also change the default for production to only make :en available.

(Note: the old approach is from before `I18n.available_locales` was available.)