### PR TITLE
seeds: adding instances of overridding to the seed data

### DIFF
--- a/lib/tasks/marks.rake
+++ b/lib/tasks/marks.rake
@@ -149,11 +149,11 @@ namespace :db do
       base_attributes[:annotation_text_id] = categories_with_criteria.second.annotation_texts.pluck(:id).to_a.sample
       base_attributes[:annotation_number] = grouping.reload.current_submission_used.annotations.count + 1
       TextAnnotation.create(
-          line_start: 12,
-          line_end: 12,
-          column_start: 1,
-          column_end: 26,
-          **base_attributes
+        line_start: 12,
+        line_end: 12,
+        column_start: 1,
+        column_end: 26,
+        **base_attributes
       )
       mark = grouping.current_result.marks.find_by(markable: categories_with_criteria.second.flexible_criterion)
       mark.update!(override: true, mark: mark.markable.max_mark)

--- a/lib/tasks/marks.rake
+++ b/lib/tasks/marks.rake
@@ -129,14 +129,11 @@ namespace :db do
 
     Grouping.joins(:assignment).where(assessments: { short_identifier: %w[A0 A1 A2] }).each do |grouping|
       submission_file = grouping.current_submission_used.submission_files.find_by(filename: 'hello.py')
+      categories_with_criteria = grouping.assignment.annotation_categories.where.not(flexible_criterion_id: nil)
       base_attributes = {
         submission_file_id: submission_file.id,
         is_remark: grouping.current_submission_used.has_remark?,
-        annotation_text_id: AnnotationText.all
-                                          .joins(:annotation_category)
-                                          .where('annotation_categories.assignment': grouping.assignment)
-                                          .where.not('annotation_texts.deduction': nil)
-                                          .pluck(:id).to_a.sample,
+        annotation_text_id: categories_with_criteria.first.annotation_texts.pluck(:id).to_a.sample,
         annotation_number: grouping.current_submission_used.annotations.count + 1,
         creator_id: Admin.first.id,
         creator_type: 'Admin',
@@ -149,6 +146,17 @@ namespace :db do
         column_end: 15,
         **base_attributes
       )
+      base_attributes[:annotation_text_id] = categories_with_criteria.second.annotation_texts.pluck(:id).to_a.sample
+      base_attributes[:annotation_number] = grouping.reload.current_submission_used.annotations.count + 1
+      TextAnnotation.create(
+          line_start: 12,
+          line_end: 12,
+          column_start: 1,
+          column_end: 26,
+          **base_attributes
+      )
+      mark = grouping.current_result.marks.find_by(markable: categories_with_criteria.second.flexible_criterion)
+      mark.update!(override: true, mark: mark.markable.max_mark)
     end
 
     puts 'Release Results for Assignments'

--- a/lib/tasks/rubric.rake
+++ b/lib/tasks/rubric.rake
@@ -64,6 +64,16 @@ namespace :db do
                               deduction: assignment.flexible_criteria.first.max_mark,
                               creator: Admin.first)
       end
+      other_ac_with_criterion = AnnotationCategory.create(assignment: assignment,
+                                                          position: 7,
+                                                          annotation_category_name: random_words(3),
+                                                          flexible_criterion_id: assignment.flexible_criteria.second.id)
+      rand(3..12).times do |index|
+        AnnotationText.create(annotation_category: other_ac_with_criterion,
+                              content: 'problem # ' + index.to_s,
+                              deduction: assignment.flexible_criteria.second.max_mark,
+                              creator: Admin.first)
+      end
 
       3.times do |index|
         CheckboxCriterion.create(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Developers would benefit from seeing instances of overridden marks in their locally deployed version of the platform.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Adding another annotation category which belongs to a different criterion. 
Applying annotations of this category to submissions, while overriding their effect as well.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Other (please specify): 
Seed data change

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Visual testing in UI. Checking database table.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
