### PR TITLE
results: Fix event handling for PDF annotations

### DIFF
--- a/app/assets/javascripts/Components/Result/pdf_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/pdf_viewer.jsx
@@ -8,14 +8,16 @@ export class PDFViewer extends React.Component {
   }
 
   componentDidMount() {
+    this.eventBus = new pdfjsViewer.EventBus();
     this.pdfViewer = new pdfjsViewer.PDFViewer({
+      eventBus: this.eventBus,
       container: this.pdfContainer.current,
       // renderer: 'svg',  TODO: investigate why some fonts don't render with SVG
     });
     window.pdfViewer = this;  // For fixing display when pane width changes
 
-    document.addEventListener('pagesinit', this.ready_annotations);
-    document.addEventListener('pagesloaded', this.refresh_annotations);
+    this.eventBus.on('pagesinit', this.ready_annotations);
+    this.eventBus.on('pagesloaded', this.refresh_annotations);
 
     if (this.props.url) {
       this.loadPDFFile();
@@ -52,8 +54,7 @@ export class PDFViewer extends React.Component {
       box.style.width   = '0';
       box.style.height  = '0';
     }
-    document.removeEventListener('pagesinit', this.ready_annotations);
-    document.removeEventListener('pagesloaded', this.refresh_annotations);
+    this.eventBus = null;
     window.pdfViewer = undefined;
   }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We couldn't add PDF annotations (click-and-drag did not create an annotation), likely a result of #4724. The default "global event bus" was deprecated, and we now need to create our own event bus to handle events.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Manually created an event bus to handle event callbacks.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested that in the UI we can create annotations on PDF files.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
