### PR TITLE
Scale marks

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -41,10 +41,8 @@ class RubricCriterion < Criterion
   def scale_marks_if_max_mark_changed
     return unless self.changed.include?('max_mark')
     return if self.changes['max_mark'][0].nil?
-    
     old_max = self.changes['max_mark'][0]
     new_max = self.changes['max_mark'][1]
-
     scale = new_max / old_max
     self.levels.each do |level|
       level.update(mark: (level.mark * scale).round(2))

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -39,12 +39,13 @@ class RubricCriterion < Criterion
   end
 
   def scale_marks_if_max_mark_changed
-    max_level = self.levels.max_by(&:mark)
-    if max_level.mark != self.criterion.max_mark
-      scale = max_level.mark / self.criterion.max_mark
-      self.levels.each { |level| 
+    max_level_mark = self.levels.max_by(&:mark).mark
+    new_max = self.max_mark
+    if max_level_mark != new_max
+      scale =  new_max / max_level_mark
+      self.levels.each do |level| 
         level.mark = level.mark * scale
-      }
+      end
     end
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -45,7 +45,10 @@ class RubricCriterion < Criterion
     new_max = self.changes['max_mark'][1]
     scale = new_max / old_max
     self.levels.each do |level|
-      level.update(mark: (level.mark * scale).round(2))
+      # don't scale levels that the user has manually changed
+      unless level.changed.include? 'mark'
+        level.update(mark: (level.mark * scale).round(2))
+      end
     end
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -39,7 +39,7 @@ class RubricCriterion < Criterion
   end
 
   def scale_marks_if_max_mark_changed
-    return if !self.changed.include?('max_mark')
+    return unless self.changed.include?('max_mark')
     old_max = self.changes['max_mark'][0]
     new_max = self.changes['max_mark'][1]
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -39,9 +39,9 @@ class RubricCriterion < Criterion
   end
 
   def scale_marks_if_max_mark_changed
-    return if !self.changed.include?("max_mark")
-    old_max = self.changes["max_mark"][0]
-    new_max = self.changes["max_mark"][1]
+    return if !self.changed.include?('max_mark')
+    old_max = self.changes['max_mark'][0]
+    new_max = self.changes['max_mark'][1]
 
     scale = new_max / old_max
     self.levels.each do |level|

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -45,7 +45,7 @@ class RubricCriterion < Criterion
 
     scale = new_max / max_level_mark
     self.levels.each do |level|
-      level.mark = level.mark * scale
+      level.mark = (level.mark * scale).round(1)
     end
   end
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -40,6 +40,8 @@ class RubricCriterion < Criterion
 
   def scale_marks_if_max_mark_changed
     return unless self.changed.include?('max_mark')
+    return if self.changes['max_mark'][0].nil?
+    
     old_max = self.changes['max_mark'][0]
     new_max = self.changes['max_mark'][1]
 

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -41,11 +41,11 @@ class RubricCriterion < Criterion
   def scale_marks_if_max_mark_changed
     max_level_mark = self.levels.max_by(&:mark).mark
     new_max = self.max_mark
-    if max_level_mark != new_max
-      scale =  new_max / max_level_mark
-      self.levels.each do |level| 
-        level.mark = level.mark * scale
-      end
+    return if max_level_mark == new_max
+
+    scale = new_max / max_level_mark
+    self.levels.each do |level|
+      level.mark = level.mark * scale
     end
   end
 

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -241,4 +241,22 @@ describe RubricCriterion do
       end
     end
   end
+
+  context 'a rubric criteria with levels' do
+    before(:each) do
+      @criterion = create(:rubric_criterion)
+      @criterion.set_default_levels
+    end
+
+    context 'can scale levels' do
+      it 'not raise error' do
+        levels = @criterion.levels
+        expect(levels[1].mark)to eq(1.0)
+        expect(@criterion.max_mark)to eq(4.0)
+        @criterion.max_mark = 8.0
+        expect(levels[1].mark)to eq(2.0)
+      end
+    end
+  end
+
 end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -248,7 +248,7 @@ describe RubricCriterion do
       @levels = @criterion.levels
     end
 
-    context 'when scaling' do
+    context 'when scaling max mark' do
       describe 'can scale levels up' do
         it 'not raise error' do
           expect(@levels[1].mark).to eq(1.0)
@@ -262,6 +262,15 @@ describe RubricCriterion do
           expect(@levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 2.0)
           expect(@levels[1].mark).to eq(0.5)
+        end
+      end 
+
+      describe 'manually changed levels won\'t be affected' do
+        it 'not raise error' do
+          expect(@levels[1].mark).to eq(1.0)
+          @levels[1].mark = 3
+          @criterion.update(max_mark: 8.0)
+          expect(@levels[1].mark).to eq(3.0)
         end
       end
     end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -251,10 +251,10 @@ describe RubricCriterion do
     context 'can scale levels' do
       it 'not raise error' do
         levels = @criterion.levels
-        expect(levels[1].mark)to eq(1.0)
-        expect(@criterion.max_mark)to eq(4.0)
+        expect(levels[1].mark).to eq(1.0)
+        expect(@criterion.max_mark).to eq(4.0)
         @criterion.max_mark = 8.0
-        expect(levels[1].mark)to eq(2.0)
+        expect(levels[1].mark).to eq(2.0)
       end
     end
   end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -242,27 +242,26 @@ describe RubricCriterion do
     end
   end
 
-  context 'a rubric criteria with levels' do
+  context 'A rubric criteria with levels' do
     before(:each) do
       @criterion = create(:rubric_criterion)
+      @levels = @criterion.levels
     end
 
     context 'when scaling' do
       describe 'can scale levels up' do
         it 'not raise error' do
-          levels = @criterion.levels
-          expect(levels[1].mark).to eq(1.0)
+          expect(@levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 8.0)
-          expect(levels[1].mark).to eq(2.0)
+          expect(@levels[1].mark).to eq(2.0)
         end
       end
 
       describe 'can scale levels down' do
         it 'not raise error' do
-          levels = @criterion.levels
-          expect(levels[1].mark).to eq(1.0)
+          expect(@levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 2.0)
-          expect(levels[1].mark).to eq(0.5)
+          expect(@levels[1].mark).to eq(0.5)
         end
       end
     end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -245,18 +245,26 @@ describe RubricCriterion do
   context 'a rubric criteria with levels' do
     before(:each) do
       @criterion = create(:rubric_criterion)
-      @criterion.set_default_levels
     end
 
-    context 'can scale levels' do
-      it 'not raise error' do
-        levels = @criterion.levels
-        expect(levels[1].mark).to eq(1.0)
-        expect(@criterion.max_mark).to eq(4.0)
-        @criterion.max_mark = 8.0
-        expect(levels[1].mark).to eq(2.0)
+    context 'when scaling' do
+      describe 'can scale levels up' do
+        it 'not raise error' do
+          levels = @criterion.levels
+          expect(levels[1].mark).to eq(1.0)
+          @criterion.update(max_mark: 8.0)
+          expect(levels[1].mark).to eq(2.0)
+        end
+      end
+
+      describe 'can scale levels down' do
+        it 'not raise error' do
+          levels = @criterion.levels
+          expect(levels[1].mark).to eq(1.0)
+          @criterion.update(max_mark: 2.0)
+          expect(levels[1].mark).to eq(0.5)
+        end
       end
     end
   end
-
 end

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -263,7 +263,7 @@ describe RubricCriterion do
           @criterion.update(max_mark: 2.0)
           expect(@levels[1].mark).to eq(0.5)
         end
-      end 
+      end
 
       describe 'manually changed levels won\'t be affected' do
         it 'not raise error' do


### PR DESCRIPTION
Created a callback method that scales levels when the max mark is updated. Each level's mark is scaled appropriately, multiplied by the ratio (previous max level mark / new max mark).
Example with marks 0, 1, 2, 3, 4 with original max mark of 4 scaled to a max mark of 12. Thus each level's mark will be tripled.

**EDIT: This PR should be merged in only after levels-migration gets merged in.**

![image](https://user-images.githubusercontent.com/46202699/75743681-c8876400-5cdf-11ea-92d3-977d7c2c0acf.png)
![image](https://user-images.githubusercontent.com/46202699/75743685-cc1aeb00-5cdf-11ea-85eb-8b277634d7d3.png)
