### PR TITLE
Enable subversion in development docker image

### DIFF
--- a/.dockerfiles/Dockerfile
+++ b/.dockerfiles/Dockerfile
@@ -47,6 +47,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     libmagickwand-dev \
     cmake \
     libssh2-1-dev \
+    openssh-client \
     libaprutil1-dev \
     libssl-dev \
     swig \

--- a/.dockerfiles/Dockerfile
+++ b/.dockerfiles/Dockerfile
@@ -1,33 +1,46 @@
+ARG UBUNTU_VERSION
+
+FROM ubuntu:$UBUNTU_VERSION
+
 ARG RUBY_VERSION
-
-FROM ruby:$RUBY_VERSION
-
 ARG PG_MAJOR
 ARG NODE_MAJOR
 ARG BUNDLER_VERSION
 ARG YARN_VERSION
 
-# Add PostgreSQL to sources list
-RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 \
-  curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends curl \
+                                                                               ca-certificates \
+                                                                               gnupg2 \
+                                                                               software-properties-common
 
 # Add NodeJS to sources list
-RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
+RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 \
+    curl -vsL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
+
+# Remove cmdtest which come pre-installed and has a package called yarn. This prevents us from installing
+# the yarn package we want otherwise.
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -yq cmdtest
 
 # Add Yarn to the sources list
 RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
+  curl -vsL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
+
+# Add ppa so that we can select different ruby versions
+RUN DEBIAN_FRONTEND=noninteractive apt-add-repository -y ppa:brightbox/ruby-ng
 
 # install packages
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     build-essential \
     postgresql-client-$PG_MAJOR \
+    tzdata \
+    libpq-dev \
     nodejs \
     yarn \
     libv8-dev \
+    ruby$RUBY_VERSION \
+    ruby${RUBY_VERSION}-dev \
     ruby-svn \
     ghostscript \
     imagemagick \
@@ -35,10 +48,12 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
     cmake \
     libssh2-1-dev \
     libaprutil1-dev \
+    libssl-dev \
     swig \
     graphviz \
     yarn \
     rsync \
+    git \
     python3 \
     python3-pip && \
     apt-get clean && \
@@ -48,15 +63,11 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
 # Enable reading of PDF files with imagemagick
 RUN sed -ri 's/(rights=")none("\s+pattern="PDF")/\1read\2/' /etc/ImageMagick-6/policy.xml
 
-# Configure bundler and PATH
-ENV LANG=C.UTF-8 \
-    GEM_HOME=/bundle \
-    BUNDLE_JOBS=4 \
-    BUNDLE_RETRY=3
-ENV BUNDLE_PATH $GEM_HOME
-ENV BUNDLE_APP_CONFIG=$BUNDLE_PATH \
-    BUNDLE_BIN=$BUNDLE_PATH/bin
-ENV PATH /app/bin:$BUNDLE_BIN:$PATH
+# install bundler
+RUN gem$RUBY_VERSION install bundler -v $BUNDLER_VERSION
+
+ENV GEM_HOME="/bundle"
+ENV PATH="$GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH"
 
 # Create key for ssh-ing to the autotester
 RUN ssh-keygen -q -N "" -f /root/.ssh/id_rsa && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
       context: .
       dockerfile: ./.dockerfiles/Dockerfile
       args:
-        RUBY_VERSION: '2.5.3'
+        UBUNTU_VERSION: bionic
+        RUBY_VERSION: '2.5'
         PG_MAJOR: '10'
-        NODE_MAJOR: '11'
+        NODE_MAJOR: '12'
         YARN_VERSION: '1.13.0'
         BUNDLER_VERSION: '1.17.3'
     image: markus-dev:1.0.0


### PR DESCRIPTION
- use ubuntu as a base image so that we can install and use svn properly in docker