### PR TITLE
assignment: Add inverse_of option to associations.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Fixed sorting in annotation table in results view (#4542)
 - Fixed N+1 queries in Assignment repo list methods (#4543)
 - Fixed submission download_repo_list file extension (#4543)
+- Fixed inverse association bug with assignments (#4551)
 
 ## [v1.9.0]
 - Added option to anonymize group membership when viewed by graders (#4331)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -24,21 +24,24 @@ class Assignment < Assessment
            -> { order(:position) },
            class_name: 'RubricCriterion',
            dependent: :destroy,
+           inverse_of: :assignment,
            foreign_key: :assessment_id
 
   has_many :flexible_criteria,
            -> { order(:position) },
            class_name: 'FlexibleCriterion',
            dependent: :destroy,
+           inverse_of: :assignment,
            foreign_key: :assessment_id
 
   has_many :checkbox_criteria,
            -> { order(:position) },
            class_name: 'CheckboxCriterion',
            dependent: :destroy,
+           inverse_of: :assignment,
            foreign_key: :assessment_id
 
-  has_many :test_groups, dependent: :destroy, foreign_key: :assessment_id
+  has_many :test_groups, dependent: :destroy, inverse_of: :assignment, foreign_key: :assessment_id
   accepts_nested_attributes_for :test_groups, allow_destroy: true, reject_if: ->(attrs) { attrs[:name].blank? }
 
   has_many :annotation_categories,
@@ -48,7 +51,7 @@ class Assignment < Assessment
 
   has_many :criterion_ta_associations, dependent: :destroy, foreign_key: :assessment_id
 
-  has_many :assignment_files, dependent: :destroy, foreign_key: :assessment_id
+  has_many :assignment_files, dependent: :destroy, inverse_of: :assignment, foreign_key: :assessment_id
   accepts_nested_attributes_for :assignment_files, allow_destroy: true
   validates_associated :assignment_files
 

--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -11,6 +11,7 @@ class GradeEntryForm < Assessment
 
   has_many                  :grade_entry_students,
                             dependent: :destroy,
+                            inverse_of: :grade_entry_form,
                             foreign_key: :assessment_id
 
   has_many                  :grades, through: :grade_entry_items

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -103,6 +103,26 @@ describe Assignment do
     end
   end
 
+  describe 'nested attributes' do
+    it 'accepts nested attributes for required files (assignment_files)' do
+      attrs = {
+        short_identifier: 't',
+        description: 't',
+        due_date: Time.current + 1.hour,
+        assignment_files_attributes: [
+          { filename: 't.py' }
+        ]
+      }
+      a = Assignment.new(attrs)
+      a.repository_folder = 't'
+      a.build_assignment_stat
+      a.build_submission_rule
+      a.save!
+
+      expect(a.assignment_files.first.filename).to eq 't.py'
+    end
+  end
+
   describe '#clone_groupings_from' do
     it 'makes an attempt to update repository permissions when cloning groupings' do
       a1 = create(:assignment, assignment_properties_attributes: { vcs_submit: true })


### PR DESCRIPTION
This fixes a bug when creating assignments where associated object passed
as nested attributes were failing a validation (no assignment id).

I noticed this on the assignment form when attempting to create an
assignment with required files.