### PR TITLE
Fix displayed number of graded assignments being larger than total allocated

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -526,7 +526,7 @@ class ResultsController < ApplicationController
                    "assignment #{assignment.short_identifier} for " +
                    "group #{group.group_name}.",
                    MarkusLogger::INFO)
-      if assignment.assign_graders_to_criteria && @current_user.ta?
+      if @current_user.ta?
         num_marked = assignment.get_num_marked(@current_user.id)
       else
         num_marked = assignment.get_num_marked(nil)


### PR DESCRIPTION
When marking assignments as a TA, the `update_mark` function only counts the number of assignments marked for the current TA if the current user is a TA AND TAs are assigned to individual criteria. Otherwise, the total number of marked assignments (across all TAs) is returned, and the UI displays something like 15/4 assignments marked (See #4200).

This PR removes the check in the aforementioned function that TAs are assigned to individual criteria (which as far as I can see isn't necessary, the `assignment.get_num_marked` method takes care of counting correctly if TAs are indeed assigned to individual criteria). In manual tests, this exhibits the expected behaviour for cases when TAs are assigned to individual criteria, and whole assignments.

Fixes #4200