### PR TITLE
Fix concurrent mark creation bug on the server side

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [unreleased]
+- Fix bug where duplicate marks can get created because of concurrent requests (#5018)
 
 ## [v1.11.0]
 - Converts annotation modals from ERB into React (#4997)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The bug from #4908 popped up again but this time the issue occurred for a flexible criteria mark. 
This indicates that a client-side fix isn't enough because we can still get concurrent requests to update the same mark (possibly from multiple clients or maybe the asychronous-ness of the ajax calls from the client are too fancy for their own good). 
Instead of trying to patch around the client side, this PR instead attempts to solve the problem server side by attempting to make mark creation more atomic and adding a check to recover from putting the database in a state where we have duplicate marks.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- wrap `find_or_create_by` in a transaction in an attempt to atomize the update
- add check to recover if there are duplicate marks by deleting all duplicates


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- added rspec tests

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
