### PR TITLE
Better byebug in development

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,11 @@
 workers 3
 preload_app!
 
+rails_env = environment ENV.fetch('RAILS_ENV') { 'development' }
+if rails_env == 'development'
+  worker_timeout 100_000_000
+end
+
 on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.establish_connection


### PR DESCRIPTION
Right now, puma workers will timeout and kill a byebug inspection. This increases the timeout limit in development to a really really high number (there is no "don't timeout" option) so that we don't have to scramble to finish using byebug in a small amount of time. 