### PR TITLE
Docker: wait for postgres to start before rails

### DIFF
--- a/.dockerfiles/entrypoint-dev-rails.sh
+++ b/.dockerfiles/entrypoint-dev-rails.sh
@@ -8,7 +8,11 @@ yarn check --integrity 2>/dev/null || yarn install --check-files
 
 # setup the database (checks for db existence first)
 cp .dockerfiles/database.yml.postgresql config/database.yml
-psql ${DATABASE_URL} -lqt 2> /dev/null | cut -d \| -f 1 | grep -wq markus_${RAILS_ENV} || rails db:setup
+until psql "${DATABASE_URL}" -lqt &>/dev/null; do
+  echo "waiting for database to start up"
+  sleep 5
+done
+psql "${DATABASE_URL}" -lqt 2> /dev/null | cut -d \| -f 1 | grep -wq "markus_${RAILS_ENV}" || rails db:setup
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile or docker-compose.yml).
 exec "$@"


### PR DESCRIPTION
- avoid seeding database unnecessarily by waiting for postgres to fully start up first
- also avoid a case where the rails service startup outpaces the postgres service startup and the database isn't seeded when it should be. 