### PR TITLE
Create grade entry student and validate user on csv upload

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Update pdfjs version and integrate with webpacker. (#4362)
 - Fixed bug where tags could not be uploaded from a csv file (#4368)
 - Fixed bug where marks were not being scaled properly after an update to a criterion's max_mark (#4369)
+- Fixed bug where grade entry students were not being created if new students were created by csv upload (#4371)
 
 ## [v1.8.2]
 - Fixed bug where all non-empty rows in a downloaded marks spreadsheet csv file were aligned to the left. (#4290)

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -133,6 +133,7 @@ class StudentsController < ApplicationController
         result = User.upload_user_list(Student, params[:upload_file].read, params[:encoding])
         flash_message(:error, result[:invalid_lines]) unless result[:invalid_lines].empty?
         flash_message(:success, result[:valid_lines]) unless result[:valid_lines].empty?
+        flash_message(:error, result[:invalid_records]) unless result[:invalid_records].empty?
       end
     end
     redirect_to action: 'index'

--- a/app/controllers/tas_controller.rb
+++ b/app/controllers/tas_controller.rb
@@ -77,6 +77,7 @@ class TasController < ApplicationController
         result = User.upload_user_list(Ta, params[:upload_file].read, params[:encoding])
         flash_message(:error, result[:invalid_lines]) unless result[:invalid_lines].empty?
         flash_message(:success, result[:valid_lines]) unless result[:valid_lines].empty?
+        flash_message(:error, result[:invalid_records]) unless result[:invalid_records].empty?
       end
     end
     redirect_to action: 'index'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,12 +198,25 @@ class User < ApplicationRecord
       parsed[:valid_lines] = '' # reset the value from MarkusCsv#parse, use import's return instead
     end
 
+    existing_user_ids = user_class.all.pluck(:id)
+    imported = nil
+    parsed[:invalid_records] = ''
     begin
-      imported = nil
       User.transaction do
         imported = user_class.import user_columns, users, on_duplicate_key_update: {
           conflict_target: [:user_name], columns: [:last_name, :first_name, :section_id, :email, :id_number]
         }
+        User.where(id: imported.ids).each do |user|
+          user.validate!
+        rescue ActiveRecord::RecordInvalid
+          error_message = user.errors
+                              .messages
+                              .map { |k, v| "#{k} #{v.flatten.join ','}" }.flatten.join MarkusCsv::INVALID_LINE_SEP
+          parsed[:invalid_records] += "#{user.user_name}: #{error_message}"
+        end
+        unless parsed[:invalid_records].empty?
+          raise ActiveRecord::Rollback
+        end
       end
       unless imported.failed_instances.empty?
         if parsed[:invalid_lines].blank?
@@ -214,14 +227,18 @@ class User < ApplicationRecord
         parsed[:invalid_lines] +=
           imported.failed_instances.map { |f| f[:user_name].to_s }.join(MarkusCsv::INVALID_LINE_SEP)
       end
-      unless imported.ids.empty?
+      if !imported.ids.empty? && parsed[:invalid_records].empty?
         parsed[:valid_lines] = I18n.t('upload_success', count: imported.ids.size)
       end
     rescue ActiveRecord::RecordNotUnique => e
       # can trigger on uniqueness constraint validation for :user_name, will invalidate the entire import
       parsed[:invalid_lines] = I18n.t('csv_upload_user_duplicate', user_name: e.message)
     end
-
+    if user_class == Student
+      new_user_ids = (imported&.ids || []) - existing_user_ids
+      # call create callbacks to make sure grade_entry_students get created
+      user_class.where(id: new_user_ids).each(&:create_all_grade_entry_students)
+    end
     parsed
   end
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -12,6 +12,28 @@ describe StudentsController do
     include_examples 'a controller supporting upload' do
       let(:params) { {} }
     end
+    it 'creates grade_entry_students as well' do
+      create :grade_entry_form
+      post :upload, params: {
+        upload_file: fixture_file_upload('files/students/form_good.csv', 'text/csv')
+      }
+      expect(GradeEntryStudent.all.count).to eq(2)
+    end
+
+    it 'reports validation errors' do
+      post :upload, params: {
+        upload_file: fixture_file_upload('files/students/form_invalid_record.csv', 'text/csv')
+      }
+      expect(flash[:error]).not_to be_nil
+    end
+
+    it 'does not create users when validation errors occur' do
+      post :upload, params: {
+          upload_file: fixture_file_upload('files/students/form_invalid_record.csv', 'text/csv')
+      }
+      expect(Student.all.count).to be 0
+    end
+
     it 'accepts a valid file' do
       post :upload, params: {
         upload_file: fixture_file_upload(

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -29,7 +29,7 @@ describe StudentsController do
 
     it 'does not create users when validation errors occur' do
       post :upload, params: {
-          upload_file: fixture_file_upload('files/students/form_invalid_record.csv', 'text/csv')
+        upload_file: fixture_file_upload('files/students/form_invalid_record.csv', 'text/csv')
       }
       expect(Student.all.count).to be 0
     end

--- a/spec/controllers/tas_controller_spec.rb
+++ b/spec/controllers/tas_controller_spec.rb
@@ -11,6 +11,20 @@ describe TasController do
       let(:params) { {} }
     end
 
+    it 'reports validation errors' do
+      post :upload, params: {
+        upload_file: fixture_file_upload('files/tas/form_invalid_record.csv', 'text/csv')
+      }
+      expect(flash[:error]).not_to be_nil
+    end
+
+    it 'does not create users when validation errors occur' do
+      post :upload, params: {
+        upload_file: fixture_file_upload('files/tas/form_invalid_record.csv', 'text/csv')
+      }
+      expect(Ta.all.count).to eq 0
+    end
+
     it 'accepts a valid file' do
       post :upload, params: {
         upload_file: fixture_file_upload('files/tas/form_good.csv', 'text/csv')

--- a/spec/fixtures/files/students/form_invalid_record.csv
+++ b/spec/fixtures/files/students/form_invalid_record.csv
@@ -1,0 +1,2 @@
+c5anthei,Antheil,George,,123
+c5bennet,Bennett,Robert Russell,,123

--- a/spec/fixtures/files/tas/form_invalid_record.csv
+++ b/spec/fixtures/files/tas/form_invalid_record.csv
@@ -1,0 +1,2 @@
+c6conley,Conley,Mike,mike@gmail.com
+c8rada,Rada,Markus,mike@gmail.com


### PR DESCRIPTION
- validate users after bulk csv upload (before we were allowing the creation of invalid users)
- make grade entry students when students get created through bulk upload