### PR TITLE
Allow user to view binary file as plain text if they want

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Fix bug where graders could be assigned to groups with empty submissions (#5031)
 - Use Fullscreen API for grading in "fullscreen mode" (#5036)
 - Render .ipynb submission files as html (#5032)
+- Add option to view a binary file as plain text while grading (#5033)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)

--- a/app/assets/javascripts/Components/Result/binary_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/binary_viewer.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export class BinaryViewer extends React.Component {
+  render() {
+    return <div>
+      <p>{this.props.content}</p>
+      <a onClick={this.props.getAnyway}>{I18n.t('submissions.get_anyway')}</a>
+    </div>
+  }
+}

--- a/app/assets/javascripts/Components/Result/file_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/file_viewer.jsx
@@ -5,6 +5,7 @@ import {ImageViewer} from './image_viewer'
 import {TextViewer} from './text_viewer'
 import {PDFViewer} from './pdf_viewer';
 import {JupyterNotebookViewer} from "./jupyter_notebook_viewer";
+import {BinaryViewer} from "./binary_viewer";
 
 
 export class FileViewer extends React.Component {
@@ -74,11 +75,12 @@ export class FileViewer extends React.Component {
   /*
    * Update the contents being displayed with the given submission file id.
    */
-  set_submission_file = (submission_file_id) => {
+  set_submission_file = (submission_file_id, force_text) => {
     if (!this.props.result_id && this.props.selectedFile === null) {
       this.setState({loading: false, type: null});
       return;
     }
+    force_text = !!force_text;
 
     // TODO: is this the right spot to remove these? Should it be done earlier?
     $('.annotation_text_display').each(function() {
@@ -90,7 +92,7 @@ export class FileViewer extends React.Component {
           fetch(Routes.get_file_assignment_submission_path(
             this.props.assignment_id,
             this.props.submission_id,
-            {submission_file_id: submission_file_id}),
+            {submission_file_id: submission_file_id, force_text: force_text}),
             {credentials: 'include'})
             .then(res => res.json())
             .then(body => {
@@ -107,7 +109,7 @@ export class FileViewer extends React.Component {
         } else {
           $.ajax({
             url: this.props.selectedFileURL,
-            data: {preview: true},
+            data: {preview: true, force_text: force_text},
             method: 'GET'
           }).then(res => {
             this.setState({content: res.replace(/\r?\n/gm, '\n'), type: this.props.selectedFileType, loading: false});
@@ -153,6 +155,12 @@ export class FileViewer extends React.Component {
         content={this.state.content}
         {...commonProps}
       />;
+    } else if (this.state.type === 'binary') {
+      return <BinaryViewer
+        content={this.state.content}
+        getAnyway={() => this.set_submission_file(this.props.selectedFile, true)}
+        {...commonProps}
+      />
     } else if (this.state.type !== '') {
       return <TextViewer
         type={this.state.type}

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -408,10 +408,10 @@ class SubmissionsController < ApplicationController
             unique_file = "#{raw_file.name}.#{submission.revision_identifier}"
             unique_path = "#{grouping.group.repo_name}/#{raw_file.path}/#{unique_file}"
             file_contents = ipynb_to_html(file_contents, unique_path)
-          elsif SubmissionFile.is_binary?(file_contents)
+          elsif params[:force_text] != 'true' && SubmissionFile.is_binary?(file_contents)
             # If the file appears to be binary, display a warning
             file_contents = I18n.t('submissions.cannot_display')
-            file_type = 'unknown'
+            file_type = 'binary'
           end
         end
         render json: { content: file_contents.to_json, type: file_type }

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -56,8 +56,8 @@ en:
 
     # Miscellaneous
     cannot_display: "Cannot display this file. Please download it to view."
-    get_anyway: "Try to render this file anyway?"
     commit_date: "Submission Date"
+    get_anyway: Try to render this file anyway?
     grace_credits_used: "Grace Credits Used"
     grading_can_begin: "Grading can begin"
     grading_can_begin_after: "Grading can begin after %{time}"

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -56,6 +56,7 @@ en:
 
     # Miscellaneous
     cannot_display: "Cannot display this file. Please download it to view."
+    get_anyway: "Try to render this file anyway?"
     commit_date: "Submission Date"
     grace_credits_used: "Grace Credits Used"
     grading_can_begin: "Grading can begin"

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -96,6 +96,7 @@ es:
 
     # Miscellaneous
     cannot_display: "Contenido binario: Use el botón de descarga para ver el archivo!"
+    get_anyway: "UPDATE ME"
     commit_date: "Fecha del Commit"
     grace_credits_used: "Créditos de Gracia Usados"
     grading_can_begin: "El proceso de calificación puede iniciar"

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -49,6 +49,7 @@ fr:
 
     # Miscellaneous
     cannot_display: "Fichier binaire : utiliser le bouton Télécharger pour voir."
+    get_anyway: "Essayez de voir le fichier quand même?"
     commit_date: "Date d'envoi (commit)"
     grace_credits_used: "Utilisation des \"grace credits\""
     grading_can_begin: "L'évaluation peut commencer"

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -54,6 +54,7 @@ pt:
 
     # Miscellaneous
     cannot_display: "Conteudo binário: Use o botao de download para ver o arquivo!"
+    get_anyway: "UPDATE ME"
     commit_date: "Data de envio"
     grace_credits_used: "Créditos de tolerância usados"
     grading_can_begin: "Avaliação pode começar"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes student submissions are categorized by MarkUs as a binary files even if they are not. For example, students can submit the output of running gdb which often looks a lot like a binary file to MarkUs even if that is not the intention. 
While grading, it would be nice to have to option to say that a file is not actually binary and display it anyway.

Note: this was a requested feature from csc209

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- add new BinaryViewer which shows an additional link to download the view the binary file as text anyway
- add a new param to the `get_file` route which specifies that a binary file should be downloaded as text anyway

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- tested in the UI
- we currently have no tests for the `get_file` route so I added a TODO to add those later

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [x] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)

- describe this additional option in the Grading View page