### PR TITLE
views: add hyperlinking to mark deduction list

### DIFF
--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -48,9 +48,7 @@ export class AnnotationTable extends React.Component {
           name = full_path;
         }
         return (
-          <a
-            href="javascript:void(0)"
-            onClick={() =>
+          <a onClick={() =>
               this.props.selectFile(
                 full_path,
                 row.original.submission_file_id,

--- a/app/assets/javascripts/Components/Result/annotation_table.jsx
+++ b/app/assets/javascripts/Components/Result/annotation_table.jsx
@@ -54,7 +54,8 @@ export class AnnotationTable extends React.Component {
               this.props.selectFile(
                 full_path,
                 row.original.submission_file_id,
-                row.original.line_start)}>
+                row.original.line_start,
+                row.original.id)}>
               {name}
           </a>
         );

--- a/app/assets/javascripts/Components/Result/file_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/file_viewer.jsx
@@ -101,6 +101,7 @@ export class FileViewer extends React.Component {
     } else if (this.state.type === 'pdf') {
       return <PDFViewer
         url={this.state.url}
+        annotationFocus={this.props.annotationFocus}
         {...commonProps}
       />;
     } else if (this.state.type !== '') {

--- a/app/assets/javascripts/Components/Result/left_pane.jsx
+++ b/app/assets/javascripts/Components/Result/left_pane.jsx
@@ -30,8 +30,8 @@ export class LeftPane extends React.Component {
   };
 
   // Display a given file. Used to changes files from the annotations panel.
-  selectFile = (file, submission_file_id, focus_line) => {
-    this.submissionFilePanel.current.selectFile(file, submission_file_id, focus_line);
+  selectFile = (file, submission_file_id, focus_line, annotation_focus) => {
+    this.submissionFilePanel.current.selectFile(file, submission_file_id, focus_line, annotation_focus);
     this.setState({tabIndex: 0});  // Switch to Submission Files tab
   };
 

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -234,7 +234,7 @@ class FlexibleCriterionInput extends React.Component {
 
   listDeductions = () => {
     let label = I18n.t('annotations.list_deductions');
-    let deductiveAnnotations = this.props.annotations.filter( a => {
+    let deductiveAnnotations = this.props.annotations.filter(a => {
       return a.criterion_id !== undefined && a.criterion_id !== null &&
         a.deduction !== 0.0 && a.criterion_id === this.props.id;
     });
@@ -248,10 +248,11 @@ class FlexibleCriterionInput extends React.Component {
       return <span key={a.id}>
                <a onClick={() =>
                     this.props.findDeductiveAnnotation(
-                    full_path,
-                    a.submission_file_id,
-                    a.line_start,
-                    a.id)}>
+                      full_path,
+                      a.submission_file_id,
+                      a.line_start,
+                      a.id
+                    )}>
                  {'-' + a.deduction}
                </a>
                {index !== deductiveAnnotations.length - 1 ? ', ' : ''}

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -233,24 +233,25 @@ class FlexibleCriterionInput extends React.Component {
   }
 
   listDeductions = () => {
-    let hyperlinkedDeductions = '';
     let label = I18n.t('annotations.list_deductions');
-    hyperlinkedDeductions = this.props.annotations.map( a => {
-      if (a.criterion_id !== undefined && a.criterion_id !== null &&
-          a.deduction !== 0.0 && a.criterion_id === this.props.id) {
-        let full_path = a.path ? a.path + '/' + a.filename : a.filename;
-        return <a href="javascript:void(0)"
-                  onClick={() =>
-                    this.props.findDeductiveAnnotation(
-                    full_path,
-                    a.submission_file_id,
-                    a.line_start,
-                    a.id)}>
-                 {'-' + a.deduction + ' '}
-               </a>;
-      }
+    let deductiveAnnotations = this.props.annotations.filter( a => {
+      return a.criterion_id !== undefined && a.criterion_id !== null &&
+        a.deduction !== 0.0 && a.criterion_id === this.props.id;
     });
-    if (hyperlinkedDeductions === '') {
+
+    let hyperlinkedDeductions = deductiveAnnotations.map( a => {
+      let full_path = a.path ? a.path + '/' + a.filename : a.filename;
+      return <a onClick={() =>
+                  this.props.findDeductiveAnnotation(
+                  full_path,
+                  a.submission_file_id,
+                  a.line_start,
+                  a.id)}>
+               {'-' + a.deduction}
+             </a>;
+    });
+    console.log(hyperlinkedDeductions === [])
+    if (hyperlinkedDeductions === []) {
       return <span></span>;
     }
 

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -96,6 +96,7 @@ export class MarksPanel extends React.Component {
       toggleExpanded: () => this.toggleExpanded(key),
       annotations: this.props.annotations,
       revertToAutomaticDeductions: this.props.revertToAutomaticDeductions,
+      findDeductiveAnnotation: this.props.findDeductiveAnnotation,
       ... markData
     };
     if (markData.criterion_type === 'CheckboxCriterion') {
@@ -232,15 +233,23 @@ class FlexibleCriterionInput extends React.Component {
   }
 
   listDeductions = () => {
-    let deductions = '';
+    let hyperlinkedDeductions = '';
     let label = I18n.t('annotations.list_deductions');
-    this.props.annotations.map( a => {
+    hyperlinkedDeductions = this.props.annotations.map( a => {
       if (a.criterion_id !== undefined && a.criterion_id !== null &&
           a.deduction !== 0.0 && a.criterion_id === this.props.id) {
-        deductions += '-' + a.deduction + ', ';
+        let full_path = a.path ? a.path + '/' + a.filename : a.filename;
+        return <a href="javascript:void(0)"
+                  onClick={() =>
+                    this.props.findDeductiveAnnotation(
+                    full_path,
+                    a.submission_file_id,
+                    a.line_start)}>
+                 {'-' + a.deduction + ' '}
+               </a>;
       }
     });
-    if (deductions.length < 1) {
+    if (hyperlinkedDeductions === '') {
       return <span></span>;
     }
 
@@ -254,7 +263,7 @@ class FlexibleCriterionInput extends React.Component {
           {label}
         </span>
         <span className={'text-deduction'}>
-          {deductions.substring(0, deductions.length - 2)}
+          {hyperlinkedDeductions}
         </span>
       </div>);
   }

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -239,21 +239,24 @@ class FlexibleCriterionInput extends React.Component {
         a.deduction !== 0.0 && a.criterion_id === this.props.id;
     });
 
-    let hyperlinkedDeductions = deductiveAnnotations.map( a => {
-      let full_path = a.path ? a.path + '/' + a.filename : a.filename;
-      return <a onClick={() =>
-                  this.props.findDeductiveAnnotation(
-                  full_path,
-                  a.submission_file_id,
-                  a.line_start,
-                  a.id)}>
-               {'-' + a.deduction}
-             </a>;
-    });
-    console.log(hyperlinkedDeductions === [])
-    if (hyperlinkedDeductions === []) {
+    if (deductiveAnnotations.length === 0) {
       return <span></span>;
     }
+
+    let hyperlinkedDeductions = deductiveAnnotations.map((a, index) => {
+      let full_path = a.path ? a.path + '/' + a.filename : a.filename;
+      return <span key={a.id}>
+               <a onClick={() =>
+                    this.props.findDeductiveAnnotation(
+                    full_path,
+                    a.submission_file_id,
+                    a.line_start,
+                    a.id)}>
+                 {'-' + a.deduction}
+               </a>
+               {index !== deductiveAnnotations.length - 1 ? ', ' : ''}
+             </span>;
+    });
 
     if (this.props['marks.override']) {
       label = '(' + I18n.t('results.overridden_deductions') + ') ' + label;

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -244,7 +244,8 @@ class FlexibleCriterionInput extends React.Component {
                     this.props.findDeductiveAnnotation(
                     full_path,
                     a.submission_file_id,
-                    a.line_start)}>
+                    a.line_start,
+                    a.id)}>
                  {'-' + a.deduction + ' '}
                </a>;
       }

--- a/app/assets/javascripts/Components/Result/pdf_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/pdf_viewer.jsx
@@ -62,7 +62,7 @@ export class PDFViewer extends React.Component {
     this.pdfViewer.currentScaleValue = 'page-width';
     this.props.annotations.forEach(this.display_annotation);
     if (this.props.annotationFocus !== null && this.props.annotationFocus !== undefined) {
-      document.getElementById('annotation_holder_' + this.props.annotationFocus).scrollIntoView()
+      document.getElementById('annotation_holder_' + this.props.annotationFocus).scrollIntoView();
     }
   };
 

--- a/app/assets/javascripts/Components/Result/pdf_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/pdf_viewer.jsx
@@ -61,6 +61,9 @@ export class PDFViewer extends React.Component {
     $('.annotation_holder').remove();
     this.pdfViewer.currentScaleValue = 'page-width';
     this.props.annotations.forEach(this.display_annotation);
+    if (this.props.annotationFocus !== null && this.props.annotationFocus !== undefined) {
+      document.getElementById('annotation_holder_' + this.props.annotationFocus).scrollIntoView()
+    }
   };
 
   display_annotation = (annotation) => {

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -470,6 +470,10 @@ class Result extends React.Component {
     });
   };
 
+  findDeductiveAnnotation = (file, submission_file_id, focus_line) => {
+    this.leftPane.current.selectFile(file, submission_file_id, focus_line);
+  };
+
   /* Callbacks for SubmissionSelector */
   toggleMarkingState = () => {
     $.ajax({
@@ -583,6 +587,7 @@ class Result extends React.Component {
                 addTag={this.addTag}
                 removeTag={this.removeTag}
                 newNote={this.newNote}
+                findDeductiveAnnotation={this.findDeductiveAnnotation}
               />
             </div>
           </div>

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -470,8 +470,8 @@ class Result extends React.Component {
     });
   };
 
-  findDeductiveAnnotation = (file, submission_file_id, focus_line) => {
-    this.leftPane.current.selectFile(file, submission_file_id, focus_line);
+  findDeductiveAnnotation = (file, submission_file_id, focus_line, annotation_id) => {
+    this.leftPane.current.selectFile(file, submission_file_id, focus_line, annotation_id);
   };
 
   /* Callbacks for SubmissionSelector */

--- a/app/assets/javascripts/Components/Result/right_pane.jsx
+++ b/app/assets/javascripts/Components/Result/right_pane.jsx
@@ -31,6 +31,7 @@ export class RightPane extends React.Component {
             updateMark={this.props.updateMark}
             destroyMark={this.props.destroyMark}
             revertToAutomaticDeductions={this.props.revertToAutomaticDeductions}
+            findDeductiveAnnotation={this.props.findDeductiveAnnotation}
           />
         </TabPanel>
         <TabPanel>

--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -12,7 +12,8 @@ export class SubmissionFilePanel extends React.Component {
     super(props);
     this.state = {
       selectedFile: null,
-      focusLine: null
+      focusLine: null,
+      annotationFocus: undefined
     };
     this.submissionFileViewer = React.createRef();
   }

--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -105,8 +105,8 @@ export class SubmissionFilePanel extends React.Component {
     return null;
   };
 
-  selectFile = (file, id, focusLine) => {
-    this.setState({selectedFile: [file, id], focusLine: focusLine});
+  selectFile = (file, id, focusLine, annotationFocus) => {
+    this.setState({selectedFile: [file, id], focusLine: focusLine, annotationFocus: annotationFocus});
     localStorage.setItem('file', file);
   };
 
@@ -156,6 +156,7 @@ export class SubmissionFilePanel extends React.Component {
             selectedFile={submission_file_id}
             annotations={visibleAnnotations}
             focusLine={this.state.focusLine}
+            annotationFocus={this.state.annotationFocus}
             released_to_students={this.props.released_to_students}
           />
         </div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After sourcing feedback from stakeholders, it seems that having each deduction listed for a mark be hyperlinked to the file and position of the deductive annotation would be useful. This PR adds the functionality whereby clicking on a listed deduction will change the submission file view to the file & position of the annotation that caused the deduction.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Add a function in the result view that uses the existing ref for the left pane to change the file/position seen.
- Change the list of deductions to be hyperlinked and trigger the (passed down as a prop) function which was added to the result component.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] New feature (non-breaking change which adds functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
Should update the Wiki to mention the deductions list is hyperlinked.