### PR TITLE
Make sure all columns are shown in marks spreadsheet download

### DIFF
--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -166,11 +166,10 @@ class GradeEntryForm < ApplicationRecord
                      .pluck('users.user_name', 'grade_entry_items.position', :grade)
                      .group_by { |x| x[0] }
     num_items = self.grade_entry_items.count
-    grade_entry_positions = self.grade_entry_items.pluck(:position).sort
     MarkusCsv.generate(students, headers) do |user_name, total_grade|
       row = [user_name]
       if grade_data.key? user_name
-        student_grades = grade_entry_positions.map { '' }
+        student_grades = Array.new(num_items, '')
         grade_data[user_name].each do |g|
           grade_index = g[1] - 1
           student_grades[grade_index] = g[2].nil? ? '' : g[2]

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -166,12 +166,15 @@ class GradeEntryForm < ApplicationRecord
                      .pluck('users.user_name', 'grade_entry_items.position', :grade)
                      .group_by { |x| x[0] }
     num_items = self.grade_entry_items.count
+    grade_entry_positions = self.grade_entry_items.pluck(:position).sort
     MarkusCsv.generate(students, headers) do |user_name, total_grade|
       row = [user_name]
       if grade_data.key? user_name
-        # Take grades sorted by position.
-        student_grades = grade_data[user_name].sort_by { |x| x[1] }
-                                              .map { |x| x[2].nil? ? '' : x[2] }
+        student_grades = grade_entry_positions.map { '' }
+        grade_data[user_name].each do |g|
+          grade_index = g[1] - 1
+          student_grades[grade_index] = g[2].nil? ? '' : g[2]
+        end
         row.concat(student_grades)
         row << (total_grade.nil? ? '' : total_grade) if self.show_total
       else


### PR DESCRIPTION
Fixes bug where if some columns didn't have data for a given row (but others did), all of the non-empty data for that row was shifted to the left. 