### PR TITLE
Handle timeout check when timeout is nil

### DIFF
--- a/app/lib/session_handler.rb
+++ b/app/lib/session_handler.rb
@@ -192,7 +192,7 @@ module SessionHandler
   end
 
   def check_imminent_expiry
-    (Time.parse(session[:timeout]) - Time.now) <= 5.minutes
+    !session[:timeout].nil? && (Time.parse(session[:timeout]) - Time.now) <= 5.minutes
   end
 
   # Clear this current user's session set by this app


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If `session[:timeout]` is nil, the `check_imminent_expiry` method will fail with an error because `Time.parse` cannot parse nil.

This is not a crucial fix because this method is only ever called asynchronously and getting an error here actually has the same affect as returning false (the warning modal is not shown) but it's not good that the error is raised.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- method now returns false if `session[:timeout]` is nil.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Required documentation changes (if applicable)
