### PR TITLE
Remove upsert gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'sprockets'
 # Models and database interactions
 gem 'activerecord-import'
 gem 'pluck_to_hash'
-gem 'upsert'
 
 # CSS and JavaScript
 gem 'autoprefixer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,6 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.13.0)
-    upsert (2.2.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
     webpacker (4.2.2)
@@ -443,7 +442,6 @@ DEPENDENCIES
   time-warp
   uglifier
   unicorn
-  upsert
   webpacker
   ya2yaml
   zxing_cpp

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -144,8 +144,9 @@ class Criterion < ApplicationRecord
                     .where(groupings: { assignment_id: assignment_id })
     all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
     # all associated marks should have their mark value scaled to the change.
-    updated_marks = all_marks.map do |mark|
-      { mark.id => mark.scale_mark(max_mark, max_mark_was, update: false) }
+    updated_marks = {}
+    all_marks.each do |mark|
+      updated_marks[mark.id] = mark.scale_mark(max_mark, max_mark_was, update: false)
     end
     unless updated_marks.empty?
       Mark.upsert_all(all_marks.pluck_to_hash.map { |h| { **h.symbolize_keys, mark: updated_marks[h['id'].to_i] } })

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -123,11 +123,12 @@ class Criterion < ApplicationRecord
              .count
 
     [RubricCriterion, FlexibleCriterion, CheckboxCriterion].each do |klass|
-      Upsert.batch(klass.connection, klass.table_name) do |upsert|
-        klass.where(assignment_id: assignment.id).find_each do |crit|
-          upsert.row({ id: crit.id }, assigned_groups_count: counts[[crit.id, klass.to_s]] || 0)
-        end
+      records = klass.where(assignment_id: assignment.id)
+                     .pluck_to_hash
+                     .map do |h|
+        { **h.symbolize_keys, assigned_groups_count: counts[[h['id'], klass.to_s]] || 0 }
       end
+      klass.upsert_all(records)
     end
   end
 
@@ -141,16 +142,18 @@ class Criterion < ApplicationRecord
                     .where(groupings: { assignment_id: assignment_id })
     all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
     # all associated marks should have their mark value scaled to the change.
-    Upsert.batch(Mark.connection, Mark.table_name) do |upsert|
-      all_marks.each do |m|
-        upsert.row({ id: m.id }, mark: m.scale_mark(max_mark, max_mark_was, update: false))
-      end
+    updated_marks = all_marks.map do |mark|
+      { mark.id => mark.scale_mark(max_mark, max_mark_was, update: false) }
+    end
+    unless updated_marks.empty?
+      Mark.upsert_all(all_marks.pluck_to_hash.map { |h| { **h.symbolize_keys, mark: updated_marks[h['id']] } })
     end
     a = Assignment.find(assignment_id)
-    Upsert.batch(Result.connection, Result.table_name) do |upsert|
-      results.each do |r|
-        upsert.row({ id: r.id }, total_mark: r.get_total_mark(assignment: a))
-      end
+    updated_results = results.map do |result|
+      { result.id => result.get_total_mark(assignment: a) }
+    end
+    unless updated_results.empty?
+      Result.upsert_all(results.pluck_to_hash.map { |h| { **h.symbolize_keys, total_mark: updated_results[h['id']] } })
     end
     a.assignment_stat.refresh_grade_distribution
   end

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -128,7 +128,9 @@ class Criterion < ApplicationRecord
                      .map do |h|
         { **h.symbolize_keys, assigned_groups_count: counts[[h['id'], klass.to_s]] || 0 }
       end
-      klass.upsert_all(records)
+      unless records.empty?
+        klass.upsert_all(records)
+      end
     end
   end
 

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -148,14 +148,16 @@ class Criterion < ApplicationRecord
       { mark.id => mark.scale_mark(max_mark, max_mark_was, update: false) }
     end
     unless updated_marks.empty?
-      Mark.upsert_all(all_marks.pluck_to_hash.map { |h| { **h.symbolize_keys, mark: updated_marks[h['id']] } })
+      Mark.upsert_all(all_marks.pluck_to_hash.map { |h| { **h.symbolize_keys, mark: updated_marks[h['id'].to_i] } })
     end
     a = Assignment.find(assignment_id)
     updated_results = results.map do |result|
       { result.id => result.get_total_mark(assignment: a) }
     end
     unless updated_results.empty?
-      Result.upsert_all(results.pluck_to_hash.map { |h| { **h.symbolize_keys, total_mark: updated_results[h['id']] } })
+      Result.upsert_all(
+        results.pluck_to_hash.map { |h| { **h.symbolize_keys, total_mark: updated_results[h['id'].to_i] } }
+      )
     end
     a.assignment_stat.refresh_grade_distribution
   end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -172,7 +172,7 @@ class Grouping < ApplicationRecord
              .count
 
     grouping_data = Grouping.where(id: grouping_ids).pluck_to_hash.map do |h|
-      { **h.symbolize_keys, criteria_coverage_count: counts[h['id'].to_i] }
+      { **h.symbolize_keys, criteria_coverage_count: counts[h['id'].to_i] || 0 }
     end
     Grouping.upsert_all(grouping_data)
   end


### PR DESCRIPTION
- replace upsert gem by using `upsert_all` in all cases
- fix bug where criterion marks were not being scaled due to a change in ActiveModel::Dirty (we wanted to look at changes made after a save not before)