### PR TITLE
Docker: remove pid file before starting service

### DIFF
--- a/.dockerfiles/entrypoint-dev-rails.sh
+++ b/.dockerfiles/entrypoint-dev-rails.sh
@@ -14,5 +14,7 @@ until psql "${DATABASE_URL}" -lqt &>/dev/null; do
 done
 psql "${DATABASE_URL}" -lqt 2> /dev/null | cut -d \| -f 1 | grep -wq "markus_${RAILS_ENV}" || rails db:setup
 
+rm ./tmp/pids/server.pid
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile or docker-compose.yml).
 exec "$@"

--- a/.dockerfiles/entrypoint-dev-rails.sh
+++ b/.dockerfiles/entrypoint-dev-rails.sh
@@ -14,7 +14,7 @@ until psql "${DATABASE_URL}" -lqt &>/dev/null; do
 done
 psql "${DATABASE_URL}" -lqt 2> /dev/null | cut -d \| -f 1 | grep -wq "markus_${RAILS_ENV}" || rails db:setup
 
-rm ./tmp/pids/server.pid
+rm -f ./tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile or docker-compose.yml).
 exec "$@"


### PR DESCRIPTION
Docker compose's `stop` command does not stop the puma server in a way that lets it remove the server.pid file. Then when the container is started up again, the server.pid file is still present even if the process it refers to is no longer running. This causes puma to complain that a server is already running.

This PR removes the server.pid file when the rails service is started (in the entrypoint) so that a leftover server.pid file will not interfere with server startup. 