### PR TITLE
Downloads: allow javascript files to be downloaded as plaintext

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Added syntax highlighting support for .tex files (#4505)
 - Fixed annotation Markdown and MathJax rendering bug (#4506) 
 - Fixed bug where a grouping could be created even when the assignment subdirectory failed to be created (#4516)
+- Fixed bug where a javascript submission/test/starter code file can't be downloaded (#4520) 
 
 ## [v1.8.4]
 - Fixed bug where test output was not being properly hidden from students (#4379)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 # Likewise, all the methods added will be available for all controllers.
 class ApplicationController < ActionController::Base
   include ApplicationHelper, SessionHandler
-  include UploadHelper
+  include UploadHelper, DownloadHelper
 
   rescue_from ActionPolicy::Unauthorized, with: :user_not_authorized
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@
 # Likewise, all the methods added will be available for all controllers.
 class ApplicationController < ActionController::Base
   include ApplicationHelper, SessionHandler
-  include UploadHelper, DownloadHelper
+  include UploadHelper
+  include DownloadHelper
 
   rescue_from ActionPolicy::Unauthorized, with: :user_not_authorized
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -489,9 +489,7 @@ class AssignmentsController < ApplicationController
         return
       end
 
-      send_data file_contents,
-                disposition: 'attachment',
-                filename: params[:file_name]
+      send_data_download file_contents, filename: params[:file_name]
     end
   end
 

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -132,7 +132,7 @@ class AutomatedTestsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     file_path = File.join(assignment.autotest_files_dir, params[:file_name])
     if File.exist?(file_path)
-      send_file file_path, filename: params[:file_name]
+      send_file_download file_path, filename: params[:file_name]
     else
       render plain: t('student.submission.missing_file', file_name: params[:file_name])
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -267,7 +267,7 @@ class GroupsController < ApplicationController
     file_contents = file.retrieve_file
 
     filename = file.filename
-    send_data file_contents, filename: filename
+    send_data_download file_contents, filename: filename
   end
 
   def download_grouplist

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -449,7 +449,7 @@ class ResultsController < ApplicationController
       send_data file_contents, type: 'image', disposition: 'inline',
         filename: filename
     else
-      send_data file_contents, filename: filename, disposition: 'attachment'
+      send_data_download file_contents, filename: filename
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -476,9 +476,7 @@ class SubmissionsController < ApplicationController
         return
       end
 
-      send_data file_contents,
-                disposition: 'attachment',
-                filename: params[:file_name]
+      send_data_download file_contents, disposition: 'attachment', filename: params[:file_name]
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -476,7 +476,7 @@ class SubmissionsController < ApplicationController
         return
       end
 
-      send_data_download file_contents, disposition: 'attachment', filename: params[:file_name]
+      send_data_download file_contents, filename: params[:file_name]
     end
   end
 

--- a/app/helpers/download_helper.rb
+++ b/app/helpers/download_helper.rb
@@ -1,0 +1,34 @@
+# Helpers for handling downloading data files for various models.
+module DownloadHelper
+  MIME_TYPE_CONVERSION = { 'application/javascript': 'text/plain' }.stringify_keys.freeze
+
+  # Wrapper around +send_file+ which converts the +type+ optional argument according
+  # to the +MIME_TYPE_CONVERSION+ hash.
+  # This also forces the +disposition+ optional argument to 'attachment' since this method
+  # should only be used to download files.
+  # For example, it will make sure a file with a .js extension will be downloaded as
+  # plain text which avoids a ActionController::InvalidCrossOriginRequest, which is raised
+  # whenever +send_file+ is asked to download a javascript file.
+  def send_file_download(path, options = {})
+    send_file path, { **options, type: get_converted_mime_type(path), disposition: 'attachment' }
+  end
+
+  # Wrapper around +send_data+ which converts the +type+ optional argument according
+  # to the +MIME_TYPE_CONVERSION+ hash.
+  # This also forces the +disposition+ optional argument to 'attachment' since this method
+  # should only be used to download the data as a file.
+  # For example, it will make sure a file with a .js extension will be downloaded as
+  # plain text which avoids a ActionController::InvalidCrossOriginRequest, which is raised
+  # whenever +send_file+ is asked to download a javascript file.
+  def send_data_download(data, options = {})
+    options = { **options, type: get_converted_mime_type(options[:filename]) } if options.key?(:filename)
+    send_data data, { **options, disposition: 'attachment' }
+  end
+
+  private
+
+  def get_converted_mime_type(filepath)
+    current_mime_type = Rack::Mime.mime_type(File.extname(filepath))
+    MIME_TYPE_CONVERSION.fetch(current_mime_type) { current_mime_type }
+  end
+end

--- a/app/helpers/download_helper.rb
+++ b/app/helpers/download_helper.rb
@@ -10,7 +10,7 @@ module DownloadHelper
   # plain text which avoids a ActionController::InvalidCrossOriginRequest, which is raised
   # whenever +send_file+ is asked to download a javascript file.
   def send_file_download(path, options = {})
-    send_file path, { **options, type: get_converted_mime_type(path), disposition: 'attachment' }
+    send_file path, **options, type: get_converted_mime_type(path), disposition: 'attachment'
   end
 
   # Wrapper around +send_data+ which converts the +type+ optional argument according
@@ -22,7 +22,7 @@ module DownloadHelper
   # whenever +send_file+ is asked to download a javascript file.
   def send_data_download(data, options = {})
     options = { **options, type: get_converted_mime_type(options[:filename]) } if options.key?(:filename)
-    send_data data, { **options, disposition: 'attachment' }
+    send_data data, **options, disposition: 'attachment'
   end
 
   private

--- a/spec/helpers/download_helper_spec.rb
+++ b/spec/helpers/download_helper_spec.rb
@@ -1,0 +1,44 @@
+describe DownloadHelper do
+  include ActionController::DataStreaming
+
+  describe 'send_file_download' do
+    it 'should call send_file with the attachment disposition option' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_file) do |_, _, kwargs|
+        expect(kwargs[:disposition]).to eq 'attachment'
+      end
+      send_file_download('tmp.txt')
+    end
+    it 'should override the disposition option' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_file) do |_, _, kwargs|
+        expect(kwargs[:disposition]).to eq 'attachment'
+      end
+      send_file_download('tmp.txt', disposition: 'inline')
+    end
+    it 'should convert the mime type for javascript files to plaintext' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_file) do |_, _, kwargs|
+        expect(kwargs[:type]).to eq 'text/plain'
+      end
+      send_file_download('tmp.js')
+    end
+  end
+  describe 'send_data_download' do
+    it 'should call send_data with the attachment disposition option' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_data) do |_, _, kwargs|
+        expect(kwargs[:disposition]).to eq 'attachment'
+      end
+      send_data_download('')
+    end
+    it 'should override the disposition option' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_data) do |_, _, kwargs|
+        expect(kwargs[:disposition]).to eq 'attachment'
+      end
+      send_data_download('', disposition: 'inline')
+    end
+    it 'should convert the mime type for javascript files to plaintext' do
+      expect_any_instance_of(ActionController::DataStreaming).to receive(:send_data) do |_, _, kwargs|
+        expect(kwargs[:type]).to eq 'text/plain'
+      end
+      send_data_download('', filename: 'text.js')
+    end
+  end
+end


### PR DESCRIPTION
- Rails will raise an `InvalidCrossOriginRequest` error when trying to download a file with a `.js` extension because it thinks we are attempting to violate the cross-origin policy even though we're just trying to download a submission/testscript/startercode file (see explanation here: https://stackoverflow.com/a/29310381/5992438)
- This PR introduces a new helper with methods that wrap `send_data` and `send_file` which avoids this issue by converting the mime type for javascript files to `text/plain`. These methods are only intended to be used in the case where we might be downloading a javascript file and we *only* want to download it as an attachment.

TODO:

- [x] update changelog
- [x] update tests