### PR TITLE
webpack-dev-server: simply config file

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -58,10 +58,8 @@ development:
   check_yarn_integrity: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
-  # For host: https://github.com/rails/webpacker/issues/1019#issuecomment-351066969.
   dev_server:
     https: false
-    host: webpacker  # <-- this is necessary if running webpack-dev-server from another container!
     port: 3035
     public: 0.0.0.0:3035
     hmr: false
@@ -76,7 +74,6 @@ development:
       'Access-Control-Allow-Origin': '*'
     watch_options:
       ignored: '**/node_modules/**'
-      poll: true
 
 
 test:


### PR DESCRIPTION
- The host should only be `webpacker` when in a docker development environment. In that case, this option in the config file is ignored anyway because it is set as environment variable in the relevant containers. 

- by removing the host option here it falls back to the default (`localhost`) if we are *not* in a docker environment (ie. we are not overriding this option with an environment variable).

- it looks like we no longer need to poll for changes with the new updates to webpack