### PR TITLE
Fix association references for student/grader views

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -132,7 +132,7 @@ class AssignmentsController < ApplicationController
       @g_id_entries = {}
       current_user.grade_entry_students.where(released_to_student: true).includes(:grade_entry_form).each do |g|
         unless g.grade_entry_form.is_hidden
-          @g_id_entries[g.grade_entry_form_id] = g
+          @g_id_entries[g.assessment_id] = g
         end
       end
 

--- a/app/views/assignments/_list.html.erb
+++ b/app/views/assignments/_list.html.erb
@@ -21,7 +21,7 @@
               <%= link_to assignment_text, route %>
               <% if assignment.has_peer_review? && !assignment.pr_assignment.is_hidden %>
                   <%= link_to "#{assignment.short_identifier} #{PeerReview.model_name.human}",
-                              peer_review_assignment_path(id: assignment.pr_assignment_id),
+                              peer_review_assignment_path(id: assignment.pr_assignment.id),
                               class: 'pr_assignment_list' %>
               <% end %>
             </td>


### PR DESCRIPTION
Change over some remaining references to old assignment/grade_entry_forms (now all under assessments)