### PR TITLE
Refactor max mark validation

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -31,14 +31,13 @@ class RubricCriterion < Criterion
 
   def validate_max_mark
     return if self.levels.empty?
-    ordered_levels = self.levels.sort_by {|level| level.mark}
     self.levels.order(mark: :desc)
-    i = ordered_levels.length - 1
+    i = self.levels.length - 1
     while i >= 0
-      if ordered_levels[i].mark.nil?
+      if self.levels[i].mark.nil?
         i -= 1
       else
-        return if self.max_mark == ordered_levels[i].mark
+        return if self.max_mark == self.levels[i].mark
         errors.add(:max_mark, 'Max mark of rubric criterion should be equal to max level mark')
         return
       end

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -31,9 +31,18 @@ class RubricCriterion < Criterion
 
   def validate_max_mark
     return if self.levels.empty?
+    ordered_levels = self.levels.sort_by {|level| level.mark}
     self.levels.order(mark: :desc)
-    return if self.max_mark == self.levels.last.mark
-    errors.add(:max_mark, 'Max mark of rubric criterion should not be greater than max level mark')
+    i = ordered_levels.length - 1
+    while i >= 0
+      if ordered_levels[i].mark.nil?
+        i -= 1
+      else
+        return if self.max_mark == ordered_levels[i].mark
+        errors.add(:max_mark, 'Max mark of rubric criterion should be equal to max level mark')
+        return
+      end
+    end
   end
 
   def update_assigned_groups_count

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -32,7 +32,7 @@ class RubricCriterion < Criterion
   def validate_max_mark
     return if self.levels.empty?
     self.levels.order(mark: :desc)
-    return if self.max_mark <= self.levels.last.mark
+    return if self.max_mark == self.levels.last.mark
     errors.add(:max_mark, 'Max mark of rubric criterion should not be greater than max level mark')
   end
 


### PR DESCRIPTION
Refactored validate_max_mark validation in rubric criterion model so that it only checks level marks that are not nil when checking the maximum mark. Originally, a level with a nil mark would be set as levels.last when ordering so I changed the validation so that it checks the maximum valid mark.