### PR TITLE
pdfjs: Switch to canvas rendering and fix annotations.

### DIFF
--- a/app/assets/javascripts/Components/Result/pdf_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/pdf_viewer.jsx
@@ -11,7 +11,7 @@ export class PDFViewer extends React.Component {
     if (this.props.url) {
       this.pdfViewer = new pdfjsViewer.PDFViewer({
         container: this.pdfContainer.current,
-        renderer: 'svg',
+        // renderer: 'svg',  TODO: investigate why some fonts don't render with SVG
       });
       this.loadPDFFile();
       window.pdfViewer = this.pdfViewer;  // For fixing display when pane width changes

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -193,6 +193,7 @@
   cursor: crosshair;
   opacity: 0.2;
   position: absolute;
+  z-index: 1;
 }
 
 .code_scroller {


### PR DESCRIPTION
Because pages are loaded lazily, the annotation_holders were added to each
page container before the pages were actually rendered, preventing the
annotation from appearing on hover.