### PR TITLE
style: correct style of deductions listing in marks summary view

### DIFF
--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -184,9 +184,8 @@
 
 .mark-deductions {
   clear: both;
-  color: $dark-blue;
-  cursor: pointer;
-  font-size: 1.1em;
+  color: $dark-grey;
+  font-size: 1em;
   padding-bottom: 5px;
   padding-top: 2px;
   text-align: right;

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -184,8 +184,6 @@
 
 .mark-deductions {
   clear: both;
-  color: $dark-grey;
-  font-size: 1em;
   padding-bottom: 5px;
   padding-top: 2px;
   text-align: right;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Students may be confused about the idea that 'deductions from annotations' or 'overridden deductions' seem clickable due to the font color and cursor pointer. This PR fixes those misleading style choices.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Fix mark-deductions css.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] Refactoring (internal change to codebase, without changing functionality)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
UI in FireFox

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Required documentation changes (if applicable)
