### PR TITLE
Rubric yml

### DIFF
--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -160,8 +160,8 @@ class CriteriaController < ApplicationController
             type = criterion_yml[1]['type']
             begin
               if type.casecmp('rubric') == 0
-                data = RubricCriterion.load_from_yml(criterion_yml)
-                criterion, levels = data[0], data[1]
+                criterion, levels = RubricCriterion.load_from_yml(criterion_yml)[0],
+                                    RubricCriterion.load_from_yml(criterion_yml)[1]
               elsif type.casecmp('flexible') == 0
                 criterion = FlexibleCriterion.load_from_yml(criterion_yml)
               elsif type.casecmp('checkbox') == 0

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -160,8 +160,7 @@ class CriteriaController < ApplicationController
             type = criterion_yml[1]['type']
             begin
               if type.casecmp('rubric') == 0
-                criterion, levels = RubricCriterion.load_from_yml(criterion_yml)[0],
-                                    RubricCriterion.load_from_yml(criterion_yml)[1]
+                criterion, levels = RubricCriterion.load_from_yml(criterion_yml)
               elsif type.casecmp('flexible') == 0
                 criterion = FlexibleCriterion.load_from_yml(criterion_yml)
               elsif type.casecmp('checkbox') == 0

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -160,7 +160,9 @@ class CriteriaController < ApplicationController
             type = criterion_yml[1]['type']
             begin
               if type.casecmp('rubric') == 0
-                criterion = RubricCriterion.load_from_yml(criterion_yml)
+                data = RubricCriterion.load_from_yml(criterion_yml)
+                criterion = data[0]
+                levels = data[1]
               elsif type.casecmp('flexible') == 0
                 criterion = FlexibleCriterion.load_from_yml(criterion_yml)
               elsif type.casecmp('checkbox') == 0
@@ -172,6 +174,10 @@ class CriteriaController < ApplicationController
               criterion.assignment_id = assignment.id
               criterion.position = pos
               criterion.save!
+              if defined? levels
+                criterion.levels = levels
+                criterion.save!
+              end
               pos += 1
               successes += 1
             rescue ActiveRecord::RecordInvalid # E.g., both visibility options are false.

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -161,8 +161,7 @@ class CriteriaController < ApplicationController
             begin
               if type.casecmp('rubric') == 0
                 data = RubricCriterion.load_from_yml(criterion_yml)
-                criterion = data[0]
-                levels = data[1]
+                criterion, levels = data[0], data[1]
               elsif type.casecmp('flexible') == 0
                 criterion = FlexibleCriterion.load_from_yml(criterion_yml)
               elsif type.casecmp('checkbox') == 0

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -174,7 +174,7 @@ class CriteriaController < ApplicationController
               criterion.assignment_id = assignment.id
               criterion.position = pos
               criterion.save!
-              if defined? levels
+              if type.casecmp('rubric') == 0
                 criterion.levels = levels
                 criterion.save!
               end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -171,13 +171,20 @@ class RubricCriterion < Criterion
     # Visibility options
     criterion.ta_visible = criterion_yml[1]['ta_visible'] unless criterion_yml[1]['ta_visible'].nil?
     criterion.peer_visible = criterion_yml[1]['peer_visible'] unless criterion_yml[1]['peer_visible'].nil?
+    levels = []
     criterion_yml[1]['levels'].each do |name, level_yml|
-      criterion.levels.create(rubric_criterion: criterion,
-                             name: name,
-                             description: level_yml['description'],
-                             mark: level_yml['mark'])
+      level = Level.new
+      level.rubric_criterion = criterion
+      level.name = name
+      level.description = level_yml['description']
+      level.mark = level_yml['mark']
+      levels.append(level)
+      # levels.append(Level.create(rubric_criterion: criterion,
+      #                              name: name,
+      #                              description: level_yml['description'],
+      #                              mark: level_yml['mark']))
     end
-    criterion
+    [criterion, levels]
   end
 
   # Returns a hash containing the information of a single rubric criterion.

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -173,12 +173,10 @@ class RubricCriterion < Criterion
     criterion.peer_visible = criterion_yml[1]['peer_visible'] unless criterion_yml[1]['peer_visible'].nil?
     levels = []
     criterion_yml[1]['levels'].each do |name, level_yml|
-      level = Level.new
-      level.rubric_criterion = criterion
-      level.name = name
-      level.description = level_yml['description']
-      level.mark = level_yml['mark']
-      levels.append(level)
+      levels << criterion.levels.build(rubric_criterion: criterion,
+                                       name: name,
+                                       description: level_yml['description'],
+                                       mark: level_yml['mark'])
     end
     [criterion, levels]
   end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -153,11 +153,15 @@ class RubricCriterion < Criterion
   #                 in the following format:
   #                 criterion_name:
   #                   max_mark: #
-  #                   level_0:
-  #                     name: level_name
-  #                     description: level_description
-  #                   level_1:
-  #                     [...]
+  #                   type: Rubric
+  #                   levels:
+  #                     <level_name>:
+  #                       mark: level_mark
+  #                       description: level_description
+  #                     <level_name>:
+  #                       [...]
+  #                   ta_visible: true/false
+  #                   peer_visible: true/false
   def self.load_from_yml(criterion_yml)
     name = criterion_yml[0]
     # Create a new RubricCriterion
@@ -167,9 +171,8 @@ class RubricCriterion < Criterion
     # Visibility options
     criterion.ta_visible = criterion_yml[1]['ta_visible'] unless criterion_yml[1]['ta_visible'].nil?
     criterion.peer_visible = criterion_yml[1]['peer_visible'] unless criterion_yml[1]['peer_visible'].nil?
-
     criterion_yml[1]['levels'].each do |name, level_yml|
-      criterion.levels.build(rubric_criterion: criterion,
+      criterion.levels.create(rubric_criterion: criterion,
                              name: name,
                              description: level_yml['description'],
                              mark: level_yml['mark'])

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -179,10 +179,6 @@ class RubricCriterion < Criterion
       level.description = level_yml['description']
       level.mark = level_yml['mark']
       levels.append(level)
-      # levels.append(Level.create(rubric_criterion: criterion,
-      #                              name: name,
-      #                              description: level_yml['description'],
-      #                              mark: level_yml['mark']))
     end
     [criterion, levels]
   end

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -879,8 +879,6 @@ describe CriteriaController do
       it 'creates criteria with rounded (up to first digit after decimal point) maximum mark' do
         post_as admin, :upload, params: { assignment_id: assignment.id,
                                           upload_file: round_max_mark_file }
-        # TODO: Fix this
-        pending('should be successfully uploaded and it should not create a rubric criterion with default setting')
         expect(assignment.get_criteria(:all, :rubric).first.name).to eq('cr90')
 
         expect(assignment.get_criteria(:all, :rubric).first.max_mark).to eq(4.6)

--- a/spec/fixtures/files/criteria/round_max_mark.yaml
+++ b/spec/fixtures/files/criteria/round_max_mark.yaml
@@ -1,25 +1,21 @@
 cr90:
   max_mark: 4.6
   type: Rubric
-  level_0:
-    name: 0
-    desription:
-    mark: 0
-  level_1:
-    name: 1
-    description:
-    mark: 1
-  level_2:
-    name: 2
-    description: A-
-    mark: 3
-  level_3:
-    name: 3
-    description: A
-    mark: 4
-  level_4:
-    name: 4
-    description: A+
-    mark: 4.6
+  levels:
+    level_0:
+      desription: B-
+      mark: 0
+    level_1:
+      description: B
+      mark: 1
+    level_2:
+      description: A-
+      mark: 3
+    level_3:
+      description: A
+      mark: 4
+    level_4:
+      description: A+
+      mark: 4.6
   ta_visible: true
   peer_visible: false

--- a/spec/fixtures/files/criteria/round_max_mark.yaml
+++ b/spec/fixtures/files/criteria/round_max_mark.yaml
@@ -3,7 +3,7 @@ cr90:
   type: Rubric
   levels:
     level_0:
-      desription: B-
+      description: B-
       mark: 0
     level_1:
       description: B


### PR DESCRIPTION
Fixed test on line 880 in criteria_controller_spec.rb file. To do this, I changed some old rubric criterion yml files so that they follow the new yml format for a rubric criterion and updated the load_from_yml method to be able to create multiple levels through a yml format, which originally was causing an error.
Possible shortcomings/other notices:

- I changed the return type for the RubricCriterion method load_from_yml from returning a new rubric criterion to returning an array whose first index is the created criterion and second index are the levels that are created. This is because levels cannot be created within the load_from_yml file as the rubric_criterion is saved within the controller, not within the model.