### PR TITLE
controllers: limit annotation category information sent to TAs with a…

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -122,7 +122,7 @@ class ResultsController < ApplicationController
 
         # Annotation categories
         if current_user.admin? || current_user.ta?
-          if current_user.ta? && !current_user.criterion_ta_associations.empty?
+          if current_user.ta? && assignment.assign_graders_to_criteria
             visible = current_user.criterion_ta_associations.pluck(:criterion_id).to_a + [nil]
             annotation_categories = assignment.annotation_categories
                                               .order(:position)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -123,7 +123,7 @@ class ResultsController < ApplicationController
         # Annotation categories
         if current_user.admin? || current_user.ta?
           if current_user.ta? && assignment.assign_graders_to_criteria
-            visible = current_user.criterion_ta_associations.pluck(:criterion_id).to_a + [nil]
+            visible = current_user.criterion_ta_associations.pluck(:criterion_id) + [nil]
             annotation_categories = assignment.annotation_categories
                                               .order(:position)
                                               .includes(:annotation_texts)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -122,9 +122,17 @@ class ResultsController < ApplicationController
 
         # Annotation categories
         if current_user.admin? || current_user.ta?
-          annotation_categories = assignment.annotation_categories
-                                            .order(:position)
-                                            .includes(:annotation_texts)
+          if current_user.ta? && !current_user.criterion_ta_associations.empty?
+            visible = current_user.criterion_ta_associations.pluck(:criterion_id).to_a + [nil]
+            annotation_categories = assignment.annotation_categories
+                                              .order(:position)
+                                              .includes(:annotation_texts)
+                                              .where('annotation_categories.flexible_criterion_id': visible)
+          else
+            annotation_categories = assignment.annotation_categories
+                                              .order(:position)
+                                              .includes(:annotation_texts)
+          end
           data[:annotation_categories] = annotation_categories.map do |category|
             name_extension = category.flexible_criterion_id.nil? ? '' : " [#{category.flexible_criterion.name}]"
             {


### PR DESCRIPTION
…ssigned criteria

<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now that annotations can affect marks, it is necessary to limit access to deductive annotations for TAs that have been assigned specific criteria if those annotations are not for the assigned criterion/ia.


## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Changes to the data sent to the result marking view.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Added a test to verify that information visible to TAs is limited to annotation categories without criteria/with criteria they're assigned.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
