### PR TITLE
Edit levels

### DIFF
--- a/app/assets/stylesheets/criteria.scss
+++ b/app/assets/stylesheets/criteria.scss
@@ -47,12 +47,6 @@
   padding: 1em;
   width: 100%;
 
-  .bold_inline_label {
-    display: inline-block;
-    font-weight: 600;
-    min-width: 8em;
-  }
-
   h2 {
     margin-bottom: 0.5em;
   }
@@ -90,6 +84,9 @@
 
     .rubric_level_header {
       margin-bottom: 0.5em;
+      display: inline-block;
+      font-weight: 600;
+      min-width: 8em;
     }
 
     input[type='number'] {

--- a/app/assets/stylesheets/criteria.scss
+++ b/app/assets/stylesheets/criteria.scss
@@ -47,6 +47,12 @@
   padding: 1em;
   width: 100%;
 
+  .bold_inline_label {
+    display: inline-block;
+    font-weight: 600;
+    min-width: 8em;
+  }
+
   h2 {
     margin-bottom: 0.5em;
   }

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -36,7 +36,6 @@ class CriteriaController < ApplicationController
       @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
       flash_now(:success, t('flash.actions.create.success',
                             resource_name: criterion_class.model_name.human))
-      @criterion
     else
       @criterion.errors.full_messages.each do |message|
         flash_message(:error, message)

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -74,7 +74,6 @@ class CriteriaController < ApplicationController
       return
     end
     if criterion_type == 'RubricCriterion'
-      byebug
       properly_updated = @criterion.update(rubric_criterion_params.except(:assignment_files))
       unless rubric_criterion_params[:assignment_files].nil?
         assignment_files = AssignmentFile.find(rubric_criterion_params[:assignment_files].select { |id| !id.empty? })

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -74,6 +74,7 @@ class CriteriaController < ApplicationController
       return
     end
     if criterion_type == 'RubricCriterion'
+      byebug
       properly_updated = @criterion.update(rubric_criterion_params.except(:assignment_files))
       unless rubric_criterion_params[:assignment_files].nil?
         assignment_files = AssignmentFile.find(rubric_criterion_params[:assignment_files].select { |id| !id.empty? })
@@ -225,13 +226,13 @@ class CriteriaController < ApplicationController
                                              :ta_visible,
                                              :peer_visible,
                                              :max_mark,
-                                             level_attributes: [:id, :name, :mark, :description],
+                                             levels_attributes: [:id, :name, :mark, :description],
                                              assignment_files: []).to_h.deep_merge(params.require(:rubric_criterion)
                                                                            .permit(:max_mark,
                                                                                    :name,
                                                                                    :ta_visible,
                                                                                    :peer_visible,
-                                                                                   level_attributes:
+                                                                                   levels_attributes:
                                                                                      [:id, :name, :mark, :description])
                                                                                      .to_h)
   end

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -226,14 +226,7 @@ class CriteriaController < ApplicationController
                                              :peer_visible,
                                              :max_mark,
                                              levels_attributes: [:id, :name, :mark, :description],
-                                             assignment_files: []).to_h.deep_merge(params.require(:rubric_criterion)
-                                                                           .permit(:max_mark,
-                                                                                   :name,
-                                                                                   :ta_visible,
-                                                                                   :peer_visible,
-                                                                                   levels_attributes:
-                                                                                     [:id, :name, :mark, :description])
-                                                                                     .to_h)
+                                             assignment_files: [])
   end
 
   def checkbox_criterion_params

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -36,6 +36,7 @@ class CriteriaController < ApplicationController
       @criterion.set_default_levels if params[:criterion_type] == 'RubricCriterion'
       flash_now(:success, t('flash.actions.create.success',
                             resource_name: criterion_class.model_name.human))
+      @criterion
     else
       @criterion.errors.full_messages.each do |message|
         flash_message(:error, message)
@@ -224,8 +225,16 @@ class CriteriaController < ApplicationController
                                              :position,
                                              :ta_visible,
                                              :peer_visible,
+                                             :max_mark,
+                                             level_attributes: [:id, :name, :mark, :description],
                                              assignment_files: []).to_h.deep_merge(params.require(:rubric_criterion)
-                                                                           .permit(:max_mark).to_h)
+                                                                           .permit(:max_mark,
+                                                                                   :name,
+                                                                                   :ta_visible,
+                                                                                   :peer_visible,
+                                                                                   level_attributes:
+                                                                                     [:id, :name, :mark, :description])
+                                                                                     .to_h)
   end
 
   def checkbox_criterion_params

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -3,10 +3,8 @@ class Level < ApplicationRecord
   belongs_to :rubric_criterion
 
   validates :name, presence: true
-  validates :number, presence: true
   validates :description, presence: true
   validates :mark, presence: true
 
-  validates_numericality_of :number, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
   validates_numericality_of :mark, greater_than_or_equal_to: 0
 end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -74,7 +74,7 @@ class RubricCriterion < Criterion
   # row::         An array representing one CSV file row. Should be in the following
   #               format: [name, weight, _levels_ ] where the _levels part contains
   #               the following information about each level in the following order:
-  #               name, number, description, mark.
+  #               name, description, mark.
   # assignment::  The assignment to which the newly created criterion should belong.
   #
   # ===Raises:

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -60,7 +60,7 @@ class RubricCriterion < Criterion
     ]
     default_levels.each_with_index do |level, index|
       # creates a new level and saves it to database
-      self.levels.build(name: level['name'],
+      self.levels.create!(name: level['name'],
                         description: level['description'],
                         mark: index)
     end

--- a/app/views/rubric_criteria/_criterion_editor.html.erb
+++ b/app/views/rubric_criteria/_criterion_editor.html.erb
@@ -64,7 +64,7 @@
 
   <div class='rubric_criteria_levels'>
     <%= render partial: 'rubric_criteria/rubric_criterion_levels',
-               locals: { criterion: criterion,
+               locals: { criterion: @criterion,
                          f: f } %>
   </div>
 

--- a/app/views/rubric_criteria/_criterion_editor.html.erb
+++ b/app/views/rubric_criteria/_criterion_editor.html.erb
@@ -64,7 +64,7 @@
 
   <div class='rubric_criteria_levels'>
     <%= render partial: 'rubric_criteria/rubric_criterion_levels',
-               locals: { criterion: @criterion,
+               locals: { criterion: criterion,
                          f: f } %>
   </div>
 

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -7,19 +7,22 @@
                      index: rubric_level_index),
               class: "bold_inline_label" %>
 </div>
-<div>
-  <%= f.label :name, Level.human_attribute_name(:name), class: 'required' %>
-  <%= f.text_field :name, value: "#{level.name}"%>
-</div>
-<div>
-  <%= f.label :mark, Level.human_attribute_name(:mark) + " (#{level.mark}/#{criterion.max_mark})",
-              class: 'required' %>
-  <%= f.number_field :mark, value: "#{level.mark}", step: 0.1%>
-</div>
-<div>
-  <%= f.label :description, Level.human_attribute_name(:description), class: 'description required' %>
-  <%= f.text_area :description, value: "#{level.description}"%>
-</div>
+
+<%= criterion_form.fields_for :level, index: level.id do |level_form|%>
+  <div>
+    <%= f.label :name, Level.human_attribute_name(:name), class: 'required' %>
+    <%= level_form.text_field :name, value: "#{level.name}" %>
+  </div>
+  <div>
+    <%= f.label :mark, Level.human_attribute_name(:mark) + " (#{level.mark}/#{criterion.max_mark})",
+                class: 'required'%>
+    <%= level_form.number_field :mark, value: "#{level.mark}", step: 0.1 %>
+  </div>
+  <div>
+    <%= f.label :description, Level.human_attribute_name(:description), class: 'description required' %>
+    <%= level_form.text_area :description, value: "#{level.description}" %>
+  </div>
+<% end %>
 
 <br>
 <br>

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -1,26 +1,19 @@
 <%#
 # Erb template for display rubric criterion levels in the assignment rubric manager
 %>
-<div class="rubric_level_header">
-  <%= f.label "level_#{rubric_level_index}_name".to_sym,
-              I18n.t("rubric_criteria.level.level_index",
-                     index: rubric_level_index),
-              class: "bold_inline_label" %>
-</div>
 
-<%= criterion_form.fields_for :level, index: level.id do |level_form|%>
+<%= criterion_form.fields_for :levels do |level_form|%>
   <div>
-    <%= f.label :name, Level.human_attribute_name(:name), class: 'required' %>
-    <%= level_form.text_field :name, value: "#{level.name}" %>
+    <%= level_form.label :name, Level.human_attribute_name(:name), class: 'required' %>
+    <%= level_form.text_field :name%>
   </div>
   <div>
-    <%= f.label :mark, Level.human_attribute_name(:mark) + " (#{level.mark}/#{criterion.max_mark})",
-                class: 'required'%>
-    <%= level_form.number_field :mark, value: "#{level.mark}", step: 0.1 %>
+    <%= level_form.label :mark, class: 'required'%>
+    <%= level_form.number_field :mark%>
   </div>
   <div>
-    <%= f.label :description, Level.human_attribute_name(:description), class: 'description required' %>
-    <%= level_form.text_area :description, value: "#{level.description}" %>
+    <%= level_form.label :description, Level.human_attribute_name(:description), class: 'description required' %>
+    <%= level_form.text_area :description%>
   </div>
 <% end %>
 

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -1,15 +1,19 @@
 <%#
 # Erb template for display rubric criterion levels in the assignment rubric manager
 %>
-
+<% i=0 %>
 <%= criterion_form.fields_for :levels do |level_form|%>
+  <div class="rubric_level_header bold_inline_label">
+    Level <%=i%>
+    <%i+=1%>
+  </div>
   <div>
     <%= level_form.label :name, Level.human_attribute_name(:name), class: 'required' %>
     <%= level_form.text_field :name%>
   </div>
   <div>
     <%= level_form.label :mark, class: 'required'%>
-    <%= level_form.number_field :mark%>
+    <%= level_form.number_field :mark, step: 0.1%>
   </div>
   <div>
     <%= level_form.label :description, Level.human_attribute_name(:description), class: 'description required' %>

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -4,7 +4,8 @@
 <% i = 0 %>
 <%= criterion_form.fields_for :levels do |level_form| %>
   <div class="rubric_level_header">
-    Level <%= i %>
+    <%= I18n.t("rubric_criteria.level.name")%>
+    <%= i %>
     <% i += 1 %>
   </div>
   <div>

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -1,23 +1,23 @@
 <%#
 # Erb template for display rubric criterion levels in the assignment rubric manager
 %>
-<% i=0 %>
-<%= criterion_form.fields_for :levels do |level_form|%>
-  <div class="rubric_level_header bold_inline_label">
-    Level <%=i%>
-    <%i+=1%>
+<% i = 0 %>
+<%= criterion_form.fields_for :levels do |level_form| %>
+  <div class="rubric_level_header">
+    Level <%= i %>
+    <% i += 1 %>
   </div>
   <div>
     <%= level_form.label :name, Level.human_attribute_name(:name), class: 'required' %>
-    <%= level_form.text_field :name%>
+    <%= level_form.text_field :name %>
   </div>
   <div>
-    <%= level_form.label :mark, class: 'required'%>
-    <%= level_form.number_field :mark, step: 0.1%>
+    <%= level_form.label :mark, class: 'required' %>
+    <%= level_form.number_field :mark, step: 0.1 %>
   </div>
   <div>
     <%= level_form.label :description, Level.human_attribute_name(:description), class: 'description required' %>
-    <%= level_form.text_area :description%>
+    <%= level_form.text_area :description %>
   </div>
 <% end %>
 

--- a/app/views/rubric_criteria/_rubric_criterion_levels.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_levels.html.erb
@@ -1,9 +1,15 @@
 <div id='rubric_levels_top'></div>
-<% criterion.levels.each_with_index do |level, rubric_level_index| %>
-  <%= render partial: 'rubric_criteria/rubric_criterion_level',
-             locals: {criterion: criterion,
-                      level: level,
-                      rubric_level_index: rubric_level_index,
-                      f: f} %>
+
+<%= form_for criterion, url: assignment_criterion_path(id: criterion.id,
+                                                       criterion_type: criterion.class.to_s),
+                                                       method: :patch, remote: true do |criterion_form| %>
+  <% criterion.levels.each_with_index do |level, rubric_level_index| %>
+    <%= render partial: 'rubric_criteria/rubric_criterion_level',
+               locals: {criterion: criterion,
+                        criterion_form: criterion_form,
+                        level: level,
+                        rubric_level_index: rubric_level_index,
+                        f: f} %>
+  <% end %>
 <% end %>
 

--- a/app/views/rubric_criteria/_rubric_criterion_levels.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_levels.html.erb
@@ -3,13 +3,9 @@
 <%= form_for criterion, url: assignment_criterion_path(id: criterion.id,
                                                        criterion_type: criterion.class.to_s),
                                                        method: :patch, remote: true do |criterion_form| %>
-  <% criterion.levels.each_with_index do |level, rubric_level_index| %>
-    <%= render partial: 'rubric_criteria/rubric_criterion_level',
-               locals: {criterion: criterion,
-                        criterion_form: criterion_form,
-                        level: level,
-                        rubric_level_index: rubric_level_index,
-                        f: f} %>
-  <% end %>
+  <%= render partial: 'rubric_criteria/rubric_criterion_level',
+             locals: {criterion: criterion,
+                      criterion_form: criterion_form,
+                      f: f} %>
 <% end %>
 

--- a/config/locales/models/levels/es.yml
+++ b/config/locales/models/levels/es.yml
@@ -1,9 +1,9 @@
-en:
+es:
   activerecord:
     models:
       level:
-        one: "Level"
-        other: "Levels"
+        one: "Nivel"
+        other: "Niveles"
     attributes:
       level:
         name: "Nombre"

--- a/config/locales/models/levels/fr.yml
+++ b/config/locales/models/levels/fr.yml
@@ -1,9 +1,9 @@
-en:
+fr:
   activerecord:
     models:
       level:
-        one: "Level"
-        other: "Levels"
+        one: "Niveau"
+        other: "Niveaux"
     attributes:
       level:
         name: "Nom"

--- a/config/locales/models/levels/pt.yml
+++ b/config/locales/models/levels/pt.yml
@@ -1,9 +1,9 @@
-en:
+pt:
   activerecord:
     models:
       level:
-        one: "Level"
-        other: "Levels"
+        one: "Nível"
+        other: "Níveis"
     attributes:
       level:
         name: "Nome"

--- a/config/locales/views/criteria/en.yml
+++ b/config/locales/views/criteria/en.yml
@@ -46,6 +46,7 @@ en:
 
   rubric_criteria:
     level:
+      name: "Level"
       level_index: "Level %{index}"
     defaults:
       level_0: "Very Poor"

--- a/config/locales/views/criteria/es.yml
+++ b/config/locales/views/criteria/es.yml
@@ -46,6 +46,7 @@ es:
 
   rubric_criteria:
     level:
+      name: "Nivel"
       level_index: "Nivel %{index}"
     defaults:
       level_0: "Insuficiente"

--- a/config/locales/views/criteria/fr.yml
+++ b/config/locales/views/criteria/fr.yml
@@ -49,6 +49,7 @@ fr:
 
   rubric_criteria:
     level:
+      name: "Niveau"
       level_index: "Niveau %{index}"
     defaults:
       level_0: "Très insuffisant"

--- a/config/locales/views/criteria/pt.yml
+++ b/config/locales/views/criteria/pt.yml
@@ -45,6 +45,7 @@ pt:
 
   rubric_criteria:
     level:
+      name: "Nível"
       level_index: "Nível %{index}"
     defaults:
       level_0: "Insuficiente"


### PR DESCRIPTION
Was able to fix bug with multiple levels of one instance showing up. Currently working on having levels save with nested attributes as the current error that occurs is 'unpermitted parameter :level'.
Also changed self.levels.build to self.levels.create in rubric_criterion.rb as it allows the level to be saved (as far as I know, build is an alias to new, other than slight changes but we want to use create in this case).