### PR TITLE
Show hidden field when getting user data from api

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Ignore the "Total" column when uploading a csv file to a grade entry form. This makes the upload and download format
   for the csv file consistent (#4425)
 - Added git hook to limit the maximum file size committed and/or pushed to a git repository (#4421)
+- Api calls will now return the 'hidden' status of users when accessing user data (#4445)
 
 ## [v1.8.4]
 - Fixed bug where test output was not being properly hidden from students (#4379)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -6,7 +6,7 @@ module Api
     before_action :authorize!
 
     # Define default fields to display for index and show methods
-    DEFAULT_FIELDS = [:id, :user_name, :type, :first_name, :last_name, :grace_credits, :notes_count].freeze
+    DEFAULT_FIELDS = [:id, :user_name, :type, :first_name, :last_name, :grace_credits, :notes_count, :hidden].freeze
 
     # Returns users and their attributes
     # Optional: filter, fields

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -61,7 +61,7 @@ describe Api::UsersController do
         it 'should return all information in the default fields' do
           get :index
           info = Hash.from_xml(response.body).dig('users', 'user')[0]
-          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
         end
       end
       context 'expecting an json response' do
@@ -84,7 +84,7 @@ describe Api::UsersController do
         it 'should return all information in the default fields' do
           get :index
           info = JSON.parse(response.body)[0]
-          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
         end
       end
     end
@@ -105,7 +105,7 @@ describe Api::UsersController do
         it 'should return all information in the default fields' do
           get :show, params: { id: students[0].id }
           info = Hash.from_xml(response.body).dig('user')
-          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
         end
       end
       context 'expecting an json response' do
@@ -123,7 +123,7 @@ describe Api::UsersController do
         it 'should return all information in the default fields' do
           get :show, params: { id: students[0].id }
           info = JSON.parse(response.body)
-          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
         end
       end
     end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -58,6 +58,11 @@ describe Api::UsersController do
           user_names = Hash.from_xml(response.body).dig('users', 'user')['user_name']
           expect(user_names).to eq(students[0].user_name)
         end
+        it 'should return all information in the default fields' do
+          get :index
+          info = Hash.from_xml(response.body).dig('users', 'user')[0]
+          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+        end
       end
       context 'expecting an json response' do
         before :each do
@@ -76,6 +81,11 @@ describe Api::UsersController do
           get :index, params: { filter: { user_name: students[0].user_name } }
           expect(JSON.parse(response.body).map { |h| h['user_name'] }).to eq([students[0].user_name])
         end
+        it 'should return all information in the default fields' do
+          get :index
+          info = JSON.parse(response.body)[0]
+          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+        end
       end
     end
     context 'GET show' do
@@ -92,6 +102,11 @@ describe Api::UsersController do
           get :show, params: { id: students[0].id }
           expect(Hash.from_xml(response.body).dig('user')['user_name']).to eq(students[0].user_name)
         end
+        it 'should return all information in the default fields' do
+          get :show, params: { id: students[0].id }
+          info = Hash.from_xml(response.body).dig('user')
+          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+        end
       end
       context 'expecting an json response' do
         before :each do
@@ -104,6 +119,11 @@ describe Api::UsersController do
         it 'should return info about the user' do
           get :show, params: { id: students[0].id }
           expect(JSON.parse(response.body)['user_name']).to eq(students[0].user_name)
+        end
+        it 'should return all information in the default fields' do
+          get :show, params: { id: students[0].id }
+          info = JSON.parse(response.body)
+          expect(Set.new info.keys.map(&:to_sym)).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
         end
       end
     end


### PR DESCRIPTION
This is useful to check which students have dropped a course or have been marked inactive for other reasons.

resolves #4429