### PR TITLE
Background submission file download

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Added git hook to limit the maximum file size committed and/or pushed to a git repository (#4421)
 - Display newlines properly in flash messages (#4443)
 - Api calls will now return the 'hidden' status of users when accessing user data (#4445)
+- Make bulk submission file downloads a background job (#4463)
 
 ## [v1.8.4]
 - Fixed bug where test output was not being properly hidden from students (#4379)

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -206,9 +206,14 @@ class RawSubmissionTable extends React.Component {
     }).then(this.fetchData);
   };
 
-  downloadGroupingFiles = (event) => {
-    if (!window.confirm(I18n.t('submissions.marking_incomplete_warning'))) {
-      event.preventDefault();
+  prepareGroupingFiles = () => {
+    if (window.confirm(I18n.t('submissions.marking_incomplete_warning'))) {
+      $.post({
+        url: Routes.zip_groupings_files_assignment_submissions_url(this.props.assignment_id),
+        data: {
+          groupings: this.props.selection
+        }
+      })
     }
   };
 
@@ -245,7 +250,7 @@ class RawSubmissionTable extends React.Component {
           can_run_tests={this.props.can_run_tests}
 
           collectSubmissions={() => {this.setState({showModal: true})}}
-          downloadGroupingFiles={this.downloadGroupingFiles}
+          downloadGroupingFiles={this.prepareGroupingFiles}
           selection={this.props.selection}
           runTests={this.runTests}
           releaseMarks={() => this.toggleRelease(true)}
@@ -353,20 +358,11 @@ class SubmissionsActionBox extends React.Component {
     }
 
     let downloadGroupingFilesButton = (
-      <form action={Routes.download_groupings_files_assignment_submissions_url(this.props.assignment_id)}
-            onSubmit={this.props.downloadGroupingFiles}
-            method="post"
+      <button onClick={this.props.downloadGroupingFiles}
+              disabled={this.props.disabled}
       >
-        {this.props.selection.map(selection => {
-          return (
-            <input type="number" name="groupings[]" defaultValue={selection} key={selection} hidden={true}/>
-          )
-        })}
-        <input type="hidden" name="authenticity_token" value={this.props.authenticity_token} />
-        <button type={'submit'} disabled={this.props.disabled}>
-          {I18n.t('download_the', {item: I18n.t('activerecord.models.submission.other')})}
-        </button>
-      </form>
+        {I18n.t('download_the', {item: I18n.t('activerecord.models.submission.other')})}
+      </button>
     );
 
     return (

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -8,7 +8,7 @@ class JobMessagesController < ApplicationController
       session[:job_id] = nil
     elsif status.completed?
       status[:progress] = status[:total]
-      flash_message(:success, t('poll_job.completed'))
+      flash_message(:success, status[:job_class].completed_message(status))
       session[:job_id] = nil
     elsif status.read.empty?
       flash_message(:error, t('poll_job.failed'))

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -488,7 +488,7 @@ class SubmissionsController < ApplicationController
   def zip_groupings_files
     assignment = Assignment.find(params[:assignment_id])
 
-    groupings = Grouping.includes(:group, :current_submission_used).where(id: params[:groupings]&.map(&:to_i))
+    groupings = assignment.groupings.where(id: params[:groupings]&.map(&:to_i))
 
     zip_path = zipped_grouping_file_name(assignment)
 
@@ -507,7 +507,13 @@ class SubmissionsController < ApplicationController
   def download_zipped_file
     assignment = Assignment.find(params[:assignment_id])
     zip_path = zipped_grouping_file_name(assignment)
-    send_file zip_path, disposition: 'inline', filename: File.basename(zip_path)
+    zip_file = File.basename(zip_path)
+    begin
+      send_file zip_path, disposition: 'inline', filename: zip_file
+    rescue ActionController::MissingFile
+      flash_message(:error, I18n.t('submissions.download_zipped_file.file_missing', zip_file: zip_file))
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   ##

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,6 +9,10 @@ class ApplicationJob < ActiveJob::Base
     I18n.t('poll_job.working_message', progress: status[:progress], total: status[:total])
   end
 
+  def self.completed_message(_status)
+    I18n.t('poll_job.completed')
+  end
+
   before_enqueue do |job|
     self.status.update(job_class: job.class)
   end

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -1,3 +1,5 @@
+# Prepares submission files from a list of groupings for download
+# by zipping them up into a single zipfile
 class DownloadSubmissionsJob < ApplicationJob
   queue_as Rails.configuration.x.queues.download_submissions
 
@@ -10,7 +12,7 @@ class DownloadSubmissionsJob < ApplicationJob
   end
 
   def self.completed_message(status)
-    {partial: 'submissions/download_zip_file', locals: {assignment_id: status[:assignment_id]}}
+    { partial: 'submissions/download_zip_file', locals: { assignment_id: status[:assignment_id] } }
   end
 
   before_enqueue do |job|

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -25,7 +25,7 @@ class DownloadSubmissionsJob < ApplicationJob
 
     progress.total = grouping_ids.length
     Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
-      Grouping.where(id: grouping_ids).each do |grouping|
+      Grouping.includes(:group, :current_submission_used).where(id: grouping_ids).each do |grouping|
         revision_id = grouping.current_submission_used&.revision_identifier
         group_name = grouping.group.group_name
         grouping.group.access_repo do |repo|

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -2,7 +2,11 @@ class DownloadSubmissionsJob < ApplicationJob
   queue_as Rails.configuration.x.queues.download_submissions
 
   def self.show_status(status)
-    I18n.t('poll_job.download_submissions_job', progress: status[:progress], total: status[:total])
+    if status[:progress] == status[:total]
+      I18n.t('poll_job.download_submissions_finalizing')
+    else
+      I18n.t('poll_job.download_submissions_job', progress: status[:progress], total: status[:total])
+    end
   end
 
   def self.completed_message(status)

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -16,16 +16,15 @@ class DownloadSubmissionsJob < ApplicationJob
   def perform(grouping_ids, zip_path, _assignment_id)
     ## delete the old file if it exists
     File.delete(zip_path) if File.exist?(zip_path)
-    zip_name = File.basename zip_path
 
     progress.total = grouping_ids.length
     Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
       Grouping.where(id: grouping_ids).each do |grouping|
         revision_id = grouping.current_submission_used&.revision_identifier
-        group_name = grouping.group.repo_name
+        group_name = grouping.group.group_name
         grouping.group.access_repo do |repo|
           revision = repo.get_revision(revision_id)
-          repo.send_tree_to_zip(grouping.assignment.repository_folder, zip_file, zip_name + group_name, revision)
+          repo.send_tree_to_zip(grouping.assignment.repository_folder, zip_file, group_name, revision)
         rescue Repository::RevisionDoesNotExist
           next
         ensure

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -1,0 +1,31 @@
+class DownloadSubmissionsJob < ApplicationJob
+  queue_as Rails.configuration.x.queues.download_submissions
+
+  def self.show_status(status)
+    I18n.t('poll_job.download_submissions_job', progress: status[:progress], total: status[:total])
+  end
+
+  def perform(groupings, zip_path, options = {})
+    ## delete the old file if it exists
+    File.delete(zip_path) if File.exist?(zip_path)
+
+    zip_name = File.basename zip_path
+
+    progress.total = groupings.size
+    Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
+      groupings.each do |grouping|
+        revision_id = grouping.current_submission_used&.revision_identifier
+        group_name = grouping.group.repo_name
+        grouping.group.access_repo do |repo|
+          revision = repo.get_revision(revision_id)
+          repo.send_tree_to_zip(assignment.repository_folder, zip_file, zip_name + group_name, revision)
+        rescue Repository::RevisionDoesNotExist
+          next
+        ensure
+          progress.increment
+        end
+      end
+    end
+  end
+
+end

--- a/app/views/submissions/_download_zip_file.html.erb
+++ b/app/views/submissions/_download_zip_file.html.erb
@@ -1,0 +1,6 @@
+<p>
+  <a id="zip_download_link"
+     href="<%= download_zipped_file_assignment_submissions_url(assignment_id: assignment_id) %>">
+    <%= I18n.t('poll_job.download_submissions_complete') %>
+  </a>
+</p>

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -7,9 +7,7 @@
           show_grace_tokens: <%= @assignment.submission_rule.type == 'GracePeriodSubmissionRule' %>,
           show_sections: <%= Section.exists? %>,
           is_admin: <%= @current_user.admin? %>,
-          can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>,
-          authenticity_token: '<%= form_authenticity_token(
-                         form_options: {action: download_groupings_files_assignment_submissions_url}) %>'
+          can_run_tests: <%= @current_user.admin? && @assignment.enable_test %>
         }
       );
     });

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -265,6 +265,8 @@ Markus::Application.configure do
   config.x.queues.create_groups = 'CSC108'
   # The name of the queue where jobs to collect submissions wait to be executed.
   config.x.queues.collect_submissions = 'CSC108'
+  # The name of the queue where jobs to download submissions wait to be executed.
+  config.x.queues.download_submissions = 'CSC108'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   config.x.queues.uncollect_submissions = 'CSC108'
   # The name of the queue where jobs to update repos with the list of required files wait to be executed.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -261,6 +261,8 @@ Markus::Application.configure do
   config.x.queues.create_groups = 'CSC108'
   # The name of the queue where jobs to collect submissions wait to be executed.
   config.x.queues.collect_submissions = 'CSC108'
+  # The name of the queue where jobs to download submissions wait to be executed.
+  config.x.queues.download_submissions = 'CSC108'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   config.x.queues.uncollect_submissions = 'CSC108'
   # The name of the queue where jobs to update repos with the list of required files wait to be executed.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -255,6 +255,8 @@ Markus::Application.configure do
   config.x.queues.create_groups = 'CSC108'
   # The name of the queue where jobs to collect submissions wait to be executed.
   config.x.queues.collect_submissions = 'CSC108'
+  # The name of the queue where jobs to download submissions wait to be executed.
+  config.x.queues.download_submissions = 'CSC108'
   # The name of the queue where jobs to uncollect submissions wait to be executed.
   config.x.queues.uncollect_submissions = 'CSC108'
   # The name of the queue where jobs to update repos with the list of required files wait to be executed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       uncollect_submissions_job: "Uncollecting assignments ... "
       submissions_job: "%{progress}/%{total} Submissions collected"
       download_submissions_job: "%{progress}/%{total} Submissions prepared for download"
+      download_submissions_finalizing: "Finalizing submissions for download"
       download_submissions_complete: "Submissions are ready. Click here to complete the download."
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
       update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
       create_groups_job_extra_info: "failed for group: %{group_name}, repo: %{repo_name}, members: %{members}"
       uncollect_submissions_job: "Uncollecting assignments ... "
       submissions_job: "%{progress}/%{total} Submissions collected"
+      download_submissions_job: "%{progress}/%{total} Submissions prepared for download"
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
       update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"
       autotest_run_job: "%{progress}/%{total} Test runs started"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       uncollect_submissions_job: "Uncollecting assignments ... "
       submissions_job: "%{progress}/%{total} Submissions collected"
       download_submissions_job: "%{progress}/%{total} Submissions prepared for download"
+      download_submissions_complete: "Submissions are ready. Click here to complete the download."
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
       update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"
       autotest_run_job: "%{progress}/%{total} Test runs started"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
       submissions_job: "%{progress}/%{total} Submissions collected"
       download_submissions_job: "%{progress}/%{total} Submissions prepared for download"
       download_submissions_finalizing: "Finalizing submissions for download"
-      download_submissions_complete: "Submissions are ready. Click here to complete the download."
+      download_submissions_complete: "Submissions are ready for download. Click here to complete the download."
       update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
       update_starter_code_job: "%{progress}/%{total} Student repositories updated with starter code"
       autotest_run_job: "%{progress}/%{total} Test runs started"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,7 @@ es:
       uncollect_submissions_job: "Asignaciones incumplidas... "
       submissions_job: "%{progress}/%{total} Envíos recibidos"
       download_submissions_job: "%{progress}/%{total} UPDATE ME"
+      download_submissions_complete: "UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
       autotest_run_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,6 +65,7 @@ es:
       create_groups_job_extra_info: "Ha fallado: %{group_name}, %{repo_name}, %{members}"
       uncollect_submissions_job: "Asignaciones incumplidas... "
       submissions_job: "%{progress}/%{total} Envíos recibidos"
+      download_submissions_job: "%{progress}/%{total} UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
       autotest_run_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,7 @@ es:
       uncollect_submissions_job: "Asignaciones incumplidas... "
       submissions_job: "%{progress}/%{total} Envíos recibidos"
       download_submissions_job: "%{progress}/%{total} UPDATE ME"
+      download_submissions_finalizing: "UPDATE ME"
       download_submissions_complete: "UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -56,6 +56,7 @@ fr:
       uncollect_submissions_job: "Tâches de décollement... "
       submissions_job: "%{progress}/%{total} Soumissions collectées"
       download_submissions_job: "%{progress}/%{total} Soumissions préparées pour téléchargement"
+      download_submissions_finalizing: "Finaliser les soumissions à télécharger"
       download_submissions_complete: "Les soumissions sont prêtes. Cliquez ici pour finaliser le téléchargement."
       update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
       update_starter_code_job: "%{progress}/%{total} repos modifiés"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,7 @@ fr:
       create_groups_job_extra_info: "Échoué pour: groupe: %{group_name}, repo: %{repo_name}, membres: %{members}"
       uncollect_submissions_job: "Tâches de décollement... "
       submissions_job: "%{progress}/%{total} Soumissions collectées"
+      download_submissions_job: "%{progress}/%{total} Soumissions préparées pour téléchargement"
       update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
       update_starter_code_job: "%{progress}/%{total} repos modifiés"
       autotest_run_job: "%{progress}/%{total} Tests commencés"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -56,6 +56,7 @@ fr:
       uncollect_submissions_job: "Tâches de décollement... "
       submissions_job: "%{progress}/%{total} Soumissions collectées"
       download_submissions_job: "%{progress}/%{total} Soumissions préparées pour téléchargement"
+      download_submissions_complete: "Les soumissions sont prêtes. Cliquez ici pour finaliser le téléchargement."
       update_repo_required_files_job: "%{progress}/%{total} repos modifiés"
       update_starter_code_job: "%{progress}/%{total} repos modifiés"
       autotest_run_job: "%{progress}/%{total} Tests commencés"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -50,6 +50,7 @@ pt:
       create_groups_job_extra_info: "Falhou: %{group_name}, %{repo_name}, %{members}"
       uncollect_submissions_job: "Tarefas não coletadas ... "
       submissions_job: "%{progress}/%{total} Submissões coletadas"
+      download_submissions_job: "%{progress}/%{total} UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
       autotest_run_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -51,6 +51,7 @@ pt:
       uncollect_submissions_job: "Tarefas não coletadas ... "
       submissions_job: "%{progress}/%{total} Submissões coletadas"
       download_submissions_job: "%{progress}/%{total} UPDATE ME"
+      download_submissions_finalizing: "UPDATE ME"
       download_submissions_complete: "UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -51,6 +51,7 @@ pt:
       uncollect_submissions_job: "Tarefas não coletadas ... "
       submissions_job: "%{progress}/%{total} Submissões coletadas"
       download_submissions_job: "%{progress}/%{total} UPDATE ME"
+      download_submissions_complete: "UPDATE ME"
       update_repo_required_files_job: "%{progress}/%{total} UPDATE ME"
       update_starter_code_job: "%{progress}/%{total} UPDATE ME"
       autotest_run_job: "%{progress}/%{total} UPDATE ME"

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -32,6 +32,8 @@ en:
       submitted_at:  "Submitted At"
       viewing_revision: "Viewing Revision:"
       server_time: "push:"
+    download_zipped_file:
+      file_missing: "No file named %{zip_file} found. Please try preparing this file for download again."
 
     student:
       file_manager: "%{short_identifier}: File Manager"

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -62,6 +62,9 @@ es:
                   que le han sido asignadas no han sido recolectadas todavía, usted puede dar click en
                   el nombre del grupo para recolectarlas. <strong>Precaución</strong>: La recolección
                   eliminará cualquier anotación o nota previa."
+    download_zipped_file:
+      file_missing: "%{zip_file} UPDATE ME"
+
     repo_browser:
       client_time: "commit:"
       collected: "recolectada"

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -43,6 +43,9 @@ fr:
       version_control_warning: "Envoi de fichiers ici annule les modifications apportées à l'aide de contrôle de version.
                                 Assurez-vous que vous avez travaillé sur les fichiers les plus récents avant de soumettre."
 
+    download_zipped_file:
+      file_missing: "Aucun fichier nommé %{zip_file} trouvé. Veuillez essayer de préparer à nouveau ce fichier pour le télécharger."
+
     # Miscellaneous
     cannot_display: "Fichier binaire : utiliser le bouton Télécharger pour voir."
     commit_date: "Date d'envoi (commit)"

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -48,6 +48,9 @@ pt:
       version_control_warning: "Submetendo arquivos aqui substitui todas as mudanças feitas usando o controle de versão.
                                 Certifique-se de que você trabalhou nos arquivos mais recentes antes de enviar."
 
+    download_zipped_file:
+      file_missing: "%{zip_file} UPDATE ME"
+
     # Miscellaneous
     cannot_display: "Conteudo binário: Use o botao de download para ver o arquivo!"
     commit_date: "Data de envio"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,7 +186,8 @@ Rails.application.routes.draw do
           post 'update_files'
           get 'server_time'
           get 'download'
-          post 'download_groupings_files'
+          post 'zip_groupings_files'
+          get 'download_zipped_file'
         end
 
         member do

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -594,6 +594,7 @@ describe SubmissionsController do
       let(:unassigned_ta) { create :ta }
       let(:assigned_ta) do
         ta = create :ta
+        grouping_ids # make sure groupings are created
         assignment.groupings.each do |grouping|
           create(:ta_membership, user: ta, grouping: grouping)
         end
@@ -630,8 +631,8 @@ describe SubmissionsController do
         end
 
         it 'should - as Ta - be able to download all groups\' submissions when assigned' do
-          expect(DownloadSubmissionsJob).to receive(:perform_later) do |grouping_ids, _zip_file, _assignment_id|
-            expect(grouping_ids).to contain_exactly(*grouping_ids)
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |gids, _zip_file, _assignment_id|
+            expect(gids).to contain_exactly(*grouping_ids)
             DownloadSubmissionsJob.new
           end
           post_as assigned_ta, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: grouping_ids }

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -583,101 +583,79 @@ describe SubmissionsController do
       is_expected.to respond_with(:redirect)
     end
 
-    describe 'attempting to download groupings files' do
-      before(:each) do
-        @assignment = create(:assignment)
-        @grouping_ids = []
-        (1..3).to_a.each do |i|
-          @grouping = create(:grouping,
-                             assignment: @assignment)
-          @grouping_ids << @grouping.id
-          @student = create(:student)
+    describe 'prepare and download a zip file' do
+      let(:assignment) { create :assignment }
+      let(:grouping_ids) do
+        create_list(:grouping_with_inviter, 3, assignment: assignment).map.with_index do |grouping, i|
+          submit_file(grouping.assignment, grouping, "file#{i}", "file#{i}'s content\n")
+          grouping.id
+        end
+      end
+      let(:unassigned_ta) { create :ta }
+      let(:assigned_ta) do
+        ta = create :ta
+        assignment.groupings.each do |grouping|
+          create(:ta_membership, user: ta, grouping: grouping)
+        end
+        ta
+      end
 
-          instance_variable_set(:"@student#{i}", @student)
-          instance_variable_set(:"@grouping#{i}",
-                                @grouping)
-          @membership = create(:student_membership,
-                               user: instance_variable_get(:"@student#{i}"),
-                               membership_status: 'inviter',
-                               grouping: instance_variable_get(
-                                 :"@grouping#{i}"
-                               ))
-          submit_file(@assignment, instance_variable_get(:"@grouping#{i}"),
-                      "file#{i}", "file#{i}'s content\n")
+      describe '#zip_groupings_files' do
+        it 'should be able to download all groups\' submissions' do
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |grouping_ids, _zip_file, _assignment_id|
+            expect(grouping_ids).to contain_exactly(*grouping_ids)
+            DownloadSubmissionsJob.new
+          end
+          post_as @admin, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: grouping_ids }
+          is_expected.to respond_with(:success)
+        end
+
+        it 'should be able to download a subset of the submissions' do
+          subset = grouping_ids[0...2]
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |grouping_ids, _zip_file, _assignment_id|
+            expect(grouping_ids).to contain_exactly(*subset)
+            DownloadSubmissionsJob.new
+          end
+          post_as @admin, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: subset }
+          is_expected.to respond_with(:success)
+        end
+
+        it 'should - as Ta - be not able to download all groups\' submissions when unassigned' do
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |grouping_ids, _zip_file, _assignment_id|
+            expect(grouping_ids).to be_empty
+            DownloadSubmissionsJob.new
+          end
+          post_as unassigned_ta, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: grouping_ids }
+          is_expected.to respond_with(:success)
+        end
+
+        it 'should - as Ta - be able to download all groups\' submissions when assigned' do
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |grouping_ids, _zip_file, _assignment_id|
+            expect(grouping_ids).to contain_exactly(*grouping_ids)
+            DownloadSubmissionsJob.new
+          end
+          post_as assigned_ta, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: grouping_ids }
+          is_expected.to respond_with(:success)
+        end
+
+        it 'should create a zip file named after the current user and the assignment' do
+          expect(DownloadSubmissionsJob).to receive(:perform_later) do |_grouping_ids, zip_file, _assignment_id|
+            expect(zip_file).to include(assignment.short_identifier)
+            expect(zip_file).to include(@admin.user_name)
+            DownloadSubmissionsJob.new
+          end
+          post_as @admin, :zip_groupings_files, params: { assignment_id: assignment.id, groupings: grouping_ids }
+          is_expected.to respond_with(:success)
         end
       end
 
-      it 'should be able to download all groups\' submissions' do
-        post_as @admin, :download_groupings_files, params: { assignment_id: @assignment.id, groupings: @grouping_ids }
-        is_expected.to respond_with(:success)
-        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@admin.user_name}.zip")
-        zip_path = Pathname.new('tmp') + zip_subpath
-        Zip::File.open(zip_path) do |zip_file|
-          (1..3).to_a.each do |i|
-            instance_variable_set(
-              :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
-            )
-            expect(zip_file.find_entry(
-                     instance_variable_get(:"@file#{i}_path"))).to_not be_nil
-            expect("file#{i}'s content\n").to eq(
-              zip_file.read(instance_variable_get(:"@file#{i}_path")))
+      describe '#download_zipped_file' do
+        it 'should download a file name after the current user and the assignment' do
+          expect(controller).to receive(:send_file) do |zip_file|
+            expect(zip_file.to_s).to include(assignment.short_identifier)
+            expect(zip_file.to_s).to include(@admin.user_name)
           end
-        end
-      end
-
-      it 'should be able to download a subset of the submissions' do
-        grouping_ids = @grouping_ids[0...2]
-        post_as @admin, :download_groupings_files, params: { assignment_id: @assignment.id, groupings: grouping_ids }
-        is_expected.to respond_with(:success)
-        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@admin.user_name}.zip")
-        zip_path = Pathname.new('tmp') + zip_subpath
-        Zip::File.open(zip_path) do |zip_file|
-          (1..2).to_a.each do |i|
-            instance_variable_set(
-              :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
-            )
-            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
-            expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
-          end
-        end
-      end
-
-      it 'should - as Ta - be not able to download all groups\' submissions when unassigned' do
-        @ta = create(:ta)
-        post_as @ta, :download_groupings_files, params: { assignment_id: @assignment.id, groupings: @grouping_ids }
-        is_expected.to respond_with(:success)
-        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@ta.user_name}.zip")
-        zip_path = Pathname.new('tmp') + zip_subpath
-        Zip::File.open(zip_path) do |zip_file|
-          (1..3).to_a.each do |i|
-            instance_variable_set(
-              :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
-            )
-            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to be_nil
-          end
-        end
-      end
-      it 'should - as Ta - be able to download all groups\' submissions when assigned' do
-        @ta = create(:ta)
-        @assignment.groupings.each do |grouping|
-          create(:ta_membership, user: @ta, grouping: grouping)
-        end
-        post_as @ta, :download_groupings_files, params: { assignment_id: @assignment.id, groupings: @grouping_ids }
-        is_expected.to respond_with(:success)
-        zip_subpath = Pathname.new("#{@assignment.short_identifier}_#{@ta.user_name}.zip")
-        zip_path = Pathname.new('tmp') + zip_subpath
-        Zip::File.open(zip_path) do |zip_file|
-          (1..3).to_a.each do |i|
-            instance_variable_set(
-              :"@file#{i}_path",
-              zip_subpath + instance_variable_get(:"@grouping#{i}").group.repo_name.to_s + "file#{i}"
-            )
-            expect(zip_file.find_entry(instance_variable_get(:"@file#{i}_path"))).to_not be_nil
-            expect("file#{i}'s content\n").to eq(zip_file.read(instance_variable_get(:"@file#{i}_path")))
-          end
+          post_as @admin, :download_zipped_file, params: { assignment_id: assignment.id }
         end
       end
     end
@@ -696,17 +674,3 @@ describe SubmissionsController do
   end
 end
 
-private
-
-def submit_file(assignment, grouping, filename = 'file', content = 'content')
-  grouping.group.access_repo do |repo|
-    txn = repo.get_transaction('test')
-    path = File.join(assignment.repository_folder, filename)
-    txn.add(path, content, '')
-    repo.commit(txn)
-
-    # Generate submission
-    Submission.generate_new_submission(
-      grouping, repo.get_latest_revision)
-  end
-end

--- a/spec/jobs/download_submissions_job_spec.rb
+++ b/spec/jobs/download_submissions_job_spec.rb
@@ -1,0 +1,44 @@
+describe DownloadSubmissionsJob do
+  let(:assignment) { create :assignment }
+  let(:groupings) do
+    create_list(:grouping_with_inviter, 3, assignment: assignment).map do |grouping|
+      gid = grouping.id
+      submit_file(assignment, grouping, "file#{gid}", "file#{gid}'s content\n")
+      grouping
+    end
+  end
+  let(:groupings_without_files) { create_list :grouping, 3 }
+
+  it 'should create a zip file containing all submission files for the given groupings' do
+    zip_path = 'tmp/test_file.zip'
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id)
+    Zip::File.open(zip_path) do |zip_file|
+      groupings.each do |grouping|
+        gid = grouping.id
+        zip_entry = Pathname.new(grouping.group.group_name) + "file#{gid}"
+        expect(zip_file.find_entry(zip_entry)).to_not be_nil
+        expect("file#{gid}'s content\n").to eq(zip_file.read(zip_entry))
+      end
+    end
+  end
+
+  it 'should skip files for groupings that do not have a submission for that assignment' do
+    zip_path = 'tmp/test_file.zip'
+    DownloadSubmissionsJob.perform_now(groupings_without_files.map(&:id), zip_path, assignment.id)
+    Zip::File.open(zip_path) do |zip_file|
+      groupings_without_files.each do |grouping|
+        gid = grouping.id
+        zip_entry = Pathname.new(grouping.group.group_name) + "file#{gid}"
+        expect(zip_file.find_entry(zip_entry)).to be_nil
+      end
+    end
+  end
+
+  it 'should remove the previous zip file if it exists' do
+    zip_path = 'tmp/test_file.zip'
+    before_text = 'the before text'
+    File.write(zip_path, before_text)
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id)
+    expect(File.read(zip_path)).not_to eq before_text
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -54,8 +54,7 @@ module Helpers
       repo.commit(txn)
 
       # Generate submission
-      Submission.generate_new_submission(
-          grouping, repo.get_latest_revision)
+      Submission.generate_new_submission(grouping, repo.get_latest_revision)
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -45,4 +45,17 @@ module Helpers
     period.hours = hours
     period.save
   end
+
+  def submit_file(assignment, grouping, filename = 'file', content = 'content')
+    grouping.group.access_repo do |repo|
+      txn = repo.get_transaction('test')
+      path = File.join(assignment.repository_folder, filename)
+      txn.add(path, content, '')
+      repo.commit(txn)
+
+      # Generate submission
+      Submission.generate_new_submission(
+          grouping, repo.get_latest_revision)
+    end
+  end
 end


### PR DESCRIPTION
Downloading bulk submissions now happens in the background.
The behaviour is now:

- click the download submissions button from the submission page
- wait for the zip file to be prepared in the background (flash messages keep the user updated on the status)
- a flash message is displayed indicating that the zip file is ready
- this flash message contains a link which triggers the file download when clicked

Resolves #4283