### PR TITLE
views: changing view of annotation category delete failure

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -57,9 +57,11 @@ class AnnotationCategoriesController < ApplicationController
   def destroy
     @assignment = Assignment.find(params[:assignment_id])
     @annotation_category = @assignment.annotation_categories.find(params[:id])
-
     if @annotation_category.destroy
       flash_message(:success, t('.success'))
+    else
+      flash_message(:error, t('.error'))
+      render 'show', assignment_id: @assignment.id, id: @annotation_category.id
     end
   end
 

--- a/config/locales/views/annotation_categories/en.yml
+++ b/config/locales/views/annotation_categories/en.yml
@@ -6,6 +6,7 @@ en:
       confirm: "Deleting this annotation will remove the text from any files it may be attached to.  Are you sure you want to do this?"
       success: "Deleted annotation"
     destroy:
+      error: 'Cannot delete this annotation category'
       success: "Annotation category deleted."
       warning: "Deleting this annotation category will also delete its annotations. Deleted annotations will no longer be attached to student submissions. Are you sure you want to do this?"
     download:

--- a/config/locales/views/annotation_categories/es.yml
+++ b/config/locales/views/annotation_categories/es.yml
@@ -6,6 +6,7 @@ es:
       confirm: "Eliminar esta anotación removerá el texto de cualquier archivo que lo contenga. ¿Está seguro/a de realizar esto?"
       success: "Eliminar la categoría de anotación"
     destroy:
+      error: 'UPDATE ME!'
       success: "Eliminar la categoría de anotación"
       warning: "Eliminar esta categoría de anotación también eliminará las anotaciones de la misma. Las anotaciones eliminadas no estarán asociadas a las entregas de los estudiantes. ¿Está seguro/a de querer hacer esto?"
     download:

--- a/config/locales/views/annotation_categories/fr.yml
+++ b/config/locales/views/annotation_categories/fr.yml
@@ -6,6 +6,7 @@ fr:
       confirm: "Supprimer cette annotation va supprimer les commentaires attachés à tous les fichiers auquels elle pourrait être rattachée. Êtes-vous sûr de vouloir faire cela ?"
       success: "Supprimer la catégorie d'annotations"
     destroy:
+      error: 'UPDATE ME!'
       success: "Supprimer la catégorie d'annotations"
       warning: "Supprimer cette catégorie d'annotation va supprimer aussi toutes les annotations. Les annotations supprimées ne seront plus rattachées au devoirs des étudiants. Êtes-vous sûr de vouloir faire cela ?"
     download:

--- a/config/locales/views/annotation_categories/pt.yml
+++ b/config/locales/views/annotation_categories/pt.yml
@@ -6,6 +6,7 @@ pt:
       confirm: "Deletar essa anotação irá remover o texto de todos os arquivos ao qual possa estar anexado. Tem certeza de que quer fazer isto?"
       success: "Apagar categoria de anotação"
     destroy:
+      error: 'UPDATE ME!'
       success: "Apagar categoria de anotação"
       warning: "Apagar esta categoria de anotação também irá apagar suas anotações. Anotações excluídas deixarão de estar ligadas à apresentações dos alunos. Tem certeza de que quer fazer isto?"
     download:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, if the deletion of an annotation category fails, the view makes it look successful. This is bad because an admin must reload the page to see if their change was successful, and may not do so if unaware of this issue.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Changing the render of the destroy action for the annotation categories controller in the case it fails. Adding internationalized error message.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Breaking change (fix or feature that would cause existing functionality to change)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Testing in UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
