### PR TITLE
Grouping: rollback grouping creation if unable to create assignment subdir

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Added option to download all test script files in the UI and through the API (#4494)
 - Added syntax highlighting support for .tex files (#4505)
 - Fixed annotation Markdown and MathJax rendering bug (#4506) 
+- Fixed bug where a grouping could be created even when the assignment subdirectory failed to be created (#4516)
 
 ## [v1.8.4]
 - Fixed bug where test output was not being properly hidden from students (#4379)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -456,7 +456,10 @@ class Grouping < ApplicationRecord
       end
     end
 
-    result
+    unless result
+      msg = I18n.t('repo.assignment_dir_creation_error', short_identifier: assignment.short_identifier)
+      raise RuntimeError, msg
+    end
   end
 
   # Get the section for this group. If assignment restricts member of a groupe

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -456,10 +456,7 @@ class Grouping < ApplicationRecord
       end
     end
 
-    unless result
-      msg = I18n.t('repo.assignment_dir_creation_error', short_identifier: assignment.short_identifier)
-      raise RuntimeError, msg
-    end
+    raise I18n.t('repo.assignment_dir_creation_error', short_identifier: assignment.short_identifier) unless result
   end
 
   # Get the section for this group. If assignment restricts member of a groupe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,3 +70,4 @@ en:
         required_files: "Update the list of required files for assignment %{assignment}"
         starter_code: "Update starter code files for assignment %{assignment}"
       timeout: 'Waited %{ms} milliseconds to access this repository. Please wait a few seconds and try again.'
+      assignment_dir_creation_error: 'Unable to create a directory for %{short_identifier}. Please retry this action.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,3 +79,4 @@ es:
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
       timeout: 'UPDATE ME %{ms}'
+      assignment_dir_creation_error: "UPDATE ME %{short_identifier}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -69,3 +69,4 @@ fr:
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
       timeout: 'Attendu %{ms} millisecondes pour accéder à ce repo. Veuillez patienter quelques secondes et réessayer.'
+      assignment_dir_creation_error: "N'a pas réussi à créer un dossier pour %{short_identifier}. Veuillez réessayer cette action"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -64,3 +64,4 @@ pt:
         required_files: "UPDATE ME %{assignment}"
         starter_code: "UPDATE ME %{assignment}"
       timeout: 'UPDATE ME %{ms}'
+      assignment_dir_creation_error: "UPDATE ME %{short_identifier}"


### PR DESCRIPTION
Rollback transaction on grouping creation if a subdirectory is not created. In all cases where this would fail, an error message is shown to the user as a flash message and they are asked to retry the action.

TODO:

- [x] update changelog
- [x] add some tests 