### PR TITLE
views: fix annotation category repeated creation scoping bug

### DIFF
--- a/app/views/annotation_categories/new.js.erb
+++ b/app/views/annotation_categories/new.js.erb
@@ -1,7 +1,9 @@
-$('#annotation_category_pane_list').prepend(
-  "<%= escape_javascript("#{render partial: 'new_annotation_category',
-                                   locals: { assignment_id: @assignment.id }}").html_safe %>");
-let new_category_form = document.getElementById('add_annotation_category');
-new_category_form.getElementsByTagName('input')[0].focus();
+(function () {
+  $('#annotation_category_pane_list').prepend(
+    "<%= escape_javascript("#{render partial: 'new_annotation_category',
+                                     locals: { assignment_id: @assignment.id }}").html_safe %>");
+  let new_category_form = document.getElementById('add_annotation_category');
+  new_category_form.getElementsByTagName('input')[0].focus();
 
-ajax_events.setUpCallbacks(new_category_form);
+  ajax_events.setUpCallbacks(new_category_form);
+})();


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, it was impossible to create annotation categories in succession due to a bug.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Fixes the variable scoping bug that prevents the UI recreating the new category tool.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Verified it was possible to create several categories in a row in the UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->


### Required documentation changes (if applicable)
