### PR TITLE
Display extra marks properly on summary and submission tables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Fixed bug preventing graders from creating new notes in results view (#4668)
 - Fixed bug preventing new tags from being created from results view (#4669)
 - Remove deprecated "detailed CSV" download link from submissions/browse (#4675)
+- Fixed bug where bonuses and deductions were not displayed properly (#4699)
 
 ## [v1.9.2]
 - Fixed bug preventing all git hooks from being run in production (#4594)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -575,7 +575,7 @@ class Assignment < Assessment
                                      result&.marking_state,
                                      result&.released_to_students,
                                      g.collection_date),
-        final_grade: criteria.values.compact.sum + extra_mark || 0,
+        final_grade: criteria.values.compact.sum + (extra_mark || 0),
         criteria: criteria,
         max_mark: max_mark,
         result_id: result&.id,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -524,7 +524,7 @@ class Assignment < Assessment
     members = groupings.joins(:accepted_students)
                        .pluck_to_hash(:id, 'users.user_name', 'users.first_name', 'users.last_name')
                        .group_by { |x| x[:id] }
-    groupings_with_results = groupings.includes(:submitted_remark, :extension, current_result: :marks)
+    groupings_with_results = groupings.includes(current_result: :marks).includes(:submitted_remark, :extension)
     result_ids = groupings_with_results.pluck('results.id').uniq.compact
     extra_marks_hash = Result.get_total_extra_marks(result_ids, max_mark: max_mark)
 
@@ -564,6 +564,7 @@ class Assignment < Assessment
       end
 
       criteria = result.nil? ? {} : result.mark_hash.select { |key, _| criteria_shown.include?(key) }
+      extra_mark = extra_marks_hash[result&.id]
       {
         group_name: group_name,
         section: section,
@@ -574,12 +575,12 @@ class Assignment < Assessment
                                      result&.marking_state,
                                      result&.released_to_students,
                                      g.collection_date),
-        final_grade: criteria.values.compact.sum,
+        final_grade: criteria.values.compact.sum + extra_mark || 0,
         criteria: criteria,
         max_mark: max_mark,
         result_id: result&.id,
         submission_id: result&.submission_id,
-        total_extra_marks: extra_marks_hash[result&.id]
+        total_extra_marks: extra_mark
       }
     end
 
@@ -1209,6 +1210,7 @@ class Assignment < Assessment
                       .transform_values { |arr| arr.map(&:second).compact.sum }
 
     max_mark = criteria.map(&:max_mark).compact.sum
+    extra_marks_hash = Result.get_total_extra_marks(result_ids, max_mark: max_mark)
 
     collection_dates = all_grouping_collection_dates
 
@@ -1237,8 +1239,9 @@ class Assignment < Assessment
       end
 
       if result_info['results.id'].present?
+        extra_mark = extra_marks_hash[result_info['results.id']] || 0
         base[:result_id] = result_info['results.id']
-        base[:final_grade] = total_marks[result_info['results.id']] || 0.0
+        base[:final_grade] = (total_marks[result_info['results.id']] || 0.0) + extra_mark
       end
 
       base[:members] = member_info.map { |h| h['users.user_name'] } unless member_info.nil?

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1686,6 +1686,18 @@ describe Assignment do
           expect(data.map { |h| h[:grace_credits_used] }.compact).to contain_exactly(1)
         end
       end
+
+      context 'there is an extra mark' do
+        let(:submission) { create :version_used_submission, grouping: groupings[0] }
+        let(:result) { create :complete_result, submission: submission }
+        let!(:extra_mark) { create :extra_mark_points, result: result }
+        it 'should include the extra mark in the total' do
+          final_grade = submission.current_result.total_mark + extra_mark.extra_mark
+          data = assignment.current_submission_data(ta)
+          expect(data.map { |h| h[:final_grade] }).to include(final_grade)
+          expect(data.select { |h| h.key? :final_grade }.count).to eq 1
+        end
+      end
     end
 
     context 'a Student user' do
@@ -1699,7 +1711,7 @@ describe Assignment do
       let(:admin) { create :admin }
       let(:tags) { create_list :tag, 3, user: admin }
       let(:groupings_with_tags) { groupings.each_with_index { |g, i| g.update(tags: [tags[i]]) && g } }
-      let(:data) { assignment.current_submission_data(admin) }
+      let(:data) { assignment.reload.current_submission_data(admin) }
       let(:submission) { create :version_used_submission, grouping: groupings[0] }
       let(:released_result) { create :released_result, submission: submission }
 
@@ -1783,6 +1795,16 @@ describe Assignment do
         final_grade = submission.current_result.total_mark
         expect(data.map { |h| h[:final_grade] }).to include(final_grade)
         expect(data.select { |h| h.key? :final_grade }.count).to eq 1
+      end
+
+      context 'there is an extra mark' do
+        let(:result) { create :complete_result, submission: submission }
+        let!(:extra_mark) { create :extra_mark_points, result: result }
+        it 'should include the extra mark in the total' do
+          final_grade = submission.current_result.total_mark + extra_mark.extra_mark
+          expect(data.map { |h| h[:final_grade] }).to include(final_grade)
+          expect(data.select { |h| h.key? :final_grade }.count).to eq 1
+        end
       end
 
       context 'there are groups without members' do
@@ -1914,6 +1936,22 @@ describe Assignment do
         it 'has group with members' do
           data = @assignment.summary_json(admin)[:data]
           expect(data[0][:members]).not_to be_empty
+        end
+
+        context 'with an extra mark' do
+          let(:grouping) { @assignment.groupings.first }
+          let!(:extra_mark) { create :extra_mark_points, result: grouping.current_result }
+          it 'should included the extra mark value' do
+            data = @assignment.summary_json(admin)[:data]
+            grouping_data = data.select { |d| d[:group_name] == grouping.group.group_name }.first
+            expect(grouping_data[:total_extra_marks]).to eq extra_mark.extra_mark
+          end
+          it 'should add the extra mark to the total mark' do
+            data = @assignment.summary_json(admin)[:data]
+            grouping_data = data.select { |d| d[:group_name] == grouping.group.group_name }.first
+            extra = grouping.current_result.extra_marks.pluck(:extra_mark).sum
+            expect(grouping_data[:final_grade]).to eq(grouping.current_result.total_mark + extra)
+          end
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- bonuses and deductions were not displayed at all on the assignment summary tables
- bonuses and deductions were not included in the total mark on the summary and submission tables
- this PR fixes these two (above) issues and makes the tables more consistent with what is visible on the results table (also what is given in the csv downloads).

Resolves #4697

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- fixed a database query to do a join properly so that results are joined
- added the extra marks to the total
- added tests to detect this issue in the future

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests for my changes, if applicable.
- [x] I have updated the Changelog.md file.
- [x] I have described any required documentation changes below, if applicable.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
