### PR TITLE
Fixes for download_repo_list and download_repo_checkout_commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 ## [unreleased]
 - Fixed bug where the output column was not shown in the test results table if the first row had no output (#4537)
 - Restrict confirmation dialog for annotation editing to annotations that belong to annotation categories (#4540)
+- Fixed N+1 queries in Assignment repo list methods (#4543)
 
 ## [v1.9.0]
 - Added option to anonymize group membership when viewed by graders (#4331)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Fixed bug where the output column was not shown in the test results table if the first row had no output (#4537)
 - Restrict confirmation dialog for annotation editing to annotations that belong to annotation categories (#4540)
 - Fixed N+1 queries in Assignment repo list methods (#4543)
+- Fixed submission download_repo_list file extension (#4543)
 
 ## [v1.9.0]
 - Added option to anonymize group membership when viewed by graders (#4331)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -614,8 +614,7 @@ class SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     send_data assignment.get_repo_list,
               disposition: 'attachment',
-              type: 'text/plain',
-              filename: "#{assignment.short_identifier}_repo_list"
+              filename: "#{assignment.short_identifier}_repo_list.csv"
   end
 
   # This action is called periodically from file_manager.

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -469,23 +469,21 @@ class Assignment < Assessment
 
   # Get a list of repo checkout client commands to be used for scripting
   def get_repo_checkout_commands
-    repo_commands = []
-    self.groupings.each do |grouping|
+    self.groupings.includes(:group, :current_submission_used).map do |grouping|
       submission = grouping.current_submission_used
       next if submission&.revision_identifier.nil?
-      repo_commands << Repository.get_class.get_checkout_command(grouping.group.repository_external_access_url,
-                                                                 submission.revision_identifier,
-                                                                 grouping.group.group_name, repository_folder)
-    end
-    repo_commands
+      Repository.get_class.get_checkout_command(grouping.group.repository_external_access_url,
+                                                submission.revision_identifier,
+                                                grouping.group.group_name, repository_folder)
+    end.compact
   end
 
   # Get a list of group_name, repo-url pairs
   def get_repo_list
     CSV.generate do |csv|
-      self.groupings.each do |grouping|
+      self.groupings.includes(:group).each do |grouping|
         group = grouping.group
-        csv << [group.group_name,group.repository_external_access_url]
+        csv << [group.group_name, group.repository_external_access_url]
       end
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -793,9 +793,8 @@ describe Assignment do
           before :each do
             2.times do
               g = create(:grouping, assignment: @assignment)
-              # StudentMembership.make({grouping: g,membership_status: StudentMembership::STATUSES[:inviter] } )
-              s = create(:submission, grouping: g)
-              r = s.get_latest_result
+              s = create(:version_used_submission, grouping: g)
+              r = s.current_result
               2.times do
                 create(:rubric_mark, result: r)  # this is create marks under rubric criterion
                 # if we create(:flexible_mark, groping: g)
@@ -840,6 +839,7 @@ describe Assignment do
               end
               g.save
             end
+            create(:version_used_submission, grouping: @assignment.groupings.first)
           end
 
           it 'be able to get_repo_checkout_commands' do


### PR DESCRIPTION
This pull request makes two improvements to the `SubmissionsController` methods `download_repo_list` and `download_repo_checkout_commands`:

1. Removes N+1 queries when generating the files.
2. Corrects the extension of the file downloaded by `download_repo_list` (which returns a csv).