### PR TITLE
Annotation table sorting

### DIFF
--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -150,7 +150,8 @@ export class AnnotationTable extends React.Component {
     if (this.props.detailed) {
       allColumns = allColumns.concat(this.detailedColumns);
     }
-    if (this.props.annotations.some(a => a.deduction !== null && a.deduction !== undefined)) {
+    if (this.props.annotations.some(a => a.deduction !== null && a.deduction !== undefined && a.deduction !== 0)) {
+      console.log(this.props.annotations)
       allColumns.push(this.deductionColumn);
     }
 
@@ -164,7 +165,7 @@ export class AnnotationTable extends React.Component {
           resizable
           defaultSorted={[
             {id: 'deduction', desc: true},
-            {id: 'filename', desc: true},
+            {id: 'filename'},
             {id: 'number'}
           ]}
         />

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -135,16 +135,16 @@ export class AnnotationTable extends React.Component {
       }
     },
     sortMethod: (a, b) => {
-      if (a === ''){
+      if (a === '') {
         return 1;
       }
-      if (b === ''){
+      else if (b === '') {
         return -1;
       }
-      if (a > b) {
+      else if (a > b) {
         return 1;
       }
-      if (a < b) {
+      else if (a < b) {
         return -1;
       }
       return 0;

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -134,6 +134,21 @@ export class AnnotationTable extends React.Component {
         );
       }
     },
+    sortMethod: (a, b) => {
+      if (a === ''){
+        return 1;
+      }
+      if (b === ''){
+        return -1;
+      }
+      if (a > b) {
+        return 1;
+      }
+      if (a < b) {
+        return -1;
+      }
+      return 0;
+    },
     maxWidth: 120
   };
 
@@ -151,7 +166,6 @@ export class AnnotationTable extends React.Component {
       allColumns = allColumns.concat(this.detailedColumns);
     }
     if (this.props.annotations.some(a => a.deduction !== null && a.deduction !== undefined && a.deduction !== 0)) {
-      console.log(this.props.annotations)
       allColumns.push(this.deductionColumn);
     }
 
@@ -164,7 +178,7 @@ export class AnnotationTable extends React.Component {
           filterable
           resizable
           defaultSorted={[
-            {id: 'deduction', desc: true},
+            {id: 'deduction'},
             {id: 'filename'},
             {id: 'number'}
           ]}
@@ -173,3 +187,4 @@ export class AnnotationTable extends React.Component {
     );
   }
 }
+

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -187,4 +187,3 @@ export class AnnotationTable extends React.Component {
     );
   }
 }
-

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -137,14 +137,11 @@ export class AnnotationTable extends React.Component {
     sortMethod: (a, b) => {
       if (a === '') {
         return 1;
-      }
-      else if (b === '') {
+      } else if (b === '') {
         return -1;
-      }
-      else if (a > b) {
+      } else if (a > b) {
         return 1;
-      }
-      else if (a < b) {
+      } else if (a < b) {
         return -1;
       }
       return 0;

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -163,7 +163,8 @@ export class AnnotationTable extends React.Component {
           filterable
           resizable
           defaultSorted={[
-            {id: 'filename'},
+            {id: 'deduction', desc: true},
+            {id: 'filename', desc: true},
             {id: 'number'}
           ]}
         />


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After sourcing feedback from stakeholders, it seems the annotation table would preferably be sorted by the criterion of the deduction first, then the filename and annotation number, so that the relevant deductions are at the top of the table.

<img width="865" alt="image" src="https://user-images.githubusercontent.com/29822176/85790570-6921e980-b6fe-11ea-919d-7942ad2cb437.png">

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- Changing the sort of the result's annotation table to first account for criteria with deductions.
- Ensuring the table does not show the deduction column if deductions are 0.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
