### PR TITLE
Remove criterion type from frontend

### DIFF
--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -33,7 +33,7 @@ export class MarksPanel extends React.Component {
       // Expand by default if a mark has not yet been given, and the current user can give the mark.
       let expanded = new Set();
       this.props.marks.forEach(data => {
-        const key = `${data.criterion_type}-${data.id}`;
+        const key = `${data.id}`;
         if ((data.mark === null || data.mark === undefined) &&
             (this.props.assigned_criteria === null || this.props.assigned_criteria.includes(key))) {
           expanded.add(key);
@@ -47,7 +47,7 @@ export class MarksPanel extends React.Component {
     let expanded = new Set();
     this.props.marks.forEach(markData => {
       if (!onlyUnmarked || markData.mark === null || markData.mark === undefined) {
-        expanded.add(`${markData.criterion_type}-${markData.id}`);
+        expanded.add(`${markData.id}`);
       }
     });
     this.setState({ expanded });
@@ -66,11 +66,11 @@ export class MarksPanel extends React.Component {
     this.setState({ expanded: this.state.expanded })
   };
 
-  updateMark = (criterion_type, criterion_id, mark) => {
-    let result = this.props.updateMark(criterion_type, criterion_id, mark);
+  updateMark = (criterion_id, mark) => {
+    let result = this.props.updateMark(criterion_id, mark);
     if (result !== undefined) {
       result.then(() => {
-        this.state.expanded.delete(`${criterion_type}-${criterion_id}`);
+        this.state.expanded.delete(`${criterion_id}`);
         this.setState({ expanded: this.state.expanded });
       })
     }
@@ -82,7 +82,7 @@ export class MarksPanel extends React.Component {
   };
 
   renderMarkComponent = (markData) => {
-    const key = `${markData.criterion_type}-${markData.id}`;
+    const key = `${markData.id}`;
     const unassigned = this.props.assigned_criteria !== null && !this.props.assigned_criteria.includes(key);
 
     const props = {
@@ -146,9 +146,9 @@ class CheckboxCriterionInput extends React.Component {
 
   handleChange = (event) => {
     if (event.target.value === 'yes') {
-      this.props.updateMark(this.props.criterion_type, this.props.id, this.props.max_mark);
+      this.props.updateMark(this.props.id, this.props.max_mark);
     } else {
-      this.props.updateMark(this.props.criterion_type, this.props.id, 0);
+      this.props.updateMark(this.props.id, 0);
     }
   };
 
@@ -300,9 +300,7 @@ class FlexibleCriterionInput extends React.Component {
       this.setState({rawText: event.target.value, invalid: true});
     } else {
       this.setState({rawText: event.target.value, invalid: false});
-      this.props.updateMark(
-        this.props.criterion_type, this.props.id, isNaN(mark) ? null : mark
-      );
+      this.props.updateMark(this.props.id, isNaN(mark) ? null : mark);
     }
   };
 
@@ -376,9 +374,7 @@ class RubricCriterionInput extends React.Component {
 
   // The parameter `level` is the level object selected
   handleChange = (level) => {
-    this.props.updateMark(
-      this.props.criterion_type, this.props.id, level.mark
-    );
+    this.props.updateMark(this.props.id, level.mark);
   };
 
   // The parameter `level` is the level object selected

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -8,7 +8,6 @@ import { SubmissionSelector } from './submission_selector';
 class Result extends React.Component {
   constructor(props) {
     super(props);
-    console.log('this.props :>> ', this.props);
     let fullscreen;
     if (typeof(Storage) !== 'undefined') {
       fullscreen = localStorage.getItem('fullscreen') === 'on';
@@ -36,7 +35,6 @@ class Result extends React.Component {
   }
 
   componentDidMount() {
-    console.log('result');
     this.fetchData();
     window.modal = new ModalMarkus('#annotation_dialog');
     // When mod+enter is pressed and the annotation modal is open, submit it

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -8,6 +8,7 @@ import { SubmissionSelector } from './submission_selector';
 class Result extends React.Component {
   constructor(props) {
     super(props);
+    console.log('this.props :>> ', this.props);
     let fullscreen;
     if (typeof(Storage) !== 'undefined') {
       fullscreen = localStorage.getItem('fullscreen') === 'on';
@@ -35,6 +36,7 @@ class Result extends React.Component {
   }
 
   componentDidMount() {
+    console.log('result');
     this.fetchData();
     window.modal = new ModalMarkus('#annotation_dialog');
     // When mod+enter is pressed and the annotation modal is open, submit it

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -131,7 +131,9 @@ class FlexibleCriterion < Criterion
     annotation_categories = self.annotation_categories.includes(:annotation_texts)
     annotation_categories.each do |category|
       category.annotation_texts.each do |text|
-        text.scale_deduction(previous_changes['max_mark'][1] / previous_changes['max_mark'][0])
+        unless previous_changes['max_mark'].nil?
+          text.scale_deduction(previous_changes['max_mark'][1] / previous_changes['max_mark'][0])
+        end
       end
     end
   end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -79,7 +79,7 @@ class Grouping < ApplicationRecord
   validates_presence_of :test_tokens
   validates_numericality_of :test_tokens, greater_than_or_equal_to: 0, only_integer: true
 
-  has_one :extension
+  has_one :extension, dependent: :destroy
 
   # Assigns a random TA from a list of TAs specified by +ta_ids+ to each
   # grouping in a list of groupings specified by +grouping_ids+. The groupings

--- a/app/views/checkbox_criteria/_criterion_editor.html.erb
+++ b/app/views/checkbox_criteria/_criterion_editor.html.erb
@@ -1,8 +1,7 @@
 <div class='float-right'>
   <%= button_to t(:delete),
                 assignment_criterion_path(assignment_id: criterion.assignment.id,
-                                          id: criterion.id,
-                                          criterion_type: criterion.class.to_s),
+                                          id: criterion.id),
                 data: { confirm: t('helpers.confirm.delete', model: Criterion.model_name.human) },
                 method: :delete,
                 class: 'delete',

--- a/app/views/criteria/_criterion.html.erb
+++ b/app/views/criteria/_criterion.html.erb
@@ -11,8 +11,7 @@
                          length: 27,
                          omission: '...'),
                 edit_assignment_criterion_path(assignment_id: @assignment.id,
-                                               id: criterion.id,
-                                               criterion_type: criterion.class.to_s),
+                                               id: criterion.id),
                 id: "criterion_title_#{criterion.class}#{criterion.id}",
                 remote: true %>
   </span>

--- a/app/views/flexible_criteria/_criterion_editor.html.erb
+++ b/app/views/flexible_criteria/_criterion_editor.html.erb
@@ -1,8 +1,7 @@
 <div class='float-right'>
   <%= button_to t(:delete),
                 assignment_criterion_path(assignment_id: criterion.assignment.id,
-                                          id: criterion.id,
-                                          criterion_type: criterion.class.to_s),
+                                          id: criterion.id),
                 data: { confirm: t('helpers.confirm.delete', model: Criterion.model_name.human) },
                 method: :delete,
                 class: 'delete',

--- a/app/views/rubric_criteria/_criterion_editor.html.erb
+++ b/app/views/rubric_criteria/_criterion_editor.html.erb
@@ -6,8 +6,7 @@
 
   <%= button_to "#{t(:delete)} #{Criterion.model_name.human}",
                 assignment_criterion_path(assignment_id: criterion.assignment.id,
-                                          id: criterion.id,
-                                          criterion_type: criterion.class.to_s),
+                                          id: criterion.id),
                 data: { confirm: t('helpers.confirm.delete', model: Criterion.model_name.human) },
                 method: :delete,
                 class: 'delete',


### PR DESCRIPTION
Removed usages of `criterion_type` from the `.erb` and `.jsx` files.

## Motivation and Context
Remove unused `criterion_type` references after STI PR from #4749.

## Your Changes
Removed unused `criterion_type` from frontend.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (internal change to codebase, without changing functionality)
- [ ] Test update (change that modifies or updates tests only)
- [ ] Other (please specify): 


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [ ] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [ ] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->

## Notes
After this PR gets merged, there should be no more unused references to `criterion_type` in Markus's codebase