### PR TITLE
Refactor usages of markable and criterion type

### DIFF
--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -324,8 +324,7 @@ class Result extends React.Component {
       ),
       method: 'PATCH',
       data: {
-        markable_type: criterion_type,
-        markable_id: criterion_id,
+        criterion_id: criterion_id,
         mark: mark
       },
       dataType: 'json'

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -137,7 +137,7 @@ module Api
           'Marking for that submission is already completed' }, status: 404
         return
       end
-      matched_criteria = assignment.criteria.select { |criterion| params.keys.include?(criterion.name) }
+      matched_criteria = assignment.criteria.where(name: params.keys)
       if matched_criteria.empty?
         render 'shared/http_status', locals: { code: '404', message:
           'No criteria were found that match that request.' }, status: 404

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -137,7 +137,7 @@ module Api
           'Marking for that submission is already completed' }, status: 404
         return
       end
-      matched_criteria = assignment.criteria.select{ |criterion| params.keys.include?(criterion.name) }
+      matched_criteria = assignment.criteria.select { |criterion| params.keys.include?(criterion.name) }
       if matched_criteria.empty?
         render 'shared/http_status', locals: { code: '404', message:
           'No criteria were found that match that request.' }, status: 404

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -145,7 +145,7 @@ module Api
       end
 
       matched_criteria.each do |crit|
-        mark_to_change = result.marks.find_or_initialize_by(markable_id: crit.id, markable_type: crit.class.name)
+        mark_to_change = result.marks.find_or_initialize_by(criterion_id: crit.id)
         mark_to_change.mark = params[crit.name] == 'nil' ? nil : params[crit.name].to_f
         unless mark_to_change.save
           # Some error occurred (including invalid mark)

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -8,7 +8,7 @@ class CriteriaController < ApplicationController
     if @assignment.marking_started?
       flash_now(:notice, I18n.t('assignments.due_date.marking_started_warning'))
     end
-    @criteria = @assignment.get_criteria
+    @criteria = @assignment.criteria
   end
 
   def new
@@ -128,7 +128,7 @@ class CriteriaController < ApplicationController
 
   def download
     assignment = Assignment.find(params[:assignment_id])
-    criteria = assignment.get_criteria.sort_by(&:position)
+    criteria = assignment.criteria.sort_by(&:position)
     yml_criteria = criteria.reduce({}) { |a, b| a.merge b.to_yml }
     send_data yml_criteria.ya2yaml(hash_order: criteria.map(&:name)),
               filename: "#{assignment.short_identifier}_criteria.yml",
@@ -152,7 +152,7 @@ class CriteriaController < ApplicationController
     else
       if data[:type] == '.yml'
         ApplicationRecord.transaction do
-          assignment.get_criteria.each(&:destroy)
+          assignment.criteria.each(&:destroy)
 
           # Create criteria based on the parsed data.
           successes = 0

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -128,7 +128,7 @@ class CriteriaController < ApplicationController
 
   def download
     assignment = Assignment.find(params[:assignment_id])
-    criteria = assignment.criteria.sort_by(&:position)
+    criteria = assignment.criteria
     yml_criteria = criteria.reduce({}) { |a, b| a.merge b.to_yml }
     send_data yml_criteria.ya2yaml(hash_order: criteria.map(&:name)),
               filename: "#{assignment.short_identifier}_criteria.yml",

--- a/app/controllers/flexible_criteria_controller.rb
+++ b/app/controllers/flexible_criteria_controller.rb
@@ -4,7 +4,7 @@ class FlexibleCriteriaController < ApplicationController
 
   def download
     @assignment = Assignment.find(params[:assignment_id])
-    criteria = @assignment.get_criteria(:all, :flexible)
+    criteria = @assignment.criteria.where(type: "FlexibleCriterion")
     file_out = MarkusCsv.generate(criteria) do |criterion|
       [criterion.name, criterion.max_mark, criterion.description]
     end

--- a/app/controllers/flexible_criteria_controller.rb
+++ b/app/controllers/flexible_criteria_controller.rb
@@ -4,7 +4,7 @@ class FlexibleCriteriaController < ApplicationController
 
   def download
     @assignment = Assignment.find(params[:assignment_id])
-    criteria = @assignment.criteria.where(type: "FlexibleCriterion")
+    criteria = @assignment.criteria.where(type: 'FlexibleCriterion')
     file_out = MarkusCsv.generate(criteria) do |criterion|
       [criterion.name, criterion.max_mark, criterion.description]
     end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -155,7 +155,7 @@ class GradersController < ApplicationController
                                                    .where(criterion_id: id, ta_id: grader_ids)
                                                    .pluck(:id))
         end
-        unassign_graders_from_criteria(criterion_associations, criterion_ids)
+        unassign_graders_from_criteria(criterion_associations)
       when 'random_assign'
         randomly_assign_graders_to_criteria(criterion_ids, grader_ids)
       end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -160,7 +160,7 @@ class GradersController < ApplicationController
 
         criterion_ids_types.each do |id, type|
           criterion_associations.concat(@assignment.criterion_ta_associations
-                                                   .where(criterion_id: id, criterion_type: type, ta_id: grader_ids)
+                                                   .where(criterion_id: id, ta_id: grader_ids)
                                                    .pluck(:id))
           criterion_ids_by_type[type.to_sym] << id
         end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -133,15 +133,9 @@ class GradersController < ApplicationController
       end
     when 'criteria_table'
       positions = params[:criteria]
-      # TODO: simplify data format interface between here and Criterion#assign_tas.
-      criterion_ids_types =
-        @assignment.criteria.where(type: 'RubricCriterion')
-          .where(position: positions).pluck(:id).map { |id| [id, 'RubricCriterion'] } +
-        @assignment.criteria.where(type: 'FlexibleCriterion')
-          .where(position: positions).pluck(:id).map { |id| [id, 'FlexibleCriterion'] } +
-        @assignment.criteria.where(type: 'CheckboxCriterion')
-          .where(position: positions).pluck(:id).map { |id| [id, 'CheckboxCriterion'] }
-      if criterion_ids_types.blank?
+      criterion_ids = @assignment.criteria.where(position: positions).ids
+
+      if criterion_ids.blank?
         flash_now(:error, I18n.t('graders.select_a_criterion'))
         head :bad_request
         return
@@ -149,27 +143,21 @@ class GradersController < ApplicationController
 
       case params[:global_actions]
       when 'assign'
-        assign_all_graders_to_criteria(criterion_ids_types, grader_ids)
+        assign_all_graders_to_criteria(criterion_ids, grader_ids)
       when 'unassign'
         # Gets criterion associations from params then
         # gets their criterion ids so we can update the
         # group counts.
         criterion_associations = []
-        criterion_ids_by_type = {
-          RubricCriterion: [],
-          FlexibleCriterion: [],
-          CheckboxCriterion: []
-        }
 
-        criterion_ids_types.each do |id, type|
+        criterion_ids.each do |id|
           criterion_associations.concat(@assignment.criterion_ta_associations
                                                    .where(criterion_id: id, ta_id: grader_ids)
                                                    .pluck(:id))
-          criterion_ids_by_type[type.to_sym] << id
         end
-        unassign_graders_from_criteria(criterion_associations, criterion_ids_by_type)
+        unassign_graders_from_criteria(criterion_associations, criterion_ids)
       when 'random_assign'
-        randomly_assign_graders_to_criteria(criterion_ids_types, grader_ids)
+        randomly_assign_graders_to_criteria(criterion_ids, grader_ids)
       end
     end
     head :ok
@@ -203,8 +191,8 @@ class GradersController < ApplicationController
     Criterion.assign_all_tas(criterion_ids, grader_ids, @assignment)
   end
 
-  def unassign_graders_from_criteria(criterion_grader_ids, criterion_ids_by_type)
-    Criterion.unassign_tas(criterion_grader_ids, criterion_ids_by_type, @assignment)
+  def unassign_graders_from_criteria(criterion_grader_ids)
+    Criterion.unassign_tas(criterion_grader_ids, @assignment)
   end
 
   def unassign_graders(grouping_ids, grader_ids)

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -64,7 +64,7 @@ class GradersController < ApplicationController
 
   def grader_criteria_mapping
     assignment = Assignment.find(params[:assignment_id])
-    criteria = assignment.get_criteria(:ta, :all, includes: [:tas])
+    criteria = assignment.get_criteria(:ta_visible, :all, includes: [:tas])
 
     file_out = MarkusCsv.generate(criteria) do |criterion|
       [criterion.name] + criterion.tas.map(&:user_name)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -193,12 +193,12 @@ class ResultsController < ApplicationController
           assigned_criteria = current_user.criterion_ta_associations
                                           .where(assessment_id: assignment.id)
                                           .pluck(:criterion_id)
-                                          .map { |id| "#{id}" }
+                                          .map { |id| id.to_s }
           if assignment.hide_unassigned_criteria
-            marks_map = marks_map.select { |m| assigned_criteria.include? "#{m[:id]}" }
+            marks_map = marks_map.select { |m| assigned_criteria.include? m[:id].to_s }
             old_marks = old_marks.select { |m| assigned_criteria.include? m }
           else
-            marks_map = marks_map.partition { |m| assigned_criteria.include? "#{m[:id]}" }
+            marks_map = marks_map.partition { |m| assigned_criteria.include? m[:id].to_s }
                                  .flatten
           end
         else

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -649,10 +649,10 @@ class ResultsController < ApplicationController
     if @result.is_a_review?
       if @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) ||
           !@grouping.membership_status(current_user).nil? || !@current_user.student?
-        @mark_criteria = @assignment.get_criteria(:peer)
+        @mark_criteria = @assignment.get_criteria(:peer_visible)
       end
     else
-      @mark_criteria = @assignment.get_criteria(:ta)
+      @mark_criteria = @assignment.get_criteria(:ta_visible)
     end
 
     @mark_criteria.each do |criterion|

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -193,7 +193,7 @@ class ResultsController < ApplicationController
           assigned_criteria = current_user.criterion_ta_associations
                                           .where(assessment_id: assignment.id)
                                           .pluck(:criterion_id)
-                                          .map { |id| id.to_s }
+                                          .map(&:to_s)
           if assignment.hide_unassigned_criteria
             marks_map = marks_map.select { |m| assigned_criteria.include? m[:id].to_s }
             old_marks = old_marks.select { |m| assigned_criteria.include? m }
@@ -230,7 +230,7 @@ class ResultsController < ApplicationController
 
         # Totals
         data[:assignment_max_mark] =
-          result.is_a_review? ? assignment.pr_assignment.max_mark(:peer) : marks_map.map { |h| h['max_mark'] }.sum
+          result.is_a_review? ? assignment.pr_assignment.max_mark(:peer_visible) : marks_map.map { |h| h['max_mark'] }.sum
         data[:total] = marks_map.map { |h| h['mark'] }
         data[:old_total] = old_marks.values.sum
 
@@ -649,10 +649,10 @@ class ResultsController < ApplicationController
     if @result.is_a_review?
       if @current_user.is_reviewer_for?(@assignment.pr_assignment, @result) ||
           !@grouping.membership_status(current_user).nil? || !@current_user.student?
-        @mark_criteria = @assignment.get_criteria(:peer_visible)
+        @mark_criteria = @assignment.criteria.where(&:peer_visible)
       end
     else
-      @mark_criteria = @assignment.get_criteria(:ta_visible)
+      @mark_criteria = @assignment.ta_criteria
     end
 
     @mark_criteria.each do |criterion|

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -229,9 +229,11 @@ class ResultsController < ApplicationController
         end
 
         # Totals
-        data[:assignment_max_mark] =
-          result.is_a_review? ? assignment.pr_assignment.max_mark(:peer_visible)
-            : marks_map.map { |h| h['max_mark'] }.sum
+        if result.is_a_review?
+          data[:assignment_max_mark] = assignment.pr_assignment.max_mark(:peer_visible)
+        else
+          data[:assignment_max_mark] = marks_map.map { |h| h['max_mark'] }.sum
+        end
         data[:total] = marks_map.map { |h| h['mark'] }
         data[:old_total] = old_marks.values.sum
 

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -192,13 +192,13 @@ class ResultsController < ApplicationController
         if assignment.assign_graders_to_criteria && current_user.ta?
           assigned_criteria = current_user.criterion_ta_associations
                                           .where(assessment_id: assignment.id)
-                                          .pluck(:criterion_type, :criterion_id)
-                                          .map { |t, id| "#{t}-#{id}" }
+                                          .pluck(:criterion_id)
+                                          .map { |id| "#{id}" }
           if assignment.hide_unassigned_criteria
-            marks_map = marks_map.select { |m| assigned_criteria.include? "#{m[:criterion_type]}-#{m[:id]}" }
+            marks_map = marks_map.select { |m| assigned_criteria.include? "#{m[:id]}" }
             old_marks = old_marks.select { |m| assigned_criteria.include? m }
           else
-            marks_map = marks_map.partition { |m| assigned_criteria.include? "#{m[:criterion_type]}-#{m[:id]}" }
+            marks_map = marks_map.partition { |m| assigned_criteria.include? "#{m[:id]}" }
                                  .flatten
           end
         else

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -230,7 +230,8 @@ class ResultsController < ApplicationController
 
         # Totals
         data[:assignment_max_mark] =
-          result.is_a_review? ? assignment.pr_assignment.max_mark(:peer_visible) : marks_map.map { |h| h['max_mark'] }.sum
+          result.is_a_review? ? assignment.pr_assignment.max_mark(:peer_visible)
+            : marks_map.map { |h| h['max_mark'] }.sum
         data[:total] = marks_map.map { |h| h['mark'] }
         data[:old_total] = old_marks.values.sum
 

--- a/app/controllers/rubric_criteria_controller.rb
+++ b/app/controllers/rubric_criteria_controller.rb
@@ -4,7 +4,7 @@ class RubricCriteriaController < ApplicationController
 
   def download_csv
     @assignment = Assignment.find(params[:assignment_id])
-    file_out = MarkusCsv.generate(@assignment.get_criteria(:all, :rubric)) do |criterion|
+    file_out = MarkusCsv.generate(@assignment.criteria.where(type: "RubricCriterion")) do |criterion|
       criterion_array = [criterion.name, criterion.max_mark]
       criterion.levels.each do |level|
         criterion_array.push(level.name)

--- a/app/controllers/rubric_criteria_controller.rb
+++ b/app/controllers/rubric_criteria_controller.rb
@@ -4,7 +4,7 @@ class RubricCriteriaController < ApplicationController
 
   def download_csv
     @assignment = Assignment.find(params[:assignment_id])
-    file_out = MarkusCsv.generate(@assignment.criteria.where(type: "RubricCriterion")) do |criterion|
+    file_out = MarkusCsv.generate(@assignment.criteria.where(type: 'RubricCriterion')) do |criterion|
       criterion_array = [criterion.name, criterion.max_mark]
       criterion.levels.each do |level|
         criterion_array.push(level.name)

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -1,6 +1,6 @@
 module AutomatedTestsHelper
   def extra_test_group_schema(assignment)
-    criterion_names, criterion_disambig = assignment.get_criteria(:ta).map do |c|
+    criterion_names, criterion_disambig = assignment.get_criteria(:ta_visible).map do |c|
       [c.name, "#{c.id}_#{c.class.name}"]
     end.transpose
     { type: :object,

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -1,6 +1,6 @@
 module AutomatedTestsHelper
   def extra_test_group_schema(assignment)
-    criterion_names, criterion_disambig = assignment.get_criteria(:ta_visible).map do |c|
+    criterion_names, criterion_disambig = assignment.ta_criteria.map do |c|
       [c.name, "#{c.id}_#{c.class.name}"]
     end.transpose
     { type: :object,

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -48,12 +48,11 @@ module AutomatedTestsHelper
         display_output = extra_data_specs['display_output'] || TestGroup.display_outputs.keys.first
         test_group_name = extra_data_specs['name'] || TestGroup.model_name.human
         criterion_id = nil
-        criterion_type = nil
         if !extra_data_specs['criterion'].nil? && extra_data_specs['criterion'].include?('_')
-          criterion_id, criterion_type = extra_data_specs['criterion'].split('_') # polymorphic field
+          criterion_id = extra_data_specs['criterion'].split('_')
         end
         fields = { assignment: assignment, name: test_group_name, display_output: display_output,
-                   criterion_id: criterion_id, criterion_type: criterion_type }
+                   criterion_id: criterion_id }
         if test_group_id.nil?
           test_group = TestGroup.create!(fields)
           test_group_id = test_group.id

--- a/app/helpers/random_assign_helper.rb
+++ b/app/helpers/random_assign_helper.rb
@@ -178,8 +178,7 @@ module RandomAssignHelper
         results.flat_map do |result|
           assignment_criteria.map do |criterion|
             { result_id: result['id'],
-              markable_id: criterion.id,
-              markable_type: criterion.class.to_s,
+              criterion_id: criterion.id,
               created_at: now,
               updated_at: now }
           end

--- a/app/helpers/random_assign_helper.rb
+++ b/app/helpers/random_assign_helper.rb
@@ -155,7 +155,7 @@ module RandomAssignHelper
   def save_peer_reviews(pr_assignment)
     return if @reviewers.empty? || @reviewees.empty?
 
-    assignment_criteria = pr_assignment.get_criteria(:peer)
+    assignment_criteria = pr_assignment.get_criteria(:peer_visible)
 
     groupings = Grouping.includes(:current_submission_used)
                         .where(id: @reviewees)

--- a/app/helpers/random_assign_helper.rb
+++ b/app/helpers/random_assign_helper.rb
@@ -155,7 +155,7 @@ module RandomAssignHelper
   def save_peer_reviews(pr_assignment)
     return if @reviewers.empty? || @reviewees.empty?
 
-    assignment_criteria = pr_assignment.get_criteria(:peer_visible)
+    assignment_criteria = pr_assignment.criteria.where(&:peer_visible)
 
     groupings = Grouping.includes(:current_submission_used)
                         .where(id: @reviewees)

--- a/app/helpers/random_assign_helper.rb
+++ b/app/helpers/random_assign_helper.rb
@@ -155,7 +155,7 @@ module RandomAssignHelper
   def save_peer_reviews(pr_assignment)
     return if @reviewers.empty? || @reviewees.empty?
 
-    assignment_criteria = pr_assignment.criteria.where(&:peer_visible)
+    assignment_criteria = pr_assignment.criteria.where(:peer_visible => true)
 
     groupings = Grouping.includes(:current_submission_used)
                         .where(id: @reviewees)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -761,7 +761,7 @@ class Assignment < Assessment
         num_assigned_criteria = ta.criterion_ta_associations.where(assignment: self).count
         marked = ta.criterion_ta_associations
                    .joins('INNER JOIN marks m ON criterion_ta_associations.criterion_id = m.criterion_id')
-                   .where('m.mark IS NOT NaULL AND assessment_id = ?', self.id)
+                   .where('m.mark IS NOT NULL AND assessment_id = ?', self.id)
                    .group('m.result_id')
                    .count
         ta_memberships.includes(grouping: :current_result).where(user_id: ta_id).find_each do |t_mem|

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -661,24 +661,15 @@ class Assignment < Assessment
 
     include_opt = options[:includes]
     if user_visibility == :all
-      @criteria[[user_visibility, type, options]] = get_all_criteria(include_opt)
+      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
+                                                      .order(:position)
     elsif user_visibility == :ta
-      @criteria[[user_visibility, type, options]] = get_ta_visible_criteria(include_opt)
+      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
+                                                      .order(:position).select(&:ta_visible)
     elsif user_visibility == :peer
-      @criteria[[user_visibility, type, options]] = get_peer_visible_criteria(include_opt)
+      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
+                                                      .order(:position).select(&:peer_visible)
     end
-  end
-
-  def get_all_criteria(include_opt)
-    criteria.includes(include_opt).order(:position)
-  end
-
-  def get_ta_visible_criteria(include_opt)
-    get_all_criteria(include_opt).select(&:ta_visible)
-  end
-
-  def get_peer_visible_criteria(include_opt)
-    get_all_criteria(include_opt).select(&:peer_visible)
   end
 
   def criteria_count
@@ -770,7 +761,7 @@ class Assignment < Assessment
         num_assigned_criteria = ta.criterion_ta_associations.where(assignment: self).count
         marked = ta.criterion_ta_associations
                    .joins('INNER JOIN marks m ON criterion_ta_associations.criterion_id = m.criterion_id')
-                   .where('m.mark IS NOT NULL AND assessment_id = ?', self.id)
+                   .where('m.mark IS NOT NaULL AND assessment_id = ?', self.id)
                    .group('m.result_id')
                    .count
         ta_memberships.includes(grouping: :current_result).where(user_id: ta_id).find_each do |t_mem|

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -495,7 +495,7 @@ class Assignment < Assessment
       if self.assign_graders_to_criteria
         assigned_criteria = user.criterion_ta_associations
                                 .where(assessment_id: self.id)
-                                .pluck(:criterion_type, :criterion_id)
+                                .pluck(:criterion_id)
                                 .map { |t, id| "#{t}-#{id}" }
       else
         assigned_criteria = nil
@@ -769,7 +769,7 @@ class Assignment < Assessment
         ta = Ta.find(ta_id)
         num_assigned_criteria = ta.criterion_ta_associations.where(assignment: self).count
         marked = ta.criterion_ta_associations
-                   .joins('INNER JOIN marks m ON marks.criterion_id = m.criterion_id')
+                   .joins('INNER JOIN marks m ON criterion_ta_associations.criterion_id = m.criterion_id')
                    .where('m.mark IS NOT NULL AND assessment_id = ?', self.id)
                    .group('m.result_id')
                    .count
@@ -1177,7 +1177,7 @@ class Assignment < Assessment
     if current_user.ta? && hide_unassigned_criteria
       assigned_criteria = current_user.criterion_ta_associations
                                       .where(assignment_id: self.id)
-                                      .pluck(:criterion_type, :criterion_id)
+                                      .pluck(:criterion_id)
                                       .map { |t, id| "#{t}-#{id}" }
     else
       assigned_criteria = nil

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -238,8 +238,8 @@ class Assignment < Assessment
   end
 
   # Returns the maximum possible mark for a particular assignment
-  def max_mark(user_visibility = :ta)
-    # TODO: sum method does not work with empty arrays. Consider updating/replacing gem:
+  def max_mark(user_visibility = :ta_visible)
+    # TODO: sum method does not work with empty arrays. Consider updating/replacing gem``:
     #       see: https://github.com/thirtysixthspan/descriptive_statistics/issues/44
     max_marks = get_criteria(user_visibility).map(&:max_mark)
     s = max_marks.empty? ? 0 : max_marks.sum
@@ -594,7 +594,7 @@ class Assignment < Assessment
     end
 
     headers = [['User name', 'Group', 'Final grade'], ['', 'Out of', self.max_mark]]
-    criteria = self.get_criteria(:ta)
+    criteria = self.get_criteria(:ta_visible)
     criteria.each do |crit|
       headers[0] << crit.name
       headers[1] << crit.max_mark
@@ -654,22 +654,7 @@ class Assignment < Assessment
 
   # Returns a filtered list of criteria.
   def get_criteria(user_visibility = :all, type = :all, options = {})
-    @criteria ||= Hash.new
-    unless @criteria[[user_visibility, type, options]].nil? || options[:no_cache]
-      return @criteria[[user_visibility, type, options]]
-    end
-
-    include_opt = options[:includes]
-    if user_visibility == :all
-      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
-                                                      .order(:position)
-    elsif user_visibility == :ta
-      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
-                                                      .order(:position).select(&:ta_visible)
-    elsif user_visibility == :peer
-      @criteria[[user_visibility, type, options]] = criteria.includes(include_opt)
-                                                      .order(:position).select(&:peer_visible)
-    end
+    criteria.includes(options[:includes]).order(:position).select(&user_visibility)
   end
 
   def criteria_count

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -520,8 +520,8 @@ class Assignment < Assessment
     criteria_shown = Set.new
     max_mark = 0
 
-    visibility = user.admin? ? :all : :ta
-    criteria_columns = criteria.select(&visibility).map do |crit|
+    selected_criteria = user.admin? ? criteria : criteria.select(&:ta_visible)
+    criteria_columns = selected_criteria.map do |crit|
       unassigned = !assigned_criteria.nil? && !assigned_criteria.include?("#{crit.class}-#{crit.id}")
       next if hide_unassigned && unassigned
 
@@ -596,7 +596,7 @@ class Assignment < Assessment
     end
 
     headers = [['User name', 'Group', 'Final grade'], ['', 'Out of', self.max_mark]]
-    criteria = criteria.select(:ta_visible)
+    criteria = self.criteria.select(&:ta_visible)
     criteria.each do |crit|
       headers[0] << crit.name
       headers[1] << crit.max_mark
@@ -1163,7 +1163,7 @@ class Assignment < Assessment
     end
 
     visibility = current_user.admin? ? :all : :ta
-    criteria = criteria.select(&visibility).reject do |crit|
+    criteria = self.criteria.select(&visibility).reject do |crit|
       !assigned_criteria.nil? && !assigned_criteria.include?("#{crit.class}-#{crit.id}")
     end
 

--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -48,7 +48,7 @@ class CheckboxCriterion < Criterion
 
     # If a CheckboxCriterion with the same name exists, load it up. Otherwise,
     # create a new one.
-    criterion = assignment.get_criteria(:all, :checkbox).find_or_create_by(name: name)
+    criterion = assignment.criteria.where(type: 'CheckboxCriterion').find_or_create_by(name: name)
 
     # Check that max is not a string.
     begin

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -118,18 +118,7 @@ class Criterion < ApplicationRecord
   # Updates the +assigned_groups_count+ field of all criteria that belong to
   # an assignment with ID +assignment_id+.
   def self.update_assigned_groups_counts(assignment)
-    counts = CriterionTaAssociation
-             .from(
-               # subquery
-               assignment.criterion_ta_associations
-                         .joins(ta: :groupings)
-                         .where('groupings.assessment_id': assignment.id)
-                         .select('criterion_ta_associations.criterion_id',
-                                 'groupings.id')
-                         .distinct
-             )
-             .group('subquery.criterion_id')
-             .count
+    counts = assignment.criterion_ta_associations.joins(ta: :groupings).group(:id).count
 
     records = Criterion.where(assessment_id: assignment.id)
                        .pluck_to_hash

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -118,7 +118,18 @@ class Criterion < ApplicationRecord
   # Updates the +assigned_groups_count+ field of all criteria that belong to
   # an assignment with ID +assignment_id+.
   def self.update_assigned_groups_counts(assignment)
-    counts = assignment.criteria.joins(tas: :groupings).group(:id).count
+    counts = CriterionTaAssociation
+             .from(
+               # subquery
+               assignment.criterion_ta_associations
+                         .joins(ta: :groupings)
+                         .where('groupings.assessment_id': assignment.id)
+                         .select('criterion_ta_associations.criterion_id',
+                                 'groupings.id')
+                         .distinct
+             )
+             .group('subquery.criterion_id')
+             .count
 
     records = Criterion.where(assessment_id: assignment.id)
                        .pluck_to_hash

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -118,7 +118,7 @@ class Criterion < ApplicationRecord
   # Updates the +assigned_groups_count+ field of all criteria that belong to
   # an assignment with ID +assignment_id+.
   def self.update_assigned_groups_counts(assignment)
-    counts = assignment.criterion_ta_associations.joins(ta: :groupings).group(:id).count
+    counts = assignment.criteria.joins(tas: :groupings).group(:id).count
 
     records = Criterion.where(assessment_id: assignment.id)
                        .pluck_to_hash

--- a/app/models/criterion_ta_association.rb
+++ b/app/models/criterion_ta_association.rb
@@ -11,7 +11,7 @@ class CriterionTaAssociation < ApplicationRecord
   before_validation       :add_assignment_reference, on: :create
 
   def self.from_csv(assignment, csv_data, remove_existing)
-    criteria = assignment.get_criteria(:ta, :all, includes: [:criterion_ta_associations])
+    criteria = assignment.get_criteria(:ta_visible, :all, includes: [:criterion_ta_associations])
     if remove_existing
       criteria.each do |criterion|
         criterion.criterion_ta_associations.destroy_all

--- a/app/models/criterion_ta_association.rb
+++ b/app/models/criterion_ta_association.rb
@@ -34,7 +34,6 @@ class CriterionTaAssociation < ApplicationRecord
         ta_id = Ta.find_by(user_name: user_name).id
         new_ta_mappings << {
           criterion_id: criterion.id,
-          criterion_type: criterion.class,
           ta_id: ta_id,
           assessment_id: assignment.id
         }

--- a/app/models/criterion_ta_association.rb
+++ b/app/models/criterion_ta_association.rb
@@ -11,7 +11,7 @@ class CriterionTaAssociation < ApplicationRecord
   before_validation       :add_assignment_reference, on: :create
 
   def self.from_csv(assignment, csv_data, remove_existing)
-    criteria = assignment.get_criteria(:ta_visible, :all, includes: [:criterion_ta_associations])
+    criteria = assignment.ta_criteria.includes(:criterion_ta_associations)
     if remove_existing
       criteria.each do |criterion|
         criterion.criterion_ta_associations.destroy_all

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -36,7 +36,7 @@ class FlexibleCriterion < Criterion
     name = working_row.shift
     # If a FlexibleCriterion with the same name exits, load it up.  Otherwise,
     # create a new one.
-    criterion = assignment.get_criteria(:all, :flexible).find_or_create_by(name: name)
+    criterion = assignment.criteria.where(type: "FlexibleCriterion").find_or_create_by(name: name)
     # Check that max is not a string.
     begin
       criterion.max_mark = Float(working_row.shift)

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -36,7 +36,7 @@ class FlexibleCriterion < Criterion
     name = working_row.shift
     # If a FlexibleCriterion with the same name exits, load it up.  Otherwise,
     # create a new one.
-    criterion = assignment.criteria.where(type: "FlexibleCriterion").find_or_create_by(name: name)
+    criterion = assignment.criteria.where(type: 'FlexibleCriterion').find_or_create_by(name: name)
     # Check that max is not a string.
     begin
       criterion.max_mark = Float(working_row.shift)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -152,7 +152,6 @@ class Grouping < ApplicationRecord
   # Updates the +criteria_coverage_count+ field of all groupings specified
   # by +grouping_ids+.
   def self.update_criteria_coverage_counts(assignment, grouping_ids = nil)
-    byebug
     if grouping_ids.nil?
       grouping_ids = assignment.groupings.pluck(:id)
     end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -159,8 +159,8 @@ class Grouping < ApplicationRecord
 
     counts = CriterionTaAssociation
              .from(
-                # subquery
-                assignment.criterion_ta_associations
+               # subquery
+               assignment.criterion_ta_associations
                          .joins(ta: :groupings)
                          .where('groupings.id': grouping_ids)
                          .select('criterion_ta_associations.criterion_id',

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -157,7 +157,18 @@ class Grouping < ApplicationRecord
     end
     return if grouping_ids.empty?
 
-    counts = assignment.criterion_ta_associations.joins(ta: :groupings).group(:id).count
+    counts = CriterionTaAssociation
+             .from(	
+               # subquery	
+               assignment.criterion_ta_associations	
+                         .joins(ta: :groupings)	
+                         .where('groupings.id': grouping_ids)	
+                         .select('criterion_ta_associations.criterion_id',	
+                                 'groupings.id')	
+                         .distinct	
+             )	
+             .group('subquery.id')	
+             .count
 
     grouping_data = Grouping.where(id: grouping_ids).pluck_to_hash.map do |h|
       { **h.symbolize_keys, criteria_coverage_count: counts[h['id'].to_i] || 0 }

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -158,16 +158,16 @@ class Grouping < ApplicationRecord
     return if grouping_ids.empty?
 
     counts = CriterionTaAssociation
-             .from(	
-               # subquery	
-               assignment.criterion_ta_associations	
-                         .joins(ta: :groupings)	
-                         .where('groupings.id': grouping_ids)	
-                         .select('criterion_ta_associations.criterion_id',	
-                                 'groupings.id')	
-                         .distinct	
-             )	
-             .group('subquery.id')	
+             .from(
+                # subquery
+                assignment.criterion_ta_associations
+                         .joins(ta: :groupings)
+                         .where('groupings.id': grouping_ids)
+                         .select('criterion_ta_associations.criterion_id',
+                                 'groupings.id')
+                         .distinct
+             )
+             .group('subquery.id')
              .count
 
     grouping_data = Grouping.where(id: grouping_ids).pluck_to_hash.map do |h|

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -69,7 +69,7 @@ class RubricCriterion < Criterion
     working_row = row.clone
     name = working_row.shift
 
-    criterion = assignment.criteria.where(type: "RubricCriterion").find_or_create_by(name: name)
+    criterion = assignment.criteria.where(type: 'RubricCriterion').find_or_create_by(name: name)
 
     # Only set the position if this is a new record.
     if criterion.new_record?

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -69,7 +69,7 @@ class RubricCriterion < Criterion
     working_row = row.clone
     name = working_row.shift
 
-    criterion = assignment.get_criteria(:all, :rubric).find_or_create_by(name: name)
+    criterion = assignment.criteria.where(type: "RubricCriterion").find_or_create_by(name: name)
 
     # Only set the position if this is a new record.
     if criterion.new_record?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -309,7 +309,7 @@ class Submission < ApplicationRecord
                                 unit: extra_mark.unit)
     end
 
-    remark_assignment.get_criteria(:ta_visible).each do |criterion|
+    remark_assignment.ta_criteria.each do |criterion|
       remark_mark = Mark.where(criterion: criterion, result_id: remark.id)
       original_mark = Mark.where(criterion: criterion, result_id: original_result.id)
       remark_mark.first.update!(mark: original_mark.first.mark)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -309,7 +309,7 @@ class Submission < ApplicationRecord
                                 unit: extra_mark.unit)
     end
 
-    remark_assignment.get_criteria(:ta).each do |criterion|
+    remark_assignment.get_criteria(:ta_visible).each do |criterion|
       remark_mark = Mark.where(criterion: criterion, result_id: remark.id)
       original_mark = Mark.where(criterion: criterion, result_id: original_result.id)
       remark_mark.first.update!(mark: original_mark.first.mark)

--- a/app/models/test_group.rb
+++ b/app/models/test_group.rb
@@ -3,7 +3,7 @@ class TestGroup < ApplicationRecord
        _prefix: :display_to
 
   belongs_to :assignment, foreign_key: :assessment_id
-  belongs_to :criterion, optional: true, polymorphic: true
+  belongs_to :criterion, optional: true
   has_many :test_group_results, dependent: :delete_all
 
   validates :name, presence: true

--- a/app/views/criteria/_criteria_pane.html.erb
+++ b/app/views/criteria/_criteria_pane.html.erb
@@ -9,7 +9,7 @@
   </header>
 
   <ul id='criteria_pane_list'>
-    <% @assignment.get_criteria.each do |criterion| %>
+    <% @assignment.criteria.each do |criterion| %>
       <%= render partial: 'criteria/criterion',
                  locals: { criterion: criterion } %>
     <% end %>

--- a/lib/tasks/marks.rake
+++ b/lib/tasks/marks.rake
@@ -92,7 +92,7 @@ namespace :db do
       )
 
       #Automate marks for assignment using appropriate criteria
-      grouping.assignment.get_criteria(:all, :all, includes: :marks).each do |criterion|
+      grouping.assignment.criteria.includes(:marks).each do |criterion|
         if criterion.class == RubricCriterion
           random_mark = criterion.max_mark / 4 * rand(0..4)
         elsif criterion.class == FlexibleCriterion

--- a/lib/tasks/remarks.rake
+++ b/lib/tasks/remarks.rake
@@ -35,7 +35,7 @@ namespace :db do
     result = remark_submission.results.first
 
     #Automate remarks for assignment using appropriate criteria
-    remark_submission.assignment.get_criteria(:all, :all, includes: :marks).each do |criterion|
+    remark_submission.assignment.criteria.includes(:marks).each do |criterion|
       if criterion.class == RubricCriterion
         random_mark = criterion.max_mark / 4 * rand(0..4)
       elsif criterion.class == FlexibleCriterion

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -230,8 +230,7 @@ describe Api::GroupsController do
       end
       context 'when a grouping does have a mark already' do
         before :each do
-          mark = submission.current_result.marks.find_or_initialize_by(markable_id: criterion.id,
-                                                                       markable_type: criterion.class.name)
+          mark = submission.current_result.marks.find_or_initialize_by(criterion_id: criterion.id)
           mark.mark = 10
           mark.save!
           post :update_marks, params: { id: grouping.group.id,
@@ -250,8 +249,7 @@ describe Api::GroupsController do
       end
       context 'when a result is complete' do
         before :each do
-          mark = submission.current_result.marks.find_or_initialize_by(markable_id: criterion.id,
-                                                                       markable_type: criterion.class.name)
+          mark = submission.current_result.marks.find_or_initialize_by(criterion_id: criterion.id)
           mark.mark = 10
           mark.save!
           submission.current_result.update(marking_state: Result::MARKING_STATES[:complete])

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -757,9 +757,9 @@ describe CriteriaController do
       it 'deletes all criteria previously created' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: "RubricCriterion").find_by(name: rubric_criterion.name)).to be_nil
-        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: flexible_criterion.name)).to be_nil
-        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: checkbox_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: 'RubricCriterion').find_by(name: rubric_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: flexible_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: 'CheckboxCriterion').find_by(name: checkbox_criterion.name)).to be_nil
       end
 
       it 'maintains the order between entries and positions for criteria' do
@@ -793,8 +793,8 @@ describe CriteriaController do
 
       it 'creates rubric criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
-        expect(assignment.criteria.where(type: "RubricCriterion").pluck(:name)).to contain_exactly('cr30', 'cr90')
-        cr1 = assignment.criteria.where(type: "RubricCriterion").find_by(name: 'cr30')
+        expect(assignment.criteria.where(type: 'RubricCriterion').pluck(:name)).to contain_exactly('cr30', 'cr90')
+        cr1 = assignment.criteria.where(type: 'RubricCriterion').find_by(name: 'cr30')
         expect(cr1.levels.size).to eq(5)
         expect(cr1.max_mark).to eq(5.0)
         expect(cr1.ta_visible).to be false
@@ -807,7 +807,7 @@ describe CriteriaController do
         expect(cr1.levels.find_by(name: 'Good', description: 'Alright', mark: 3)).not_to be_nil
         expect(cr1.levels.find_by(name: 'Excellent', description: 'Impressive', mark: 5)).not_to be_nil
 
-        cr2 = assignment.criteria.where(type: "RubricCriterion").find_by(name: 'cr90')
+        cr2 = assignment.criteria.where(type: 'RubricCriterion').find_by(name: 'cr90')
         expect(cr2.max_mark).to eq(4.6)
         expect(cr2.levels.size).to eq(5)
         expect(cr2.ta_visible).to be true
@@ -817,27 +817,27 @@ describe CriteriaController do
       it 'creates flexible criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: "FlexibleCriterion").pluck(:name)).to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name)).to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
 
-        cr80 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr80')
+        cr80 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr80')
         expect(cr80.max_mark).to eq(10.0)
         expect(cr80.description).to eq('')
         expect(cr80.ta_visible).to be true
         expect(cr80.peer_visible).to be true
 
-        cr20 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr20')
+        cr20 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr20')
         expect(cr20.max_mark).to eq(2.0)
         expect(cr20.description).to eq('I am flexible')
         expect(cr20.ta_visible).to be true
         expect(cr20.peer_visible).to be true
 
-        cr50 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr50')
+        cr50 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr50')
         expect(cr50.max_mark).to eq(1.0)
         expect(cr50.description).to eq('Another flexible.')
         expect(cr50.ta_visible).to be true
         expect(cr50.peer_visible).to be false
 
-        cr60 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60')
+        cr60 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr60')
         expect(cr60.max_mark).to eq(10.0)
         expect(cr60.description).to eq('')
         expect(cr60.ta_visible).to be true
@@ -847,8 +847,8 @@ describe CriteriaController do
       it 'creates checkbox criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: "CheckboxCriterion").pluck(:name)).to contain_exactly('cr100', 'cr40')
-        cr1 = assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100')
+        expect(assignment.criteria.where(type: 'CheckboxCriterion').pluck(:name)).to contain_exactly('cr100', 'cr40')
+        cr1 = assignment.criteria.where(type: 'CheckboxCriterion').find_by(name: 'cr100')
         expect(cr1.max_mark).to eq(5.0)
         expect(cr1.description).to eq('I am checkbox')
         expect(cr1.ta_visible).to be true
@@ -858,30 +858,30 @@ describe CriteriaController do
       it 'creates criteria being case insensitive with the type given' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: "FlexibleCriterion").pluck(:name)).to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name)).to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
       end
 
       it 'creates criteria that lack a description' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: "FlexibleCriterion").map(&:name)).to include('cr80')
-        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr80').description).to eq('')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').map(&:name)).to include('cr80')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr80').description).to eq('')
       end
 
       it 'creates criteria with the default visibility options if these are not given in the entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
         expect(assignment.criteria.map(&:name)).to include('cr100', 'cr60')
-        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100').ta_visible).to be true
-        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100').peer_visible).to be false
-        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60').ta_visible).to be true
-        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60').peer_visible).to be false
+        expect(assignment.criteria.where(type: 'CheckboxCriterion').find_by(name: 'cr100').ta_visible).to be true
+        expect(assignment.criteria.where(type: 'CheckboxCriterion').find_by(name: 'cr100').peer_visible).to be false
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr60').ta_visible).to be true
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr60').peer_visible).to be false
       end
 
       it 'creates criteria with rounded (up to first digit after decimal point) maximum mark' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: round_max_mark_file }
-        expect(assignment.criteria.where(type: "RubricCriterion").first.name).to eq('cr90')
+        expect(assignment.criteria.where(type: 'RubricCriterion').first.name).to eq('cr90')
 
-        expect(assignment.criteria.where(type: "RubricCriterion").first.max_mark).to eq(4.6)
+        expect(assignment.criteria.where(type: 'RubricCriterion').first.max_mark).to eq(4.6)
       end
       it 'does not create criteria with format errors in entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: invalid_mixed_file }
@@ -904,9 +904,9 @@ describe CriteriaController do
       end
 
       it 'does not create criteria that have unmatched keys / more keys than required' do
-        expect(assignment.criteria.where(type: "RubricCriterion").length).to eq(1)
+        expect(assignment.criteria.where(type: 'RubricCriterion').length).to eq(1)
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: partially_valid_file }
-        expect(assignment.criteria.where(type: "RubricCriterion").length).to eq(1)
+        expect(assignment.criteria.where(type: 'RubricCriterion').length).to eq(1)
         expect(flash[:error]).not_to be_nil
       end
 

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -818,7 +818,7 @@ describe CriteriaController do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
         expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name))
-                                  .to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
+          .to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
 
         cr80 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr80')
         expect(cr80.max_mark).to eq(10.0)
@@ -860,7 +860,7 @@ describe CriteriaController do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
         expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name))
-                                  .to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
+          .to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
       end
 
       it 'creates criteria that lack a description' do

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -817,7 +817,8 @@ describe CriteriaController do
       it 'creates flexible criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name)).to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name))
+                                  .to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
 
         cr80 = assignment.criteria.where(type: 'FlexibleCriterion').find_by(name: 'cr80')
         expect(cr80.max_mark).to eq(10.0)
@@ -858,7 +859,8 @@ describe CriteriaController do
       it 'creates criteria being case insensitive with the type given' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name)).to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
+        expect(assignment.criteria.where(type: 'FlexibleCriterion').pluck(:name))
+                                  .to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
       end
 
       it 'creates criteria that lack a description' do

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -757,15 +757,15 @@ describe CriteriaController do
       it 'deletes all criteria previously created' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.rubric_criteria.find_by(name: rubric_criterion.name)).to be_nil
-        expect(assignment.flexible_criteria.find_by(name: flexible_criterion.name)).to be_nil
-        expect(assignment.checkbox_criteria.find_by(name: checkbox_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: "RubricCriterion").find_by(name: rubric_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: flexible_criterion.name)).to be_nil
+        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: checkbox_criterion.name)).to be_nil
       end
 
       it 'maintains the order between entries and positions for criteria' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria.map { |cr| [cr.name, cr.position] })
+        expect(assignment.criteria.map { |cr| [cr.name, cr.position] })
           .to match_array([['cr30', 1],
                            ['cr20', 2],
                            ['cr100', 3],
@@ -779,7 +779,7 @@ describe CriteriaController do
       it 'creates all criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria.map(&:name)).to contain_exactly('cr30',
+        expect(assignment.criteria.map(&:name)).to contain_exactly('cr30',
                                                                        'cr20',
                                                                        'cr100',
                                                                        'cr80',
@@ -793,8 +793,8 @@ describe CriteriaController do
 
       it 'creates rubric criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
-        expect(assignment.get_criteria(:all, :rubric).pluck(:name)).to contain_exactly('cr30', 'cr90')
-        cr1 = assignment.get_criteria(:all, :rubric).find_by(name: 'cr30')
+        expect(assignment.criteria.where(type: "RubricCriterion").pluck(:name)).to contain_exactly('cr30', 'cr90')
+        cr1 = assignment.criteria.where(type: "RubricCriterion").find_by(name: 'cr30')
         expect(cr1.levels.size).to eq(5)
         expect(cr1.max_mark).to eq(5.0)
         expect(cr1.ta_visible).to be false
@@ -807,7 +807,7 @@ describe CriteriaController do
         expect(cr1.levels.find_by(name: 'Good', description: 'Alright', mark: 3)).not_to be_nil
         expect(cr1.levels.find_by(name: 'Excellent', description: 'Impressive', mark: 5)).not_to be_nil
 
-        cr2 = assignment.get_criteria(:all, :rubric).find_by(name: 'cr90')
+        cr2 = assignment.criteria.where(type: "RubricCriterion").find_by(name: 'cr90')
         expect(cr2.max_mark).to eq(4.6)
         expect(cr2.levels.size).to eq(5)
         expect(cr2.ta_visible).to be true
@@ -817,27 +817,27 @@ describe CriteriaController do
       it 'creates flexible criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria(:all, :flexible).pluck(:name)).to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
+        expect(assignment.criteria.where(type: "FlexibleCriterion").pluck(:name)).to contain_exactly('cr20', 'cr50', 'cr80', 'cr60')
 
-        cr80 = assignment.get_criteria(:all, :flexible).find_by(name: 'cr80')
+        cr80 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr80')
         expect(cr80.max_mark).to eq(10.0)
         expect(cr80.description).to eq('')
         expect(cr80.ta_visible).to be true
         expect(cr80.peer_visible).to be true
 
-        cr20 = assignment.get_criteria(:all, :flexible).find_by(name: 'cr20')
+        cr20 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr20')
         expect(cr20.max_mark).to eq(2.0)
         expect(cr20.description).to eq('I am flexible')
         expect(cr20.ta_visible).to be true
         expect(cr20.peer_visible).to be true
 
-        cr50 = assignment.get_criteria(:all, :flexible).find_by(name: 'cr50')
+        cr50 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr50')
         expect(cr50.max_mark).to eq(1.0)
         expect(cr50.description).to eq('Another flexible.')
         expect(cr50.ta_visible).to be true
         expect(cr50.peer_visible).to be false
 
-        cr60 = assignment.get_criteria(:all, :flexible).find_by(name: 'cr60')
+        cr60 = assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60')
         expect(cr60.max_mark).to eq(10.0)
         expect(cr60.description).to eq('')
         expect(cr60.ta_visible).to be true
@@ -847,8 +847,8 @@ describe CriteriaController do
       it 'creates checkbox criteria with properly formatted entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria(:all, :checkbox).pluck(:name)).to contain_exactly('cr100', 'cr40')
-        cr1 = assignment.get_criteria(:all, :checkbox).find_by(name: 'cr100')
+        expect(assignment.criteria.where(type: "CheckboxCriterion").pluck(:name)).to contain_exactly('cr100', 'cr40')
+        cr1 = assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100')
         expect(cr1.max_mark).to eq(5.0)
         expect(cr1.description).to eq('I am checkbox')
         expect(cr1.ta_visible).to be true
@@ -858,35 +858,35 @@ describe CriteriaController do
       it 'creates criteria being case insensitive with the type given' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria(:all, :flexible).pluck(:name)).to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
+        expect(assignment.criteria.where(type: "FlexibleCriterion").pluck(:name)).to contain_exactly('cr20', 'cr80', 'cr60', 'cr50')
       end
 
       it 'creates criteria that lack a description' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
 
-        expect(assignment.get_criteria(:all, :flexible).map(&:name)).to include('cr80')
-        expect(assignment.get_criteria(:all, :flexible).find_by(name: 'cr80').description).to eq('')
+        expect(assignment.criteria.where(type: "FlexibleCriterion").map(&:name)).to include('cr80')
+        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr80').description).to eq('')
       end
 
       it 'creates criteria with the default visibility options if these are not given in the entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: mixed_file }
-        expect(assignment.get_criteria.map(&:name)).to include('cr100', 'cr60')
-        expect(assignment.get_criteria(:all, :checkbox).find_by(name: 'cr100').ta_visible).to be true
-        expect(assignment.get_criteria(:all, :checkbox).find_by(name: 'cr100').peer_visible).to be false
-        expect(assignment.get_criteria(:all, :flexible).find_by(name: 'cr60').ta_visible).to be true
-        expect(assignment.get_criteria(:all, :flexible).find_by(name: 'cr60').peer_visible).to be false
+        expect(assignment.criteria.map(&:name)).to include('cr100', 'cr60')
+        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100').ta_visible).to be true
+        expect(assignment.criteria.where(type: "CheckboxCriterion").find_by(name: 'cr100').peer_visible).to be false
+        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60').ta_visible).to be true
+        expect(assignment.criteria.where(type: "FlexibleCriterion").find_by(name: 'cr60').peer_visible).to be false
       end
 
       it 'creates criteria with rounded (up to first digit after decimal point) maximum mark' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: round_max_mark_file }
-        expect(assignment.get_criteria(:all, :rubric).first.name).to eq('cr90')
+        expect(assignment.criteria.where(type: "RubricCriterion").first.name).to eq('cr90')
 
-        expect(assignment.get_criteria(:all, :rubric).first.max_mark).to eq(4.6)
+        expect(assignment.criteria.where(type: "RubricCriterion").first.max_mark).to eq(4.6)
       end
       it 'does not create criteria with format errors in entries' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: invalid_mixed_file }
 
-        expect(assignment.get_criteria.map(&:name)).not_to include('cr40', 'cr50', 'cr70')
+        expect(assignment.criteria.map(&:name)).not_to include('cr40', 'cr50', 'cr70')
         expect(flash[:error].map { |f| extract_text f })
           .to eq([I18n.t('criteria.errors.invalid_format') + ' cr40, cr70, cr50'].map { |f| extract_text f })
       end
@@ -894,19 +894,19 @@ describe CriteriaController do
       it 'does not create criteria with an invalid mark' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: invalid_mixed_file }
 
-        expect(assignment.get_criteria.map(&:name)).not_to include('cr40', 'cr50')
+        expect(assignment.criteria.map(&:name)).not_to include('cr40', 'cr50')
       end
 
       it 'does not create criteria that have both visibility options set to false' do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: invalid_mixed_file }
 
-        expect(assignment.get_criteria.map(&:name)).not_to include('cr70')
+        expect(assignment.criteria.map(&:name)).not_to include('cr70')
       end
 
       it 'does not create criteria that have unmatched keys / more keys than required' do
-        expect(assignment.get_criteria(:all, :rubric).length).to eq(1)
+        expect(assignment.criteria.where(type: "RubricCriterion").length).to eq(1)
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: partially_valid_file }
-        expect(assignment.get_criteria(:all, :rubric).length).to eq(1)
+        expect(assignment.criteria.where(type: "RubricCriterion").length).to eq(1)
         expect(flash[:error]).not_to be_nil
       end
 

--- a/spec/controllers/graders_controller_spec.rb
+++ b/spec/controllers/graders_controller_spec.rb
@@ -244,6 +244,9 @@ describe GradersController do
                   params: { assignment_id: @assignment.id, upload_file: @criteria_grader_map_file, criteria: true }
 
           expect(response).to be_redirect
+          @criterion1.reload
+          @criterion2.reload
+          @criterion3.reload
           expect(@criterion1.tas.count).to eq 2
           expect(@criterion1.tas).to include(@ta1)
           expect(@criterion1.tas).to include(@ta2)
@@ -265,6 +268,9 @@ describe GradersController do
                   params: { assignment_id: @assignment.id, upload_file: @criteria_grader_map_file, criteria: true }
 
           expect(response).to be_redirect
+          @criterion1.reload
+          @criterion2.reload
+          @criterion3.reload
           expect(@criterion1.tas.count).to eq 0 # entire row is ignored
           expect(@criterion2.tas.count).to eq 1
           expect(@criterion2.tas).to include(@ta1)
@@ -284,6 +290,9 @@ describe GradersController do
                   params: { assignment_id: @assignment.id, upload_file: @criteria_grader_map_file, criteria: true }
 
           expect(response).to be_redirect
+          @criterion1.reload
+          @criterion2.reload
+          @criterion3.reload
           expect(@criterion1.tas.count).to eq 2
           expect(@criterion1.tas).to include(@ta1)
           expect(@criterion2.tas.count).to eq 0
@@ -1010,6 +1019,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id, @ta3.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas).to eq []
             expect(@criterion2.tas).to eq []
             expect(@criterion3.tas).to eq []
@@ -1074,6 +1086,9 @@ describe GradersController do
                               criteria: [@criterion1.position], graders: [@ta1.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq @ta1.id
             expect(@criterion2.tas).to eq []
             expect(@criterion3.tas).to eq []
@@ -1087,6 +1102,9 @@ describe GradersController do
                               graders: [@ta1.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq @ta1.id
             expect(@criterion2.tas[0].id).to eq @ta1.id
             expect(@criterion3.tas).to eq []
@@ -1100,6 +1118,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq(@ta1.id).or(eq(@ta2.id))
             expect(@criterion2.tas).to eq []
             expect(@criterion3.tas).to eq []
@@ -1113,6 +1134,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq(@ta1.id).or(eq(@ta2.id))
             expect(@criterion2.tas[0].id).to eq(@ta1.id).or(eq(@ta2.id))
             expect(@criterion1.tas[0].id).not_to eq(@criterion2.tas[0].id)
@@ -1128,6 +1152,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id, @ta3.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas.size).to eq 1
             expect(@criterion2.tas.size).to eq 1
             expect(@criterion3.tas.size).to eq 1
@@ -1149,6 +1176,7 @@ describe GradersController do
                     :global_actions,
                     params: { assignment_id: @assignment.id, global_actions: 'assign', current_table: 'criteria_table' }
             expect(response.status).to eq(400)
+            @assignment.reload
             @assignment.criteria do |criterion|
               expect(criterion.tas).to eq []
             end
@@ -1160,6 +1188,7 @@ describe GradersController do
                     params: { assignment_id: @assignment.id, global_actions: 'assign', graders: [@ta1],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(400)
+            @assignment.reload
             @assignment.criteria do |criterion|
               expect(criterion.tas).to eq []
             end
@@ -1184,6 +1213,9 @@ describe GradersController do
                               graders: [@ta1.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq @ta1.id
             expect(@criterion2.tas).to eq []
             expect(@criterion3.tas).to eq []
@@ -1197,6 +1229,9 @@ describe GradersController do
                               graders: [@ta1.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas[0].id).to eq @ta1.id
             expect(@criterion2.tas[0].id).to eq @ta1.id
             expect(@criterion3.tas).to eq []
@@ -1210,6 +1245,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas.length).to eq 2
             expect(@criterion1.tas).to include(@ta1)
             expect(@criterion1.tas).to include(@ta2)
@@ -1225,6 +1263,9 @@ describe GradersController do
                               graders: [@ta1.id, @ta2.id],
                               current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas.length).to eq 2
             expect(@criterion1.tas).to include(@ta1)
             expect(@criterion1.tas).to include(@ta2)
@@ -1242,6 +1283,9 @@ describe GradersController do
                               criteria: [@criterion1.position, @criterion2.position, @criterion3.position],
                               graders: [@ta1.id, @ta2.id, @ta3.id], current_table: 'criteria_table' }
             expect(response.status).to eq(200)
+            @criterion1.reload
+            @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas.length).to eq 3
             expect(@criterion1.tas).to include(@ta1)
             expect(@criterion1.tas).to include(@ta2)
@@ -1263,6 +1307,7 @@ describe GradersController do
             expect(response.status).to eq(200)
             @criterion1.reload
             @criterion2.reload
+            @criterion3.reload
             expect(@criterion1.tas.length).to eq 2
             expect(@criterion1.tas).to include(@ta1)
             expect(@criterion1.tas).to include(@ta2)

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -592,7 +592,6 @@ describe ResultsController do
 
         it 'should only include marks for the assigned criteria' do
           expected = [[rubric_criterion.class.to_s, rubric_criterion.id]]
-          byebug
           expect(data['marks'].map { |m| [m['criterion_type'], m['id']] }).to eq expected
         end
 

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -582,7 +582,7 @@ describe ResultsController do
       end
 
       it 'should include assigned criteria list' do
-        expect(data['assigned_criteria']).to eq ["#{rubric_criterion.id}"]
+        expect(data['assigned_criteria']).to eq [rubric_criterion.id.to_s]
       end
 
       context 'when unassigned criteria are hidden from the grader' do

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -582,7 +582,7 @@ describe ResultsController do
       end
 
       it 'should include assigned criteria list' do
-        expect(data['assigned_criteria']).to eq ["#{rubric_criterion.class}-#{rubric_criterion.id}"]
+        expect(data['assigned_criteria']).to eq ["#{rubric_criterion.id}"]
       end
 
       context 'when unassigned criteria are hidden from the grader' do
@@ -592,6 +592,7 @@ describe ResultsController do
 
         it 'should only include marks for the assigned criteria' do
           expected = [[rubric_criterion.class.to_s, rubric_criterion.id]]
+          byebug
           expect(data['marks'].map { |m| [m['criterion_type'], m['id']] }).to eq expected
         end
 

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
       3.times { create(:grouping_with_inviter_and_submission, assignment: a) }
       a.groupings.each do |grouping|
         result = grouping.current_result
-        a.get_criteria(:ta_visible).each do |criterion|
+        a.criteria.select(&:ta_visible).each do |criterion|
           result.marks.create(criterion: criterion, mark: Random.rand(criterion.max_mark + 1))
         end
         result.update_total_mark

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
       3.times { create(:grouping_with_inviter_and_submission, assignment: a) }
       a.groupings.each do |grouping|
         result = grouping.current_result
-        a.criteria.select(&:ta_visible).each do |criterion|
+        a.ta_criteria.each do |criterion|
           result.marks.create(criterion: criterion, mark: Random.rand(criterion.max_mark + 1))
         end
         result.update_total_mark

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
       3.times { create(:grouping_with_inviter_and_submission, assignment: a) }
       a.groupings.each do |grouping|
         result = grouping.current_result
-        a.get_criteria(:ta).each do |criterion|
+        a.get_criteria(:ta_visible).each do |criterion|
           result.marks.create(criterion: criterion, mark: Random.rand(criterion.max_mark + 1))
         end
         result.update_total_mark

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -186,8 +186,8 @@ describe Assignment do
           end
 
           it 'shows the criteria visible to tas only' do
-            expect(@assignment.criteria.where(&:ta_visible).where(&:id)).to match_array(@ta_criteria.where(&:id) +
-                                                                                @ta_and_peer_criteria.where(&:id))
+            expect(@assignment.ta_criteria.select(&:id)).to match_array(@ta_criteria.select(&:id) +
+                                                                         @ta_and_peer_criteria.select(&:id))
           end
 
           context 'a submission and a result are created' do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -192,7 +192,7 @@ describe Assignment do
           end
 
           it 'shows the criteria visible to tas only' do
-            expect(@assignment.get_criteria(:ta).select(&:id)).to match_array(@ta_criteria.select(&:id) +
+            expect(@assignment.get_criteria(:ta_visible).select(&:id)).to match_array(@ta_criteria.select(&:id) +
                                                                                 @ta_and_peer_criteria.select(&:id))
           end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -186,8 +186,8 @@ describe Assignment do
           end
 
           it 'shows the criteria visible to tas only' do
-            expect(@assignment.get_criteria(:ta_visible).select(&:id)).to match_array(@ta_criteria.select(&:id) +
-                                                                                @ta_and_peer_criteria.select(&:id))
+            expect(@assignment.criteria.where(&:ta_visible).where(&:id)).to match_array(@ta_criteria.where(&:id) +
+                                                                                @ta_and_peer_criteria.where(&:id))
           end
 
           context 'a submission and a result are created' do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -12,12 +12,6 @@ describe Assignment do
     it { is_expected.to have_many(:section_due_dates) }
     it { is_expected.to accept_nested_attributes_for(:section_due_dates) }
     it { is_expected.to have_one(:assignment_stat).dependent(:destroy) }
-    it do
-      is_expected.to have_many(:rubric_criteria).dependent(:destroy).order(:position)
-    end
-    it do
-      is_expected.to have_many(:flexible_criteria).dependent(:destroy).order(:position)
-    end
 
     it { is_expected.to have_many(:assignment_files).dependent(:destroy) }
     it { is_expected.to have_many(:test_groups).dependent(:destroy) }

--- a/spec/models/criterion_ta_association_spec.rb
+++ b/spec/models/criterion_ta_association_spec.rb
@@ -3,7 +3,6 @@ describe CriterionTaAssociation do
     subject { build_stubbed :criterion_ta_association }
     it { is_expected.to belong_to :ta }
     it { is_expected.to belong_to :criterion }
-    it { is_expected.to validate_presence_of :criterion_type }
     it { is_expected.to belong_to :assignment }
     it { is_expected.to allow_values(subject.criterion.assignment.id).for :assessment_id }
   end

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -1,5 +1,5 @@
 describe Level do
-  it { is_expected.to belong_to(:rubric_criterion) }
+  it { is_expected.to belong_to(:criterion) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to allow_value('').for(:description) }
   it { is_expected.to_not allow_value(nil).for(:description) }


### PR DESCRIPTION
Refactor usages of `markable` and `criterion_type` as a response to the STI PR.

## Motivation and Context
This replaces unused usages of `criterion_type` and `markable` due to the STI migration as well as the function `get_criteria` in `assignment.rb`.


## Your Changes
- Fixed tests in `result_controller_spec.rb`
- Removed usages of `criterion_type` in `test_groups.rb`
- Removed usages of 'get_criteria` in the code base
- Fixed other failing tests in code base due to the removal of `get_criteria`

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (internal change to codebase, without changing functionality)
- [x] Test update (change that modifies or updates tests only)
- [ ] Other (please specify): 


## Testing
Run rspec tests on `result_controller_spec.rb` to ensure they still work.


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the Changelog.md file.
- [ ] I have described any required documentation changes below, if applicable.
- [ ] I have fixed any Hound bot comments (check after opening pull request).
- [ ] I have verified that the TravisCI tests have passed (check after opening pull request).
- [ ] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


## Notes
- After this PR gets merged in, all unneeded usages of `criterion_type` and `markable` (from before the STI migration) will be removed from Markus! Woohoo!