### PR TITLE
Docker: remove unnecessary runner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,6 @@ services:
       - postgres
       - redis
 
-  runner:
-    <<: *backend
-    command: /bin/bash
-
   rails:
     <<: *backend
     entrypoint: .dockerfiles/entrypoint-dev-rails.sh


### PR DESCRIPTION
- Instead, we recommend connecting to the running rails container instead with:

```sh
docker-compose exec rails bash
```
or
```sh
 docker exec -it markus_rails_1 bash
```