### PR TITLE
Updated rake files so seeding works properly for levels

### DIFF
--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,6 +1,6 @@
 # Level represent a level within a Rubric Criterion
 class Level < ApplicationRecord
-  belongs_to :rubric_criterion
+  belongs_to :rubric_criterion, optional: true
 
   validates :name, presence: true
   validates :number, presence: true

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -13,6 +13,7 @@ class RubricCriterion < Criterion
   has_many :tas, through: :criterion_ta_associations
 
   has_many :levels, -> { order(:mark) }
+  accepts_nested_attributes_for :levels
 
   belongs_to :assignment, counter_cache: true
 

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -87,16 +87,19 @@ namespace :markus do
       updated_at:              nil,
       assigned_groups_count:   nil
     )
-    rubric = RubricCriterion.create(
-      name:                  'Mark3',
-      assignment_id:         a.id,
-      position:              2,
-      max_mark:              4,
-    )
+
+    attributes = []
     5.times do |number|
-      rubric.levels.create(name: random_words(1), number: number,
-                           description: random_sentences(5), mark: number)
+      lvl = { name: random_words(1), number: number,
+              description: random_sentences(5), mark: number }
+      attributes.push(lvl)
     end
+    params = { rubric: {
+      name: 'Mark3', assignment_id: a.id,
+      position: 2, max_mark: 4, levels_attributes: attributes
+    } }
+    RubricCriterion.create!(params[:rubric])
+    
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -91,13 +91,12 @@ namespace :markus do
       name:                  'Mark3',
       assignment_id:         a.id,
       position:              2,
-      max_mark:              10,
+      max_mark:              4,
     )
     5.times do |number|
       rubric.levels.create(name: random_words(1), number: number,
                            description: random_sentences(5), mark: number)
     end
-    byebug
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -97,7 +97,6 @@ namespace :markus do
       rubric.levels.create(name: random_words(1), number: number,
                            description: random_sentences(5), mark: number)
     end
-    byebug
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -97,6 +97,7 @@ namespace :markus do
       rubric.levels.create(name: random_words(1), number: number,
                            description: random_sentences(5), mark: number)
     end
+    byebug
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -99,7 +99,6 @@ namespace :markus do
       position: 2, max_mark: 4, levels_attributes: attributes
     } }
     RubricCriterion.create!(params[:rubric])
-    
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -87,22 +87,17 @@ namespace :markus do
       updated_at:              nil,
       assigned_groups_count:   nil
     )
-    RubricCriterion.create(
+    rubric = RubricCriterion.create(
       name:                  'Mark3',
       assignment_id:         a.id,
       position:              2,
       max_mark:              10,
-      level_0_name:          'Very Poor',
-      level_0_description:   'Very Poor',
-      level_1_name:          'Weak',
-      level_1_description:   'Weak',
-      level_2_name:          'Passable',
-      level_2_description:   'Passable',
-      level_3_name:          'Good',
-      level_3_description:   'Good',
-      level_4_name:          'Excellent',
-      level_4_description:   'Excellent'
     )
+    5.times do |number|
+      rubric.levels.create(name: random_words(1), number: number,
+                           description: random_sentences(5), mark: number)
+    end
+    byebug
   end
 
   def submit_half_on_time(a)

--- a/lib/tasks/results.rake
+++ b/lib/tasks/results.rake
@@ -48,7 +48,8 @@ namespace :markus do
       end
 
       # create rubric criteria for a1
-      rubric_criteria = [{name: 'Uses Conditionals', max_mark: 4}, {name: 'Code Clarity', max_mark: 8}, {name: 'Code Is Documented', max_mark: 12}, {name: 'Uses For Loop', max_mark: 4}]
+      rubric_criteria = [{ name: 'Uses Conditionals', max_mark: 4 }, { name: 'Code Clarity', max_mark: 8 },
+                         { name: 'Code Is Documented', max_mark: 12 }, { name: 'Uses For Loop', max_mark: 4 }]
       default_levels = [{ name: 'Quite Poor', number: 0, description: 'This criterion was not satisfied whatsoever', mark: 0 },
                         { name: 'Satisfactory', number: 1, description: 'This criterion was satisfied', mark: 1 },
                         { name: 'Good', number: 2, description: 'This criterion was satisfied well', mark: 2 },

--- a/lib/tasks/results.rake
+++ b/lib/tasks/results.rake
@@ -48,20 +48,18 @@ namespace :markus do
       end
 
       # create rubric criteria for a1
-      rubric_criteria = [{name: "Uses Conditionals", max_mark: 4}, {name: "Code Clarity", max_mark: 8}, {name: "Code Is Documented", max_mark: 12}, {name: "Uses For Loop", max_mark: 4}]
-      default_levels = [{name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
-                        {name: "Satisfactory", description: "This criterion was satisfied", mark: 1},
-                        {name: "Good", description: "This criterion was satisfied well", mark: 2},
-                        {name: "Great", description: "This criterion was satisfied really well!", mark: 3},
-                        {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4}]
+      rubric_criteria = [{name: 'Uses Conditionals', max_mark: 4}, {name: 'Code Clarity', max_mark: 8}, {name: 'Code Is Documented', max_mark: 12}, {name: 'Uses For Loop', max_mark: 4}]
+      default_levels = [{ name: 'Quite Poor', number: 0, description: 'This criterion was not satisfied whatsoever', mark: 0 },
+                        { name: 'Satisfactory', number: 1, description: 'This criterion was satisfied', mark: 1 },
+                        { name: 'Good', number: 2, description: 'This criterion was satisfied well', mark: 2 },
+                        { name: 'Great', number: 3, description: 'This criterion was satisfied really well!', mark: 3 },
+                        { name: 'Excellent', number: 4, description: 'This criterion was satisfied excellently', mark: 4 }]
       rubric_criteria.each do |rubric_criteria|
-        rc = RubricCriterion.new
-        rc.update(rubric_criteria)
-        default_levels.each do |level|
-          rc.levels.create(level)
-        end
-        rc.assignment = a1
-        rc.save
+        params = { rubric: {
+          assignment: a1, levels_attributes: default_levels
+        } }
+        rubric_criteria.merge(params[:rubric])
+        RubricCriterion.create(rubric_criterion)
       end
 
       # create submissions

--- a/lib/tasks/results.rake
+++ b/lib/tasks/results.rake
@@ -49,11 +49,17 @@ namespace :markus do
 
       # create rubric criteria for a1
       rubric_criteria = [{name: "Uses Conditionals", max_mark: 4}, {name: "Code Clarity", max_mark: 8}, {name: "Code Is Documented", max_mark: 12}, {name: "Uses For Loop", max_mark: 4}]
-      default_levels = {level_0_name: "Quite Poor", level_0_description: "This criterion was not satisifed whatsoever", level_1_name: "Satisfactory", level_1_description: "This criterion was satisfied", level_2_name: "Good", level_2_description: "This criterion was satisfied well", level_3_name: "Great", level_3_description: "This criterion was satisfied really well!", level_4_name: "Excellent", level_4_description: "This criterion was satisfied excellently"}
+      default_levels = [{name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
+                        {name: "Satisfactory", description: "This criterion was satisfied", mark: 1},
+                        {name: "Good", description: "This criterion was satisfied well", mark: 2},
+                        {name: "Great", description: "This criterion was satisfied really well!", mark: 3},
+                        {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4}]
       rubric_criteria.each do |rubric_criteria|
         rc = RubricCriterion.new
         rc.update(rubric_criteria)
-        rc.update(default_levels)
+        default_levels.each do |level|
+          rc.levels.create(level)
+        end
         rc.assignment = a1
         rc.save
       end

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -30,22 +30,17 @@ namespace :db do
       end
 
       3.times do |index|
-        RubricCriterion.create(
+        rubric = RubricCriterion.create(
             name:                  random_sentences(1),
             assignment_id:         assignment.id,
             position:              index + 1,
             max_mark:              pos_rand(3),
-            level_0_name:          random_words(5),
-            level_0_description:   random_sentences(5),
-            level_1_name:          random_words(5),
-            level_1_description:   random_sentences(5),
-            level_2_name:          random_words(5),
-            level_2_description:   random_sentences(5),
-            level_3_name:          random_words(5),
-            level_3_description:   random_sentences(5),
-            level_4_name:          random_words(5),
-            level_4_description:   random_sentences(5)
         )
+        5.times do |number|
+          rubric.levels.create(name: random_words(1), number: number,
+                             description: random_sentences(5), mark: number)
+        end
+        byebug
       end
 
       3.times do |index|

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -30,16 +30,19 @@ namespace :db do
       end
 
       3.times do |index|
-        rubric = RubricCriterion.create(
-            name:                  random_sentences(1),
-            assignment_id:         assignment.id,
-            position:              index + 1,
-            max_mark:              4,
-        )
+        attributes = []
         5.times do |number|
-          rubric.levels.create(name: random_words(1), number: number,
-                             description: random_sentences(5), mark: number)
+          lvl = { name: random_words(1), number: number,
+                  description: random_sentences(5), mark: number }
+          attributes.push(lvl)
         end
+
+        params = { rubric: {
+          name: random_sentences(1), assignment_id: assignment.id,
+          position: index + 1, max_mark: 4, levels_attributes: attributes
+        } }
+
+        RubricCriterion.create!(params[:rubric])
       end
 
       3.times do |index|

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -40,7 +40,6 @@ namespace :db do
           rubric.levels.create(name: random_words(1), number: number,
                              description: random_sentences(5), mark: number)
         end
-        byebug
       end
 
       3.times do |index|

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -34,7 +34,7 @@ namespace :db do
             name:                  random_sentences(1),
             assignment_id:         assignment.id,
             position:              index + 1,
-            max_mark:              pos_rand(3),
+            max_mark:              4,
         )
         5.times do |number|
           rubric.levels.create(name: random_words(1), number: number,

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -93,19 +93,17 @@ namespace :markus do
             max_mark: max_mark_3},
           {name: "Uses For Loop",
            max_mark: max_mark_4}]
-        default_levels = [ {name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
-                          {name: "Satisfactory", description: "This criterion was satisfied", mark: 1},
-                          {name: "Good", description: "This criterion was satisfied well", mark: 2},
-                          {name: "Great", description: "This criterion was satisfied really well!", mark: 3},
-                          {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4} ]
+        default_levels = [ {name: 'Quite Poor', number: 0, description: 'This criterion was not satisfied whatsoever', mark: 0 },
+                          { name: 'Satisfactory', number: 1, description: 'This criterion was satisfied', mark: 1 },
+                          { name: 'Good', number: 2, description: 'This criterion was satisfied well', mark: 2 },
+                          { name: 'Great', number: 3, description: 'This criterion was satisfied really well!', mark: 3 },
+                          { name: 'Excellent', number: 4, description: 'This criterion was satisfied excellently', mark: 4 } ]
         rubric_criteria.each do |rubric_criterion|
-          rc = RubricCriterion.create
-          rc.update(rubric_criterion)
-          default_levels.each do |level|
-            rc.levels.create(level)
-          end
-          rc.assignment = assignment
-          rc.save!
+          params = { rubric: {
+            assignment: assignment, levels_attributes: default_levels
+          } }
+          rubric_criterion.merge(params[:rubric])
+          RubricCriterion.create(rubric_criterion)
           assignment.get_criteria << rc
         end
         assignment.save

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -93,11 +93,11 @@ namespace :markus do
             max_mark: max_mark_3},
           {name: "Uses For Loop",
            max_mark: max_mark_4}]
-        default_levels = [ {name: 'Quite Poor', number: 0, description: 'This criterion was not satisfied whatsoever', mark: 0 },
+        default_levels = [{name: 'Quite Poor', number: 0, description: 'This criterion was not satisfied whatsoever', mark: 0 },
                           { name: 'Satisfactory', number: 1, description: 'This criterion was satisfied', mark: 1 },
                           { name: 'Good', number: 2, description: 'This criterion was satisfied well', mark: 2 },
                           { name: 'Great', number: 3, description: 'This criterion was satisfied really well!', mark: 3 },
-                          { name: 'Excellent', number: 4, description: 'This criterion was satisfied excellently', mark: 4 } ]
+                          { name: 'Excellent', number: 4, description: 'This criterion was satisfied excellently', mark: 4 }]
         rubric_criteria.each do |rubric_criterion|
           params = { rubric: {
             assignment: assignment, levels_attributes: default_levels

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -93,11 +93,11 @@ namespace :markus do
             max_mark: max_mark_3},
           {name: "Uses For Loop",
            max_mark: max_mark_4}]
-        default_levels = [{name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
+        default_levels = [ {name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
                           {name: "Satisfactory", description: "This criterion was satisfied", mark: 1},
                           {name: "Good", description: "This criterion was satisfied well", mark: 2},
                           {name: "Great", description: "This criterion was satisfied really well!", mark: 3},
-                          {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4}]
+                          {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4} ]
         rubric_criteria.each do |rubric_criterion|
           rc = RubricCriterion.create
           rc.update(rubric_criterion)

--- a/lib/tasks/simulator.rake
+++ b/lib/tasks/simulator.rake
@@ -93,11 +93,17 @@ namespace :markus do
             max_mark: max_mark_3},
           {name: "Uses For Loop",
            max_mark: max_mark_4}]
-        default_levels = {level_0_name: "Quite Poor", level_0_description: "This criterion was not satisifed whatsoever", level_1_name: "Satisfactory", level_1_description: "This criterion was satisfied", level_2_name: "Good", level_2_description: "This criterion was satisfied well", level_3_name: "Great", level_3_description: "This criterion was satisfied really well!", level_4_name: "Excellent", level_4_description: "This criterion was satisfied excellently"}
+        default_levels = [{name: "Quite Poor", description: "This criterion was not satisfied whatsoever", mark: 0},
+                          {name: "Satisfactory", description: "This criterion was satisfied", mark: 1},
+                          {name: "Good", description: "This criterion was satisfied well", mark: 2},
+                          {name: "Great", description: "This criterion was satisfied really well!", mark: 3},
+                          {name: "Excellent", description: "This criterion was satisfied excellently", mark: 4}]
         rubric_criteria.each do |rubric_criterion|
           rc = RubricCriterion.create
           rc.update(rubric_criterion)
-          rc.update(default_levels)
+          default_levels.each do |level|
+            rc.levels.create(level)
+          end
           rc.assignment = assignment
           rc.save!
           assignment.get_criteria << rc


### PR DESCRIPTION
Updated the Rake tasks so that they integrate the new levels model. In each Rake task, Rubric.levels.create() is used to create levels rather than setting level_name_x and level_description_x to a value. 
Considerations:
- I changed the max mark of each rubric criterion so it would stay consistent when viewing on Markus (level would be 4.0/3.0 with a random number rather than 4.0/4.0, as max mark was random from 0 to 3)
- added an optional field to levels model to pass a validation