### PR TITLE
Mark override callback

### DIFF
--- a/app/models/mark.rb
+++ b/app/models/mark.rb
@@ -4,6 +4,7 @@ class Mark < ApplicationRecord
   before_save :ensure_not_released_to_students
 
   after_save :update_result
+  after_update :ensure_mark_value
 
   belongs_to :result
   validates_presence_of :markable_type
@@ -34,6 +35,13 @@ class Mark < ApplicationRecord
     return if self.override?
     deduction = calculate_deduction
     self.update!(mark: deduction > self.markable.max_mark ? 0.0 : self.markable.max_mark - deduction)
+  end
+
+  def ensure_mark_value
+    return unless previous_changes.key?('override')
+    if previous_changes['override'].first == true && previous_changes['override'].second == false
+      update_deduction
+    end
   end
 
   def scale_mark(curr_max_mark, prev_max_mark, update: true)

--- a/spec/models/mark_spec.rb
+++ b/spec/models/mark_spec.rb
@@ -171,6 +171,16 @@ describe Mark do
       expect(mark.mark).to eq(2.0)
     end
   end
+
+  describe '#ensure_mark_value' do
+    it 'updates the mark value to be calculated from annotation deductions if override changed from true to false' do
+      assignment = create(:assignment_with_deductive_annotations)
+      mark = assignment.groupings.first.current_result.marks.first
+      mark.update!(override: true, mark: mark.markable.max_mark)
+      mark.update!(override: false)
+      expect(mark.reload.mark).to eq 2.0
+    end
+  end
   # private methods
   describe '#ensure_not_released_to_students'
   describe '#update_grouping_mark'


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Marks should reset their mark value to the one calculated by taking into account annotation deductions if their override value changes from `true` to `false`.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- Add callback to recalculate mark value

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Other (please specify): 
Model change.

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
New rspec example for this scenario.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have fixed any Hound bot comments (check after opening pull request).
- [ ] I have verified that the TravisCI tests have passed (check after opening pull request).
- [ ] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
