### PR TITLE
gems: remove ya2yaml gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem 'net-ssh'
 gem 'redcarpet'
 gem 'rubyzip', require: 'zip'
 gem 'rugged'
-gem 'ya2yaml'
 
 # Rails miscellany
 gem 'activerecord-session_store'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,6 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    ya2yaml (0.31)
     zeitwerk (2.3.0)
     zxing_cpp (0.1.1)
       ffi (~> 1.1)
@@ -454,7 +453,6 @@ DEPENDENCIES
   uglifier
   unicorn
   webpacker
-  ya2yaml
   zxing_cpp
 
 BUNDLED WITH

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -130,7 +130,7 @@ class CriteriaController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     criteria = assignment.get_criteria.sort_by(&:position)
     yml_criteria = criteria.reduce({}) { |a, b| a.merge b.to_yml }
-    send_data yml_criteria.ya2yaml(hash_order: criteria.map(&:name)),
+    send_data yml_criteria.to_yaml,
               filename: "#{assignment.short_identifier}_criteria.yml",
               disposition: 'attachment'
   end

--- a/app/helpers/annotation_categories_helper.rb
+++ b/app/helpers/annotation_categories_helper.rb
@@ -13,6 +13,6 @@ module AnnotationCategoriesHelper
   end
 
   def convert_to_yml(annotation_categories)
-    prepare_for_conversion(annotation_categories).ya2yaml
+    prepare_for_conversion(annotation_categories).to_yaml
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The pre existing yaml downloading functionality was less than ideal in that the yaml formatting could have been simpler/cleaner.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Getting rid of `ya2yaml` gem dependency. 
Replacing calls to `ya2yaml` with `.to_yaml`

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- Existing download tests work in criteria_controller_spec
- Downloading criteria in yaml format, and downloading annotation category information in yaml format, still works.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Although this change results in the loss of the ya2yaml option for hash ordering, the default behaviour of `.to_yaml` will preserve the order of the previous query in the criteria_controller download action.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
