### PR TITLE
flash-context-menu-restrictions

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -125,6 +125,7 @@ class AnnotationsController < ApplicationController
                                                                                            .flexible_criterion_id)
         flash_message(:error, t('annotations.prevent_ta_delete'))
         head :bad_request
+        return
       end
     end
     text = @annotation.annotation_text
@@ -144,9 +145,11 @@ class AnnotationsController < ApplicationController
       if current_user.ta?
         flash_message(:error, t('annotations.prevent_update'))
         head :bad_request
+        return
       elsif !@annotation_text.annotations.joins(:result).where('results.released_to_students' => true).empty?
         flash_message(:error, t('annotations.prevent_update'))
         head :bad_request
+        return
       end
     end
     @annotation_text.update(content: params[:content])

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -121,9 +121,8 @@ class AnnotationsController < ApplicationController
       assignment = result.grouping.assignment
       if assignment.assign_graders_to_criteria &&
           !current_user.criterion_ta_associations.where(criterion_type: 'FlexibleCriterion')
-                                                 .pluck(:criterion_id).include?(@annotation.annotation_text
-                                                                                           .annotation_category
-                                                                                           .flexible_criterion_id)
+                       .pluck(:criterion_id)
+                       .include?(@annotation.annotation_text.annotation_category.flexible_criterion_id)
         flash_message(:error, t('annotations.prevent_ta_delete'))
         head :bad_request
         return

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -124,7 +124,7 @@ class AnnotationsController < ApplicationController
                                                                                            .annotation_category
                                                                                            .flexible_criterion_id)
         flash_message(:error, t('annotations.prevent_ta_delete'))
-        return
+        head :bad_request
       end
     end
     text = @annotation.annotation_text

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -143,11 +143,10 @@ class AnnotationsController < ApplicationController
     unless @annotation_text.deduction.nil?
       if current_user.ta?
         flash_message(:error, t('annotations.prevent_update'))
-        render
-        return
+        head :bad_request
       elsif !@annotation_text.annotations.joins(:result).where('results.released_to_students' => true).empty?
         flash_message(:error, t('annotations.prevent_update'))
-        return
+        head :bad_request
       end
     end
     @annotation_text.update(content: params[:content])

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -117,6 +117,16 @@ class AnnotationsController < ApplicationController
   def destroy
     result = Result.find(params[:result_id])
     @annotation = result.annotations.find(params[:id])
+    unless @annotation.annotation_text.deduction.nil? || !current_user.ta?
+      assignment = result.grouping.assignment
+      if assignment.assign_graders_to_criteria &&
+          !current_user.criterion_ta_associations.pluck(:criterion_id).include?(@annotation.annotation_text
+                                                                                           .annotation_category
+                                                                                           .flexible_criterion_id)
+        flash_message(:error, 'cannot delete this')
+        return
+      end
+    end
     text = @annotation.annotation_text
     text.destroy if text.annotation_category_id.nil?
     @annotation.destroy

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -120,7 +120,8 @@ class AnnotationsController < ApplicationController
     unless @annotation.annotation_text.deduction.nil? || !current_user.ta?
       assignment = result.grouping.assignment
       if assignment.assign_graders_to_criteria &&
-          !current_user.criterion_ta_associations.pluck(:criterion_id).include?(@annotation.annotation_text
+          !current_user.criterion_ta_associations.where(criterion_type: 'FlexibleCriterion')
+                                                 .pluck(:criterion_id).include?(@annotation.annotation_text
                                                                                            .annotation_category
                                                                                            .flexible_criterion_id)
         flash_message(:error, t('annotations.prevent_ta_delete'))

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -123,7 +123,7 @@ class AnnotationsController < ApplicationController
           !current_user.criterion_ta_associations.pluck(:criterion_id).include?(@annotation.annotation_text
                                                                                            .annotation_category
                                                                                            .flexible_criterion_id)
-        flash_message(:error, 'cannot delete this')
+        flash_message(:error, t('annotations.prevent_ta_delete'))
         return
       end
     end
@@ -140,6 +140,16 @@ class AnnotationsController < ApplicationController
   def update
     @annotation = Annotation.find(params[:id])
     @annotation_text = @annotation.annotation_text
+    unless @annotation_text.deduction.nil?
+      if current_user.ta?
+        flash_message(:error, t('annotations.prevent_update'))
+        render
+        return
+      elsif !@annotation_text.annotations.joins(:result).where('results.released_to_students' => true).empty?
+        flash_message(:error, t('annotations.prevent_update'))
+        return
+      end
+    end
     @annotation_text.update(content: params[:content])
   end
 end

--- a/config/locales/views/annotations/en.yml
+++ b/config/locales/views/annotations/en.yml
@@ -5,6 +5,8 @@ en:
     text: "Text"
     default_deduction: 'This annotation will have no deduction. Admins can configure deductions in assignment settings.'
     list_deductions: 'Deductions from annotations: '
+    prevent_ta_delete: 'You cannot delete this deductive annotation because you are not assigned its criterion.'
+    prevent_update: 'You cannot update this annotation because you may not have permission or it is deductive and already applied to released results.'
 
     download_submission_file:
       begin_annotation: "%{comment_start} ANNOTATION %{id}: %{text} %{comment_end}"

--- a/config/locales/views/annotations/es.yml
+++ b/config/locales/views/annotations/es.yml
@@ -4,6 +4,8 @@ es:
     last_edited_by: "Editado por última vez por:"
     default_deduction: 'UPDATE ME!'
     list_deductions: 'UPDATE ME!'
+    prevent_ta_delete: 'UPDATE ME!'
+    prevent_update: 'UPDATE ME!'
 
     download_submission_file:
       begin_annotation: "%{comment_start} ANOTACIÓN %{id}: %{text} %{comment_end}"

--- a/config/locales/views/annotations/fr.yml
+++ b/config/locales/views/annotations/fr.yml
@@ -4,6 +4,8 @@ fr:
     last_edited_by: "Dernière édition par :"
     default_deduction: 'UPDATE ME!'
     list_deductions: 'UPDATE ME!'
+    prevent_ta_delete: 'UPDATE ME!'
+    prevent_update: 'UPDATE ME!'
 
     download_submission_file:
       begin_annotation: "%{comment_start} ANNOTATION %{id}: %{text} %{comment_end}"

--- a/config/locales/views/annotations/pt.yml
+++ b/config/locales/views/annotations/pt.yml
@@ -4,6 +4,8 @@ pt:
     last_edited_by: "Última edição por:"
     default_deduction: 'UPDATE ME!'
     list_deductions: 'UPDATE ME!'
+    prevent_ta_delete: 'UPDATE ME!'
+    prevent_update: 'UPDATE ME!'
 
     download_submission_file:
       begin_annotation: "%{comment_start} ANOTAÇÃO %{id}: %{text} %{comment_end}"

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -267,8 +267,7 @@ describe AnnotationsController do
                 params: { content: 'New content!',
                           id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         expect(annotation.reload.annotation_text.content).to eq 'New content!'
       end
@@ -276,14 +275,13 @@ describe AnnotationsController do
       it 'cannot update deductive annotation content if that content has been applied to released results' do
         assignment.groupings.first.current_result.update(released_to_students: true)
         other_grouping = assignment.reload.groupings.joins(submissions: :results)
-                                                    .where(results: {released_to_students: false}).first
+                                   .where(results: { released_to_students: false }).first
         post_as user,
                 :update,
                 params: { content: 'New content!',
                           id: annotation.id,
                           result_id: other_grouping.current_result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         assert_response :bad_request
         expect(annotation.reload.annotation_text.content).to_not eq 'New content!'
@@ -294,8 +292,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         expect(result.reload.annotations.size).to eq 0
       end
@@ -306,8 +303,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         expect(result.reload.annotations.size).to eq 0
       end
@@ -328,8 +324,7 @@ describe AnnotationsController do
                 params: { content: 'New content!',
                           id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         assert_response :bad_request
         expect(annotation.reload.annotation_text.content).to_not eq 'New content!'
@@ -343,8 +338,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         assert_response :bad_request
         expect(result.reload.annotations.size).to eq 1
@@ -359,8 +353,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         assert_response :bad_request
         expect(result.reload.annotations.size).to eq 1
@@ -373,8 +366,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         expect(result.reload.annotations.size).to eq 0
       end
@@ -385,8 +377,7 @@ describe AnnotationsController do
                 :destroy,
                 params: { id: annotation.id,
                           result_id: result.id,
-                          assignment_id: assignment.id
-                },
+                          assignment_id: assignment.id },
                 format: :js
         assert_response :bad_request
         expect(result.reload.annotations.size).to eq 1

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -350,6 +350,22 @@ describe AnnotationsController do
         expect(result.reload.annotations.size).to eq 1
       end
 
+      it 'cannot destroy a deductive annotation if assigned to a criterion of a different type '\
+         'with the same id annotation\'s criterion' do
+        other_criterion = create(:rubric_criterion, assignment: assignment, id: assignment.flexible_criteria.first.id)
+        assignment.assignment_properties.update(assign_graders_to_criteria: true)
+        create(:criterion_ta_association, criterion: other_criterion, ta: user)
+        post_as user,
+                :destroy,
+                params: { id: annotation.id,
+                          result_id: result.id,
+                          assignment_id: assignment.id
+                },
+                format: :js
+        assert_response :bad_request
+        expect(result.reload.annotations.size).to eq 1
+      end
+
       it 'can destroy a deductive annotation if assigned to the annotation\'s criterion' do
         assignment.assignment_properties.update(assign_graders_to_criteria: true)
         create(:criterion_ta_association, criterion: assignment.flexible_criteria.first, ta: user)

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -345,7 +345,7 @@ describe AnnotationsController do
       end
 
       it 'cannot destroy a deductive annotation if assigned to a criterion of a different type '\
-         'with the same id annotation\'s criterion' do
+         'with the same id as the annotation\'s criterion' do
         other_criterion = create(:rubric_criterion, assignment: assignment, id: assignment.flexible_criteria.first.id)
         assignment.assignment_properties.update(assign_graders_to_criteria: true)
         create(:criterion_ta_association, criterion: other_criterion, ta: user)

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -259,7 +259,7 @@ describe AnnotationsController do
   end
 
   describe 'an authenticated TA' do
-    let!(:user) { create(:admin) }
+    let!(:user) { create(:ta) }
     include_examples 'an authenticated admin or TA'
   end
 

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -261,6 +261,21 @@ describe AnnotationsController do
   describe 'an authenticated TA' do
     let!(:user) { create(:ta) }
     include_examples 'an authenticated admin or TA'
+
+    it 'cannot update a deductive annotation' do
+      assignment = create(:assignment_with_deductive_annotations)
+      result = assignment.groupings.first.current_result
+      annotation = result.annotations.first
+      post_as user,
+              :update,
+              params: { content: 'New content!',
+                        id: annotation.id,
+                        result_id: result.id,
+                        assignment_id: assignment.id
+              },
+              format: :js
+      assert_response :bad_request
+    end
   end
 
   context 'An authenticated and authorized Student doing a POST' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, TAs who are assigned criteria can still remove deductive annotations through the annotations table or the hover context menu on the submission (thus allowing them to affect marks which they should not be able to). Also, admins will believe they can edit an annotation in the context menu even though, if any results with that annotation have been released, they will not be able to. 

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Prevent wrong TA access to delete/edit for annotations in marking view.
Add flash messages explaining the issues described in context.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Breaking change (fix or feature that would cause existing functionality to change)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
New examples for `update` and `destroy` actions for a TA and an Admin in the annotations_controller_spec

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
