### PR TITLE
Don't add new lines at the end of files when writing to zipfiles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [unreleased]
+- Fix bug where newlines were being added to files in zip archives (#5030)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -349,7 +349,7 @@ module Repository
         if obj.is_a? Repository::RevisionFile
           file_contents = block_given? ? block.call(obj) : download_as_string(obj)
           zip_file.get_output_stream(File.join(zip_name, path)) do |f|
-            f.puts file_contents
+            f.print file_contents
           end
         end
       end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1203,7 +1203,7 @@ class Assignment < Assessment
         if abs_path.directory?
           zip_file.mkdir(path)
         else
-          zip_file.get_output_stream(path) { |f| f.puts abs_path.read }
+          zip_file.get_output_stream(path) { |f| f.print File.read(abs_path.to_s, mode: 'rb') }
         end
       end
     end

--- a/app/models/starter_file_entry.rb
+++ b/app/models/starter_file_entry.rb
@@ -30,7 +30,7 @@ class StarterFileEntry < ApplicationRecord
       if abs_path.directory?
         zip_file.mkdir(zip_entry_path)
       else
-        zip_file.get_output_stream(zip_entry_path) { |f| f.puts abs_path.read }
+        zip_file.get_output_stream(zip_entry_path) { |f| f.print File.read(abs_path.to_s, mode: 'rb') }
       end
     end
   end

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -35,7 +35,7 @@ class StarterFileGroup < ApplicationRecord
         if abs_path.directory?
           zip_file.mkdir(zip_entry_path)
         else
-          zip_file.get_output_stream(zip_entry_path) { |f| f.puts abs_path.read }
+          zip_file.get_output_stream(zip_entry_path) { |f| f.print File.read(abs_path.to_s, mode: 'rb') }
         end
       end
     end

--- a/spec/support/zip_file_helper.rb
+++ b/spec/support/zip_file_helper.rb
@@ -25,6 +25,12 @@ shared_examples 'zip file download' do
     it 'should have files that contain the correct content' do
       check_file_content(content, ['test_content'])
     end
+    context 'when there is a newline at the end of the file' do
+      let(:files) { { 'test.txt': 'test_content\n' } }
+      it 'should have files that contain the correct content' do
+        check_file_content(content, ['test_content\n'])
+      end
+    end
   end
   context 'when there is a single test directory' do
     let(:dirs) { ['test_dir'] }
@@ -63,7 +69,7 @@ def check_file_content(content, expected_file_content)
   file_content = []
   Zip::InputStream.open(StringIO.new(content)) do |io|
     while (entry = io.get_next_entry)
-      file_content << io.read.strip.force_encoding('utf-8') unless entry.name_is_directory?
+      file_content << io.read.force_encoding('utf-8') unless entry.name_is_directory?
     end
   end
   expect(file_content).to contain_exactly(*expected_file_content)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We were using `f.puts` to write files to zipfiles which appends a newline to the file content (if it doesn't end with one already). This was causing problems when zipping binary files because often adding a newline corrupted the file.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- use `f.print` which does not add a newline
- when reading content from files on disk, always read in a binary (`rb`) mode so that we don't mess up binary files in other ways by trying to decode them.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- in the UI, through the API
- added test to check file content that both contains a newline at the end and does not
- change test so that it compares the actual file content instead of stripping it first

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
