### PR TITLE
Fix code to avoid deprecation warnings

### DIFF
--- a/app/models/student_membership.rb
+++ b/app/models/student_membership.rb
@@ -74,8 +74,9 @@ class StudentMembership < Membership
   def one_accepted_per_assignment
     return unless user.try(:student?)
 
-    all_groupings = user.accepted_groupings.where('groupings.assessment_id': grouping.assessment_id)
-    all_memberships = StudentMembership.accepted_or_inviter.where(grouping_id: all_groupings.ids)
+    all_memberships = user.accepted_memberships
+                          .joins(:grouping)
+                          .where('groupings.assessment_id': grouping.assessment_id)
     return if all_memberships.empty? || all_memberships.find_by(id: self.id)
 
     errors.add(:base, I18n.t('csv.memberships_not_unique'))

--- a/app/models/student_membership.rb
+++ b/app/models/student_membership.rb
@@ -70,19 +70,15 @@ class StudentMembership < Membership
     end
   end
 
+  # Raises an error if this user already has an accepted membership for a different grouping for this assignment
   def one_accepted_per_assignment
-    return true unless membership_status_changed?
-    old, new = membership_status_change
-    accepted_or_inviter = [STATUSES[:accepted], STATUSES[:inviter]]
-    return true unless accepted_or_inviter.include?(new) && !accepted_or_inviter.include?(old)
-    other_users = StudentMembership.joins(:grouping)
-                                   .where('groupings.assessment_id': grouping.assessment_id)
-                                   .where(membership_status: [:inviter, :accepted])
-                                   .where(user_id: user_id)
-    unless other_users.empty?
-      errors.add(:base, I18n.t('csv.memberships_not_unique'))
-      return false
-    end
-    true
+    return unless user.try(:student?)
+
+    all_groupings = user.accepted_groupings.where('groupings.assessment_id': grouping.assessment_id)
+    all_memberships = StudentMembership.accepted_or_inviter.where(grouping_id: all_groupings.ids)
+    return if all_memberships.empty? || all_memberships.find_by(id: self.id)
+
+    errors.add(:base, I18n.t('csv.memberships_not_unique'))
+    throw(:abort)
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -307,7 +307,7 @@ describe Assignment do
           end
 
           it 'raises an exception' do
-            expect { @assignment.add_group(@group_name) }.to raise_error
+            expect { @assignment.add_group(@group_name) }.to raise_error(RuntimeError)
           end
         end
 
@@ -1120,7 +1120,6 @@ describe Assignment do
           @section_due_date = SectionDueDate.create(section: create(:section),
                                                     assignment: @assignment,
                                                     due_date: 1.days.ago)
-          puts @section_due_date.inspect
         end
 
         it 'returns false' do

--- a/spec/models/student_membership_spec.rb
+++ b/spec/models/student_membership_spec.rb
@@ -84,6 +84,40 @@ describe StudentMembership do
     it 'should not belong to an ta' do
       expect { create :student_membership, user: create(:ta) }.to raise_error(ActiveRecord::RecordInvalid)
     end
+    context 'validates if a student is accepted to multiple memberships for a single assignment' do
+      let(:student) { create :student }
+      let(:assignment) { create :assignment }
+      let(:grouping) { create :grouping, assignment: assignment }
+      let(:accepted_membership) { create :accepted_student_membership, user: student, grouping: grouping }
+      let(:pending_membership) { create :student_membership, user: student, grouping: grouping }
+      it 'should not allow if both are accepted' do
+        create :grouping_with_inviter, inviter: student, assignment: assignment
+        expect { accepted_membership }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+      it 'should not allow if there is already an accepted grouping' do
+        create :grouping_with_inviter, inviter: student, assignment: assignment
+        expect { pending_membership }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+      it 'should allow if there is already a pending grouping and the new one is accepted' do
+        first_grouping = create :grouping, assignment: assignment
+        create :student_membership, user: student, grouping: first_grouping
+        expect { accepted_membership }.not_to raise_error
+      end
+      it 'should allow if both memberships are pending' do
+        first_grouping = create :grouping, assignment: assignment
+        create :student_membership, user: student, grouping: first_grouping
+        expect { pending_membership }.not_to raise_error
+      end
+      it 'should allow you to modify an existing accepted grouping' do
+        accepted_grouping = create :grouping_with_inviter, inviter: student, assignment: assignment
+        membership = accepted_grouping.accepted_student_memberships.first
+        expect { membership.update!(membership_status: StudentMembership::STATUSES[:pending]) }.not_to raise_error
+      end
+      it 'should allow you to modify an existing pending grouping' do
+        membership = create :student_membership, user: student, grouping: create(:grouping, assignment: assignment)
+        expect { membership.update!(membership_status: StudentMembership::STATUSES[:accepted]) }.not_to raise_error
+      end
+    end
   end
 
   context 'when is inviter' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make the test output look nicer due to:

- running tests reveal several deprecation warnings that should be addressed before updating to rails 6
- these deprecation warnings are railed in a validation method that is not tested
- puts statements in tests are unnecessary

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- reconfigured the validation to not raise a deprecation warning
- added tests for this validation
- fixed an unrelated warning in the tests
- removed a puts statement in the tests (for debugging?)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)
- [x] Test update (change that modifies or updates tests only)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests for my changes, if applicable.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
