### PR TITLE
results: Show 'grouping submitted late' alert based on collection time.

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -282,7 +282,7 @@ class ResultsController < ApplicationController
                  "#{@grouping.group.group_name}'")
 
     # Check whether this group made a submission after the final deadline.
-    if @grouping.past_due_date?
+    if @grouping.submitted_after_collection_date?
       flash_message(:warning,
                     t('results.late_submission_warning_html',
                       url: repo_browser_assignment_submission_path(@assignment, @grouping)))

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -504,9 +504,10 @@ class Grouping < ApplicationRecord
     start_time + extension_time + assignment.duration
   end
 
-  # Finds the correct due date (section or not) and checks if the last commit is after it.
-  def past_due_date?
-    grouping_due_date = due_date
+  # Returns whether the last submission for this grouping is after the grouping's collection date.
+  # Takes into account assignment late penalties, sections, and extensions.
+  def submitted_after_collection_date?
+    grouping_due_date = collection_date
     revision = nil
     group.access_repo do |repo|
       # get the last revision that changed the assignment repo folder after the due date; some repos may not be able to


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the "This group submitted work after the due date" message is displayed even when the submission was before the final collection time (taking into account late penalties/grace periods). This means this notice is displayed far more often than necessary.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Changed the alert to only be displayed when a submission is made after the collection date.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Manually checked in the UI that the notice no longer appears for submissions made during the late penalty period.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

Related to, but does not directly fix, issue #4459. Could pretty easily add an additional check to see whether the latest revision is the one that's collected, which might be a step closer to resolving this issue. @mishaschwartz what do you think?

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [ ] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [ ] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
