### PR TITLE
views: correct annotation table filtering

### DIFF
--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -107,7 +107,14 @@ export class AnnotationTable extends React.Component {
 
   deductionColumn = {
     Header: I18n.t('activerecord.attributes.annotation_text.deduction'),
-    accessor: row => '[' + row.criterion_name + '] -' + row.deduction,
+    accessor: row => {
+      if (row.deduction === undefined || row.deduction === null ||
+        row.deduction === 0.0) {
+        return '';
+      } else {
+        return '[' + row.criterion_name + '] -' + row.deduction;
+      }
+    },
     id: 'deduction',
     filterMethod: this.deductionFilter,
     Cell: data => {
@@ -153,6 +160,7 @@ export class AnnotationTable extends React.Component {
           data={this.props.annotations}
           columns={allColumns}
           filterable
+          resizable
           defaultSorted={[
             {id: 'filename'},
             {id: 'number'}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, annotations with a deduction of 0 would be included in filters for their criterion, and bracket characters `[` and `]` were treated as existing in every row.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
This PR fixes the accessor for the annotation table deduction column.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)




## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Visual testing in UI to confirm changes stated above.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
For some reason resizing worked poorly on Chrome and Firefox on my laptop before. I added the resizable prop to the table, but the behavior persists, so it merits checking on another person's computer.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
