### PR TITLE
Show starter files after timed assessments are due

### DIFF
--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -147,7 +147,7 @@
     <% end %>
 <% end %>
 <% unless @assignment.starter_file_updated_at.nil? || @grouping.nil? %>
-  <% if !@assignment.is_timed || !@grouping.start_time.nil? %>
+  <% if !@assignment.is_timed || !@grouping.start_time.nil? || @grouping.past_collection_date? %>
     <h3><%= I18n.t('assignments.starter_file.title') %></h3>
     <p><%= I18n.t('assignments.starter_file.provided') %></p>
     <p><%= I18n.t('assignments.starter_file.changed_at',


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

addendum to #4935 to make sure that starter files are visible after the deadline if a student doesn't start the assessment at all.


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- added a condition to an if block

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- in UI

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Required documentation changes (if applicable)
