### PR TITLE
Ta display grace credits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [unreleased]
+- Fixed bug where grace credits were not displayed to Graders viewing the submissions table (#4332)
 
 ## [v1.8.2]
 - Fixed bug where all non-empty rows in a downloaded marks spreadsheet csv file were aligned to the left. (#4290)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1168,7 +1168,9 @@ class Assignment < ApplicationRecord
     if current_user.admin?
       groupings = self.groupings
     elsif current_user.ta?
-      groupings = self.groupings.joins(:ta_memberships).where('memberships.user_id': current_user.id)
+      groupings = self.groupings.where(id: self.groupings.joins(:ta_memberships)
+                                                         .where('memberships.user_id': current_user.id)
+                                                         .select(:'groupings.id'))
     else
       return []
     end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1575,6 +1575,19 @@ describe Assignment do
         expect(data.size).to eq 1
         expect(data[0][:_id]).to be groupings[0].id
       end
+
+      context 'when a grace period deduction has been applied' do
+        let(:assignment) { create :assignment, submission_rule: create(:grace_period_submission_rule) }
+        let!(:grace_period_deduction) do
+          create(:grace_period_deduction,
+                 membership: groupings[0].accepted_student_memberships.first,
+                 deduction: 1)
+        end
+        it 'should include grace credit deductions' do
+          data = assignment.current_submission_data(ta)
+          expect(data.map { |h| h[:grace_credits_used] }.compact).to contain_exactly(1)
+        end
+      end
     end
 
     context 'a Student user' do


### PR DESCRIPTION
- fix bug where grace credits were not being displayed to Tas on the submissions table
- this was due to the fact that grace credits are an association through the memberships table which was also being used to filter groupings initially. This is fixed by making the filter in the initial query to select groupings part of a subquery so that the where condition doesn't re-apply itself later on. 