### PR TITLE
Timed assessment timing fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@
 - UI for enable/disable variable permissions for graders (#4756)
 - Image rotation tools added in marking UI (#4789)
 - Fixed a bug preventing total marks from updating properly if one of the grades is nil (#4887)
+- Fixed a bug where due dates in a flash message were incorrect for timed assessments (#4915)
+- Allowed the difference between the start and end times of a timed assessment to be less than the duration (#4915)
 
 ## [v1.10.2]
 - Ensure that assignment subdirectories in repositories are maintained (#4893)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -675,13 +675,13 @@ class SubmissionsController < ApplicationController
   # Used in update_files and file_manager actions.
   # Requires @grouping, @assignment, and @missing_assignment_files variables to be set.
   def flash_file_manager_messages
-    if @assignment.submission_rule.can_collect_now?(@grouping.inviter.section)
+    if @assignment.is_timed
+      flash_message(:notice, I18n.t('assignments.timed.time_until_due_warning', due_date: I18n.l(@grouping.due_date)))
+    elsif @assignment.submission_rule.can_collect_now?(@grouping.inviter.section)
       flash_message(:warning,
                     @assignment.submission_rule.class.human_attribute_name(:after_collection_message))
     elsif @assignment.grouping_past_due_date?(@grouping)
       flash_message(:warning, @assignment.submission_rule.overtime_message(@grouping))
-    elsif @assignment.is_timed
-      flash_message(:notice, I18n.t('assignments.timed.time_until_due_warning', due_date: I18n.l(@grouping.due_date)))
     end
 
     if !@grouping.is_valid?

--- a/app/models/assignment_properties.rb
+++ b/app/models/assignment_properties.rb
@@ -54,7 +54,6 @@ class AssignmentProperties < ApplicationRecord
   attribute :duration, :duration
   validates :duration, numericality: { greater_than: 0 }, allow_nil: false, if: :is_timed
   validates_presence_of :start_time, if: :is_timed
-  validate :start_before_due, if: :is_timed
   validate :not_timed_and_scanned
 
   STARTER_FILE_TYPES = %w[simple sections shuffle group].freeze
@@ -113,17 +112,6 @@ class AssignmentProperties < ApplicationRecord
     return unless repository_folder_changed?
     errors.add(:repo_folder_change, 'repository folder should not be changed once an assignment has been created')
     false
-  end
-
-  # Add an error if this the duration attribute is greater than the amount of time
-  # between the start_time and due_date.
-  #
-  # Note that this will fail silently if either the start_time or duration is nil since
-  # those values are checked by other validations and so should not be checked twice.
-  def start_before_due
-    return if start_time.nil? || duration.nil?
-    msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.start_time.before_due_date')
-    errors.add(:start_time, msg) if start_time > assignment.due_date - duration
   end
 
   # Add an error if the is_timed and scanned_exam attributes for this assignment

--- a/app/models/assignment_properties.rb
+++ b/app/models/assignment_properties.rb
@@ -115,15 +115,14 @@ class AssignmentProperties < ApplicationRecord
     false
   end
 
-  # Add an error if this the duration attribute is greater than the amount of time
-  # between the start_time and due_date.
+  # Add an error if the start time is after the due date
   #
   # Note that this will fail silently if either the start_time or duration is nil since
   # those values are checked by other validations and so should not be checked twice.
   def start_before_due
     return if start_time.nil? || duration.nil?
     msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.start_time.before_due_date')
-    errors.add(:start_time, msg) if start_time > assignment.due_date - duration
+    errors.add(:start_time, msg) if start_time > assignment.due_date
   end
 
   # Add an error if the is_timed and scanned_exam attributes for this assignment


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- timed assessment warnings about when submission is due by are determined differently than regular assessments and the flash message warnings should reflect that.
- timed assessments no longer require the student to submit before the assessment due date.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- switched the order of an if statement so the correct message is shown
- removed an obsolete validation

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
