### PR TITLE
Update install scripts for vagrant

### DIFF
--- a/script/install-markus-autotesting.sh
+++ b/script/install-markus-autotesting.sh
@@ -20,7 +20,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confd
 yes | server/bin/install.sh
 
 # Note: install jdbc jar
-JAVA_JAR_PATH=${AUTOTEST_ROOT}/testers/testers/jdbc/bin/
+JAVA_JAR_PATH=${AUTOTEST_ROOT}/testers/testers/java/bin/
 wget -P ${JAVA_JAR_PATH} https://jdbc.postgresql.org/download/postgresql-42.2.5.jar
 
 # install all testers
@@ -31,5 +31,3 @@ yes | ${AUTOTEST_ROOT}/testers/testers/java/bin/install.sh
 yes | ${AUTOTEST_ROOT}/testers/testers/py/bin/install.sh
 yes | ${AUTOTEST_ROOT}/testers/testers/pyta/bin/install.sh
 yes | ${AUTOTEST_ROOT}/testers/testers/racket/bin/install.sh
-yes | ${AUTOTEST_ROOT}/testers/testers/sql/bin/install.sh
-yes | ${AUTOTEST_ROOT}/testers/testers/jdbc/bin/install.sh "${JAVA_JAR_PATH}/postgresql-42.2.5.jar"

--- a/script/install-markus.sh
+++ b/script/install-markus.sh
@@ -37,7 +37,7 @@ sudo apt-get install -y postgresql postgresql-client postgresql-contrib libpq-de
 
 # Install node
 echo "- - - Installing Node, Step 1 - - -"
-curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
 echo "- - - Installing Node, Step 2 - - -"
 sudo apt-get install -y nodejs
 


### PR DESCRIPTION
- use node version 11
- don't try to install deprecated testers