### PR TITLE
Git: use revision identifier when pushing to walker

### DIFF
--- a/app/lib/git_repository.rb
+++ b/app/lib/git_repository.rb
@@ -244,7 +244,7 @@ class GitRepository < Repository::AbstractRepository
     # walk through the commits and get revisions
     walker = Rugged::Walker.new(@repos)
     walker.sorting(Rugged::SORT_TOPO)
-    walker.push(last_commit)
+    walker.push(last_commit.oid)
     walker.map do |commit|
       current_reflog_entry = GitRepository.try_advance_reflog!(reflog, reflog_entries, commit)
       revision = get_revision(commit.oid)

--- a/app/lib/git_revision.rb
+++ b/app/lib/git_revision.rb
@@ -137,7 +137,7 @@ class GitRevision < Repository::AbstractRevision
     found = false
     walker = Rugged::Walker.new(@repo)
     walker.sorting(Rugged::SORT_TOPO)
-    walker.push(last_commit)
+    walker.push(last_commit.oid)
     walker.each do |commit|
       current_reflog_entry = GitRepository.try_advance_reflog!(reflog, reflog_entries, commit)
       found = true if @commit.oid == commit.oid


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), add the "WIP" label to this pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Rugged updated to version 1.0.0 (#4570) which seems to no longer support passing a revision object to the `Rugged::Walker.push` method. Now, the revision id should be passed instead.

This PR is required before #4570 can be pulled in.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- Pass the oid attribute instead of the git revision object

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ensured that tests pass with the current version of rugged as well as with version 1.0.0

## Questions (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the Changelog.md file.
- [ ] My change requires a change to the documentation (add details below).
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [ ] I have verified that the TravisCI tests have passed (check after opening pull request).
- [ ] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
