### PR TITLE
Settings UI improvements

### DIFF
--- a/app/views/users/_key_display.html.erb
+++ b/app/views/users/_key_display.html.erb
@@ -13,7 +13,7 @@
     <% else %>
       <%= t('users.api_key.unavailable') %>
     <% end %>
-    <div class='float-right'>
+    <div>
       <%= form_tag reset_api_key_users_path, remote: true do %>
         <%= submit_tag t('users.api_key.reset') %>
       <% end %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -1,30 +1,29 @@
-<% content_for :title, t('students.account_settings') %>
+<% content_for :title, t('users.account_settings') %>
 <%= form_with url: 'update_settings', method: 'patch', model: @current_user, scope: :user, local: true do |f| %>
-  <p>
+  <div class="inline-labels">
     <%= f.label :display_name, User.human_attribute_name(:display_name) %>
     <%= f.text_field :display_name,
                      value: @current_user.display_name %>
-  </p>
-  <p>
+
     <%= f.label :locale, User.human_attribute_name(:locale) %>
     <%= f.select :locale, options_for_select(I18n.available_locales, selected: "#{@current_user.locale}") %>
-  </p>
-  <p>
+
     <%= f.label :theme, User.human_attribute_name(:theme) %>
     <%= f.select(:theme, [%w[dark dark], %w[light light]]) %>
-  </p>
+  </div>
   <% if @current_user.student? %>
     <p>
       <%= f.check_box :receives_results_emails %>
-      <%= f.label :receives_results_emails, t('students.toggle_results_notifications') %>
+      <%= f.label :receives_results_emails, Student.human_attribute_name(:receives_results_emails) %>
     </p>
+
     <p>
       <%= f.check_box :receives_invite_emails %>
-      <%= f.label :receives_invite_emails, t('students.toggle_invite_notifications') %>
+      <%= f.label :receives_invite_emails, Student.human_attribute_name(:receives_invite_emails) %>
     </p>
   <% end %>
   <p>
-    <%= f.submit t('users.update_settings') %>
+    <%= f.submit t('save') %>
   </p>
 <% end %>
 
@@ -35,41 +34,47 @@
 <% end %>
 
 <% if allowed_to?(:manage?, KeyPair) %>
-  <h2><%= t('key_pairs.key_pairs_title') %></h2>
+  <fieldset>
+  <legend><span><%= t('key_pairs.key_pairs_title') %></span></legend>
 
-  <br>
+  <% if @current_user.key_pairs.exists? %>
+    <div class="table">
+    <table>
+      <thead>
+        <tr>
+          <th><%= t('key_pairs.time_of_upload') %></th>
+          <th><%= t('key_pairs.key_content') %></th>
+          <th><%= t('actions') %></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% @current_user.key_pairs.each do |key_pair| %>
+        <tr>
+          <td><%= l(key_pair.created_at) %></td>
+          <td><pre style="word-break: break-all"><%= key_pair.public_key %></pre></td>
+          <td><%= link_to t('key_pairs.remove_key'), key_pair, method: :delete %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+    </div>
+  <% end %>
 
-  <table>
-    <tr>
-      <th><%= t('key_pairs.time_of_upload') %> |</th>
-      <th><%= t('key_pairs.key_content') %></th>
-      <th></th>
-    </tr>
-
-
-    <% @current_user.key_pairs.each do |key_pair| %>
-      <tr>
-        <td><%= key_pair.created_at %></td>
-        <td><textarea cols="55" rows="10" readonly><%= key_pair.public_key %></textarea></td>
-        <td><%= link_to t('key_pairs.remove_key'), key_pair, method: :delete, data: { confirm: t('key_pairs.are_you_sure') } %></td>
-      </tr>
-
-    <% end %>
-  </table>
-
-  <br />
-
-  <%= link_to t('key_pairs.new_key_pair'), new_key_pair_path %>
-
+  <p>
+    <%= link_to t('key_pairs.new_key_pair'), new_key_pair_path, class: 'button' %>
+  </p>
   <hr>
-  <h2>Need help?</h2>
-  <br>
-  <a href="https://github.com/MarkUsProject/Markus/wiki/SSH_Keypair_Instructions_Windows" target="_blank">
-    Instructions for users on Windows
-  </a>
-  <br>
-  <a href="https://github.com/MarkUsProject/Markus/wiki/SSH_Keypair_Instructions_Linux-OSX" target="_blank">
-    Instructions for users on Mac OS / Linux
-  </a>
+  <h3><%= t('help') %></h3>
+  <p>
+    <a href="https://github.com/MarkUsProject/Markus/wiki/SSH_Keypair_Instructions_Windows" target="_blank">
+      <%= t('key_pairs.help.windows') %>
+    </a>
+  </p>
+  <p>
+    <a href="https://github.com/MarkUsProject/Markus/wiki/SSH_Keypair_Instructions_Linux-OSX" target="_blank">
+      <%= t('key_pairs.help.macOS_linux') %>
+    </a>
+  </p>
+  </fieldset>
 <% end %>
 

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -11,7 +11,7 @@
     <%= f.label :theme, User.human_attribute_name(:theme) %>
     <%= f.select(:theme, [%w[dark dark], %w[light light]]) %>
   </div>
-  <% if @current_user.student? %>
+  <% if @current_user.student? && Rails.configuration.action_mailer.perform_deliveries %>
     <p>
       <%= f.check_box :receives_results_emails %>
       <%= f.label :receives_results_emails, Student.human_attribute_name(:receives_results_emails) %>

--- a/config/locales/models/users/en.yml
+++ b/config/locales/models/users/en.yml
@@ -12,6 +12,9 @@ en:
       user:
         one: "User"
     attributes:
+      student:
+        receives_invite_emails: "Receive email notification when invited to a group"
+        receives_results_emails: "Receive email notification when marking results are released"
       user:
         api_key: "Your API Key"
         display_name: "Display Name"

--- a/config/locales/models/users/es.yml
+++ b/config/locales/models/users/es.yml
@@ -11,6 +11,9 @@ es:
       user:
         one: "Usuario"
     attributes:
+      student:
+        receives_invite_emails: "UPDATE ME!"
+        receives_results_emails: "UPDATE ME!"
       user:
         api_key: "Su clave API"
         display_name: "Nombre para Mostrar"

--- a/config/locales/models/users/fr.yml
+++ b/config/locales/models/users/fr.yml
@@ -11,6 +11,9 @@ fr:
       user:
         one: "Utilisateur"
     attributes:
+      student:
+        receives_invite_emails: "UPDATE ME!"
+        receives_results_emails: "UPDATE ME!"
       user:
         api_key: "Votre clé - API"
         display_name: "Afficher un Nom"

--- a/config/locales/models/users/pt.yml
+++ b/config/locales/models/users/pt.yml
@@ -11,6 +11,9 @@ pt:
       user:
         one: "Usuário"
     attributes:
+      student:
+        receives_invite_emails: "UPDATE ME!"
+        receives_results_emails: "UPDATE ME!"
       user:
         api_key: "Chave da API"
         display_name: "Nome em Exibição"

--- a/config/locales/views/key_pairs/en.yml
+++ b/config/locales/views/key_pairs/en.yml
@@ -1,19 +1,22 @@
 en:
   key_pairs:
-    are_you_sure: "Are you sure?"
-    add_key_pair: "Add a Key Pair"
+    add_key_pair: "Add an SSH Key"
     back: "Back"
     copy_paste_key: "Copy and paste your public key"
     create:
-      invalid_key: "Key Pair was not created: Invalid key"
-      success: "Key Pair was created successfully"
-    create_key_pair: "Create Key Pair"
+      invalid_key: "Upload failed: Invalid key"
+      success: "SSH Key was uploaded successfully"
+    create_key_pair: "Upload SSH Key"
     delete:
-      success: "Key Pair was removed successfully"
+      success: "SSH Key was deleted successfully"
     file: "File"
+    help:
+      macOS_linux: "Instructions for users on macOS/Linux"
+      windows: "Instructions for users on Windows"
     key_content: "Key Content"
-    key_pairs_title: "Your Key Pairs"
+    key_pairs_title: "Your SSH Keys"
     or: "OR"
-    new_key_pair: "New Key Pair"
-    remove_key: "Remove Key"
+    new_key_pair: "Add New SSH Key"
+    remove_key: "Remove SSH Key"
     time_of_upload: "Time Of Upload"
+

--- a/config/locales/views/key_pairs/es.yml
+++ b/config/locales/views/key_pairs/es.yml
@@ -1,7 +1,6 @@
 es:
   key_pairs:
     add_key_pair:    "Añadir un Par de Claves"
-    are_you_sure:    "¿Está seguro/a?"
     back:            "Atrás"
     copy_paste_key:  "Copie y pegue su clave pública"
     create_key_pair: "Crear Par de Claves"
@@ -11,6 +10,9 @@ es:
     delete:
       success: "El Par de Claves fue removido exitosamente"
     file:            "Archivo"
+    help:
+      macOS_linux: "UPDATE ME"
+      windows: "UPDATE ME"
     key_content:     "Contenido de la clave"
     key_pairs_title: "Sus Pares de Claves"
     new_key_pair:    "Nuevo Par de Claves"

--- a/config/locales/views/key_pairs/fr.yml
+++ b/config/locales/views/key_pairs/fr.yml
@@ -1,7 +1,6 @@
 fr:
   key_pairs:
     add_key_pair: "Ajouter une Paire de Clés"
-    are_you_sure: "Êtes-vous sûr?"
     back: "Retourner"
     copy_paste_key: "Copiez et Collez Votre clé Publique"
     create_key_pair: "Créer une Paire de Clés"
@@ -11,6 +10,9 @@ fr:
     delete:
       success: "Paire de Clés supprimé avec succès"
     file: "Fichier"
+    help:
+      macOS_linux: "UPDATE ME"
+      windows: "UPDATE ME"
     key_content: "Contenu de Key"
     key_pairs_title: "Vos Paires de Clés"
     new_key_pair: "Nouvelle Paire de Clés"

--- a/config/locales/views/key_pairs/pt.yml
+++ b/config/locales/views/key_pairs/pt.yml
@@ -1,7 +1,6 @@
 pt:
   key_pairs:
     add_key_pair: "Adicionar um Par de Chaves"
-    are_you_sure: "Tem certeza?"
     back: "De Volta"
     copy_paste_key: "Copie e Cole a Sua Chave Pública"
     create_key_pair: "Criar Par de Chaves"
@@ -11,6 +10,9 @@ pt:
     delete:
       success: "Par de Chaves foi removido com sucesso"
     file: "Arquivo"
+    help:
+      macOS_linux: "UPDATE ME"
+      windows: "UPDATE ME"
     key_content: "Conteúdo de Chave"
     key_pairs_title: "Os Seus Pares de Chaves"
     new_key_pair: "Novo Par de Chaves"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -6,7 +6,6 @@ en:
     new: "Add an Admin"
 
   students:
-    account_settings: "Account Settings"
     active: "Active"
     admin_actions:
       add_section: "Add to section"
@@ -25,8 +24,6 @@ en:
     not_successfully_added_message_3: "Student names are alphanumeric."
     not_successfully_added_message_4: "Each field is separated by a comma (no spaces)."
     not_successfully_added_message_5: "Each line has the required fields specified near the upload form."
-    toggle_invite_notifications: 'Receive email notifications when I am invited to a group.'
-    toggle_results_notifications: 'Receive email notifications when results are released.'
 
   tas:
     edit: "Edit a Grader"
@@ -36,11 +33,11 @@ en:
 
   # Miscellaneous
   users:
+    account_settings: "Account Settings"
     api_key:
-      help_html: "The API key is used for the REST interface for authentication.
+      help_html: "The API key is used for authentication for the MarkUs API.
                   See <a href=\"https://github.com/MarkUsProject/Markus/wiki/RESTful-API\">MarkUs Wiki</a>
-                  for information on how to use the REST API."
-      reset: "Reset my API key"
+                  for information on using the API."
+      reset: "Reset API key"
       unavailable: "Unavailable"
-    update_settings: 'Update Settings'
     verify_settings_update: 'Your settings have been updated!'

--- a/config/locales/views/users/es.yml
+++ b/config/locales/views/users/es.yml
@@ -7,7 +7,6 @@ es:
     new: "Crear un nuevo Administrador"
 
   students:
-    account_settings: "UPDATE ME"
     active: "Activo"
     admin_actions:
       add_section: "Añadir sección"
@@ -27,8 +26,6 @@ es:
     not_successfully_added_message_4: "Cada campo está separado por una coma (no espacios)."
     not_successfully_added_message_5: "Cada línea tiene los campos requeridos especificados cerca de la forma
       para subir archivos."
-    toggle_invite_notifications: 'UPDATE ME'
-    toggle_results_notifications: 'UPDATE ME'
 
   tas:
     edit: "Editar la información del evaluador"
@@ -37,11 +34,11 @@ es:
       manage_graders: "Crear evaluadores."
 
   users:
+    account_settings: "UPDATE ME"
     api_key:
       help_html: "La clave API es usada como autenticación para la interface REST. Mira la
                   <a href=\"https://github.com/MarkUsProject/Markus/wiki/RESTful-API\">
                   Wiki de MarkUs</a> para más información acerca del uso de la REST API."
       reset: "Reiniciar mi clave API"
       unavailable: "No disponible"
-    update_settings: 'Ajustes de actualización'
     verify_settings_update: 'UPDATE ME'

--- a/config/locales/views/users/fr.yml
+++ b/config/locales/views/users/fr.yml
@@ -6,7 +6,6 @@ fr:
     new: "Créer un nouvel administrateur"
 
   students:
-    account_settings: "UPDATE ME"
     active: "Actif"
     admin_actions:
       add_section: "Ajouter à une section"
@@ -25,8 +24,6 @@ fr:
     not_successfully_added_message_3: "Les noms des étudiants sont en caractères alphanumériques."
     not_successfully_added_message_4: "Chaque champ est séparé par une virgule (pas d'espace)."
     not_successfully_added_message_5: "Chaque ligne a le bon nombre de champs comme spécifié."
-    toggle_invite_notifications: 'UPDATE ME'
-    toggle_results_notifications: 'UPDATE ME'
 
   tas:
     edit: "Modifier un correcteur"
@@ -35,8 +32,8 @@ fr:
       manage_graders: "Créer un nouveau correcteur"
 
   users:
+    account_settings: "UPDATE ME"
     api_key:
       reset: "Générer une nouvelle clé"
       unavailable: "Non disponible"
-    update_settings: 'Mettre à jour les paramètres'
     verify_settings_update: 'UPDATE ME'

--- a/config/locales/views/users/pt.yml
+++ b/config/locales/views/users/pt.yml
@@ -6,7 +6,6 @@ pt:
     new: "Criar novo Administrador"
 
   students:
-    account_settings: "UPDATE ME"
     active: "Ativo"
     admin_actions:
       add_section: "Adicionar a sessão"
@@ -25,8 +24,6 @@ pt:
     not_successfully_added_message_3: "Nome dos alunos são alfa-numéricos."
     not_successfully_added_message_4: "Cada campo é separado por uma vírgula (sem espaços)."
     not_successfully_added_message_5: "Cada linha tem os campos necesários especificados junto ao formulário de carregamento."
-    toggle_invite_notifications: 'UPDATE ME'
-    toggle_results_notifications: 'UPDATE ME'
 
   tas:
     edit: "Editar avaliador"
@@ -35,8 +32,8 @@ pt:
       manage_graders: "Create graders."
 
   users:
+    account_settings: "UPDATE ME"
     api_key:
       reset: "Gerar outra chave para a API"
       unavailable: "Indisponível"
-    update_settings: 'Atualizar configurações'
     verify_settings_update: 'UPDATE ME'


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. The current UI for the new Account Settings page had some clutter, and some strings that weren't localized (under "Key Pairs").
2. The name "Key Pairs" is misleading (since users only upload their public keys).
3. The student email notification settings were being displayed, but if the MarkUs instance didn't turn on `Rails.configuration.action_mailer.perform_deliveries`, these settings wouldn't do anything.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

1. Tidied up CSS for the Settings page.
2. Renamed "Key Pairs" to "SSH Keys" in UI (but left the model called `KeyPair`---could change this later).
3. Hid the two student mailer settings when the `action_mailer.perform_deliveries` option is turned off.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested these changes in Firefox and Chrome.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
