### PR TITLE
moved visible validation to parent criterion model

### DIFF
--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -8,8 +8,6 @@ class CheckboxCriterion < Criterion
   has_many :tas, through: :criterion_ta_associations
   has_many :test_groups, as: :criterion
 
-  validate :visible?
-
   DEFAULT_MAX_MARK = 1
 
   def self.symbol

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -16,6 +16,8 @@ class Criterion < ApplicationRecord
            through: :criteria_assignment_files_joins
   accepts_nested_attributes_for :criteria_assignment_files_joins, allow_destroy: true
 
+  validate :visible?
+
   self.abstract_class = true
 
   # Assigns a random TA from a list of TAs specified by +ta_ids+ to each

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -15,8 +15,6 @@ class FlexibleCriterion < Criterion
 
   has_many :test_groups, as: :criterion
 
-  validate :visible?
-
   DEFAULT_MAX_MARK = 1
 
   def self.symbol

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -25,8 +25,6 @@ class RubricCriterion < Criterion
 
   has_many :test_groups, as: :criterion
 
-  validate :visible?
-
   def self.symbol
     :rubric
   end


### PR DESCRIPTION
Moved the visible? validation from each of rubric, flexible, and checkbox criterion to parent criterion model.