### PR TITLE
Handle respond_with for a js request for annotation categories

### DIFF
--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -49,7 +49,9 @@ class AnnotationCategoriesController < ApplicationController
         format.js { render :insert_new_annotation_category }
       end
     else
-      respond_with @annotation_category, render: { body: nil, status: :bad_request }
+      respond_with @annotation_category do |format|
+        format.js { head :bad_request }
+      end
     end
   end
 

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -29,7 +29,8 @@ describe AnnotationCategoriesController do
       post :create,
            params: {
              assignment_id: assignment.id,
-             annotation_category: { annotation_category_name: category.annotation_category_name }
+             annotation_category: { annotation_category_name: category.annotation_category_name },
+             format: :js
            }
 
       expect(assignment.annotation_categories.count).to eq 1


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- `respond_with` raises an error if there is no template to render for a request with `format: :js` where there are validation failures.
- this is what was happening in the `AnnotationCategoryController.create` when we actually want `respond_with` to flash an error message and then render nothing.
- however, the tests that were testing the failure condition were testing without `format: :js` so the tests were still passing.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- changed `AnnotationCategoryController.create` to not raise an error if there are validation failures when creating a new annotation category
- update the test to call the route with the proper format


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
