### PR TITLE
file manager: Bugfix for #4493.

### DIFF
--- a/app/assets/javascripts/Components/markus_file_manager.jsx
+++ b/app/assets/javascripts/Components/markus_file_manager.jsx
@@ -25,10 +25,12 @@ class RawFileManager extends RawFileBrowser {
   folderTarget = (selectedItem) => {
     // treat multiple selections as not targeting a folder
     const selectionIsFolder = !!selectedItem && selectedItem.relativeKey.endsWith('/');
-    if (selectionIsFolder) {
+    if (selectedItem === null) {
+      return null;
+    } else if (selectionIsFolder) {
       return selectedItem.relativeKey;
-    } else  {
-      return selectedItem.relativeKey.substring(0, key.lastIndexOf("/") + 1)
+    } else {
+      return selectedItem.relativeKey.substring(0, selectedItem.relativeKey.lastIndexOf('/') + 1);
     }
   };
 


### PR DESCRIPTION
`selectedItem` is `null` when nothing is selected, which is a special case for the `folderTarget` method.