### PR TITLE
results: Fix bug where criteria were not expanded on initial load.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Added option to only display assigned criteria to graders as opposed to showing unassigned criteria but making them
   ungradeable (#4331)
 - Fixed bug where test output was not being properly hidden from students (#4379)
+- Fixed bug where criteria were not expanded for grading (to both Admins and TAs) (#4380)
 
 ## [v1.8.3]
 - Fixed bug where grace credits were not displayed to Graders viewing the submissions table (#4332)

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -26,18 +26,21 @@ export class MarksPanel extends React.Component {
         }
       });
     }
+  }
 
-    // Expand by default if:
-    //   1) The result has been released, or
-    //   2) A mark has not yet been given, and the current user can give the mark.
-    let expanded = new Set();
-    this.props.marks.forEach(data => {
-      const key = `${data.criterion_type}-${data.id}`;
-      if ((data.mark === null || data.mark === undefined) &&
-          (this.props.assigned_criteria === null || this.props.assigned_criteria.includes(key))) {
-        expanded.add(key);
-      }
-    });
+  componentDidUpdate(prevProps) {
+    if (prevProps.marks.length !== this.props.marks.length) {
+      // Expand by default if a mark has not yet been given, and the current user can give the mark.
+      let expanded = new Set();
+      this.props.marks.forEach(data => {
+        const key = `${data.criterion_type}-${data.id}`;
+        if ((data.mark === null || data.mark === undefined) &&
+            (this.props.assigned_criteria === null || this.props.assigned_criteria.includes(key))) {
+          expanded.add(key);
+        }
+      });
+      this.setState({ expanded });
+    }
   }
 
   expandAll = (onlyUnmarked) => {


### PR DESCRIPTION
Before, the code that was supposed to handle this was in `componentDidMount`, but the component didn't have any marks when first mounted.