### PR TITLE
Levels Migration

### DIFF
--- a/db/migrate/20200225050808_remove_level_attributes_from_rubric_criteria.rb
+++ b/db/migrate/20200225050808_remove_level_attributes_from_rubric_criteria.rb
@@ -1,0 +1,14 @@
+class RemoveLevelAttributesFromRubricCriteria < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :rubric_criteria, :level_0_name, :text
+    remove_column :rubric_criteria, :level_0_description, :text
+    remove_column :rubric_criteria, :level_1_name, :text
+    remove_column :rubric_criteria, :level_1_description, :text
+    remove_column :rubric_criteria, :level_2_name, :text
+    remove_column :rubric_criteria, :level_2_description, :text
+    remove_column :rubric_criteria, :level_3_name, :text
+    remove_column :rubric_criteria, :level_3_description, :text
+    remove_column :rubric_criteria, :level_4_name, :text
+    remove_column :rubric_criteria, :level_4_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_10_143220) do
+ActiveRecord::Schema.define(version: 2020_02_25_050808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -409,16 +409,6 @@ ActiveRecord::Schema.define(version: 2019_12_10_143220) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "position"
-    t.text "level_0_name"
-    t.text "level_0_description"
-    t.text "level_1_name"
-    t.text "level_1_description"
-    t.text "level_2_name"
-    t.text "level_2_description"
-    t.text "level_3_name"
-    t.text "level_3_description"
-    t.text "level_4_name"
-    t.text "level_4_description"
     t.decimal "max_mark", precision: 10, scale: 1, null: false
     t.integer "assigned_groups_count", default: 0
     t.boolean "ta_visible", default: true, null: false

--- a/spec/factories/levels.rb
+++ b/spec/factories/levels.rb
@@ -1,8 +1,7 @@
 FactoryBot.define do
   factory :level do
-    association :rubric_criteria
     name { Faker::Lorem.word }
     description { Faker::Lorem.word }
-    mark
+    rubric_criteria
   end
 end

--- a/spec/factories/levels.rb
+++ b/spec/factories/levels.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :level do
+    association :rubric_criteria
+    name { Faker::Lorem.word }
+    description { Faker::Lorem.word }
+    mark
+  end
+end

--- a/spec/factories/levels.rb
+++ b/spec/factories/levels.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :level do
     name { Faker::Lorem.word }
     description { Faker::Lorem.word }
-    rubric_criteria
+    rubric_criterion
   end
 end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
   end
 
   factory :rubric_criteria_with_levels do
-    after(:create) do |criteria|
+    after(:create) do
       5.times.each { |i| create(:level, rubric_criteria: rubric_criteria, mark: i) }
     end
   end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     peer_visible { false }
     sequence(:position)
     after(:create) do |criterion|
-      5.times.each { |i| create(:level, rubric_criteria: criterion, mark: i) }
+      5.times.each { |i| create(:level, rubric_criterion: criterion, mark: i) }
     end
   end
 end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -6,11 +6,8 @@ FactoryBot.define do
     ta_visible { true }
     peer_visible { false }
     sequence(:position)
-  end
-
-  factory :rubric_criteria_with_levels do
-    after(:create) do
-      5.times.each { |i| create(:level, rubric_criteria: rubric_criteria, mark: i) }
+    after(:create) do |criterion|
+      5.times.each { |i| create(:level, rubric_criteria: criterion, mark: i) }
     end
   end
 end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -5,16 +5,14 @@ FactoryBot.define do
     max_mark { 4.0 }
     ta_visible { true }
     peer_visible { false }
-    level_0_name { 'Poor' }
-    level_0_description { 'This criterion was not satisifed whatsoever.' }
-    level_1_name { 'Satisfactory' }
-    level_1_description { 'This criterion was satisfied.' }
-    level_2_name { 'Good' }
-    level_2_description { 'This criterion was satisfied well.' }
-    level_3_name { 'Great' }
-    level_3_description { 'This criterion was satisfied very well.' }
-    level_4_name { 'Excellent' }
-    level_4_description { 'This criterion was satisfied exceptionally well.' }
     sequence(:position)
+  end
+
+  factory :rubric_with_levels, parent: :rubric_criterion do
+    after(:build) do |criteria| # called by both create and build
+      5.times.each { |i|
+        create(:level, rubric_criterion: criteria, mark: i)
+      }
+    end
   end
 end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -5,7 +5,12 @@ FactoryBot.define do
     max_mark { 4.0 }
     ta_visible { true }
     peer_visible { false }
-    5.times.each { |i| create(:level, rubric_criterion: criteria, mark: i) }
     sequence(:position)
+  end
+
+  factory :rubric_criteria_with_levels do
+    after(:create) do |criteria|
+      5.times.each { |i| create(:level, rubric_criteria: rubric_criteria, mark: i) }
+    end
   end
 end

--- a/spec/factories/rubric_criteria.rb
+++ b/spec/factories/rubric_criteria.rb
@@ -5,14 +5,7 @@ FactoryBot.define do
     max_mark { 4.0 }
     ta_visible { true }
     peer_visible { false }
+    5.times.each { |i| create(:level, rubric_criterion: criteria, mark: i) }
     sequence(:position)
-  end
-
-  factory :rubric_with_levels, parent: :rubric_criterion do
-    after(:build) do |criteria| # called by both create and build
-      5.times.each { |i|
-        create(:level, rubric_criterion: criteria, mark: i)
-      }
-    end
   end
 end


### PR DESCRIPTION
Generated migration to remove level_x_name and description columns from rubric criteria. 

Possible shortcomings and other notes:

- This should be merged in after results-levels gets merged in, because that branch removes all uses of level_x_name and description in results controller.