### PR TITLE
Background jobs: hide progress flash messages once the job has finished

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Added syntax highlighting support for .tex files (#4505)
 - Fixed annotation Markdown and MathJax rendering bug (#4506) 
 - Fixed bug where a grouping could be created even when the assignment subdirectory failed to be created (#4516)
+- Progress messages for background jobs now are hidden once the job is completed (#4519)
 
 ## [v1.8.4]
 - Fixed bug where test output was not being properly hidden from students (#4379)

--- a/app/assets/javascripts/ajax_events.js
+++ b/app/assets/javascripts/ajax_events.js
@@ -9,25 +9,38 @@ export function setUpCallbacks(elem) {
 
 /*
  * Display flash messages sent in response to an AJAX request.
+ * If a message key is in the X-Message-Discard header, hide
+ * it instead.
  */
 export function renderFlash(event, request) {
   // For rails-ujs, request is stored in event.
   if (request === undefined) {
     request = event.detail[0];
   }
+  let discard = [];
+  const discardMessage = request.getResponseHeader('X-Message-Discard');
+  if (discardMessage) {
+    discard = discardMessage.split(';');
+  }
   FLASH_KEYS.forEach((key) => {
-    const flashMessage = request.getResponseHeader(`X-Message-${key}`);
     const flashDiv = document.getElementsByClassName(key)[0];
-    if (!flashMessage || flashDiv === undefined) {
+    if (flashDiv === undefined) {
       return;
     }
-    const messages = flashMessage.split(';');
-    const contents = flashDiv.getElementsByClassName('flash-content')[0] || flashDiv;
-    contents.innerHTML = '';
-    messages.forEach(message => {
-      contents.insertAdjacentHTML('beforeend', message);
-    });
-    flashDiv.style.display = '';
+    if (discard.includes(key)) {
+      flashDiv.style.display = 'none';
+    } else {
+      const flashMessage = request.getResponseHeader(`X-Message-${key}`);
+      if (flashMessage) {
+        const messages = flashMessage.split(';');
+        const contents = flashDiv.getElementsByClassName('flash-content')[0] || flashDiv;
+        contents.innerHTML = '';
+        messages.forEach(message => {
+          contents.insertAdjacentHTML('beforeend', message);
+        });
+        flashDiv.style.display = '';
+      }
+    }
   });
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,11 +95,11 @@ class ApplicationController < ActionController::Base
   def hide_flash(key)
     return unless request.xhr?
 
-    discard_header = response.headers["X-Message-Discard"]
+    discard_header = response.headers['X-Message-Discard']
     if discard_header.nil?
-      response.headers["X-Message-Discard"] = key.to_s
+      response.headers['X-Message-Discard'] = key.to_s
     else
-      response.headers["X-Message-Discard"] = "#{key.to_s};#{discard_header}"
+      response.headers['X-Message-Discard'] = "#{key};#{discard_header}"
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,6 +91,18 @@ class ApplicationController < ActionController::Base
     flash.discard
   end
 
+  # dynamically hide a flash message (for AJAX requests only)
+  def hide_flash(key)
+    return unless request.xhr?
+
+    discard_header = response.headers["X-Message-Discard"]
+    if discard_header.nil?
+      response.headers["X-Message-Discard"] = key.to_s
+    else
+      response.headers["X-Message-Discard"] = "#{key.to_s};#{discard_header}"
+    end
+  end
+
   def user_not_authorized
     render 'shared/http_status',
            formats: [:html], locals: { code: '403', message: HttpStatusHelper::ERROR_CODE['message']['403'] },

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -13,7 +13,7 @@ class JobMessagesController < ApplicationController
     elsif status.read.empty?
       flash_message(:error, t('poll_job.failed'))
       session[:job_id] = nil
-      render 'shared/http_status', locals: { code: '404', message: t('poll_job.not_enqueued') }, status: 404
+      render json: { code: '404', message: t('poll_job.not_enqueued') }, status: 404
       return
     end
     flash_job_messages(status)

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -25,8 +25,10 @@ class JobMessagesController < ApplicationController
   def flash_job_messages(status)
     flash_message(:error, status[:error_message]) if status[:error_message].present?
     current_status = status[:job_class]&.show_status(status)
-    return if current_status.nil?
-
-    status.queued? ? flash_message(:notice, t('poll_job.queued')) : flash_message(:notice, current_status)
+    if current_status.nil? || session[:job_id].nil?
+      hide_flash :notice
+    else
+      status.queued? ? flash_message(:notice, t('poll_job.queued')) : flash_message(:notice, current_status)
+    end
   end
 end

--- a/spec/controllers/job_messages_controller_spec.rb
+++ b/spec/controllers/job_messages_controller_spec.rb
@@ -1,0 +1,76 @@
+describe JobMessagesController do
+  describe '.get' do
+    let(:admin) { create :admin }
+    let(:job) { ApplicationJob.perform_later }
+    let(:status) { ActiveJob::Status.get(job.job_id) }
+    context 'when a job has been enqueued' do
+      before :each do
+        status[:status] = status_type
+        params = { job_id: job.job_id }
+        get_as admin, :get, params: params, session: params
+      end
+      after :each do
+        flash.discard
+      end
+      context 'when the job failed' do
+        let(:status_type) { :failed }
+        it 'should flash an error message' do
+          expect(flash[:error]).not_to be_nil
+        end
+        it 'should set the session[:job_id] to nil' do
+          expect(request.session[:job_id]).to be_nil
+        end
+        it 'should remove any progress flash messages' do
+          expect(response.headers['X-Message-Discard']).to include 'notice'
+        end
+      end
+      context 'when the job completed successfully' do
+        let(:status_type) { :completed }
+        it 'should flash an success message' do
+          expect(flash[:success]).not_to be_nil
+        end
+        it 'should set the session[:job_id] to nil' do
+          expect(request.session[:job_id]).to be_nil
+        end
+        it 'should remove any progress flash messages' do
+          expect(response.headers['X-Message-Discard']).to include 'notice'
+        end
+      end
+      context 'when the job is queued' do
+        let(:status_type) { :queued }
+        it 'should flash a notice message' do
+          expect(flash[:notice]).to include "<p>#{I18n.t('poll_job.queued')}</p>"
+        end
+        it 'should not set the session[:job_id] to nil' do
+          expect(request.session[:job_id]).to eq job.job_id
+        end
+        it 'should not remove any progress flash messages' do
+          expect(response.headers['X-Message-Discard']).to be_nil
+        end
+      end
+      context 'when the job is working' do
+        let(:status_type) { :working }
+        it 'should flash a notice message' do
+          expect(flash[:notice]).to include "<p>#{ApplicationJob.show_status(status)}</p>"
+        end
+        it 'should not set the session[:job_id] to nil' do
+          expect(request.session[:job_id]).to eq job.job_id
+        end
+        it 'should not remove any progress flash messages' do
+          expect(response.headers['X-Message-Discard']).to be_nil
+        end
+      end
+    end
+    context 'when no job has been enqueued' do
+      before :each do
+        get_as admin, :get, params: { job_id: 'a' }
+      end
+      it 'should flash an error message' do
+        expect(flash[:error]).not_to be_nil
+      end
+      it 'should set the session[:job_id] to nil' do
+        expect(request.session[:job_id]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -13,26 +13,26 @@ module AuthenticationHelper
     @controller = real_controller
   end
 
-  def get_as(user, action, params: {}, format: nil)
+  def get_as(user, action, params: {}, format: nil, session: {})
     sign_in user
-    get action, xhr: true, params: params, format: format
+    get action, xhr: true, params: params, format: format, session: session
   end
 
   # Performs POST request as the supplied user for authentication
-  def post_as(user, action, params: {}, format: nil)
+  def post_as(user, action, params: {}, format: nil, session: {})
     sign_in user
-    post action, xhr: true, params: params, format: format
+    post action, xhr: true, params: params, format: format, session: session
   end
 
   # Performs PUT request as the supplied user for authentication
-  def put_as(user, action, params: {}, format: nil)
+  def put_as(user, action, params: {}, format: nil, session: {})
     sign_in user
-    put action, xhr: true, params: params, format: format
+    put action, xhr: true, params: params, format: format, session: session
   end
 
   # Performs DELETE request as the supplied user for authentication
-  def delete_as(user, action, params: {}, format: nil)
+  def delete_as(user, action, params: {}, format: nil, session: {})
     sign_in user
-    delete action, xhr: true, params: params, format: format
+    delete action, xhr: true, params: params, format: format, session: session
   end
 end


### PR DESCRIPTION
- adds ability to hide flash messages based on the message type (:notice, :error, etc.)
- only available for ajax requests currently
- used here to hide the progress messages for background jobs once the job has finished, either successfully or due to an error/failure. 


TODO:

- [x] update changelog
- [x] update tests for `flash_job_messages`