### PR TITLE
marks spreadsheets: Hide release/unrelease buttons for TAs.

### DIFF
--- a/app/assets/javascripts/Components/marks_spreadsheet.jsx
+++ b/app/assets/javascripts/Components/marks_spreadsheet.jsx
@@ -260,6 +260,7 @@ class RawMarksSpreadsheet extends React.Component {
           ref={(r) => this.actionBox = r}
           toggleRelease={this.toggleRelease}
           showHidden={this.state.show_hidden}
+          is_allowed_to_release_unrelease={this.props.is_allowed_to_release_unrelease}
           updateShowHidden={this.updateShowHidden} />
         <CheckboxTable
           ref={(r) => this.checkboxTable = r}
@@ -391,15 +392,24 @@ class SpreadsheetActionBox extends React.Component {
   };
 
   render() {
-    return (
-      <div className='rt-action-box'>
-        {this.hiddenInput()}
+    let releaseButton, unreleaseButton;
+    if (this.props.is_allowed_to_release_unrelease) {
+      releaseButton = (
         <button onClick={() => this.props.toggleRelease(true)}>
           {I18n.t('submissions.release_marks')}
         </button>
+      );
+      unreleaseButton = (
         <button onClick={() => this.props.toggleRelease(false)}>
           {I18n.t('submissions.unrelease_marks')}
         </button>
+      );
+    }
+    return (
+      <div className='rt-action-box'>
+        {this.hiddenInput()}
+        {releaseButton}
+        {unreleaseButton}
       </div>
     );
   }

--- a/app/views/grade_entry_forms/grades.html.erb
+++ b/app/views/grade_entry_forms/grades.html.erb
@@ -10,7 +10,8 @@
         grade_entry_form_id: <%= @grade_entry_form.id %>,
         show_total: <%= @grade_entry_form.show_total ? 'true' : 'false' %>,
         out_of_total: <%= @grade_entry_form.out_of_total %>,
-        show_sections: <%= Section.exists? %>
+        show_sections: <%= Section.exists? %>,
+        is_allowed_to_release_unrelease: <%= @current_user.admin? %>
       }
     );
   })


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the release/unrelease marks buttons are shown to TAs for marks spreadsheets, which is misleading (since TAs don't actually have permissions to perform these actions). This will be fixed in #4601, but for v1.10 we should hide the buttons altogether.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Ported over the changes from #4601 to use the user class (admin or TA) to hide/show the buttons.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually in the UI that the buttons are no longer visible for TAs (but still visible for instructors).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
