### PR TITLE
annotations: Reduce height of modal elements.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@
 - Introduces timed assignments (#4665)
 - Introduces uncategorized annotations grouping in Annotations settings tab (#4733)
 - Set SameSite=Lax on cookies (#4742)
+- Fix annotation modal overflow issue (#4748)
 
 ## [v1.9.3]
 - Fixed inverse association bug with assignments (#4551)

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -714,7 +714,9 @@ ul.tags {
   background: $white;
   border-radius: $radius;
   box-shadow: 0 0 10px $grey;
+  max-height: 90%;
   max-width: 100%;
+  overflow-y: auto;
   padding: 2.5em 1.5em;
   z-index: 10000 !important;
 
@@ -738,6 +740,10 @@ ul.tags {
 
   textarea {
     width: 100%;
+  }
+
+  .preview {
+    max-height: 10em;
   }
 }
 

--- a/app/views/annotations/_annotation_modal.html.erb
+++ b/app/views/annotations/_annotation_modal.html.erb
@@ -12,7 +12,7 @@
       <p>
         <%= f.text_area :content, id: 'new_annotation_content', name: 'content', value: content, required: true,
                         placeholder: t('results.annotation.placeholder'),
-                        rows: 10 %>
+                        rows: 8 %>
       </p>
       <h3><%= t(:preview) %></h3>
       <div id="annotation_preview" class="preview"></div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Long, multi-line annotations were causing the annotation modal to stretch vertically, hiding the button for submitting annotation changes.

Fixes #4694 and fixes #3594.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: I updated the element heights to make it less likely for long annotations to overflow. As a safety net, I've also added a CSS rule for restricting the maximum height of the modal and a vertical scroll bar. Eventually can resolve these issues by
switching over to react-modal.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

I tested the annotation modal UI changes in Firefox and Chrome.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
