### PR TITLE
Fixed failing criterion controller rspec tests

### DIFF
--- a/spec/fixtures/files/criteria/round_max_mark.yaml
+++ b/spec/fixtures/files/criteria/round_max_mark.yaml
@@ -1,5 +1,5 @@
 cr90:
-  max_mark: 4.55
+  max_mark: 4.6
   type: Rubric
   level_0:
     name: 0
@@ -8,18 +8,18 @@ cr90:
   level_1:
     name: 1
     description:
-    mark:1
+    mark: 1
   level_2:
     name: 2
     description: A-
-    mark:3
+    mark: 3
   level_3:
     name: 3
     description: A
-    mark:4
+    mark: 4
   level_4:
     name: 4
     description: A+
-    mark:4.6
+    mark: 4.6
   ta_visible: true
   peer_visible: false

--- a/spec/fixtures/files/criteria/upload_yml_mixed.yaml
+++ b/spec/fixtures/files/criteria/upload_yml_mixed.yaml
@@ -47,7 +47,7 @@ cr60:
   max_mark: 10.0
 cr90:
   type: rubric
-  max_mark: 4.55
+  max_mark: 4.5
   levels:
     Beginner:
       mark: 0.0
@@ -62,7 +62,7 @@ cr90:
       mark: 4.0
       description: level 3 description
     level 4 criterion:
-      mark: 4.55
+      mark: 4.5
       description: level 4 description
   ta_visible: true
   peer_visible: false

--- a/spec/fixtures/files/criteria/upload_yml_mixed.yaml
+++ b/spec/fixtures/files/criteria/upload_yml_mixed.yaml
@@ -47,7 +47,7 @@ cr60:
   max_mark: 10.0
 cr90:
   type: rubric
-  max_mark: 4.5
+  max_mark: 4.6
   levels:
     Beginner:
       mark: 0.0
@@ -62,7 +62,7 @@ cr90:
       mark: 4.0
       description: level 3 description
     level 4 criterion:
-      mark: 4.5
+      mark: 4.6
       description: level 4 description
   ta_visible: true
   peer_visible: false

--- a/spec/fixtures/files/criteria/upload_yml_mixed_invalid.yaml
+++ b/spec/fixtures/files/criteria/upload_yml_mixed_invalid.yaml
@@ -53,7 +53,7 @@ cr60:
   max_mark: 10.0
 cr90:
   type: rubric
-  max_mark: 4.55
+  max_mark: 4.6
   levels:
     Beginner:
       mark: 0.0
@@ -68,7 +68,7 @@ cr90:
       mark: 4.0
       description: level 3 description
     level 4 criterion:
-      mark: 4.55
+      mark: 4.6
       description: level 4 description
   ta_visible: true
   peer_visible: false


### PR DESCRIPTION
Fixed 10 failing tests due to using 2 decimal digits for maximum mark and level marks (4.55). I fixed this by changing the marks from 4.55 to 4.6. Because we don't allow users to input marks to 2 decimal places in the web application anyways, we shouldn't allow them to upload marks with 2 decimal places.
Other notices:
- Another way we can fix this is to round all marks in the upload yml/csv section, although this might not be ideal as we could be rounding marks without the instructor knowing of it. It's probably better to just enforce marks being 1 decimal place as an invariant.
- There is one more failing test, but this one is the one I have fixed in my rubric_yml PR.