### PR TITLE
Disable multiple selection in file manager

### DIFF
--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -263,6 +263,13 @@ class FileManagerFile extends FileRenderers.RawTableFile {
     }
   };
 
+  handleItemClick = (event) => {
+    // This disables the option to select multiple rows in the file manager
+    // To re-enable multiple selection, remove this method entirely.
+    event.stopPropagation();
+    this.props.browserProps.select(this.props.fileKey, 'file')
+  };
+
   render() {
     let icon;
     if (this.getFileType() === 'Image') {


### PR DESCRIPTION
This disables special handling of a click event when the ctrl or shift keys are pressed.

This is the previous behaviour of this method before multi-selection was enabled for the react-keyed-file-browser:

https://github.com/uptick/react-keyed-file-browser/pull/86/files#diff-7f75774c4a6e6acc72d96c90325e4c42R75 