### PR TITLE
Set defaultFiltered values for submissions table in url

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -266,6 +266,7 @@ class RawSubmissionTable extends React.Component {
           ]}
           filterable
           defaultFilterMethod={stringFilter}
+          defaultFiltered={this.props.defaultFiltered}
           loading={loading}
 
           getTrProps={this.getTrProps}

--- a/app/views/assignments/_assignment_info_summary.html.erb
+++ b/app/views/assignments/_assignment_info_summary.html.erb
@@ -6,7 +6,7 @@
   <p>
     <%= link_to t(:outstanding_remark_request,
                   count: assignment.outstanding_remark_request_count),
-        browse_assignment_submissions_path(assignment, sort_by: 'marking_state') %>
+        browse_assignment_submissions_path(assignment, filter_by: 'marking_state', filter_value: 'remark') %>
   </p>
 <% end %>
 

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -9,7 +9,8 @@
           is_admin: <%= @current_user.admin? %>,
           can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
           authenticity_token: '<%= form_authenticity_token(
-                         form_options: {action: download_groupings_files_assignment_submissions_url}) %>'
+                         form_options: {action: download_groupings_files_assignment_submissions_url}) %>',
+          defaultFiltered: [{ id: '<%= params[:filter_by] %>', value: '<%= params[:filter_value] %>' }]
         }
       );
     });


### PR DESCRIPTION
Previously we could set the sort value for this table in the URL. This no longer works since we moved this table over to use react.

This PR reintroduces the idea of being able to set default values for the table in the URL but instead of sorting, it focuses on filtering since the main use for this is to show the remark requests easily. It makes more sense to filter the table to show remark requests instead of sorting the table by marking state. 

resolves #4426