### PR TITLE
File manager: handle multiple selection once

### DIFF
--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -10,40 +10,32 @@ import { RawFileBrowser, Headers, FileRenderers, BaseFileConnectors } from 'reac
 
 
 class RawFileManager extends RawFileBrowser {
-  handleActionBarAddFileClick = (event, selected) => {
+  handleActionBarAddFileClick = (event, selectedItem) => {
     event.preventDefault();
-    let uploadTarget = '';
-    if (!!selected && selected.length === 1) { // treat multiple selections as an invalid target
-      if (selected[0].relativeKey.endsWith('/')) {
-        uploadTarget = selected[0].relativeKey;
-      } else {
-        uploadTarget = selected[0].relativeKey.substring(0, selected.relativeKey.lastIndexOf(selected.name));
-      }
-    }
-    this.props.onActionBarAddFileClick(uploadTarget);
+    this.props.onActionBarAddFileClick(this.folderTarget(selectedItem));
   };
 
-  handleActionBarAddFolderClickSetSelection = (event, target) => {
+  handleActionBarAddFolderClickSetSelection = (event, selectedItem) => {
     event.persist();
+    const target = this.folderTarget(selectedItem);
     this.select(target, "folder");
     this.handleActionBarAddFolderClick(event)
   };
 
   folderTarget = (selectedItem) => {
     // treat multiple selections as not targeting a folder
-    const selectionIsFolder = selectedItem.length === 1 && selectedItem[0].relativeKey.endsWith('/');
+    const selectionIsFolder = !!selectedItem && selectedItem.relativeKey.endsWith('/');
     if (selectionIsFolder) {
-      return selectedItem[0].relativeKey;
+      return selectedItem.relativeKey;
     } else  {
-      const key = selectedItem.length === 1 ? selectedItem[0].relativeKey : '';
-      return key.substring(0, key.lastIndexOf("/") + 1)
+      return selectedItem.relativeKey.substring(0, key.lastIndexOf("/") + 1)
     }
   };
 
   renderActionBar(selectedItems) {
     // treat multiple selections the same as not targeting
-    const selectionIsFolder = selectedItems.length === 1 && selectedItems[0].relativeKey.endsWith('/');
     let selectedItem = selectedItems.length === 1 ? selectedItems[0] : null;
+    const selectionIsFolder = !!selectedItem && selectedItem.relativeKey.endsWith('/');
     let filter;
     if (this.props.canFilter) {
       filter = (
@@ -89,11 +81,10 @@ class RawFileManager extends RawFileBrowser {
           typeof this.props.onCreateFolder === 'function' &&
           !this.state.nameFilter
         ) {
-          let target = this.folderTarget(selectedItem);
           actions.push(
             <li key="action-add-folder">
               <a
-                onClick={(event) => this.handleActionBarAddFolderClickSetSelection(event, target)}
+                onClick={(event) => this.handleActionBarAddFolderClickSetSelection(event, selectedItem)}
                 href="#"
                 role="button"
               >


### PR DESCRIPTION
Handle the ability to select multiple rows in one place only so that there is less room for error. 

Keeps the same behaviour as before:

- if a single row is selected, treat that row as selected
- if multiple rows are selected, treat no rows as selected