### PR TITLE
Get correct filename when downloading nested files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Fixed bug where bonuses and deductions were not displayed properly (#4699)
 - Fixed bug where image annotations did not stay fixed relative to the image (#4706)
 - Fixed bug where image annotations did not load properly (#4706)
+- Fixed bug where downloading files in nested directories renamed the downloaded file (#4730)
 
 ## [v1.9.3]
 - Fixed inverse association bug with assignments (#4551)

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -94,8 +94,7 @@ class AutomatedTestsController < ApplicationController
       else
         file_keys << file
         { key: file, size: 1,
-          url: download_file_assignment_automated_tests_url(assignment_id: assignment.id,
-                                                            file_name: File.basename(file)) }
+          url: download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: file) }
       end
     end
     if File.exist? testers_schema_path
@@ -119,10 +118,11 @@ class AutomatedTestsController < ApplicationController
   def download_file
     assignment = Assignment.find(params[:assignment_id])
     file_path = File.join(assignment.autotest_files_dir, params[:file_name])
+    filename = File.basename params[:file_name]
     if File.exist?(file_path)
-      send_file_download file_path, filename: params[:file_name]
+      send_file_download file_path, filename: filename
     else
-      render plain: t('student.submission.missing_file', file_name: params[:file_name])
+      render plain: t('student.submission.missing_file', file_name: filename)
     end
   end
 

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -94,7 +94,8 @@ class AutomatedTestsController < ApplicationController
       else
         file_keys << file
         { key: file, size: 1,
-          url: download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: file) }
+          url: download_file_assignment_automated_tests_url(assignment_id: assignment.id,
+                                                            file_name: File.basename(file)) }
       end
     end
     if File.exist? testers_schema_path

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -95,6 +95,32 @@ describe AutomatedTestsController do
           expect(JSON.parse(response.body).slice(*properties.keys.map(&:to_s))).to eq(properties.transform_keys(&:to_s))
         end
       end
+      context 'files data' do
+        it 'should include assignment files' do
+          allow_any_instance_of(Assignment).to receive(:autotest_files).and_return ['file.txt']
+          subject
+          url = download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: 'file.txt')
+          data = [{key: 'file.txt', size: 1, url: url}.transform_keys(&:to_s)]
+          expect(JSON.parse(response.body)['files']).to eq(data)
+        end
+        it 'should include directories' do
+          allow_any_instance_of(Assignment).to receive(:autotest_files).and_return ['some_dir']
+          allow_any_instance_of(Pathname).to receive(:directory?).and_return true
+          subject
+          data = [{key: 'some_dir/'}.transform_keys(&:to_s)]
+          expect(JSON.parse(response.body)['files']).to eq(data)
+        end
+        it 'should include nested files' do
+          allow_any_instance_of(Assignment).to receive(:autotest_files).and_return %w[some_dir some_dir/file.txt]
+          allow_any_instance_of(Pathname).to receive(:directory?).and_wrap_original do |m, *_args|
+            m.receiver.basename.to_s == 'some_dir'
+          end
+          subject
+          url = download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: 'file.txt')
+          data = [{key: 'some_dir/'}, {key: 'some_dir/file.txt', size: 1, url: url}]
+          expect(JSON.parse(response.body)['files']).to eq(data.map { |h| h.transform_keys(&:to_s) })
+        end
+      end
     end
     context 'GET download_file' do
       before { get_as admin, :download_file, params: params }

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -116,7 +116,8 @@ describe AutomatedTestsController do
             m.receiver.basename.to_s == 'some_dir'
           end
           subject
-          url = download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: 'file.txt')
+          url = download_file_assignment_automated_tests_url(assignment_id: assignment.id,
+                                                             file_name: 'some_dir/file.txt')
           data = [{ key: 'some_dir/' }, { key: 'some_dir/file.txt', size: 1, url: url }]
           expect(JSON.parse(response.body)['files']).to eq(data.map { |h| h.transform_keys(&:to_s) })
         end

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -100,14 +100,14 @@ describe AutomatedTestsController do
           allow_any_instance_of(Assignment).to receive(:autotest_files).and_return ['file.txt']
           subject
           url = download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: 'file.txt')
-          data = [{key: 'file.txt', size: 1, url: url}.transform_keys(&:to_s)]
+          data = [{ key: 'file.txt', size: 1, url: url }.transform_keys(&:to_s)]
           expect(JSON.parse(response.body)['files']).to eq(data)
         end
         it 'should include directories' do
           allow_any_instance_of(Assignment).to receive(:autotest_files).and_return ['some_dir']
           allow_any_instance_of(Pathname).to receive(:directory?).and_return true
           subject
-          data = [{key: 'some_dir/'}.transform_keys(&:to_s)]
+          data = [{ key: 'some_dir/' }.transform_keys(&:to_s)]
           expect(JSON.parse(response.body)['files']).to eq(data)
         end
         it 'should include nested files' do
@@ -117,7 +117,7 @@ describe AutomatedTestsController do
           end
           subject
           url = download_file_assignment_automated_tests_url(assignment_id: assignment.id, file_name: 'file.txt')
-          data = [{key: 'some_dir/'}, {key: 'some_dir/file.txt', size: 1, url: url}]
+          data = [{ key: 'some_dir/' }, { key: 'some_dir/file.txt', size: 1, url: url }]
           expect(JSON.parse(response.body)['files']).to eq(data.map { |h| h.transform_keys(&:to_s) })
         end
       end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, downloading a file in a subdirectory in from the the "Automated Tests" page downloaded a file with a file name that included the relative path from the root of the directory. For example:

```ruby
some_dir/test.txt # <- downloading this file
test.txt # <- expected filename of downloaded file
some_dir_test.txt # <- actual name of the downloaded file
```

This PR makes sure the expected file name is given.

## Your Changes

<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- take the basename of downloaded files not the entire path from the root
- add tests

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests for my changes, if applicable.
- [x] I have updated the Changelog.md file.
- [x] I have fixed any Hound bot comments (check after opening pull request).
- [x] I have verified that the TravisCI tests have passed (check after opening pull request).
- [x] I have reviewed the test coverage changes reported on Coveralls (check after opening pull request).


### Required documentation changes (if applicable)
