### PR TITLE
Exam template: fix associations and bugfix

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -23,10 +23,10 @@ class ExamTemplatesController < ApplicationController
     else
       filename = new_uploaded_io.original_filename
       exam_template = ExamTemplate.create_with_file(new_uploaded_io.read,
-                                                    assignment_id: assignment.id,
+                                                    assessment_id: assignment.id,
                                                     filename: filename,
                                                     name: name)
-      if exam_template.valid?
+      if exam_template&.valid?
         flash_message(:success, t('exam_templates.create.success'))
       else
         flash_message(:error, t('exam_templates.create.failure'))
@@ -144,7 +144,7 @@ class ExamTemplatesController < ApplicationController
   def split
     assignment = Assignment.find(params[:assignment_id])
     exam_template = assignment.exam_templates.find(params[:id])
-    split_exam = params[:exam_template][:pdf_to_split]
+    split_exam = params[:exam_template]&.fetch(:pdf_to_split) { nil }
     unless split_exam.nil?
       if split_exam.content_type != 'application/pdf'
         flash_message(:error, t('exam_templates.split.invalid'))
@@ -178,7 +178,7 @@ class ExamTemplatesController < ApplicationController
       format.html
       format.json do
         split_pdf_logs = SplitPdfLog.joins(exam_template: :assignment)
-                           .where(assignments: {id: @assignment.id})
+                           .where(assessments: {id: @assignment.id})
                            .includes(:exam_template)
                            .includes(:user)
                            .includes(split_pages: :group)

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -178,10 +178,10 @@ class ExamTemplatesController < ApplicationController
       format.html
       format.json do
         split_pdf_logs = SplitPdfLog.joins(exam_template: :assignment)
-                           .where(assessments: {id: @assignment.id})
-                           .includes(:exam_template)
-                           .includes(:user)
-                           .includes(split_pages: :group)
+                                    .where(assessments: { id: @assignment.id })
+                                    .includes(:exam_template)
+                                    .includes(:user)
+                                    .includes(split_pages: :group)
 
         data = split_pdf_logs.map do |log|
           pages = log.split_pages.select do |p|

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -12,7 +12,10 @@ class ExamTemplate < ApplicationRecord
 
   has_many :split_pdf_logs, dependent: :destroy
   has_many :template_divisions, dependent: :destroy
-  accepts_nested_attributes_for :template_divisions, allow_destroy: true, update_only: true, reject_if: :exam_been_uploaded?
+  accepts_nested_attributes_for :template_divisions,
+                                allow_destroy: true,
+                                update_only: true,
+                                reject_if: :exam_been_uploaded?
 
   before_save :undo_mark_for_destruction
 
@@ -262,6 +265,11 @@ class ExamTemplate < ApplicationRecord
     imglist.first.write(File.join(self.base_path, 'cover.jpg'))
   end
 
+  # any changes to template divisions should be rejected once exams have been uploaded
+  def exam_been_uploaded?
+    self.split_pdf_logs.exists?
+  end
+
   private
 
   # name and filename shouldn't include whitespace
@@ -294,11 +302,6 @@ class ExamTemplate < ApplicationRecord
       )
       File.rename old_directory_name, new_directory_name
     end
-  end
-
-  # any changes to template divisions should be rejected once exams have been uploaded
-  def exam_been_uploaded?
-    self.split_pdf_logs.any?
   end
 
   # any attempts to delete template divisions should be rejected once exams have been uploaded

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -15,7 +15,7 @@
 <%= form_for @assignment do |f| %>
   <%= f.fields_for :assignment_properties do |ap_f| %>
 
-    <input type="hidden" name="assignment.assignment_properties[scanned_exam]" value="<%= @assignment.scanned_exam %>">
+    <%= ap_f.hidden_field :scanned_exam, value: @assignment.scanned_exam  %>
 
     <label class='required'><%= t('required_fields') %></label>
 

--- a/app/views/exam_templates/_template_division.html.erb
+++ b/app/views/exam_templates/_template_division.html.erb
@@ -1,16 +1,16 @@
 <%= f.fields_for :template_divisions do |form| %>
   <li>
     <span class="label">
-      <%= form.text_field :label, required: true %>
+      <%= form.text_field :label, required: true, disabled: disabled %>
     </span>
     <span class="start">
-      <%= form.number_field :start, min: 1 %>
+      <%= form.number_field :start, min: 1, disabled: disabled %>
     </span>
     <span class="end">
-      <%= form.number_field :end, min: 1 %>
+      <%= form.number_field :end, min: 1, disabled: disabled %>
     </span>
     <span class="delete">
-      <%= form.check_box :_destroy %>
+      <%= form.check_box :_destroy, disabled: disabled %>
     </span>
   </li>
 <% end %>

--- a/app/views/exam_templates/_template_division_pane.html.erb
+++ b/app/views/exam_templates/_template_division_pane.html.erb
@@ -7,12 +7,15 @@
   </header>
 
   <ul class="template-division-section-<%= exam_template.id %>">
+      <% disabled = exam_template.exam_been_uploaded? %>
       <%= render partial: 'exam_templates/template_division',
-                 locals: { f: f } %>
-      <li class="add_template">
-        <%= link_to t('exam_templates.create.add_division'),
-                      '#',
-                      onClick: "add_template_division(#{exam_template.id.to_s}); return false;"%>
-      </li>
+                 locals: { f: f, disabled: disabled } %>
+      <% unless disabled %>
+        <li class="add_template">
+          <%= link_to t('exam_templates.create.add_division'),
+                        '#',
+                        onClick: "add_template_division(#{exam_template.id.to_s}); return false;"%>
+        </li>
+      <% end %>
   </ul>
 </div>

--- a/spec/factories/exam_templates.rb
+++ b/spec/factories/exam_templates.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :exam_template_midterm, class: ExamTemplate do
-    association :assessment, factory: :assignment_for_scanned_exam
+    association :assignment, factory: :assignment_for_scanned_exam
     filename { 'midterm1-v2-test.pdf' }
     num_pages { 6 }
 


### PR DESCRIPTION
- After reconfig of assignments/assessments, some associations with exam templates were not updated properly. 
- Fixes a bug where a user could delete a template division after logs had been created.
- Fixes a bug where new scanned exam assignments were created as regular assignments because the `:scanned` param was not being passed by the form properly when the scanned exam was being created. 
