### PR TITLE
Fix bug where criterion marks were not being scaled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Fixed filtering and sorting of grace credit column in students table. (#4327)
 - Added feature to set multiple submissions to in/complete from the submissions table (#4336)
 - Update pdfjs version and integrate with webpacker. (#4362)
+- Fixed bug where marks were not being scaled properly after an update to a criterion's max_mark (#4369)
 
 ## [v1.8.2]
 - Fixed bug where all non-empty rows in a downloaded marks spreadsheet csv file were aligned to the left. (#4290)

--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -86,7 +86,7 @@ class CheckboxCriterion < Criterion
 
     # If a CheckboxCriterion with the same name exists, load it up. Otherwise,
     # create a new one.
-    criterion = assignment.get_criteria.find_or_create_by(name: name)
+    criterion = assignment.get_criteria(:all, :checkbox).find_or_create_by(name: name)
 
     # Check that max is not a string.
     begin

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -135,6 +135,7 @@ class Criterion < ApplicationRecord
   def scale_marks
     return unless max_mark_previously_changed? && !previous_changes[:max_mark].first.nil? # if max_mark was not updated
 
+    max_mark_was = previous_changes[:max_mark].first
     # results with specific assignment
     results = Result.includes(submission: :grouping)
                     .where(groupings: {assignment_id: assignment_id})
@@ -142,7 +143,7 @@ class Criterion < ApplicationRecord
     # all associated marks should have their mark value scaled to the change.
     Upsert.batch(Mark.connection, Mark.table_name) do |upsert|
       all_marks.each do |m|
-        upsert.row({ id: m.id }, mark: m.scale_mark(max_mark, max_mark_was, update: false) )
+        upsert.row({ id: m.id }, mark: m.scale_mark(max_mark, max_mark_was, update: false))
       end
     end
     a = Assignment.find(assignment_id)

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -133,25 +133,25 @@ class Criterion < ApplicationRecord
 
   # When max_mark of criterion is changed, all associated marks should have their mark value scaled to the change.
   def scale_marks
-    if max_mark_changed? && !max_mark_was.nil?  # if max_mark is updated
-      # results with specific assignment
-      results = Result.includes(submission: :grouping)
-                      .where(groupings: {assignment_id: assignment_id})
-      all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
-      # all associated marks should have their mark value scaled to the change.
-      Upsert.batch(Mark.connection, Mark.table_name) do |upsert|
-        all_marks.each do |m|
-          upsert.row({ id: m.id }, mark: m.scale_mark(max_mark, max_mark_was, update: false) )
-        end
+    return unless max_mark_previously_changed? && !previous_changes[:max_mark].first.nil? # if max_mark was not updated
+
+    # results with specific assignment
+    results = Result.includes(submission: :grouping)
+                    .where(groupings: {assignment_id: assignment_id})
+    all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
+    # all associated marks should have their mark value scaled to the change.
+    Upsert.batch(Mark.connection, Mark.table_name) do |upsert|
+      all_marks.each do |m|
+        upsert.row({ id: m.id }, mark: m.scale_mark(max_mark, max_mark_was, update: false) )
       end
-      a = Assignment.find(assignment_id)
-      Upsert.batch(Result.connection, Result.table_name) do |upsert|
-        results.each do |r|
-          upsert.row({ id: r.id }, total_mark: r.get_total_mark(assignment: a))
-        end
-      end
-      a.assignment_stat.refresh_grade_distribution
     end
+    a = Assignment.find(assignment_id)
+    Upsert.batch(Result.connection, Result.table_name) do |upsert|
+      results.each do |r|
+        upsert.row({ id: r.id }, total_mark: r.get_total_mark(assignment: a))
+      end
+    end
+    a.assignment_stat.refresh_grade_distribution
   end
 
   private

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -138,7 +138,7 @@ class Criterion < ApplicationRecord
     max_mark_was = previous_changes[:max_mark].first
     # results with specific assignment
     results = Result.includes(submission: :grouping)
-                    .where(groupings: {assignment_id: assignment_id})
+                    .where(groupings: { assignment_id: assignment_id })
     all_marks = marks.where.not(mark: nil).where(result_id: results.ids)
     # all associated marks should have their mark value scaled to the change.
     Upsert.batch(Mark.connection, Mark.table_name) do |upsert|

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -34,17 +34,17 @@ describe CheckboxCriterion do
 
     it 'raises en error message on an empty row' do
       expect { CheckboxCriterion.create_or_update_from_csv_row([], @assignment) }
-          .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
 
     it 'raises an error message on a 1 element row' do
-      expect { CheckboxCriterion.create_or_update_from_csv_row(%w(name), @assignment) }
-          .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name], @assignment) }
+        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
 
     it 'raises an error message on an invalid maximum value' do
-      expect { CheckboxCriterion.create_or_update_from_csv_row(%w(name max_value), @assignment) }
-          .to raise_error(CsvInvalidLineError)
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name max_value], @assignment) }
+        .to raise_error(CsvInvalidLineError)
     end
   end
 

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -1,10 +1,10 @@
-describe FlexibleCriterion do
-  let(:criterion_factory_name) { :flexible_criterion }
+describe CheckboxCriterion do
+  let(:criterion_factory_name) { :checkbox_criterion }
 
   it_behaves_like 'a criterion'
-  context 'A good FlexibleCriterion model' do
+  context 'A good CheckboxCriterion model' do
     before :each do
-      @criterion = create(:flexible_criterion)
+      @criterion = create(:checkbox_criterion)
     end
 
     it { is_expected.to belong_to(:assignment) }
@@ -33,18 +33,18 @@ describe FlexibleCriterion do
     end
 
     it 'raises en error message on an empty row' do
-      expect { FlexibleCriterion.create_or_update_from_csv_row([], @assignment) }
-        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+      expect { CheckboxCriterion.create_or_update_from_csv_row([], @assignment) }
+          .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
 
     it 'raises an error message on a 1 element row' do
-      expect { FlexibleCriterion.create_or_update_from_csv_row(%w(name), @assignment) }
-        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w(name), @assignment) }
+          .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
 
     it 'raises an error message on an invalid maximum value' do
-      expect { FlexibleCriterion.create_or_update_from_csv_row(%w(name max_value), @assignment) }
-        .to raise_error(CsvInvalidLineError)
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w(name max_value), @assignment) }
+          .to raise_error(CsvInvalidLineError)
     end
   end
 
@@ -55,7 +55,7 @@ describe FlexibleCriterion do
 
     context 'with criterion from a 2 element row with no description overwritten' do
       before :each do
-        @criterion = FlexibleCriterion.create_or_update_from_csv_row(['name', 10.0], @assignment)
+        @criterion = CheckboxCriterion.create_or_update_from_csv_row(['name', 10.0], @assignment)
       end
 
       describe '.name' do
@@ -79,7 +79,7 @@ describe FlexibleCriterion do
 
     context 'with criterion from a 3 elements row that includes a description overwritten' do
       before :each do
-        @criterion = FlexibleCriterion.create_or_update_from_csv_row(['name', 10.0, 'description'], @assignment)
+        @criterion = CheckboxCriterion.create_or_update_from_csv_row(['name', 10.0, 'description'], @assignment)
       end
 
       describe '.name' do
@@ -107,20 +107,20 @@ describe FlexibleCriterion do
       end
     end
 
-    context 'with three flexible criteria allows criterion with same name to overwrite' do
+    context 'with three checkbox criteria allows criterion with same name to overwrite' do
       before :each do
-        create(:flexible_criterion,
+        create(:checkbox_criterion,
                assignment: @assignment,
                name: 'criterion1',
                description: 'description1, for criterion 1',
                max_mark: 10)
-        create(:flexible_criterion,
+        create(:checkbox_criterion,
                assignment: @assignment,
                name: 'criterion2',
                description: 'description2, "with quotes"',
                max_mark: 10,
                position: 2)
-        create(:flexible_criterion,
+        create(:checkbox_criterion,
                assignment: @assignment,
                name: 'criterion3',
                description: 'description3!',
@@ -128,7 +128,7 @@ describe FlexibleCriterion do
                position: 3)
         @csv_base_row = ['criterion2', '10', 'description2, "with quotes"']
 
-        @criterion = FlexibleCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
+        @criterion = CheckboxCriterion.create_or_update_from_csv_row(@csv_base_row, @assignment)
       end
 
       describe '.name' do


### PR DESCRIPTION
Changes to the ActiveModel::Dirty module meant that we were not detecting if the max mark had been updated _after_ the model was saved (in an after_update callback)

- [x] update tests
- [x] update changelog