### PR TITLE
Spreadsheet marks release email notifications

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -199,7 +199,7 @@ class GradeEntryFormsController < ApplicationController
       end
       params[:students].each do |student|
         NotificationMailer.with(student: GradeEntryStudent.find_by(id: student), form: grade_entry_form)
-            .release_spreadsheet_email.deliver_now
+                          .release_spreadsheet_email.deliver_now
       end
     end
   end

--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -197,6 +197,10 @@ class GradeEntryFormsController < ApplicationController
         flash_message(:error, e.message)
         raise ActiveRecord::Rollback
       end
+      params[:students].each do |student|
+        NotificationMailer.with(student: GradeEntryStudent.find_by(id: student), form: grade_entry_form)
+            .release_spreadsheet_email.deliver_now
+      end
     end
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -7,6 +7,7 @@ class NotificationMailer < ApplicationMailer
     mail(to: @user.email, subject: default_i18n_subject(course: Rails.configuration.course_name,
                                                         assignment: @grouping.assignment.short_identifier))
   end
+
   def release_spreadsheet_email
     @form = params[:form]
     @student = params[:student]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -7,4 +7,10 @@ class NotificationMailer < ApplicationMailer
     mail(to: @user.email, subject: default_i18n_subject(course: Rails.configuration.course_name,
                                                         assignment: @grouping.assignment.short_identifier))
   end
+  def release_spreadsheet_email
+    @form = params[:form]
+    @student = params[:student]
+    mail(to: @student.user.email, subject: default_i18n_subject(course: Rails.configuration.course_name,
+                                                                form: @form.short_identifier))
+  end
 end

--- a/app/views/notification_mailer/release_spreadsheet_email.html.erb
+++ b/app/views/notification_mailer/release_spreadsheet_email.html.erb
@@ -1,0 +1,24 @@
+<div class="emailbkgd dark-scheme">
+  <div class="top_section dark-scheme">
+    <%= image_tag('markus_logo_big.png', class: 'logo_header')%>
+  </div>
+  <hr class="divider">
+  <p class="to_text dark-scheme">
+    <%= t('.greeting', first_name: @student.user.first_name, last_name: @student.user.last_name) %>
+  </p>
+  <p class="body_text dark-scheme">
+    <%= t('.text_body', form: @form.short_identifier) %>
+  </p>
+  <div class="button_enclosure">
+    <%= link_to t('.button_text'),
+                student_interface_grade_entry_form_url(id: @form.id),
+                class: 'redirectbutton' %>
+  </div>
+  <p class="alert_text dark-scheme">
+    <%= t('.explicit_link',
+          link: student_interface_grade_entry_form_url(id: @form.id)) %>
+  </p>
+  <p class="alert_text dark-scheme">
+    <%= t('.disclaimer') %>
+  </p>
+</div>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -7,3 +7,11 @@ en:
       button_text: 'View Results'
       explicit_link: "If the above button doesn't work, copy-and-paste this link into your web browser: %{link}"
       disclaimer: 'This is an automated email. Please do not reply.'
+
+    release_spreadsheet_email:
+      subject: 'MarkUs Notification (%{course}) Your marks for %{form} have been released!'
+      greeting: 'Hello %{first_name} %{last_name},'
+      text_body: 'Your marks for %{form} have now been released on MarkUs and can be viewed.'
+      button_text: 'View Results'
+      explicit_link: "If the above button doesn't work, copy-and-paste this link into your web browser: %{link}"
+      disclaimer: 'This is an automated email. Please do not reply.'

--- a/config/locales/mailers/es.yml
+++ b/config/locales/mailers/es.yml
@@ -7,3 +7,11 @@ es:
       button_text: 'UPDATE ME'
       explicit_link: 'UPDATE ME'
       disclaimer: 'UPDATE ME'
+
+    release_spreadsheet_email:
+      subject: 'UPDATE ME'
+      greeting: 'UPDATE ME'
+      text_body: 'UPDATE ME'
+      button_text: 'UPDATE ME'
+      explicit_link: "UPDATE ME"
+      disclaimer: 'UPDATE ME'

--- a/config/locales/mailers/fr.yml
+++ b/config/locales/mailers/fr.yml
@@ -7,3 +7,11 @@ fr:
       button_text: 'UPDATE ME'
       explicit_link: 'UPDATE ME'
       disclaimer: 'UPDATE ME'
+
+    release_spreadsheet_email:
+      subject: 'UPDATE ME'
+      greeting: 'UPDATE ME'
+      text_body: 'UPDATE ME'
+      button_text: 'UPDATE ME'
+      explicit_link: "UPDATE ME"
+      disclaimer: 'UPDATE ME'

--- a/config/locales/mailers/pt.yml
+++ b/config/locales/mailers/pt.yml
@@ -7,3 +7,11 @@ pt:
       button_text: 'UPDATE ME'
       explicit_link: 'UPDATE ME'
       disclaimer: 'UPDATE ME'
+
+    release_spreadsheet_email:
+      subject: 'UPDATE ME'
+      greeting: 'UPDATE ME'
+      text_body: 'UPDATE ME'
+      button_text: 'UPDATE ME'
+      explicit_link: "UPDATE ME"
+      disclaimer: 'UPDATE ME'

--- a/spec/controllers/grade_entry_forms_controller_spec.rb
+++ b/spec/controllers/grade_entry_forms_controller_spec.rb
@@ -288,13 +288,14 @@ describe GradeEntryFormsController do
   describe "update_grade_entry_students" do
     before :each do
       @student = grade_entry_form_with_data.grade_entry_students.joins(:user).find_by('users.user_name': 'c8shosta')
+      @this_form = grade_entry_form_with_data
     end
     it 'sends an email to each student who can now view their marks for this grade entry form' do
       expect do
-        post_as @admin,
-                :update_grade_entry_students,
-                params: { students: @student.id,
-                          release_results: 'true' }
+        post :update_grade_entry_students,
+             params: { id: @this_form.id,
+                       students: [@student.id],
+                       release_results: 'true' }
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
 

--- a/spec/controllers/grade_entry_forms_controller_spec.rb
+++ b/spec/controllers/grade_entry_forms_controller_spec.rb
@@ -284,4 +284,19 @@ describe GradeEntryFormsController do
       expect(grade_entry_form.reload.date).to eq Date.new(2019, 11, 14)
     end
   end
+
+  describe "update_grade_entry_students" do
+    before :each do
+      @student = grade_entry_form_with_data.grade_entry_students.joins(:user).find_by('users.user_name': 'c8shosta')
+    end
+    it 'sends an email to each student who can now view their marks for this grade entry form' do
+      expect do
+        post_as @admin,
+                :update_grade_entry_students,
+                params: { students: @student.id,
+                          release_results: 'true' }
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+  end
 end

--- a/spec/controllers/grade_entry_forms_controller_spec.rb
+++ b/spec/controllers/grade_entry_forms_controller_spec.rb
@@ -285,7 +285,7 @@ describe GradeEntryFormsController do
     end
   end
 
-  describe "update_grade_entry_students" do
+  describe 'update_grade_entry_students' do
     before :each do
       @student = grade_entry_form_with_data.grade_entry_students.joins(:user).find_by('users.user_name': 'c8shosta')
       @this_form = grade_entry_form_with_data
@@ -298,6 +298,5 @@ describe GradeEntryFormsController do
                        release_results: 'true' }
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
-
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -35,4 +35,39 @@ RSpec.describe NotificationMailer, type: :mailer do
       expect(@mail.body.to_s).to match(@fake_assignment.short_identifier.to_s)
     end
   end
+
+  describe 'release_spreadsheet_email' do
+    before(:each) do
+      @user = create(:student)
+      @grade_entry_student = create(:grade_entry_student, user: @user)
+      @grade_entry_form = create(:grade_entry_form_with_data)
+      @mail = described_class.with(student: @grade_entry_student, form: @grade_entry_form).release_email.deliver_now
+    end
+
+    it 'renders the subject' do
+      subject_line = 'MarkUs Notification (' + Rails.configuration.course_name + ') Your marks for ' +
+      @grade_entry_form.short_identifier + ' have been released!'
+      expect(@mail.subject).to eq(subject_line)
+    end
+
+    it 'renders the receiver email' do
+      expect(@mail.to).to eq([@grade_entry_student.user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(@mail.from).to eq(['noreply@markus.com'])
+    end
+
+    it 'renders the student name in the body of the email.' do
+      expect(@mail.body.to_s).to match("#{@grade_entry_student.user.first_name} #{@grade_entry_student.user.last_name}")
+    end
+
+    it 'renders the disclaimer in the body of the email.' do
+      expect(@mail.body.to_s).to match('This is an automated email. Please do not reply.')
+    end
+
+    it 'renders the assignment in the body of the email.' do
+      expect(@mail.body.to_s).to match(@grade_entry_form.short_identifier.to_s)
+    end
+  end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -24,15 +24,15 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it 'renders the student name in the body of the email.' do
-      expect(@mail.body.to_s).to match("#{@user.first_name} #{@user.last_name}")
+      expect(@mail.body.to_s).to include("#{@user.first_name} #{@user.last_name}")
     end
 
     it 'renders the disclaimer in the body of the email.' do
-      expect(@mail.body.to_s).to match('This is an automated email. Please do not reply.')
+      expect(@mail.body.to_s).to include('This is an automated email. Please do not reply.')
     end
 
     it 'renders the assignment in the body of the email.' do
-      expect(@mail.body.to_s).to match(@fake_assignment.short_identifier.to_s)
+      expect(@mail.body.to_s).to include(@fake_assignment.short_identifier.to_s)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       @grade_entry_form = create(:grade_entry_form_with_data)
       @grade_entry_student = @grade_entry_form.grade_entry_students.find_or_create_by(user: @user)
       @mail = described_class.with(student: @grade_entry_student, form: @grade_entry_form)
-                  .release_spreadsheet_email.deliver_now
+                             .release_spreadsheet_email.deliver_now
     end
 
     it 'renders the subject' do
@@ -60,15 +60,17 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it 'renders the student name in the body of the email.' do
-      expect(@mail.body.to_s).to match("#{@grade_entry_student.user.first_name} #{@grade_entry_student.user.last_name}")
+      first_name = @grade_entry_student.user.first_name
+      last_name = @grade_entry_student.user.last_name
+      expect(@mail.body.to_s).to include("#{first_name} #{last_name}")
     end
 
     it 'renders the disclaimer in the body of the email.' do
-      expect(@mail.body.to_s).to match('This is an automated email. Please do not reply.')
+      expect(@mail.body.to_s).to include('This is an automated email. Please do not reply.')
     end
 
     it 'renders the spreadsheet name in the body of the email.' do
-      expect(@mail.body.to_s).to match(@grade_entry_form.short_identifier.to_s)
+      expect(@mail.body.to_s).to include(@grade_entry_form.short_identifier.to_s)
     end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -39,9 +39,10 @@ RSpec.describe NotificationMailer, type: :mailer do
   describe 'release_spreadsheet_email' do
     before(:each) do
       @user = create(:student)
-      @grade_entry_student = create(:grade_entry_student, user: @user)
       @grade_entry_form = create(:grade_entry_form_with_data)
-      @mail = described_class.with(student: @grade_entry_student, form: @grade_entry_form).release_email.deliver_now
+      @grade_entry_student = @grade_entry_form.grade_entry_students.find_or_create_by(user: @user)
+      @mail = described_class.with(student: @grade_entry_student, form: @grade_entry_form)
+                  .release_spreadsheet_email.deliver_now
     end
 
     it 'renders the subject' do
@@ -66,7 +67,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       expect(@mail.body.to_s).to match('This is an automated email. Please do not reply.')
     end
 
-    it 'renders the assignment in the body of the email.' do
+    it 'renders the spreadsheet name in the body of the email.' do
       expect(@mail.body.to_s).to match(@grade_entry_form.short_identifier.to_s)
     end
   end


### PR DESCRIPTION
Email Notifications for release of spreadsheet marks.
Including functional testing and unit testing.

One test is still failing, but unclear why:

This is the failure: 
![image](https://user-images.githubusercontent.com/29822176/77458285-554faa00-6dd4-11ea-9e69-93d67ec54fe3.png)
But, in the email body one can see the short identifier is present:
![image](https://user-images.githubusercontent.com/29822176/77458349-6f898800-6dd4-11ea-99b8-a5fd24f4054f.png)


**Edit:** All fixed now.