### PR TITLE
Additional annotation text callback

### DIFF
--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -5,6 +5,7 @@ class AnnotationText < ApplicationRecord
 
   after_update :update_mark_deductions
   before_update :check_if_released
+  before_destroy :check_if_released
 
   # An AnnotationText has many Annotations that are destroyed when an
   # AnnotationText is destroyed.
@@ -30,6 +31,7 @@ class AnnotationText < ApplicationRecord
   end
 
   def check_if_released
+    # Cannot update if any results have been released with the annotation and the deduction is non nil
     return if self.annotations.joins(:result).where('results.released_to_students' => true).empty? ||
         self.deduction.nil?
     errors.add(:base, 'Cannot update annotation text deduction once results are released.')

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -34,7 +34,7 @@ class AnnotationText < ApplicationRecord
     # Cannot update if any results have been released with the annotation and the deduction is non nil
     return if self.annotations.joins(:result).where('results.released_to_students' => true).empty? ||
         self.deduction.nil?
-    errors.add(:base, 'Cannot update annotation text deduction once results are released.')
+    errors.add(:base, 'Cannot update/destroy annotation_text once results are released.')
     throw(:abort)
   end
 

--- a/spec/models/annotation_text_spec.rb
+++ b/spec/models/annotation_text_spec.rb
@@ -76,8 +76,17 @@ describe AnnotationText do
       expect(deductive_text.update(content: 'Do not plagiarize!')).to be(false)
     end
 
-    it 'does not prevent an update of content if any results are released and there is no deduction' do
+    it 'do not prevent an update of content if any results are released and there is no deduction' do
       expect(deductive_text.update(content: 'Do not plagiarize!')).to be(true)
+    end
+
+    it 'prevent a destruction of the annotation_text if any results are released and there is a deduction value' do
+      assignment.groupings.first.current_result.update!(released_to_students: true)
+      expect(deductive_text.destroy).to be(false)
+    end
+
+    it 'do not prevent a destruction of the annotation_text if no results are released even with a deduction value' do
+      expect(deductive_text.destroy).to eq(deductive_text)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AnnotationTexts with deductions should not be destroyable after results in which they have been applied are released. This callback was missed as a requirement in earlier planning stages.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Adding before destroy callback to annotation_text model.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Breaking change (fix or feature that would cause existing functionality to change)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Additional RSpec examples

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
It may be prudent to also add a before_create callback which does not allow an annotation text to be created if the annotation category it belongs to is associated with an assignment that already has some results released. Currently, I have not implemented this due to a thought. In the spirit of changing things minimally, we could allow users to create annotation_texts in such a scenario if the default deduction stays at zero, thus acting like a non-deductive annotation.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests for my changes, if applicable.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
