### PR TITLE
Added tests for Create method in submission_file_controller api

### DIFF
--- a/app/controllers/api/submission_files_controller.rb
+++ b/app/controllers/api/submission_files_controller.rb
@@ -114,8 +114,7 @@ module Api
                                                       filename: params[:filename],
                                                       type: params[:mime_type])
         success, messages = grouping.group.access_repo do |repo|
-          file_path = File.dirname(params[:filename]).gsub(%r{^/}, '')
-          path = Pathname.new(grouping.assignment.repository_folder).join(file_path)
+          path = Pathname.new(grouping.assignment.repository_folder)
           add_files([file], @current_user, repo, path: path)
         end
       ensure

--- a/spec/controllers/api/submission_files_controller_spec.rb
+++ b/spec/controllers/api/submission_files_controller_spec.rb
@@ -51,6 +51,24 @@ describe Api::SubmissionFilesController do
         Submission.generate_new_submission(grouping, repo.get_latest_revision)
       end
     end
+    context 'POST create' do
+      before :each do
+        post :create, params: { assignment_id: assignment.id, group_id: group.id, filename: 'v1/x/y/test.txt',
+                                mime_type: 'text', file_content: 'This is a test file' }
+      end
+      it 'should be successful' do
+        expect(response.status).to eq(201)
+      end
+      it 'should create a file in the corresponding directory' do
+        path = Pathname.new('v1/x/y')
+        success, _messages = group.access_repo do |repo|
+          file_path = Pathname.new(assignment.repository_folder).join path
+          files = repo.get_latest_revision.files_at_path(file_path.to_s)
+          files.keys.include? 'test.txt'
+        end
+        expect(success).to be_truthy
+      end
+    end
     context 'GET index' do
       let(:aid) { assignment.id }
       let(:gid) { group.id }

--- a/spec/controllers/api/submission_files_controller_spec.rb
+++ b/spec/controllers/api/submission_files_controller_spec.rb
@@ -68,6 +68,23 @@ describe Api::SubmissionFilesController do
         end
         expect(success).to be_truthy
       end
+      context 'when adding a file which is already exist ' do
+        before :each do
+          post :create, params: { assignment_id: assignment.id, group_id: group.id, filename: 'v1/x/y/test.txt',
+                                  mime_type: 'text', file_content: 'This is an updated test file' }
+        end
+        it 'should replace the old file with the new one' do
+          path = Pathname.new('v1/x/y')
+          file_contents = ''
+          group.access_repo do |repo|
+            file_path = Pathname.new(assignment.repository_folder).join path
+            file = repo.get_latest_revision.files_at_path(file_path.to_s)['test.txt']
+            file_contents = repo.download_as_string(file)
+          end
+          content = 'This is an updated test file'
+          expect(content).to eq(file_contents)
+        end
+      end
     end
     context 'GET index' do
       let(:aid) { assignment.id }


### PR DESCRIPTION
1. Added tests for create method in submission_file_controller
2. Modified the submission_file_controller so whenever we are adding a new file under new sub directory it won't add the path twice, previously it was adding twice but we were not creating directories before so it didn't raise any problem
3. Added tests for If we are adding a file which is already exist