### PR TITLE
Fix grouping creation bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Update pdfjs version and integrate with webpacker. (#4362)
 - Fixed bug where tags could not be uploaded from a csv file (#4368)
 - Fixed bug where marks were not being scaled properly after an update to a criterion's max_mark (#4369)
+- Fixed bug where the student interface page wasn't rendered if creating a single student grouping at the same time (#4372)
 
 ## [v1.8.2]
 - Fixed bug where all non-empty rows in a downloaded marks spreadsheet csv file were aligned to the left. (#4290)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -78,7 +78,8 @@ class AssignmentsController < ApplicationController
         end
         @grouping = @student.accepted_grouping_for(@assignment.id)
       end
-    else
+    end
+    unless @grouping.nil?
       # We look for the information on this group...
       # The members
       @studentmemberships = @grouping.student_memberships


### PR DESCRIPTION
Bug:

- when students are not allowed to work in groups (max group size == 1) for an assignment, the student_interface method tries to create a new grouping the first time a student navigates to the page for that assignment.
- certain instance attributes required by the student interface view were only being set if the the grouping *already* existed, not if the grouping was newly created. Then later when the view was being rendered an error was being raised since the grouping did exist (it had just been created) but the relevant attributes had not been set.

Fix:
- set the attributes whenever a grouping already exists *or* if it has just been created
