### PR TITLE
Added dependent destroy attribute to levels in rubric criterion

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -12,7 +12,7 @@ class RubricCriterion < Criterion
 
   has_many :tas, through: :criterion_ta_associations
 
-  has_many :levels, -> { order(:mark) }, inverse_of: :rubric_criterion
+  has_many :levels, -> { order(:mark) }, inverse_of: :rubric_criterion, dependent: :destroy
   accepts_nested_attributes_for :levels, allow_destroy: true
 
   belongs_to :assignment, counter_cache: true


### PR DESCRIPTION
Added a dependent: :destroy attribute to levels in the rubric criterion model, so that when rubric criterion is deleted, levels will also be deleted.