### PR TITLE
Simplify css for graders and groups views and related views

### DIFF
--- a/app/assets/javascripts/Components/Modals/extension_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/extension_modal.jsx
@@ -128,7 +128,7 @@ class ExtensionModal extends React.Component {
   render() {
     return (
       <Modal
-        className="react-modal"
+        className="react-modal dialog"
         isOpen={this.props.isOpen}
         onRequestClose={this.props.onRequestClose}
       >
@@ -156,7 +156,6 @@ class ExtensionModal extends React.Component {
             <div>
               <label>
                 <textarea
-                  className={'extension-note'}
                   placeholder={I18n.t('activerecord.attributes.extensions.note') + '...'}
                   value={this.state.note}
                   name={'note'}

--- a/app/assets/javascripts/Components/graders_manager.jsx
+++ b/app/assets/javascripts/Components/graders_manager.jsx
@@ -399,7 +399,7 @@ class RawGroupsTable extends React.Component {
         accessor: 'graders',
         Cell: row => {
           return row.value.map((ta) =>
-            <div key={`${row.original._id}-${ta}`} className='grader-row'>
+            <div key={`${row.original._id}-${ta}`}>
               {ta}
               <a href='#'
                  className="remove-icon"
@@ -464,7 +464,7 @@ class RawCriteriaTable extends React.Component {
         accessor: 'graders',
         Cell: row => {
           return row.value.map((ta) =>
-            <div key={`${row.original._id}-${ta}`} className='grader-row'>
+            <div key={`${row.original._id}-${ta}`}>
               {ta}
               <a href='#'
                  className="remove-icon"

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -277,7 +277,7 @@ class RawGroupsTable extends React.Component {
             } else {
               status = `(${member[1]})`;
             }
-            return <div key={`${row.original._id}-${member[0]}`} className='grader-row'>
+            return <div key={`${row.original._id}-${member[0]}`}>
               {member[0]} {status}
               <a href='#'
                  className="remove-icon"

--- a/app/assets/javascripts/Components/marks_graders_manager.jsx
+++ b/app/assets/javascripts/Components/marks_graders_manager.jsx
@@ -237,7 +237,7 @@ class RawMarksStudentsTable extends React.Component {
         accessor: 'graders',
         Cell: row => {
           return row.value.map((ta) =>
-                                 <div key={`${row.original._id}-${ta}`} className='grader-row'>
+                                 <div key={`${row.original._id}-${ta}`}>
                                    {ta}
                                    <a href='#'
                                       className="remove-icon"

--- a/app/assets/stylesheets/common/_columns.scss
+++ b/app/assets/stylesheets/common/_columns.scss
@@ -12,4 +12,8 @@
 .mapping-table {
   flex: 50%;
   padding: 0 5px;
+
+  .rt-td {
+    line-height: 1.7em;
+  }
 }

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -1068,6 +1068,14 @@ nav {
   transform-origin: right top;
 }
 
+// jQuery UI autocomplete
+.ui-autocomplete {
+  max-height: 250px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 5px;
+}
+
 // Login
 .cookies-eu-ok {
   background-color: $primary-three;

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -2,6 +2,7 @@
 
 @import 'reset';
 @import 'constants';
+@import 'columns';
 @import 'mixins';
 @import 'icons';
 @import 'react_json_schema_form';

--- a/app/assets/stylesheets/exam_templates.scss
+++ b/app/assets/stylesheets/exam_templates.scss
@@ -110,34 +110,6 @@
   font-weight: bold;
 }
 
-#viewerContainer {
-  top: 0;
-}
-
-#codeviewer {
-  border-radius: 0;
-}
-
-.display_pane {
-  border: 1px solid $line;
-}
-
-.input_pane {
-  padding: 15px !important;
-}
-
-.input_pane {
-  input[type="text"] {
-    margin-bottom: 5px;
-  }
-}
-
-.side_header {
-  border-bottom: 1px solid $background-support;
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-}
-
 #info_form label {
   //min-width: initial;
   margin-bottom: 3px;

--- a/app/assets/stylesheets/exam_templates.scss
+++ b/app/assets/stylesheets/exam_templates.scss
@@ -110,10 +110,6 @@
   font-weight: bold;
 }
 
-.toolbar {
-  //display: none;
-}
-
 #viewerContainer {
   top: 0;
 }

--- a/app/assets/stylesheets/graders.scss
+++ b/app/assets/stylesheets/graders.scss
@@ -1,12 +1,4 @@
 @import 'common/core';
-@import 'common/columns';
-
-.grader-row {
-  display: block;
-  line-height: 1.7em;
-  padding-bottom: 0.2em;
-  width: 100%;
-}
 
 .grader-summary-graph {
   display: inline-block;

--- a/app/assets/stylesheets/graders.scss
+++ b/app/assets/stylesheets/graders.scss
@@ -1,10 +1,1 @@
 @import 'common/core';
-
-.grader-summary-graph {
-  display: inline-block;
-  width: 400px;
-}
-
-.grader-summary-content {
-  text-align: center;
-}

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,9 +1,3 @@
 @import 'common/core';
-
 @import 'common/assignment_dropdown';
-
 @import 'common/modals';
-
-.extension-note {
-  width: 100%;
-}

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -4,62 +4,6 @@
 
 @import 'common/modals';
 
-#viewerContainer {
-  top: 0px;
-}
-
-#codeviewer {
-  border-radius: 0px;
-}
-
-.display_pane {
-  border: 1px solid $background-main;
-}
-
-.input_pane {
-  padding: 15px !important;
-}
-
-.input_pane input[type="text"] {
-  margin-bottom: 5px;
-  min-width: 50%;
-}
-
-.side_header {
-  border-bottom: 1px solid $background-main;
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-}
-
-/* highlight results */
-.ui-autocomplete span.hl_results {
-  background-color: #ffff66;
-}
-
-/* scroll results */
-.ui-autocomplete {
-  max-height: 250px;
-  overflow-y: auto;
-  /* prevent horizontal scrollbar */
-  overflow-x: hidden;
-  /* add padding for vertical scrollbar */
-  padding-right: 5px;
-}
-
-.ui-autocomplete li {
-  font-size: 16px;
-  .stuid {
-    font-size: 12px;
-  }
-}
-
-/* IE 6 doesn't support max-height
-* we use height instead, but this forces the menu to always be this tall
-*/
-* html .ui-autocomplete {
-  height: 250px;
-}
-
 .extension-note {
   width: 100%;
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,25 +1,8 @@
 @import 'common/core';
 
-@import 'common/columns';
-
 @import 'common/assignment_dropdown';
 
 @import 'common/modals';
-
-.floatRight {
-  float: right;
-}
-
-.grader-row {
-  display: block;
-  line-height: 1.7em;
-  padding-bottom: 0.2em;
-  width: 100%;
-}
-
-.toolbar {
-  display: none;
-}
 
 #viewerContainer {
   top: 0px;

--- a/app/assets/stylesheets/key_pairs.scss
+++ b/app/assets/stylesheets/key_pairs.scss
@@ -1,4 +1,1 @@
 @import "common/core";
-
-@import "common/columns";
-

--- a/app/assets/stylesheets/marks_graders.scss
+++ b/app/assets/stylesheets/marks_graders.scss
@@ -1,9 +1,1 @@
-@import 'common/columns';
 @import 'common/core';
-
-.grader-row {
-  display: block;
-  line-height: 1.7em;
-  padding-bottom: 0.2em;
-  width: 100%;
-}

--- a/app/assets/stylesheets/peer_reviews.scss
+++ b/app/assets/stylesheets/peer_reviews.scss
@@ -1,5 +1,4 @@
 @import 'common/core';
-@import 'common/columns';
 @import 'common/assignment_dropdown';
 
 .peer-review-amount-spinner {

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -163,7 +163,7 @@ class GradersController < ApplicationController
       return
     end
     @assignment = Assignment.find(params[:assignment_id])
-    render :grader_summary, layout: 'content'
+    render :grader_summary
   end
 
   private

--- a/app/views/exam_templates/assign_errors.html.erb
+++ b/app/views/exam_templates/assign_errors.html.erb
@@ -28,17 +28,15 @@
       link_path: view_logs_assignment_exam_templates_path },
 ] %>
 
-<div id='panes-content'>
-  <div id='left-pane' class='display_pane'>
-    <div id='codeviewer' class='flex-col'>
-      <div id="pdfContainer">
-        <div id="viewer" class="pdfViewer"></div>
-      </div>
+<div class='pane-wrapper' style='height: calc(70vh);'>
+  <div class='pane' style='overflow-y: scroll'>
+    <div id="pdfContainer">
+      <div id="viewer" class="pdfViewer"></div>
     </div>
   </div>
 
-  <div id='right-pane' class='input_pane'>
-    <h2 class="side_header"><%= t('exam_templates.assign_errors.document_info') %></h2>
+  <div class='pane' style="width: 29.5%; flex: 0 auto;">
+    <h2><%= t('exam_templates.assign_errors.document_info') %></h2>
     <%= form_tag fix_error_assignment_exam_template_path(id: @exam_template.id),
                  id: 'info_form',
                  remote: true do %>

--- a/app/views/graders/grader_summary.html.erb
+++ b/app/views/graders/grader_summary.html.erb
@@ -1,25 +1,16 @@
-<div class='title_bar'>
-  <h2>
-    <% if assignment.is_peer_review? %>
-        <%= link_to "#{assignment.parent_assignment.short_identifier}: #{PeerReview.model_name.human}",
-                    browse_assignment_submissions_path(assignment.id) %>
-    <% else %>
-        <%= link_to "#{assignment.short_identifier}: #{assignment.description}",
-                    browse_assignment_submissions_path(assignment.id) %>
-    <% end %>
-  </h2>
-</div>
-<div class='wrapper'>
-  <div id='section'>
-    <div class='grader-summary-content'>
-      <% @assignment.tas.each do |ta| %>
-        <div class='grader-summary-graph'>
-          <div id='assignment_<%= @assignment.id %>_ta_<% ta.id %>_graph'>
-            <%= render partial: 'graders/ta_grade_distribution_graph',
-                       locals: { assignment: @assignment, tas: [ta] } %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+<% content_for :title do %>
+  <% if @assignment.is_peer_review? %>
+    <%= link_to "#{@assignment.parent_assignment.short_identifier}: #{PeerReview.model_name.human}",
+                browse_assignment_submissions_path(@assignment.id) %>
+  <% else %>
+    <%= link_to "#{@assignment.short_identifier}: #{@assignment.description}",
+                browse_assignment_submissions_path(@assignment.id) %>
+  <% end %>
+<% end %>
+
+<% @assignment.tas.each do |ta| %>
+  <div style="width: 400px; display: inline-block;">
+    <%= render partial: 'graders/ta_grade_distribution_graph',
+               locals: { assignment: @assignment, tas: [ta] } %>
   </div>
-</div>
+<% end %>

--- a/app/views/groups/assign_scans.html.erb
+++ b/app/views/groups/assign_scans.html.erb
@@ -24,8 +24,8 @@
     }).data("ui-autocomplete")._renderItem = function (ul, item) {
       return $("<li>")
         .data("ui-autocomplete-item", item)
-        .append("<div>" + item.label + "<br>" +
-          "<span class='stuid'>" + item.id_number + " | " + item.user_name + "</span></div>")
+        .append(`<div><strong>${item.label}</strong><br>` +
+          `<span>${item.id_number} | ${item.user_name}</span></div>`)
         .appendTo(ul);
     };
     $("#assign_student").submit(function (e) {
@@ -100,36 +100,33 @@
     &nbsp;|&nbsp;
     <%= link_to t('groups.manage_groups'), :assignment_groups %>
 <% end %>
-<div id='panes-content'>
-  <div id='panes'>
-    <div id='left-pane' class='display_pane'>
-      <div id="pdfContainer">
-        <div id="viewer" class="pdfViewer"></div>
-      </div>
+<div class='pane-wrapper' style='height: calc(70vh);'>
+  <div class='pane' style='overflow-y: scroll'>
+    <div id="pdfContainer">
+      <div id="viewer" class="pdfViewer"></div>
     </div>
+  </div>
 
-    <div id='drag'></div>
+  <div class='pane' style="width: 29.5%; flex: 0 auto;">
+    <div>
+      <h2 id="group_name"></h2>
+      <form id="assign_student">
+        <input id="names" name="names" type="text" placeholder="<%= User.human_attribute_name(:full_name) %>">
+        <input id="student_id" name="s_id" type="hidden">
+        <input id="grouping_id" name="g_id" value="" type="hidden">
 
-    <div id='right-pane' class='input_pane'>
-      <div class='ui-tabs-panel flex-col'>
-        <div class="side_header">
-          <h2 id="group_name"></h2>
-        </div>
-        <form id="assign_student" class="side_header">
-          <input id="names" name="names" type="text" placeholder="<%= User.human_attribute_name(:full_name) %>">
-          <input id="student_id" name="s_id" type="hidden">
-          <input id="grouping_id" name="g_id" value="" type="hidden">
-          <br>
+        <p>
           <label for="skip"><%= t('exam_templates.assign_scans.skip_group') %></label>
           <input type="checkbox" name="skip" id="skip" value="1">
-          <br>
+        </p>
+        <p>
           <button type="submit"><%= t('save') %></button>
-        </form>
-        <h3>
-          <%= Group.human_attribute_name(:student_memberships) %>
-        </h3>
-        <div id="group_members">
-        </div>
+        </p>
+      </form>
+      <h3>
+        <%= Group.human_attribute_name(:student_memberships) %>
+      </h3>
+      <div id="group_members">
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is part of an ongoing effort to simplify the CSS used in MarkUs


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: I reviewed the ad-hoc css in `graders.scss` and `groups.scss` and simplified it. This affected similar structures on other pages: all "two-table manager" pages (assigning students to groups, assigning graders to groups/criteria, assigning peer reviews). Also simplified CSS for the exam template assign_errors page, which is similar to the groups assign_scans page.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

I tested the changes in the UI on both Firefox and Chrome.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
