### PR TITLE
views: round total marks for submissions

### DIFF
--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -138,9 +138,9 @@ class RawSubmissionTable extends React.Component {
       Header: I18n.t('activerecord.attributes.result.total_mark'),
       accessor: 'final_grade',
       Cell: row => {
-        const value = row.original.final_grade;
+        const value = row.original.final_grade === undefined ? '-' : Math.round(row.original.final_grade * 100) / 100;
         const max_mark = Math.round(row.original.max_mark * 100) / 100;
-        return (value === undefined ? '-' : value) + ' / ' + max_mark;
+        return value + ' / ' + max_mark;
       },
       className: 'number',
       minWidth: 80,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves [issue #4667](https://github.com/MarkUsProject/Markus/issues/4667) 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Add rounding to total grade value in the client.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Other (please specify): 
Minor UI alteration, same functionality.

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Checking rounding in UI with FireFox. (altering component prop values to introduce various decimal values)

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Unclear if rounding should be done in UI where JS rounding may cause minor discrepancies. Currently, rounding in the UI is what is done for the max mark, so in keeping with pre existing code rounding for the total mark was implemented as such as well. However, could alternatively add rounding to assignment model method which creates the data.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
