### PR TITLE
Add postgres host info for development on osx

### DIFF
--- a/config/database.yml.postgresql
+++ b/config/database.yml.postgresql
@@ -10,6 +10,7 @@
 #       Install PostgreSQL and put its /bin directory on your path.
 development:
   adapter: postgresql
+  host: localhost
   encoding: unicode
   database: markus_development
   username: markus
@@ -35,6 +36,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: postgresql
+  host: localhost
   encoding: unicode
   database: markus_test
   username: markus
@@ -44,6 +46,7 @@ test:
 # each MarkUs instance.
 production:
   adapter: postgresql
+  host: localhost
   encoding: unicode
   database: markus_production
   username: markus


### PR DESCRIPTION
- with postgresql 10 installed on OSX 10.14.3 with homebrew, the default host name for the database connection seems to be required.
- `'localhost'` is the assumed default so there shouldn't be any issue with explicitly adding it to the configuration file for other installations. 