### PR TITLE
internationalization: fix key difference across languages for mailer

### DIFF
--- a/config/locales/mailers/es.yml
+++ b/config/locales/mailers/es.yml
@@ -1,7 +1,7 @@
 es:
   notification_mailer:
     release_email:
-      subject_line: 'UPDATE ME'
+      subject: 'UPDATE ME'
       greeting: 'UPDATE ME'
       text_body: 'UPDATE ME'
       button_text: 'UPDATE ME'

--- a/config/locales/mailers/fr.yml
+++ b/config/locales/mailers/fr.yml
@@ -1,7 +1,7 @@
 fr:
   notification_mailer:
     release_email:
-      subject_line: 'UPDATE ME'
+      subject: 'UPDATE ME'
       greeting: 'UPDATE ME'
       text_body: 'UPDATE ME'
       button_text: 'UPDATE ME'

--- a/config/locales/mailers/pt.yml
+++ b/config/locales/mailers/pt.yml
@@ -1,7 +1,7 @@
 pt:
   notification_mailer:
     release_email:
-      subject_line: 'UPDATE ME'
+      subject: 'UPDATE ME'
       greeting: 'UPDATE ME'
       text_body: 'UPDATE ME'
       button_text: 'UPDATE ME'


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, an error with the internationalization for the mailer went unchecked. Now thanks to @mishaschwartz we caught the subject_line issue.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Fix the French, Portuguese, and Spanish keys for the subject line of the email.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
