### PR TITLE
Results levels

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -151,13 +151,6 @@ class ResultsController < ApplicationController
         common_fields = [:id, :name, :position, :max_mark]
         marks_map = [CheckboxCriterion, FlexibleCriterion, RubricCriterion].flat_map do |klass|
           if klass == RubricCriterion
-            # fields = common_fields + [
-            #   :level_0_name, :level_0_description,
-            #   :level_1_name, :level_1_description,
-            #   :level_2_name, :level_2_description,
-            #   :level_3_name, :level_3_description,
-            #   :level_4_name, :level_4_description
-            # ]
             fields = common_fields
           end
           if klass != RubricCriterion
@@ -169,29 +162,10 @@ class ResultsController < ApplicationController
          
           criteria_info = criteria.pluck_to_hash(*fields)
           
-          # if klass == RubricCriterion
-          #   criteria_info.each do |cr|
-          #     cr[:levels] = Level.where(rubric_criterion_id: cr[:id]).pluck_to_hash(:name, :description, :mark);
-          #   end
-          # end
-
-          # if klass == RubricCriterion
-          #   marks_info = criteria.joins(:marks)
-          #                      .where('marks.result_id': result.id)
-          #                      .pluck_to_hash(*fields, 'marks.mark')
-          #                      .group_by { |h| h[:id] }
-          #   levels_info = criteria.joins(:levels)
-          #                      .pluck_to_hash('levels.name', 'levels.description', 'levels.mark')
-          #                      .group_by { |h| h[:id] }
-          # else
-          
-          # we need to combine marks_info with the hash information of criteria_info
           marks_info = criteria.joins(:marks)
                               .where('marks.result_id': result.id)
                               .pluck_to_hash(*fields, 'marks.mark')
                               .group_by { |h| h[:id] }
-          # I want to try and merge each levels array into the respective marks, matching the rubric criterion id
-          # try merging stuff here!!!!
           levels_info = []
           if klass == RubricCriterion
             criteria_info.map do |cr|
@@ -200,12 +174,8 @@ class ResultsController < ApplicationController
               rubric_marks.merge!(levels: levels_info)
             end
           end
-          # try and merge rubric marks with levels:level info, try with a simpler string first
-          # end
           criteria_info.map do |cr|
-            # this line sets info to the first marks with the same id as the current criteria, cr
             infor = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)
-            # adds a criterion type to infor
             infor.merge(criterion_type: klass.name)
           end
         end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -160,14 +160,15 @@ class ResultsController < ApplicationController
                                  peer_visible: is_review)
           criteria_info = criteria.pluck_to_hash(*fields)
           marks_info = criteria.joins(:marks)
-                              .where('marks.result_id': result.id)
-                              .pluck_to_hash(*fields, 'marks.mark')
-                              .group_by { |h| h[:id] }
+                                .where('marks.result_id': result.id)
+                                .pluck_to_hash(*fields, 'marks.mark')
+                                .group_by { |h| h[:id] }
           # adds an extra levels field to the marks info hash with the same rubric criterion id
           levels_info = []
           if klass == RubricCriterion
             criteria_info.map do |cr|
-              levels_info = Level.where(rubric_criterion_id: cr[:id]).pluck_to_hash(:rubric_criterion_id, :name, :description, :mark)
+              levels_info = Level.where(rubric_criterion_id: cr[:id])
+                                  .pluck_to_hash(:name, :description, :mark)
               rubric_marks = marks_info[cr[:id]]&.first
               rubric_marks.merge!(levels: levels_info)
             end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -168,7 +168,7 @@ class ResultsController < ApplicationController
           if klass == RubricCriterion
             criteria_info.map do |cr|
               levels_info = Level.where(rubric_criterion_id: cr[:id])
-                                  .pluck_to_hash(:name, :description, :mark)
+                                .pluck_to_hash(:name, :description, :mark)
               rubric_marks = marks_info[cr[:id]]&.first
               rubric_marks.merge!(levels: levels_info)
             end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -175,8 +175,8 @@ class ResultsController < ApplicationController
           end
           # adds a criterion type to each of the marks info hashes
           criteria_info.map do |cr|
-            infor = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)
-            infor.merge(criterion_type: klass.name)
+            info = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)
+            info.merge(criterion_type: klass.name)
           end
         end
         marks_map.sort! { |a, b| a[:position] <=> b[:position] }

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -160,15 +160,15 @@ class ResultsController < ApplicationController
                                  peer_visible: is_review)
           criteria_info = criteria.pluck_to_hash(*fields)
           marks_info = criteria.joins(:marks)
-                                 .where('marks.result_id': result.id)
-                                 .pluck_to_hash(*fields, 'marks.mark')
-                                 .group_by { |h| h[:id] }
+                               .where('marks.result_id': result.id)
+                               .pluck_to_hash(*fields, 'marks.mark')
+                               .group_by { |h| h[:id] }
           # adds a criterion type to each of the marks info hashes
           criteria_info.map do |cr|
             # adds an extra levels field to the marks info hash with the same rubric criterion id
             if klass == RubricCriterion
               levels_info = Level.where(rubric_criterion_id: cr[:id])
-                                .pluck_to_hash(:name, :description, :mark)
+                                 .pluck_to_hash(:name, :description, :mark)
               marks_info[cr[:id]]&.first&.merge!(levels: levels_info)
             end
             info = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -167,10 +167,9 @@ class ResultsController < ApplicationController
           criteria_info.map do |cr|
             # adds an extra levels field to the marks info hash with the same rubric criterion id
             if klass == RubricCriterion
-              levels_info = []
               levels_info = Level.where(rubric_criterion_id: cr[:id])
                                 .pluck_to_hash(:name, :description, :mark)
-              rubric_marks = marks_info[cr[:id]]&.first&.merge!(levels: levels_info)
+              marks_info[cr[:id]]&.first&.merge!(levels: levels_info)
             end
             info = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)
             info.merge(criterion_type: klass.name)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -160,15 +160,15 @@ class ResultsController < ApplicationController
                                  peer_visible: is_review)
           criteria_info = criteria.pluck_to_hash(*fields)
           marks_info = criteria.joins(:marks)
-                                .where('marks.result_id': result.id)
-                                .pluck_to_hash(*fields, 'marks.mark')
-                                .group_by { |h| h[:id] }
+                              .where('marks.result_id': result.id)
+                              .pluck_to_hash(*fields, 'marks.mark')
+                              .group_by { |h| h[:id] }
           # adds an extra levels field to the marks info hash with the same rubric criterion id
           levels_info = []
           if klass == RubricCriterion
             criteria_info.map do |cr|
               levels_info = Level.where(rubric_criterion_id: cr[:id])
-                                .pluck_to_hash(:name, :description, :mark)
+                                  .pluck_to_hash(:name, :description, :mark)
               rubric_marks = marks_info[cr[:id]]&.first
               rubric_marks.merge!(levels: levels_info)
             end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -151,13 +151,14 @@ class ResultsController < ApplicationController
         common_fields = [:id, :name, :position, :max_mark]
         marks_map = [CheckboxCriterion, FlexibleCriterion, RubricCriterion].flat_map do |klass|
           if klass == RubricCriterion
-            fields = common_fields + [
-              # :level_0_name, :level_0_description,
-              # :level_1_name, :level_1_description,
-              # :level_2_name, :level_2_description,
-              # :level_3_name, :level_3_description,
-              # :level_4_name, :level_4_description
-            ]
+            # fields = common_fields + [
+            #   :level_0_name, :level_0_description,
+            #   :level_1_name, :level_1_description,
+            #   :level_2_name, :level_2_description,
+            #   :level_3_name, :level_3_description,
+            #   :level_4_name, :level_4_description
+            # ]
+            fields = common_fields
           end
           if klass != RubricCriterion
             fields = common_fields + [:description]
@@ -168,16 +169,26 @@ class ResultsController < ApplicationController
          
           criteria_info = criteria.pluck_to_hash(*fields)
           
-          if klass == RubricCriterion
-            criteria_info.each do |cr|
-              cr[:levels] = Level.where(rubric_criterion_id: cr[:id]).pluck_to_hash(:name, :description, :mark);
-            end
-          end
+          # if klass == RubricCriterion
+          #   criteria_info.each do |cr|
+          #     cr[:levels] = Level.where(rubric_criterion_id: cr[:id]).pluck_to_hash(:name, :description, :mark);
+          #   end
+          # end
 
+          # if klass == RubricCriterion
+          #   marks_info = criteria.joins(:marks)
+          #                      .where('marks.result_id': result.id)
+          #                      .pluck_to_hash(*fields, 'marks.mark')
+          #                      .group_by { |h| h[:id] }
+          #   levels_info = criteria.joins(:levels)
+          #                      .pluck_to_hash('levels.name', 'levels.description', 'levels.mark')
+          #                      .group_by { |h| h[:id] }
+          # else
           marks_info = criteria.joins(:marks)
-                               .where('marks.result_id': result.id)
-                               .pluck_to_hash(*fields, 'marks.mark')
-                               .group_by { |h| h[:id] }
+                              .where('marks.result_id': result.id)
+                              .pluck_to_hash(*fields, 'marks.mark')
+                              .group_by { |h| h[:id] }
+          # end
           criteria_info.map do |h|
             info = marks_info[h[:id]]&.first || h.merge('marks.mark': nil)
             info.merge(criterion_type: klass.name)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -151,7 +151,13 @@ class ResultsController < ApplicationController
         common_fields = [:id, :name, :position, :max_mark]
         marks_map = [CheckboxCriterion, FlexibleCriterion, RubricCriterion].flat_map do |klass|
           if klass == RubricCriterion
-            fields = common_fields + ["levels.name", "levels.description", "levels.mark"]
+            fields = common_fields + [
+              # :level_0_name, :level_0_description,
+              # :level_1_name, :level_1_description,
+              # :level_2_name, :level_2_description,
+              # :level_3_name, :level_3_description,
+              # :level_4_name, :level_4_description
+            ]
           end
           if klass != RubricCriterion
             fields = common_fields + [:description]
@@ -159,16 +165,22 @@ class ResultsController < ApplicationController
           criteria = klass.where(assignment_id: is_review ? assignment.pr_assignment.id : assignment.id,
                                  ta_visible: !is_review,
                                  peer_visible: is_review)
+         
           criteria_info = criteria.pluck_to_hash(*fields)
+          
+          if klass == RubricCriterion
+            criteria_info.each do |cr|
+              cr[:levels] = Level.where(rubric_criterion_id: cr[:id]).pluck_to_hash(:name, :description, :mark);
+            end
+          end
+
           marks_info = criteria.joins(:marks)
                                .where('marks.result_id': result.id)
                                .pluck_to_hash(*fields, 'marks.mark')
                                .group_by { |h| h[:id] }
-          byebug
           criteria_info.map do |h|
             info = marks_info[h[:id]]&.first || h.merge('marks.mark': nil)
             info.merge(criterion_type: klass.name)
-            # byebug
           end
         end
         marks_map.sort! { |a, b| a[:position] <=> b[:position] }

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -160,21 +160,18 @@ class ResultsController < ApplicationController
                                  peer_visible: is_review)
           criteria_info = criteria.pluck_to_hash(*fields)
           marks_info = criteria.joins(:marks)
-                              .where('marks.result_id': result.id)
-                              .pluck_to_hash(*fields, 'marks.mark')
-                              .group_by { |h| h[:id] }
-          # adds an extra levels field to the marks info hash with the same rubric criterion id
-          levels_info = []
-          if klass == RubricCriterion
-            criteria_info.map do |cr|
-              levels_info = Level.where(rubric_criterion_id: cr[:id])
-                                  .pluck_to_hash(:name, :description, :mark)
-              rubric_marks = marks_info[cr[:id]]&.first
-              rubric_marks.merge!(levels: levels_info)
-            end
-          end
+                                 .where('marks.result_id': result.id)
+                                 .pluck_to_hash(*fields, 'marks.mark')
+                                 .group_by { |h| h[:id] }
           # adds a criterion type to each of the marks info hashes
           criteria_info.map do |cr|
+            # adds an extra levels field to the marks info hash with the same rubric criterion id
+            if klass == RubricCriterion
+              levels_info = []
+              levels_info = Level.where(rubric_criterion_id: cr[:id])
+                                .pluck_to_hash(:name, :description, :mark)
+              rubric_marks = marks_info[cr[:id]]&.first&.merge!(levels: levels_info)
+            end
             info = marks_info[cr[:id]]&.first || cr.merge('marks.mark': nil)
             info.merge(criterion_type: klass.name)
           end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -151,14 +151,9 @@ class ResultsController < ApplicationController
         common_fields = [:id, :name, :position, :max_mark]
         marks_map = [CheckboxCriterion, FlexibleCriterion, RubricCriterion].flat_map do |klass|
           if klass == RubricCriterion
-            fields = common_fields + [
-              :level_0_name, :level_0_description,
-              :level_1_name, :level_1_description,
-              :level_2_name, :level_2_description,
-              :level_3_name, :level_3_description,
-              :level_4_name, :level_4_description
-            ]
-          else
+            fields = common_fields + ["levels.name", "levels.description", "levels.mark"]
+          end
+          if klass != RubricCriterion
             fields = common_fields + [:description]
           end
           criteria = klass.where(assignment_id: is_review ? assignment.pr_assignment.id : assignment.id,
@@ -169,9 +164,11 @@ class ResultsController < ApplicationController
                                .where('marks.result_id': result.id)
                                .pluck_to_hash(*fields, 'marks.mark')
                                .group_by { |h| h[:id] }
+          byebug
           criteria_info.map do |h|
             info = marks_info[h[:id]]&.first || h.merge('marks.mark': nil)
             info.merge(criterion_type: klass.name)
+            # byebug
           end
         end
         marks_map.sort! { |a, b| a[:position] <=> b[:position] }


### PR DESCRIPTION
Updated show method in results_controller so that it uses information passed in by each rubric criterion's associated level's model rather than hard coded level_x_name and level_x_description. To do this I created levels_information as an array and merged it into the preexisting marks_info hash.
It is being passed into the view now, where we can access level information in files such as result.jsx and marks_panel.jsx.