### PR TITLE
Temporary fix to properly align qr-code

### DIFF
--- a/app/jobs/generate_job.rb
+++ b/app/jobs/generate_job.rb
@@ -38,7 +38,10 @@ class GenerateJob < ApplicationJob
           qrcode_content = "#{exam_template.name}-#{exam_num}-#{page_num + 1}"
           qrcode = RQRCode::QRCode.new qrcode_content, level: :l, size: 2
           alignment = page_num.even? ? :right : :left
-          render_qr_code(qrcode, align: alignment, dot: 4.0, stroke: false)
+          # TODO: remove the line below and the pos: argument in render_qr_code once the align: argument is fixed
+          #       see: https://github.com/jabbrwcky/prawn-qrcode/pull/33 (probably in release v0.5.2 of prawn-qrcode)
+          pos = [page_num.even? ? bounds.width - 140 : 0, cursor]
+          render_qr_code(qrcode, align: alignment, dot: 4.0, stroke: false, pos: pos)
           draw_text(qrcode_content,
                     at: [alignment == :left ? 140 : bounds.width - 140 - qrcode_content.length * 6, bounds.height - 30])
           start_new_page


### PR DESCRIPTION
- qr codes no longer align properly after an update to the prawn-qrcode gem.
- A bugfix (https://github.com/jabbrwcky/prawn-qrcode/pull/33) has been submitted and merged but we should wait until that fix makes its way into a release
- until then, this PR manually sets the position of right-aligned qr codes 
- This PR should be reverted once the prawn-qrcode gem has been updated