### PR TITLE
Properly hide result data from students

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Added option to anonymize group membership when viewed by graders (#4331)
 - Added option to only display assigned criteria to graders as opposed to showing unassigned criteria but making them
   ungradeable (#4331)
+- Fixed bug where test output was not being properly hidden from students (#4379)
 
 ## [v1.8.3]
 - Fixed bug where grace credits were not displayed to Graders viewing the submissions table (#4332)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -716,8 +716,8 @@ class Grouping < ApplicationRecord
     filtered = filter_test_runs(filters: { 'users.type': 'Admin', 'test_runs.submission': submission })
     plucked = Grouping.pluck_test_runs(filtered)
     plucked.map! do |data|
-      if data['test_groups.display_output'] == 'instructors_and_student_tests' ||
-         data['test_groups.display_output'] == 'instructors'
+      if data['test_groups.display_output'] == TestGroup.display_outputs[:instructors_and_student_tests] ||
+         data['test_groups.display_output'] == TestGroup.display_outputs[:instructors]
         data.delete('test_results.output')
       end
       data.delete('test_group_results.extra_info')
@@ -730,7 +730,7 @@ class Grouping < ApplicationRecord
     filtered = filter_test_runs(filters: { 'test_runs.user': self.accepted_students })
     plucked = Grouping.pluck_test_runs(filtered)
     plucked.map! do |data|
-      if data['test_groups.display_output'] == 'instructors'
+      if data['test_groups.display_output'] == TestGroup.display_outputs[:instructors]
         data.delete('test_results.output')
       end
       data.delete('test_group_results.extra_info')

--- a/spec/factories/test_results.rb
+++ b/spec/factories/test_results.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :test_result do
+    name { Faker::Lorem.word }
+    status { 'pass' }
+    marks_earned { 1 }
+    output { Faker::TvShows::HeyArnold.quote }
+    marks_total { 1 }
+    association :test_group_result
+    time { Faker::Number.number(digits: 4) }
+  end
+end


### PR DESCRIPTION
- fixes a bug where test output was always being shown to students
- adds tests to check for this in the future