### PR TITLE
Refactored scaling marks callback

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -55,6 +55,8 @@ class RubricCriterion < Criterion
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
       unless (level.changed.include? 'mark') || level.mark.nil?
+        # use update_attribute to skip validatation in case updating level mark
+        # overlaps another mark temporarily
         level.update_attribute(:mark, (level.mark * scale).round(2))
       end
     end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -55,9 +55,7 @@ class RubricCriterion < Criterion
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
       unless (level.changed.include? 'mark') || level.mark.nil?
-        level.update_attributes(mark: (level.mark * scale).round(2))
-        # don't validate in case updating level mark overlaps another mark temporarily
-        level.save(validate: false)
+        level.update_attribute(:mark, (level.mark * scale).round(2))
       end
     end
   end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -54,8 +54,10 @@ class RubricCriterion < Criterion
     scale = new_max / old_max
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
-      unless level.changed.include? 'mark'
-        level.update(mark: (level.mark * scale).round(2))
+      unless level.changed.include? 'mark' or level.mark.nil?
+        level.update_attributes(mark: (level.mark * scale).round(2))
+        # don't validate in case updating level mark overlaps another mark temporarily
+        level.save(validate: false)
       end
     end
   end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -54,7 +54,7 @@ class RubricCriterion < Criterion
     scale = new_max / old_max
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
-      unless level.changed.include? 'mark' or level.mark.nil?
+      unless level.changed.include? 'mark' || level.mark.nil?
         level.update_attributes(mark: (level.mark * scale).round(2))
         # don't validate in case updating level mark overlaps another mark temporarily
         level.save(validate: false)

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -54,7 +54,7 @@ class RubricCriterion < Criterion
     scale = new_max / old_max
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
-      unless level.changed.include? 'mark' || level.mark.nil?
+      unless (level.changed.include? 'mark') || (level.mark.nil?)
         level.update_attributes(mark: (level.mark * scale).round(2))
         # don't validate in case updating level mark overlaps another mark temporarily
         level.save(validate: false)

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -54,7 +54,7 @@ class RubricCriterion < Criterion
     scale = new_max / old_max
     self.levels.each do |level|
       # don't scale levels that the user has manually changed
-      unless (level.changed.include? 'mark') || (level.mark.nil?)
+      unless (level.changed.include? 'mark') || level.mark.nil?
         level.update_attributes(mark: (level.mark * scale).round(2))
         # don't validate in case updating level mark overlaps another mark temporarily
         level.save(validate: false)

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -248,9 +248,9 @@ describe RubricCriterion do
       end
       describe 'levels will be saved when scaling marks up' do
         it 'not raise error' do
-          expect(@levels[1].mark).to eq(1.0)
+          expect(@criterion.levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 8.0)
-          expect(@levels[1].save).to be true
+          expect(@criterion.levels[1].save).to be true
         end
       end
       describe 'manually changed levels won\'t be affected' do

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -232,18 +232,25 @@ describe RubricCriterion do
     end
 
     context 'when scaling max mark' do
-      describe 'can scale levels up to twice' do
+      describe 'can scale levels up' do
         it 'not raise error' do
           expect(@criterion.levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 8.0)
           expect(@criterion.levels[1].mark).to eq(2.0)
         end
       end
-      describe 'can scale levels down by half' do
+      describe 'can scale levels down' do
         it 'not raise error' do
           expect(@criterion.levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 2.0)
           expect(@criterion.levels[1].mark).to eq(0.5)
+        end
+      end
+      describe 'levels will be saved when scaling marks up' do
+        it 'not raise error' do
+          expect(@levels[1].mark).to eq(1.0)
+          @criterion.update(max_mark: 8.0)
+          expect(@levels[1].save).to be true
         end
       end
       describe 'manually changed levels won\'t be affected' do

--- a/spec/models/rubric_criterion_spec.rb
+++ b/spec/models/rubric_criterion_spec.rb
@@ -232,14 +232,14 @@ describe RubricCriterion do
     end
 
     context 'when scaling max mark' do
-      describe 'can scale levels up' do
+      describe 'can scale levels up to twice' do
         it 'not raise error' do
           expect(@criterion.levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 8.0)
           expect(@criterion.levels[1].mark).to eq(2.0)
         end
       end
-      describe 'can scale levels down' do
+      describe 'can scale levels down by half' do
         it 'not raise error' do
           expect(@criterion.levels[1].mark).to eq(1.0)
           @criterion.update(max_mark: 2.0)


### PR DESCRIPTION
Refactored scale_marks_if_max_mark_changed callback in rubric criterion model. Originally if a level mark would scale and have the same mark as another level temporarily, then an error would be raised as a result of uniqueness of level marks within a rubric criterion.
 For example, if a rubric has levels with marks 0, 1, 2 and the max mark was doubled, an error would be raised as 1 would double to 2 so there would be two duplicate level marks temporarily. To fix this, when saving the level, I disable the validation check when scaling.