### PR TITLE
views: change conditions to include null case

### DIFF
--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -66,7 +66,8 @@ export class AnnotationTable extends React.Component {
       accessor: 'content',
       Cell: data => {
         let edit_button = "";
-        if (!this.props.released_to_students && isNaN(data.original.deduction)) {
+        if (!this.props.released_to_students && (data.original.deduction === undefined ||
+            data.original.deduction === null)) {
           edit_button = <a
             href="#"
             className="edit-icon"

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -213,7 +213,7 @@ class Result extends React.Component {
                    new_subtotal = null, new_total = null, new_num_marked = null) => {
     this.setState({annotations: this.state.annotations.concat([annotation])});
 
-    if (!isNaN(criterion_id)) {
+    if (criterion_id !== null && criterion_id !== undefined) {
       let newMarks = [...this.state.marks];
       let i = newMarks.findIndex(m => m.id === criterion_id && m.criterion_type === "FlexibleCriterion");
       if (i >= 0) {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Essentially, in PR#4652 the introduction of null values into JSON data given to the view was not accounted for in some conditions where `isNaN()` was used. This resulted in different behavior than intended.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- Change display of edit text option in annotations table
- Change condition for updating mark state in result view.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).
