### PR TITLE
Calculate collected submissions consistently

### DIFF
--- a/app/views/assignments/_list_manage.html.erb
+++ b/app/views/assignments/_list_manage.html.erb
@@ -101,9 +101,7 @@
                   <% if @current_user.admin? && assignment.submission_rule.can_collect_all_now? %>
                     <span id='collected_submissions_<%= assignment.short_identifier %>'>
                       <%= link_to t('submissions.collect.progress',
-                                    count: assignment.groupings
-                                                     .where(is_collected: true)
-                                                     .size,
+                                    count: assignment.current_submissions_used.size,
                                     size: assignment.groupings.size),
                                     controller: :submissions,
                                     action: :browse,

--- a/app/views/assignments/update_collected_submissions.js.erb
+++ b/app/views/assignments/update_collected_submissions.js.erb
@@ -2,8 +2,7 @@
   <% if assignment.submission_rule.can_collect_all_now? %>
     $("#collected_submissions_<%= assignment.short_identifier %>").html(
            " | <%= link_to(t('submissions.collect.progress',
-                              count: assignment.groupings
-                                               .where(is_collected: true).size,
+                              count: assignment.current_submissions_used.size,
                               size: assignment.groupings.size),
                            controller: :submissions,
                            action: :browse,


### PR DESCRIPTION
- calculate the number of collected submissions by finding the number of version used submissions instead of using the `is_collected` value which I think was not being consistently updated