### PR TITLE
Add path when uploading autotest subdirs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@
 - Allow feedback files to be updated by uploading a binary file object through the API (#4964)
 - Fix a bug where some error messages reported by the API caused a json formatting error (#4964)
 - Updated all authorization to use ActionPolicy (#4865)
+- Fix bug where subdirectories were not being created with the right path in the autotest file manager (#4969)
 
 ## [v1.10.3]
 - Allow for more concurrent access to git repositories (#4895)

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -92,7 +92,7 @@ class AutotestManager extends React.Component {
   handleCreateFolder = (folderKey) => {
     $.post({
       url: Routes.upload_files_assignment_automated_tests_path(this.props.assignment_id),
-      data: {new_folders: [folderKey]}
+      data: {new_folders: [folderKey], path: this.state.uploadTarget || ''}
     }).then(this.fetchFileDataOnly)
       .then(() => this.toggleFormChanged(true))
       .then(this.endAction);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- subdirectories in the autotest file manager were not being created with the correct path prefix

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- added the path prefix to be sent with the directory creation request

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
