### PR TITLE
timed assessments: Hide submission/required file info before start time

### DIFF
--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -106,7 +106,7 @@
     </ul>
   <% end %>
 
-  <% unless peer_review %>
+  <% if !peer_review && (!@assignment.is_timed || !@grouping.start_time.nil? || @grouping.past_collection_date?) %>
     <h3><%= Submission.model_name.human.pluralize %></h3>
     <% if @grouping.nil? %>
       <p><%= t('submissions.student.no_submission') %></p>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make the timed assessments behave more like "hidden" assignments before students have started the assessment, we should hide submission and required file information until after they've started.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: This hides submission and required file information from students until after they have started the test.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI, both before the test is started, after the final collection date (when the info should appear, just like #4990).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
