### PR TITLE
Assignment stat: add tests for assignment stat model

### DIFF
--- a/app/models/assignment_stat.rb
+++ b/app/models/assignment_stat.rb
@@ -16,7 +16,7 @@ class AssignmentStat < ApplicationRecord
       grade_distribution_percentage.parse_csv.map(&:to_i)
     else
       # Default, empty distribution
-      '[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]'
+      Array.new(20) { 0 }
     end
   end
 end

--- a/spec/factories/assignment_stats.rb
+++ b/spec/factories/assignment_stats.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :assignment_stat do
+    association :assignment
+    grade_distribution_percentage { '1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0' }
+  end
+end

--- a/spec/models/assignment_stat_spec.rb
+++ b/spec/models/assignment_stat_spec.rb
@@ -1,0 +1,29 @@
+describe AssignmentStat do
+  it { is_expected.to belong_to :assignment }
+
+  let(:assignment_stat) { create :assignment_stat }
+
+  describe '#refresh_grade_distribution' do
+    it 'updates grade distribution' do
+      distribution = Array.new(20) { rand(1...9) }
+      dist_str = distribution.to_csv
+      allow(assignment_stat.assignment).to receive(:grade_distribution_array).and_return distribution
+      assignment_stat.refresh_grade_distribution
+      expect(assignment_stat.reload.grade_distribution_percentage).to eq dist_str
+    end
+  end
+
+  describe '#grade_distribution_array' do
+    context 'the grade distribution exists' do
+      it 'gets grade the grade distribution' do
+        expect(assignment_stat.grade_distribution_array).to eq(Array.new(20) { 1 })
+      end
+    end
+    context 'the grade distribution is nil' do
+      let(:assignment_stat) { create :assignment_stat, grade_distribution_percentage: nil }
+      it 'gets grade the grade distribution' do
+        expect(assignment_stat.grade_distribution_array).to eq(Array.new(20) { 0 })
+      end
+    end
+  end
+end


### PR DESCRIPTION
- added tests for AssignmentStat model
- fixed return value for `grade_distribution_array` if the array is null in the db (it was returning a string before when it should return a list of integers to keep the return value type consistent).