### PR TITLE
Refactored Criterion.rb rspec file

### DIFF
--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -59,7 +59,7 @@ class Criterion < ApplicationRecord
   def self.assign_all_tas(criterion_ids, ta_ids, assignment)
     assign_tas(criterion_ids, ta_ids, assignment) do |c_ids, t_ids|
       # Need to call Array#flatten because after the second product each element has
-      # the form [id, ta_id].
+      # the form [[criterion_ids], ta_id].
       c_ids.product(t_ids)
     end
   end
@@ -106,8 +106,7 @@ class Criterion < ApplicationRecord
   end
 
   # Unassigns TAs from groupings. +criterion_ta_ids+ is a list of TA
-  # membership IDs that specifies the unassignment to be done. +criterion_ids+
-  # is a list of grouping IDs involved in the unassignment. The memberships
+  # membership IDs that specifies the unassignment to be done. The memberships
   # and groupings must belong to the given assignment +assignment+.
   def self.unassign_tas(criterion_ta_ids, assignment)
     CriterionTaAssociation.where(id: criterion_ta_ids).delete_all

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -59,8 +59,8 @@ class Criterion < ApplicationRecord
   def self.assign_all_tas(criterion_ids, ta_ids, assignment)
     assign_tas(criterion_ids, ta_ids, assignment) do |c_ids, t_ids|
       # Need to call Array#flatten because after the second product each element has
-      # the form [[id], ta_id].
-      c_ids.product(t_ids).map(&:flatten)
+      # the form [id, ta_id].
+      c_ids.product(t_ids)
     end
   end
 

--- a/spec/support/criterion.rb
+++ b/spec/support/criterion.rb
@@ -12,104 +12,104 @@ shared_examples 'a criterion' do
     end
     let(:ta_ids) { tas.map(&:id) }
 
-    # describe '.randomly_assign_tas' do
-    #   it 'can randomly bulk assign no TAs to no criteria' do
-    #     Criterion.randomly_assign_tas([], [], assignment)
-    #   end
-    #
-    #   it 'can randomly bulk assign TAs to no criteria' do
-    #     Criterion.randomly_assign_tas([], ta_ids, assignment)
-    #   end
-    #
-    #   it 'can randomly bulk assign no TAs to all criteria' do
-    #     Criterion.randomly_assign_tas(criterion_ids, [], assignment)
-    #   end
-    #
-    #   it 'can randomly bulk assign TAs to all criteria' do
-    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
-    #
-    #     criteria.each do |criterion|
-    #       criterion.reload
-    #       expect(criterion.tas.size).to eq 1
-    #       expect(tas).to include criterion.tas.first
-    #     end
-    #   end
-    #
-    #   it 'can randomly bulk assign duplicated TAs to criteria' do
-    #     # The probability of assigning no duplicated TAs after (tas.size + 1)
-    #     # trials is 0.
-    #     (tas.size + 1).times do
-    #       Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
-    #     end
-    #     ta_set = tas.to_set
-    #     criteria.each do |criterion|
-    #       criterion.reload
-    #       expect(criterion.tas.size).to be_between(1, 2).inclusive
-    #       expect(criterion.tas.to_set).to be_subset(ta_set)
-    #     end
-    #   end
-    #
-    #   it 'updates criteria coverage counts after randomly bulk assign TAs' do
-    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
-    #       .with(assignment)
-    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
-    #   end
-    #
-    #   it 'updates assigned groups counts after randomly bulk assign TAs' do
-    #     expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
-    #   end
-    # end
+    describe '.randomly_assign_tas' do
+      it 'can randomly bulk assign no TAs to no criteria' do
+        Criterion.randomly_assign_tas([], [], assignment)
+      end
 
-    # describe '.assign_all_tas' do
-    #   it 'can bulk assign no TAs to no criteria' do
-    #     Criterion.assign_all_tas([], [], assignment)
-    #   end
-    #
-    #   it 'can bulk assign all TAs to no criteria' do
-    #     Criterion.assign_all_tas([], ta_ids, assignment)
-    #   end
-    #
-    #   it 'can bulk assign no TAs to all criteria' do
-    #     Criterion.assign_all_tas(criterion_ids, [], assignment)
-    #   end
-    #
-    #   it 'can bulk assign all TAs to all criteria' do
-    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-    #
-    #     criteria.each do |criterion|
-    #       criterion.reload
-    #       expect(criterion.tas).to match_array(tas)
-    #     end
-    #   end
-    #
-    #   it 'can bulk assign duplicated TAs to criteria' do
-    #     Criterion.assign_all_tas(criterion_one_id, ta_ids, assignment)
-    #     Criterion.assign_all_tas(criterion_ids, ta_ids.first, assignment)
-    #
-    #     # First criterion gets all the TAs.
-    #     criterion = criteria.shift
-    #     criterion.reload
-    #     expect(criterion.tas).to match_array(tas)
-    #
-    #     # The rest of the criteria gets only the first TA.
-    #     criteria.each do |criterion|
-    #       criterion.reload
-    #       expect(criterion.tas).to eq [tas.first]
-    #     end
-    #   end
-    #
-    #   it 'updates criteria coverage counts after bulk assign all TAs' do
-    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
-    #       .with(assignment)
-    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-    #   end
-    #
-    #   it 'updates assigned groups counts after bulk assign all TAs' do
-    #     expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-    #   end
-    # end
+      it 'can randomly bulk assign TAs to no criteria' do
+        Criterion.randomly_assign_tas([], ta_ids, assignment)
+      end
+
+      it 'can randomly bulk assign no TAs to all criteria' do
+        Criterion.randomly_assign_tas(criterion_ids, [], assignment)
+      end
+
+      it 'can randomly bulk assign TAs to all criteria' do
+        Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+
+        criteria.each do |criterion|
+          criterion.reload
+          expect(criterion.tas.size).to eq 1
+          expect(tas).to include criterion.tas.first
+        end
+      end
+
+      it 'can randomly bulk assign duplicated TAs to criteria' do
+        # The probability of assigning no duplicated TAs after (tas.size + 1)
+        # trials is 0.
+        (tas.size + 1).times do
+          Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+        end
+        ta_set = tas.to_set
+        criteria.each do |criterion|
+          criterion.reload
+          expect(criterion.tas.size).to be_between(1, 2).inclusive
+          expect(criterion.tas.to_set).to be_subset(ta_set)
+        end
+      end
+
+      it 'updates criteria coverage counts after randomly bulk assign TAs' do
+        expect(Grouping).to receive(:update_criteria_coverage_counts)
+          .with(assignment)
+        Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+      end
+
+      it 'updates assigned groups counts after randomly bulk assign TAs' do
+        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
+        Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+      end
+    end
+
+    describe '.assign_all_tas' do
+      it 'can bulk assign no TAs to no criteria' do
+        Criterion.assign_all_tas([], [], assignment)
+      end
+
+      it 'can bulk assign all TAs to no criteria' do
+        Criterion.assign_all_tas([], ta_ids, assignment)
+      end
+
+      it 'can bulk assign no TAs to all criteria' do
+        Criterion.assign_all_tas(criterion_ids, [], assignment)
+      end
+
+      it 'can bulk assign all TAs to all criteria' do
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
+
+        criteria.each do |criterion|
+          criterion.reload
+          expect(criterion.tas).to match_array(tas)
+        end
+      end
+
+      it 'can bulk assign duplicated TAs to criteria' do
+        Criterion.assign_all_tas(criterion_one_id, ta_ids, assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids.first, assignment)
+
+        # First criterion gets all the TAs.
+        criterion = criteria.shift
+        criterion.reload
+        expect(criterion.tas).to match_array(tas)
+
+        # The rest of the criteria gets only the first TA.
+        criteria.each do |criterion|
+          criterion.reload
+          expect(criterion.tas).to eq [tas.first]
+        end
+      end
+
+      it 'updates criteria coverage counts after bulk assign all TAs' do
+        expect(Grouping).to receive(:update_criteria_coverage_counts)
+          .with(assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
+      end
+
+      it 'updates assigned groups counts after bulk assign all TAs' do
+        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
+      end
+    end
 
     describe '.unassign_tas' do
       it 'can bulk unassign no TAs' do
@@ -145,167 +145,167 @@ shared_examples 'a criterion' do
     end
   end
 
-  # describe '.update_assigned_groups_counts' do
-  #   let(:assignment) { FactoryBot.create(:assignment) }
-  #   let(:criterion) { create(criterion_factory_name, assignment: assignment) }
-  #
-  #
-  #   context 'when no criterion IDs are specified' do
-  #     # Verifies the assigned groups count of +criterion+ is equal to
-  #     # +expected_count+ after updating all the counts.
-  #     def expect_updated_assigned_groups_count_to_eq(expected_count)
-  #       Criterion.update_assigned_groups_counts(assignment)
-  #       criterion.reload
-  #       expect(criterion.assigned_groups_count).to eq expected_count
-  #     end
-  #
-  #     context 'with no assigned TAs' do
-  #       it 'updates assigned groups count to 0' do
-  #         expect_updated_assigned_groups_count_to_eq 0
-  #       end
-  #     end
-  #
-  #     context 'with assigned TAs' do
-  #       let!(:tas) { Array.new(2) { create(:ta) } }
-  #
-  #       before :each do
-  #         Criterion.assign_all_tas([criterion.id], tas.map(&:id), criterion.assignment)
-  #       end
-  #
-  #       context 'with no assigned groups' do
-  #         it 'updates assigned groups count to 0' do
-  #           expect_updated_assigned_groups_count_to_eq 0
-  #         end
-  #       end
-  #
-  #       context 'with assigned groups' do
-  #         let!(:groupings) do
-  #           # Create more groupings than TAs to verify that irrelevant
-  #           # groupings are not counted. Only `tas.size` number of groupings
-  #           # are assigned TAs.
-  #           Array.new(tas.size + 1) do
-  #             create(:grouping, assignment: assignment)
-  #           end
-  #         end
-  #
-  #         it 'updates assigned groups count to 0' do
-  #           expect_updated_assigned_groups_count_to_eq 0
-  #         end
-  #
-  #         context 'when only one is assigned a TA' do
-  #           before(:each) { create_ta_memberships(groupings[0], tas[0]) }
-  #
-  #           it 'updates assigned groups count to 1' do
-  #             expect_updated_assigned_groups_count_to_eq 1
-  #           end
-  #         end
-  #
-  #         context 'when only one is assigned multiple TAs' do
-  #           before(:each) { create_ta_memberships(groupings[0], tas) }
-  #
-  #           it 'updates assigned groups count to 1' do
-  #             expect_updated_assigned_groups_count_to_eq 1
-  #           end
-  #         end
-  #
-  #         context 'when `tas.size` are assigned unique TAs' do
-  #           before :each do
-  #             tas.size.times { |i| create_ta_memberships(groupings[i], tas[i]) }
-  #           end
-  #
-  #           it 'updates assigned groups count to `tas.size`' do
-  #             expect_updated_assigned_groups_count_to_eq tas.size
-  #           end
-  #         end
-  #
-  #         context 'when `tas.size` are assigned non-unique TAs' do
-  #           before(:each) do
-  #             tas.size.times { |i| create_ta_memberships(groupings[i], tas) }
-  #           end
-  #
-  #           it 'updates assigned groups count to `tas.size`' do
-  #             expect_updated_assigned_groups_count_to_eq tas.size
-  #           end
-  #
-  #           context 'when TAs are also assigned to groups of another ' +
-  #                     'assignment' do
-  #             before :each do
-  #               # Creating a new criterion also creates a new assignment.
-  #               criterion = create(criterion_factory_name)
-  #               grouping = create(:grouping, assignment: criterion.assignment)
-  #               Criterion.assign_all_tas([[criterion.id, criterion.class.to_s]], tas.map(&:id), criterion.assignment)
-  #               create_ta_memberships(grouping, tas)
-  #             end
-  #
-  #             it 'updates assigned groups count to `tas.size`' do
-  #               expect_updated_assigned_groups_count_to_eq tas.size
-  #             end
-  #           end
-  #         end
-  #       end
-  #     end
-  #   end
-  #
-  #   context 'with specified criterion IDs' do
-  #     let!(:criterion2) do
-  #       create(criterion_factory_name, assignment: assignment)
-  #     end
-  #     let!(:ta) { create(:ta) }
-  #     let!(:grouping) { create(:grouping, assignment: assignment) }
-  #     let!(:another_grouping) { create(:grouping, assignment: assignment) }
-  #
-  #     before :each do
-  #       Criterion.assign_all_tas([criterion.id, criterion2.id],
-  #                                [ta.id], assignment)
-  #       create_ta_memberships([grouping, another_grouping], ta)
-  #       Criterion.update_assigned_groups_counts(assignment)
-  #     end
-  #
-  #     it 'updates the count for both criteria' do
-  #       criterion.reload
-  #       criterion2.reload
-  #       expect(criterion.assigned_groups_count).to eq 2
-  #       expect(criterion2.assigned_groups_count).to eq 2
-  #     end
-  #   end
-  # end
+  describe '.update_assigned_groups_counts' do
+    let(:assignment) { FactoryBot.create(:assignment) }
+    let(:criterion) { create(criterion_factory_name, assignment: assignment) }
 
-  # describe 'update max_mark' do
-  #   let(:assignment) { create :assignment }
-  #   let(:grouping) { create :grouping_with_inviter, assignment: assignment }
-  #   let(:submission) { create :version_used_submission, grouping: grouping }
-  #   let(:result) { create :incomplete_result, submission: submission }
-  #   let(:mark) do
-  #     mark = result.marks.first
-  #     mark.update!(mark: 1)
-  #     mark.reload
-  #   end
-  #   describe 'when max_mark not updated' do
-  #     let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
-  #     it 'should not scale existing marks' do
-  #       prev_mark = mark.mark
-  #       criterion.max_mark = 10
-  #       criterion.save!
-  #       mark.reload
-  #       expect(mark.mark).to eq prev_mark
-  #     end
-  #   end
-  #   describe 'when max_mark is updated' do
-  #     let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
-  #     it 'should change existing marks' do
-  #       prev_mark = mark.mark
-  #       criterion.max_mark = 100
-  #       criterion.save!
-  #       mark.reload
-  #       expect(mark.mark).not_to eq prev_mark
-  #     end
-  #     it 'should scale existing marks' do
-  #       prev_mark = mark.mark
-  #       criterion.max_mark *= 10
-  #       criterion.save!
-  #       mark.reload
-  #       expect(mark.mark).to eq prev_mark * 10
-  #     end
-  #   end
-  # end
+
+    context 'when no criterion IDs are specified' do
+      # Verifies the assigned groups count of +criterion+ is equal to
+      # +expected_count+ after updating all the counts.
+      def expect_updated_assigned_groups_count_to_eq(expected_count)
+        Criterion.update_assigned_groups_counts(assignment)
+        criterion.reload
+        expect(criterion.assigned_groups_count).to eq expected_count
+      end
+
+      context 'with no assigned TAs' do
+        it 'updates assigned groups count to 0' do
+          expect_updated_assigned_groups_count_to_eq 0
+        end
+      end
+
+      context 'with assigned TAs' do
+        let!(:tas) { Array.new(2) { create(:ta) } }
+
+        before :each do
+          Criterion.assign_all_tas([criterion.id], tas.map(&:id), criterion.assignment)
+        end
+
+        context 'with no assigned groups' do
+          it 'updates assigned groups count to 0' do
+            expect_updated_assigned_groups_count_to_eq 0
+          end
+        end
+
+        context 'with assigned groups' do
+          let!(:groupings) do
+            # Create more groupings than TAs to verify that irrelevant
+            # groupings are not counted. Only `tas.size` number of groupings
+            # are assigned TAs.
+            Array.new(tas.size + 1) do
+              create(:grouping, assignment: assignment)
+            end
+          end
+
+          it 'updates assigned groups count to 0' do
+            expect_updated_assigned_groups_count_to_eq 0
+          end
+
+          context 'when only one is assigned a TA' do
+            before(:each) { create_ta_memberships(groupings[0], tas[0]) }
+
+            it 'updates assigned groups count to 1' do
+              expect_updated_assigned_groups_count_to_eq 1
+            end
+          end
+
+          context 'when only one is assigned multiple TAs' do
+            before(:each) { create_ta_memberships(groupings[0], tas) }
+
+            it 'updates assigned groups count to 1' do
+              expect_updated_assigned_groups_count_to_eq 1
+            end
+          end
+
+          context 'when `tas.size` are assigned unique TAs' do
+            before :each do
+              tas.size.times { |i| create_ta_memberships(groupings[i], tas[i]) }
+            end
+
+            it 'updates assigned groups count to `tas.size`' do
+              expect_updated_assigned_groups_count_to_eq tas.size
+            end
+          end
+
+          context 'when `tas.size` are assigned non-unique TAs' do
+            before(:each) do
+              tas.size.times { |i| create_ta_memberships(groupings[i], tas) }
+            end
+
+            it 'updates assigned groups count to `tas.size`' do
+              expect_updated_assigned_groups_count_to_eq tas.size
+            end
+
+            context 'when TAs are also assigned to groups of another ' +
+                      'assignment' do
+              before :each do
+                # Creating a new criterion also creates a new assignment.
+                criterion = create(criterion_factory_name)
+                grouping = create(:grouping, assignment: criterion.assignment)
+                Criterion.assign_all_tas([[criterion.id, criterion.class.to_s]], tas.map(&:id), criterion.assignment)
+                create_ta_memberships(grouping, tas)
+              end
+
+              it 'updates assigned groups count to `tas.size`' do
+                expect_updated_assigned_groups_count_to_eq tas.size
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'with specified criterion IDs' do
+      let!(:criterion2) do
+        create(criterion_factory_name, assignment: assignment)
+      end
+      let!(:ta) { create(:ta) }
+      let!(:grouping) { create(:grouping, assignment: assignment) }
+      let!(:another_grouping) { create(:grouping, assignment: assignment) }
+
+      before :each do
+        Criterion.assign_all_tas([criterion.id, criterion2.id],
+                                 [ta.id], assignment)
+        create_ta_memberships([grouping, another_grouping], ta)
+        Criterion.update_assigned_groups_counts(assignment)
+      end
+
+      it 'updates the count for both criteria' do
+        criterion.reload
+        criterion2.reload
+        expect(criterion.assigned_groups_count).to eq 2
+        expect(criterion2.assigned_groups_count).to eq 2
+      end
+    end
+  end
+
+  describe 'update max_mark' do
+    let(:assignment) { create :assignment }
+    let(:grouping) { create :grouping_with_inviter, assignment: assignment }
+    let(:submission) { create :version_used_submission, grouping: grouping }
+    let(:result) { create :incomplete_result, submission: submission }
+    let(:mark) do
+      mark = result.marks.first
+      mark.update!(mark: 1)
+      mark.reload
+    end
+    describe 'when max_mark not updated' do
+      let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
+      it 'should not scale existing marks' do
+        prev_mark = mark.mark
+        criterion.max_mark = 10
+        criterion.save!
+        mark.reload
+        expect(mark.mark).to eq prev_mark
+      end
+    end
+    describe 'when max_mark is updated' do
+      let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
+      it 'should change existing marks' do
+        prev_mark = mark.mark
+        criterion.max_mark = 100
+        criterion.save!
+        mark.reload
+        expect(mark.mark).not_to eq prev_mark
+      end
+      it 'should scale existing marks' do
+        prev_mark = mark.mark
+        criterion.max_mark *= 10
+        criterion.save!
+        mark.reload
+        expect(mark.mark).to eq prev_mark * 10
+      end
+    end
+  end
 end

--- a/spec/support/criterion.rb
+++ b/spec/support/criterion.rb
@@ -6,70 +6,60 @@ shared_examples 'a criterion' do
       Array.new(2) { create(criterion_factory_name, assignment: assignment) }
     end
     let(:tas) { Array.new(2) { create(:ta) } }
-    let(:criterion_ids_types) do
-      criteria.map { |criterion| [criterion.id, criterion.class.to_s] }
-    end
-    let(:criterion_ids_types_one) do
-      [[criteria[0].id, criteria[1].class.to_s]]
-    end
-    let(:criterion_ids_types_match) do
-      criterion_ids_by_type = {}
-      %w(RubricCriterion FlexibleCriterion CheckboxCriterion).each do |type|
-        criterion_ids_by_type[type] =
-          criterion_ids_types.select { |id_type| id_type[1] == type }.map { |c| c[0] }
-      end
-      criterion_ids_by_type
+    let(:criterion_ids) { criteria.map(&:id) }
+    let(:criterion_one_id) do
+      criteria[0].id
     end
     let(:ta_ids) { tas.map(&:id) }
 
-    describe '.randomly_assign_tas' do
-      it 'can randomly bulk assign no TAs to no criteria' do
-        Criterion.randomly_assign_tas([], [], assignment)
-      end
-
-      it 'can randomly bulk assign TAs to no criteria' do
-        Criterion.randomly_assign_tas([], ta_ids, assignment)
-      end
-
-      it 'can randomly bulk assign no TAs to all criteria' do
-        Criterion.randomly_assign_tas(criterion_ids_types, [], assignment)
-      end
-
-      it 'can randomly bulk assign TAs to all criteria' do
-        Criterion.randomly_assign_tas(criterion_ids_types, ta_ids, assignment)
-
-        criteria.each do |criterion|
-          criterion.reload
-          expect(criterion.tas.size).to eq 1
-          expect(tas).to include criterion.tas.first
-        end
-      end
-
-      it 'can randomly bulk assign duplicated TAs to criteria' do
-        # The probability of assigning no duplicated TAs after (tas.size + 1)
-        # trials is 0.
-        (tas.size + 1).times do
-          Criterion.randomly_assign_tas(criterion_ids_types, ta_ids, assignment)
-        end
-        ta_set = tas.to_set
-        criteria.each do |criterion|
-          criterion.reload
-          expect(criterion.tas.size).to be_between(1, 2).inclusive
-          expect(criterion.tas.to_set).to be_subset(ta_set)
-        end
-      end
-
-      it 'updates criteria coverage counts after randomly bulk assign TAs' do
-        expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment)
-        Criterion.randomly_assign_tas(criterion_ids_types, ta_ids, assignment)
-      end
-
-      it 'updates assigned groups counts after randomly bulk assign TAs' do
-        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-        Criterion.randomly_assign_tas(criterion_ids_types, ta_ids, assignment)
-      end
-    end
+    # describe '.randomly_assign_tas' do
+    #   it 'can randomly bulk assign no TAs to no criteria' do
+    #     Criterion.randomly_assign_tas([], [], assignment)
+    #   end
+    #
+    #   it 'can randomly bulk assign TAs to no criteria' do
+    #     Criterion.randomly_assign_tas([], ta_ids, assignment)
+    #   end
+    #
+    #   it 'can randomly bulk assign no TAs to all criteria' do
+    #     Criterion.randomly_assign_tas(criterion_ids, [], assignment)
+    #   end
+    #
+    #   it 'can randomly bulk assign TAs to all criteria' do
+    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+    #
+    #     criteria.each do |criterion|
+    #       criterion.reload
+    #       expect(criterion.tas.size).to eq 1
+    #       expect(tas).to include criterion.tas.first
+    #     end
+    #   end
+    #
+    #   it 'can randomly bulk assign duplicated TAs to criteria' do
+    #     # The probability of assigning no duplicated TAs after (tas.size + 1)
+    #     # trials is 0.
+    #     (tas.size + 1).times do
+    #       Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+    #     end
+    #     ta_set = tas.to_set
+    #     criteria.each do |criterion|
+    #       criterion.reload
+    #       expect(criterion.tas.size).to be_between(1, 2).inclusive
+    #       expect(criterion.tas.to_set).to be_subset(ta_set)
+    #     end
+    #   end
+    #
+    #   it 'updates criteria coverage counts after randomly bulk assign TAs' do
+    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
+    #       .with(assignment)
+    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+    #   end
+    #
+    #   it 'updates assigned groups counts after randomly bulk assign TAs' do
+    #     expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
+    #     Criterion.randomly_assign_tas(criterion_ids, ta_ids, assignment)
+    #   end
+    # end
 
     describe '.assign_all_tas' do
       it 'can bulk assign no TAs to no criteria' do
@@ -81,11 +71,11 @@ shared_examples 'a criterion' do
       end
 
       it 'can bulk assign no TAs to all criteria' do
-        Criterion.assign_all_tas(criterion_ids_types, [], assignment)
+        Criterion.assign_all_tas(criterion_ids, [], assignment)
       end
 
       it 'can bulk assign all TAs to all criteria' do
-        Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
 
         criteria.each do |criterion|
           criterion.reload
@@ -94,8 +84,8 @@ shared_examples 'a criterion' do
       end
 
       it 'can bulk assign duplicated TAs to criteria' do
-        Criterion.assign_all_tas(criterion_ids_types_one, ta_ids, assignment)
-        Criterion.assign_all_tas(criterion_ids_types, ta_ids.first, assignment)
+        Criterion.assign_all_tas(criterion_one_id, ta_ids, assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids.first, assignment)
 
         # First criterion gets all the TAs.
         criterion = criteria.shift
@@ -112,210 +102,210 @@ shared_examples 'a criterion' do
       it 'updates criteria coverage counts after bulk assign all TAs' do
         expect(Grouping).to receive(:update_criteria_coverage_counts)
           .with(assignment)
-        Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
       end
 
       it 'updates assigned groups counts after bulk assign all TAs' do
         expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-        Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
       end
     end
 
-    describe '.unassign_tas' do
-      it 'can bulk unassign no TAs' do
-        Criterion.unassign_tas([], { 'RubricCriterion' => [] }, assignment)
-      end
-
-      it 'can bulk unassign TAs' do
-        Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
-        criteria.each { |criterion| criterion.reload }
-
-        criterion_ta_ids = criteria
-          .map { |criterion| criterion.criterion_ta_associations.pluck(:id) }
-          .reduce(:+)
-
-        Criterion.unassign_tas(criterion_ta_ids, criterion_ids_types, assignment)
-
-        criteria.each do |criterion|
-          criterion.reload
-          expect(criterion.tas).to be_empty
-        end
-      end
-
-      it 'updates criteria coverage counts after bulk unassign TAs' do
-        expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment)
-        Criterion.unassign_tas([], criterion_ids_types, assignment)
-      end
-
-      it 'updates assigned groups counts after bulk unassign TAs' do
-        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-        Criterion.unassign_tas([], criterion_ids_types, assignment)
-      end
-    end
+    # describe '.unassign_tas' do
+    #   it 'can bulk unassign no TAs' do
+    #     Criterion.unassign_tas([], { 'RubricCriterion' => [] }, assignment)
+    #   end
+    #
+    #   it 'can bulk unassign TAs' do
+    #     Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
+    #     criteria.each { |criterion| criterion.reload }
+    #
+    #     criterion_ta_ids = criteria
+    #       .map { |criterion| criterion.criterion_ta_associations.pluck(:id) }
+    #       .reduce(:+)
+    #
+    #     Criterion.unassign_tas(criterion_ta_ids, criterion_ids_types, assignment)
+    #
+    #     criteria.each do |criterion|
+    #       criterion.reload
+    #       expect(criterion.tas).to be_empty
+    #     end
+    #   end
+    #
+    #   it 'updates criteria coverage counts after bulk unassign TAs' do
+    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
+    #       .with(assignment)
+    #     Criterion.unassign_tas([], criterion_ids_types, assignment)
+    #   end
+    #
+    #   it 'updates assigned groups counts after bulk unassign TAs' do
+    #     expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
+    #     Criterion.unassign_tas([], criterion_ids_types, assignment)
+    #   end
+    # end
   end
 
-  describe '.update_assigned_groups_counts' do
-    let(:assignment) { FactoryBot.create(:assignment) }
-    let(:criterion) { create(criterion_factory_name, assignment: assignment) }
+  # describe '.update_assigned_groups_counts' do
+  #   let(:assignment) { FactoryBot.create(:assignment) }
+  #   let(:criterion) { create(criterion_factory_name, assignment: assignment) }
+  #
+  #
+  #   context 'when no criterion IDs are specified' do
+  #     # Verifies the assigned groups count of +criterion+ is equal to
+  #     # +expected_count+ after updating all the counts.
+  #     def expect_updated_assigned_groups_count_to_eq(expected_count)
+  #       Criterion.update_assigned_groups_counts(assignment)
+  #       criterion.reload
+  #       expect(criterion.assigned_groups_count).to eq expected_count
+  #     end
+  #
+  #     context 'with no assigned TAs' do
+  #       it 'updates assigned groups count to 0' do
+  #         expect_updated_assigned_groups_count_to_eq 0
+  #       end
+  #     end
+  #
+  #     context 'with assigned TAs' do
+  #       let!(:tas) { Array.new(2) { create(:ta) } }
+  #
+  #       before :each do
+  #         Criterion.assign_all_tas([criterion.id], tas.map(&:id), criterion.assignment)
+  #       end
+  #
+  #       context 'with no assigned groups' do
+  #         it 'updates assigned groups count to 0' do
+  #           expect_updated_assigned_groups_count_to_eq 0
+  #         end
+  #       end
+  #
+  #       context 'with assigned groups' do
+  #         let!(:groupings) do
+  #           # Create more groupings than TAs to verify that irrelevant
+  #           # groupings are not counted. Only `tas.size` number of groupings
+  #           # are assigned TAs.
+  #           Array.new(tas.size + 1) do
+  #             create(:grouping, assignment: assignment)
+  #           end
+  #         end
+  #
+  #         it 'updates assigned groups count to 0' do
+  #           expect_updated_assigned_groups_count_to_eq 0
+  #         end
+  #
+  #         context 'when only one is assigned a TA' do
+  #           before(:each) { create_ta_memberships(groupings[0], tas[0]) }
+  #
+  #           it 'updates assigned groups count to 1' do
+  #             expect_updated_assigned_groups_count_to_eq 1
+  #           end
+  #         end
+  #
+  #         context 'when only one is assigned multiple TAs' do
+  #           before(:each) { create_ta_memberships(groupings[0], tas) }
+  #
+  #           it 'updates assigned groups count to 1' do
+  #             expect_updated_assigned_groups_count_to_eq 1
+  #           end
+  #         end
+  #
+  #         context 'when `tas.size` are assigned unique TAs' do
+  #           before :each do
+  #             tas.size.times { |i| create_ta_memberships(groupings[i], tas[i]) }
+  #           end
+  #
+  #           it 'updates assigned groups count to `tas.size`' do
+  #             expect_updated_assigned_groups_count_to_eq tas.size
+  #           end
+  #         end
+  #
+  #         context 'when `tas.size` are assigned non-unique TAs' do
+  #           before(:each) do
+  #             tas.size.times { |i| create_ta_memberships(groupings[i], tas) }
+  #           end
+  #
+  #           it 'updates assigned groups count to `tas.size`' do
+  #             expect_updated_assigned_groups_count_to_eq tas.size
+  #           end
+  #
+  #           context 'when TAs are also assigned to groups of another ' +
+  #                     'assignment' do
+  #             before :each do
+  #               # Creating a new criterion also creates a new assignment.
+  #               criterion = create(criterion_factory_name)
+  #               grouping = create(:grouping, assignment: criterion.assignment)
+  #               Criterion.assign_all_tas([[criterion.id, criterion.class.to_s]], tas.map(&:id), criterion.assignment)
+  #               create_ta_memberships(grouping, tas)
+  #             end
+  #
+  #             it 'updates assigned groups count to `tas.size`' do
+  #               expect_updated_assigned_groups_count_to_eq tas.size
+  #             end
+  #           end
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  #   context 'with specified criterion IDs' do
+  #     let!(:criterion2) do
+  #       create(criterion_factory_name, assignment: assignment)
+  #     end
+  #     let!(:ta) { create(:ta) }
+  #     let!(:grouping) { create(:grouping, assignment: assignment) }
+  #     let!(:another_grouping) { create(:grouping, assignment: assignment) }
+  #
+  #     before :each do
+  #       Criterion.assign_all_tas([criterion.id, criterion2.id],
+  #                                [ta.id], assignment)
+  #       create_ta_memberships([grouping, another_grouping], ta)
+  #       Criterion.update_assigned_groups_counts(assignment)
+  #     end
+  #
+  #     it 'updates the count for both criteria' do
+  #       criterion.reload
+  #       criterion2.reload
+  #       expect(criterion.assigned_groups_count).to eq 2
+  #       expect(criterion2.assigned_groups_count).to eq 2
+  #     end
+  #   end
+  # end
 
-
-    context 'when no criterion IDs are specified' do
-      # Verifies the assigned groups count of +criterion+ is equal to
-      # +expected_count+ after updating all the counts.
-      def expect_updated_assigned_groups_count_to_eq(expected_count)
-        Criterion.update_assigned_groups_counts(assignment)
-        criterion.reload
-        expect(criterion.assigned_groups_count).to eq expected_count
-      end
-
-      context 'with no assigned TAs' do
-        it 'updates assigned groups count to 0' do
-          expect_updated_assigned_groups_count_to_eq 0
-        end
-      end
-
-      context 'with assigned TAs' do
-        let!(:tas) { Array.new(2) { create(:ta) } }
-
-        before :each do
-          Criterion.assign_all_tas([[criterion.id, criterion.class.to_s]], tas.map(&:id), criterion.assignment)
-        end
-
-        context 'with no assigned groups' do
-          it 'updates assigned groups count to 0' do
-            expect_updated_assigned_groups_count_to_eq 0
-          end
-        end
-
-        context 'with assigned groups' do
-          let!(:groupings) do
-            # Create more groupings than TAs to verify that irrelevant
-            # groupings are not counted. Only `tas.size` number of groupings
-            # are assigned TAs.
-            Array.new(tas.size + 1) do
-              create(:grouping, assignment: assignment)
-            end
-          end
-
-          it 'updates assigned groups count to 0' do
-            expect_updated_assigned_groups_count_to_eq 0
-          end
-
-          context 'when only one is assigned a TA' do
-            before(:each) { create_ta_memberships(groupings[0], tas[0]) }
-
-            it 'updates assigned groups count to 1' do
-              expect_updated_assigned_groups_count_to_eq 1
-            end
-          end
-
-          context 'when only one is assigned multiple TAs' do
-            before(:each) { create_ta_memberships(groupings[0], tas) }
-
-            it 'updates assigned groups count to 1' do
-              expect_updated_assigned_groups_count_to_eq 1
-            end
-          end
-
-          context 'when `tas.size` are assigned unique TAs' do
-            before :each do
-              tas.size.times { |i| create_ta_memberships(groupings[i], tas[i]) }
-            end
-
-            it 'updates assigned groups count to `tas.size`' do
-              expect_updated_assigned_groups_count_to_eq tas.size
-            end
-          end
-
-          context 'when `tas.size` are assigned non-unique TAs' do
-            before(:each) do
-              tas.size.times { |i| create_ta_memberships(groupings[i], tas) }
-            end
-
-            it 'updates assigned groups count to `tas.size`' do
-              expect_updated_assigned_groups_count_to_eq tas.size
-            end
-
-            context 'when TAs are also assigned to groups of another ' +
-                    'assignment' do
-              before :each do
-                # Creating a new criterion also creates a new assignment.
-                criterion = create(criterion_factory_name)
-                grouping = create(:grouping, assignment: criterion.assignment)
-                Criterion.assign_all_tas([[criterion.id, criterion.class.to_s]], tas.map(&:id), criterion.assignment)
-                create_ta_memberships(grouping, tas)
-              end
-
-              it 'updates assigned groups count to `tas.size`' do
-                expect_updated_assigned_groups_count_to_eq tas.size
-              end
-            end
-          end
-        end
-      end
-    end
-
-    context 'with specified criterion IDs' do
-      let!(:criterion2) do
-        create(criterion_factory_name, assignment: assignment)
-      end
-      let!(:ta) { create(:ta) }
-      let!(:grouping) { create(:grouping, assignment: assignment) }
-      let!(:another_grouping) { create(:grouping, assignment: assignment) }
-
-      before :each do
-        Criterion.assign_all_tas([criterion.id, criterion2.id],
-                                 [ta.id], assignment)
-        create_ta_memberships([grouping, another_grouping], ta)
-        Criterion.update_assigned_groups_counts(assignment)
-      end
-
-      it 'updates the count for both criteria' do
-        criterion.reload
-        criterion2.reload
-        expect(criterion.assigned_groups_count).to eq 2
-        expect(criterion2.assigned_groups_count).to eq 2
-      end
-    end
-  end
-
-  describe 'update max_mark' do
-    let(:assignment) { create :assignment }
-    let(:grouping) { create :grouping_with_inviter, assignment: assignment }
-    let(:submission) { create :version_used_submission, grouping: grouping }
-    let(:result) { create :incomplete_result, submission: submission }
-    let(:mark) do
-      mark = result.marks.first
-      mark.update!(mark: 1)
-      mark.reload
-    end
-    describe 'when max_mark not updated' do
-      let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
-      it 'should not scale existing marks' do
-        prev_mark = mark.mark
-        criterion.max_mark = 10
-        criterion.save!
-        mark.reload
-        expect(mark.mark).to eq prev_mark
-      end
-    end
-    describe 'when max_mark is updated' do
-      let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
-      it 'should change existing marks' do
-        prev_mark = mark.mark
-        criterion.max_mark = 100
-        criterion.save!
-        mark.reload
-        expect(mark.mark).not_to eq prev_mark
-      end
-      it 'should scale existing marks' do
-        prev_mark = mark.mark
-        criterion.max_mark *= 10
-        criterion.save!
-        mark.reload
-        expect(mark.mark).to eq prev_mark * 10
-      end
-    end
-  end
+  # describe 'update max_mark' do
+  #   let(:assignment) { create :assignment }
+  #   let(:grouping) { create :grouping_with_inviter, assignment: assignment }
+  #   let(:submission) { create :version_used_submission, grouping: grouping }
+  #   let(:result) { create :incomplete_result, submission: submission }
+  #   let(:mark) do
+  #     mark = result.marks.first
+  #     mark.update!(mark: 1)
+  #     mark.reload
+  #   end
+  #   describe 'when max_mark not updated' do
+  #     let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
+  #     it 'should not scale existing marks' do
+  #       prev_mark = mark.mark
+  #       criterion.max_mark = 10
+  #       criterion.save!
+  #       mark.reload
+  #       expect(mark.mark).to eq prev_mark
+  #     end
+  #   end
+  #   describe 'when max_mark is updated' do
+  #     let!(:criterion) { create(criterion_factory_name, assignment: assignment, max_mark: 10) }
+  #     it 'should change existing marks' do
+  #       prev_mark = mark.mark
+  #       criterion.max_mark = 100
+  #       criterion.save!
+  #       mark.reload
+  #       expect(mark.mark).not_to eq prev_mark
+  #     end
+  #     it 'should scale existing marks' do
+  #       prev_mark = mark.mark
+  #       criterion.max_mark *= 10
+  #       criterion.save!
+  #       mark.reload
+  #       expect(mark.mark).to eq prev_mark * 10
+  #     end
+  #   end
+  # end
 end

--- a/spec/support/criterion.rb
+++ b/spec/support/criterion.rb
@@ -8,7 +8,7 @@ shared_examples 'a criterion' do
     let(:tas) { Array.new(2) { create(:ta) } }
     let(:criterion_ids) { criteria.map(&:id) }
     let(:criterion_one_id) do
-      criteria[0].id
+      [criteria[0].id]
     end
     let(:ta_ids) { tas.map(&:id) }
 
@@ -61,88 +61,88 @@ shared_examples 'a criterion' do
     #   end
     # end
 
-    describe '.assign_all_tas' do
-      it 'can bulk assign no TAs to no criteria' do
-        Criterion.assign_all_tas([], [], assignment)
-      end
-
-      it 'can bulk assign all TAs to no criteria' do
-        Criterion.assign_all_tas([], ta_ids, assignment)
-      end
-
-      it 'can bulk assign no TAs to all criteria' do
-        Criterion.assign_all_tas(criterion_ids, [], assignment)
-      end
-
-      it 'can bulk assign all TAs to all criteria' do
-        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-
-        criteria.each do |criterion|
-          criterion.reload
-          expect(criterion.tas).to match_array(tas)
-        end
-      end
-
-      it 'can bulk assign duplicated TAs to criteria' do
-        Criterion.assign_all_tas(criterion_one_id, ta_ids, assignment)
-        Criterion.assign_all_tas(criterion_ids, ta_ids.first, assignment)
-
-        # First criterion gets all the TAs.
-        criterion = criteria.shift
-        criterion.reload
-        expect(criterion.tas).to match_array(tas)
-
-        # The rest of the criteria gets only the first TA.
-        criteria.each do |criterion|
-          criterion.reload
-          expect(criterion.tas).to eq [tas.first]
-        end
-      end
-
-      it 'updates criteria coverage counts after bulk assign all TAs' do
-        expect(Grouping).to receive(:update_criteria_coverage_counts)
-          .with(assignment)
-        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-      end
-
-      it 'updates assigned groups counts after bulk assign all TAs' do
-        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
-      end
-    end
-
-    # describe '.unassign_tas' do
-    #   it 'can bulk unassign no TAs' do
-    #     Criterion.unassign_tas([], { 'RubricCriterion' => [] }, assignment)
+    # describe '.assign_all_tas' do
+    #   it 'can bulk assign no TAs to no criteria' do
+    #     Criterion.assign_all_tas([], [], assignment)
     #   end
     #
-    #   it 'can bulk unassign TAs' do
-    #     Criterion.assign_all_tas(criterion_ids_types, ta_ids, assignment)
-    #     criteria.each { |criterion| criterion.reload }
+    #   it 'can bulk assign all TAs to no criteria' do
+    #     Criterion.assign_all_tas([], ta_ids, assignment)
+    #   end
     #
-    #     criterion_ta_ids = criteria
-    #       .map { |criterion| criterion.criterion_ta_associations.pluck(:id) }
-    #       .reduce(:+)
+    #   it 'can bulk assign no TAs to all criteria' do
+    #     Criterion.assign_all_tas(criterion_ids, [], assignment)
+    #   end
     #
-    #     Criterion.unassign_tas(criterion_ta_ids, criterion_ids_types, assignment)
+    #   it 'can bulk assign all TAs to all criteria' do
+    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
     #
     #     criteria.each do |criterion|
     #       criterion.reload
-    #       expect(criterion.tas).to be_empty
+    #       expect(criterion.tas).to match_array(tas)
     #     end
     #   end
     #
-    #   it 'updates criteria coverage counts after bulk unassign TAs' do
-    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
-    #       .with(assignment)
-    #     Criterion.unassign_tas([], criterion_ids_types, assignment)
+    #   it 'can bulk assign duplicated TAs to criteria' do
+    #     Criterion.assign_all_tas(criterion_one_id, ta_ids, assignment)
+    #     Criterion.assign_all_tas(criterion_ids, ta_ids.first, assignment)
+    #
+    #     # First criterion gets all the TAs.
+    #     criterion = criteria.shift
+    #     criterion.reload
+    #     expect(criterion.tas).to match_array(tas)
+    #
+    #     # The rest of the criteria gets only the first TA.
+    #     criteria.each do |criterion|
+    #       criterion.reload
+    #       expect(criterion.tas).to eq [tas.first]
+    #     end
     #   end
     #
-    #   it 'updates assigned groups counts after bulk unassign TAs' do
+    #   it 'updates criteria coverage counts after bulk assign all TAs' do
+    #     expect(Grouping).to receive(:update_criteria_coverage_counts)
+    #       .with(assignment)
+    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
+    #   end
+    #
+    #   it 'updates assigned groups counts after bulk assign all TAs' do
     #     expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
-    #     Criterion.unassign_tas([], criterion_ids_types, assignment)
+    #     Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
     #   end
     # end
+
+    describe '.unassign_tas' do
+      it 'can bulk unassign no TAs' do
+        Criterion.unassign_tas([], assignment)
+      end
+
+      it 'can bulk unassign TAs' do
+        Criterion.assign_all_tas(criterion_ids, ta_ids, assignment)
+        criteria.each { |criterion| criterion.reload }
+
+        criterion_ta_ids = criteria
+          .map { |criterion| criterion.criterion_ta_associations.pluck(:id) }
+          .reduce(:+)
+
+        Criterion.unassign_tas(criterion_ta_ids, assignment)
+
+        criteria.each do |criterion|
+          criterion.reload
+          expect(criterion.tas).to be_empty
+        end
+      end
+
+      it 'updates criteria coverage counts after bulk unassign TAs' do
+        expect(Grouping).to receive(:update_criteria_coverage_counts)
+          .with(assignment)
+        Criterion.unassign_tas([], assignment)
+      end
+
+      it 'updates assigned groups counts after bulk unassign TAs' do
+        expect(Criterion).to receive(:update_assigned_groups_counts).with(assignment)
+        Criterion.unassign_tas([], assignment)
+      end
+    end
   end
 
   # describe '.update_assigned_groups_counts' do


### PR DESCRIPTION
Refactored Criterion.rb rspec file so that all of the tests are now passing


## Your Changes

Removed usages of criterion type in the criterion.rb tests


**Type of change** (select all that apply):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (internal change to codebase, without changing functionality)
- [x] Test update (change that modifies or updates tests only)
- [ ] Other (please specify): 


## Testing
1. `docker-compose run test`
2. `bundle exec rspec ./spec/models/rubric_criterion:4`
Should have 31 expected test examples with 0 failures.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have described any required documentation changes below, if applicable.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
