### PR TITLE
Bug fix: display output column in test run table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [unreleased]
+- Fixed bug where the output column was not shown in the test results table if the first row had no output (#4537)
 
 ## [v1.9.0]
 - Added option to anonymize group membership when viewed by graders (#4331)

--- a/app/assets/javascripts/Components/test_run_table.jsx
+++ b/app/assets/javascripts/Components/test_run_table.jsx
@@ -120,9 +120,17 @@ class TestGroupResultTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      show_output: props.data[0] && 'test_results.output' in props.data[0]
+      show_output: this.showOutput(props.data)
     };
   }
+
+  showOutput = (data) => {
+    if (data) {
+      return data.some((row) => 'test_results.output' in row);
+    } else {
+      return false;
+    }
+  };
 
   columns = () => [
     {


### PR DESCRIPTION
- previous behaviour: if the first test group in the table does not display output, no output column was displayed for the entire table
- fixed behaviour: if any test group displays output, the output column is shown for the entire table (it just contains blank cells for the groups that don't display output)