### PR TITLE
Hide rubric levels if name is not given

### DIFF
--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -364,7 +364,11 @@ class RubricCriterionInput extends React.Component {
   };
 
   render() {
-    const levels = [0, 1, 2, 3, 4].map(this.renderRubricLevel);
+    const levels = [0, 1, 2, 3, 4].map( (i) => {
+      if (!!this.props[`level_${i}_name`]) {
+        return this.renderRubricLevel(i);
+      }
+    });
     const expandedClass = this.props.expanded ? 'expanded' : 'collapsed';
     const unassignedClass = this.props.unassigned ? 'unassigned' : '';
     return (


### PR DESCRIPTION
- if no name is given for a rubric criterion level then hide it from the grading view
- apparently this was the old behaviour (and there have been several requests to bring it back)
- this will likely be a temporary fix until the new, more flexible rubric criterion is implemented