### PR TITLE
results: Make entire li clickable for submission file selector entry.

### DIFF
--- a/app/assets/javascripts/Components/Result/submission_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/submission_file_panel.jsx
@@ -210,10 +210,8 @@ export class FileSelector extends React.Component {
         {hash['files'].map(f => {
           const [name, id] = f;
           const fullPath = hash.path.concat([name]).join('/');
-          return (<li className='file_item' key={fullPath}>
-            <a
-              key={`${fullPath}-a`}
-              onClick={(e) => this.selectFile(e, fullPath, id)}>
+          return (<li className='file_item' key={fullPath} onClick={(e) => this.selectFile(e, fullPath, id)}>
+            <a key={`${fullPath}-a`}>
               {f[0]}
             </a>
           </li>)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current submission file selector only allows you to click on the text (`a` tag) to select the file, but the CSS shows the entire enclosing `li` tag as highlighted. This leads the user to click on blank space in the li tag, which does nothing.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Moved the `onClick` from the `a` tag to its enclosing `li` tag.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Checked manually in the UI that clicking anywhere in an `li` tag selects the corresponding file.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
