### PR TITLE
ui: vertically align flash dismiss button

### DIFF
--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -130,6 +130,7 @@ strong a {
   background: transparent asset-url('icons/cross.png') no-repeat 5px center;
   float: right;
   width: 2em;
+  height: 100%;
 }
 
 /** Text field inputs */


### PR DESCRIPTION
This PR proposes a minor UI tweak to the alignment of the flash dismissal button.

Before:
![image](https://user-images.githubusercontent.com/1403503/70091151-8a4bad00-15e9-11ea-9359-ef79f00ce358.png)

After:
![image](https://user-images.githubusercontent.com/1403503/70091171-920b5180-15e9-11ea-8719-524291b4639b.png)
