### PR TITLE
File Manger: further updates now that multi-select is enabled

### DIFF
--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -68,13 +68,13 @@ class AutotestManager extends React.Component {
       .then(this.onSubmit); // uploading files will send changes to the autotester without requiring an explicit save
   };
 
-  handleDeleteFile = (fileKey) => {
-    if (!this.state.files.some(f => f.key === fileKey)) {
+  handleDeleteFile = (fileKeys) => {
+    if (!this.state.files.some(f => fileKeys.includes(f.key))) {
       return;
     }
     $.post({
       url: Routes.upload_files_assignment_automated_tests_path(this.props.assignment_id),
-      data: {delete_files: [fileKey]}
+      data: {delete_files: fileKeys}
     }).then(this.fetchFileDataOnly)
       .then(this.onSubmit) // deleting files will send changes to the autotester without requiring an explicit save
       .then(this.endAction);

--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -13,7 +13,7 @@ class RawFileManager extends RawFileBrowser {
   handleActionBarAddFileClick = (event, selected) => {
     event.preventDefault();
     let uploadTarget = '';
-    if (selected.length === 1) { // treat multiple selections as an invalid target (default to root folder as target)
+    if (!!selected && selected.length === 1) { // treat multiple selections as an invalid target
       if (selected[0].relativeKey.endsWith('/')) {
         uploadTarget = selected[0].relativeKey;
       } else {
@@ -40,9 +40,10 @@ class RawFileManager extends RawFileBrowser {
     }
   };
 
-  renderActionBar(selectedItem) {
+  renderActionBar(selectedItems) {
     // treat multiple selections the same as not targeting
-    const selectionIsFolder = selectedItem.length === 1 && selectedItem[0].relativeKey.endsWith('/');
+    const selectionIsFolder = selectedItems.length === 1 && selectedItems[0].relativeKey.endsWith('/');
+    let selectedItem = selectedItems.length === 1 ? selectedItems[0] : null;
     let filter;
     if (this.props.canFilter) {
       filter = (

--- a/app/assets/javascripts/Components/starter_code_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_code_file_manager.jsx
@@ -43,21 +43,15 @@ class StarterCodeFileManager extends React.Component {
     }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData);
   };
 
-  handleDeleteFile = (fileKey) => {
-    let deleteFiles = [];
-    this.state.files.map((file) => {
-      if (file.key === fileKey) {
-        deleteFiles.push(file)
-      }
-    });
-    if (!deleteFiles) {
+  handleDeleteFile = (fileKeys) => {
+    if (!this.state.files.some(f => fileKeys.includes(f.key))) {
       return;
     }
 
     $.post({
       url: Routes.upload_starter_code_assignment_path(this.props.assignment_id),
       data: {
-        delete_files: [deleteFiles[0].key],
+        delete_files: fileKeys,
       }
     }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData)
       .then(this.endAction);

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -71,20 +71,15 @@ class SubmissionFileManager extends React.Component {
       .then(this.endAction);
   };
 
-  handleDeleteFile = (fileKey) => {
-    let deleteFiles = [];
-    this.state.files.map((file) => {
-      if (file.key === fileKey) {
-        deleteFiles.push(file)
-      }
-    });
-    if (!deleteFiles) {
+  handleDeleteFile = (fileKeys) => {
+    if (!this.state.files.some(f => fileKeys.includes(f.key))) {
       return;
     }
+
     $.post({
       url: Routes.update_files_assignment_submissions_path(this.props.assignment_id),
       data: {
-        delete_files: [deleteFiles[0].key],
+        delete_files: fileKeys,
         grouping_id: this.props.grouping_id
       }
     }).then(typeof this.props.onChange === 'function' ? this.props.onChange : this.fetchData)


### PR DESCRIPTION
A continuation of #4370

Changes to the following code to handle the fact that selections are now passed as a list of items instead of just a single item:

- action bar renderer (`renderActionBar`)
- action bar button click (`handleActionBarAddFileClick`)
- file deletion (`handleDeleteFile `)