### PR TITLE
Results css

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 ## [unreleased]
 - Fix bug where newlines were being added to files in zip archives (#5030)
 - Fix bug where graders could be assigned to groups with empty submissions (#5031)
+- Use Fullscreen API for grading in "fullscreen mode" (#5036)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -31,7 +31,7 @@ class Result extends React.Component {
         $('footer')
       ];
       $.each(toggle_elements, (idx, element) => element.toggle());
-      $('#content').toggleClass('expanded_view');
+      $('#wrapper').toggleClass('fullscreen-view');
     }
 
     this.state = {
@@ -174,7 +174,7 @@ class Result extends React.Component {
       $('footer')
     ];
     $.each(toggle_elements, (idx, element) => element.toggle());
-    $('#content').toggleClass('expanded_view');
+    $('#wrapper').toggleClass('fullscreen-view');
 
     this.setState({fullscreen: !this.state.fullscreen}, fix_panes);
     if (typeof(Storage) !== 'undefined') {

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -19,27 +19,13 @@ const INITIAL_ANNOTATION_MODAL_STATE = {
 class Result extends React.Component {
   constructor(props) {
     super(props);
-    let fullscreen;
-    if (typeof(Storage) !== 'undefined') {
-      fullscreen = localStorage.getItem('fullscreen') === 'on';
-    }
-
-    if (fullscreen) {
-      let toggle_elements = [
-        $('#menus'),
-        $('.title_bar'),
-        $('footer')
-      ];
-      $.each(toggle_elements, (idx, element) => element.toggle());
-      $('#wrapper').toggleClass('fullscreen-view');
-    }
 
     this.state = {
       annotation_categories: [],
       loading: true,
       feedback_files: [],
       submission_files: {files: [], directories: {}, name: '', path: []},
-      fullscreen,
+      fullscreen: false,
       annotationModal: INITIAL_ANNOTATION_MODAL_STATE,
     };
 
@@ -51,6 +37,10 @@ class Result extends React.Component {
     window.modal = new ModalMarkus('#annotation_dialog');
     window.modalNotesGroup = new ModalMarkus('#notes_dialog');
     window.modal_create_new_tag = new ModalMarkus('#create_new_tag');
+
+    document.addEventListener('fullscreenchange', () => {
+      this.setState({fullscreen: !!document.fullscreenElement}, fix_panes);
+    });
   }
 
   fetchData = () => {
@@ -168,19 +158,10 @@ class Result extends React.Component {
   };
 
   toggleFullscreen = () => {
-    let toggle_elements = [
-      $('#menus'),
-      $('.title_bar'),
-      $('footer')
-    ];
-    $.each(toggle_elements, (idx, element) => element.toggle());
-    $('#wrapper').toggleClass('fullscreen-view');
-
-    this.setState({fullscreen: !this.state.fullscreen}, fix_panes);
-    if (typeof(Storage) !== 'undefined') {
-      let compact_view = localStorage.getItem('fullscreen');
-      if (compact_view) localStorage.removeItem('fullscreen');
-      else localStorage.setItem('fullscreen', 'on');
+    if (!document.fullscreenElement) {
+      document.getElementById('content').requestFullscreen();
+    } else {
+      document.exitFullscreen();
     }
   };
 

--- a/app/assets/stylesheets/common/_core.scss
+++ b/app/assets/stylesheets/common/_core.scss
@@ -96,6 +96,10 @@ label.required::after, th.required::after {
     margin-top: 3.5em;
     padding: $dimen-vertical $dimen-hor-mobile;
   }
+
+  &:fullscreen {
+    padding: 0;
+  }
 }
 
 #loggedIn {

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -438,6 +438,11 @@ kbd {
   text-shadow: 0 1px 0 $background-main;
 }
 
+.shortcuts-table {
+  border-collapse: separate;
+  border-spacing: 5px;
+}
+
 /** Test script results table */
 
 .test-result-pass {
@@ -972,6 +977,10 @@ nav {
   z-index: 1;
 }
 
+#image_container {
+  position: relative;  // For image annotations
+}
+
 
 // Text editing and previews
 .preview {
@@ -1087,3 +1096,10 @@ nav {
 .cookies-eu-ok {
   background-color: $primary-three;
 }
+
+// Flexbox layout for Results/edit and Results/view_marks
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+

--- a/app/assets/stylesheets/common/_react_tabs.scss
+++ b/app/assets/stylesheets/common/_react_tabs.scss
@@ -20,6 +20,10 @@
   h4 {
     margin-bottom: 10px;
   }
+
+  textarea {
+    width: 100%;
+  }
 }
 
 .react-tabs__tab--selected {

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -2,12 +2,3 @@
 @import 'common/assignment_dropdown';
 @import 'automated_tests';
 @import 'common/notes_dialog';
-
-.fullscreen-view {
-  height: 100%;
-  padding: 0;
-
-  #content {
-    padding: 0;
-  }
-}

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -3,61 +3,11 @@
 @import 'automated_tests';
 @import 'common/notes_dialog';
 
-
-#remark_request {
-  h3 + h3 {
-    margin: 1em 0 0.5em;
-  }
-}
-
-.wrapper_flex {
+.fullscreen-view {
   height: 100%;
-  display: flex;
-  flex-direction: column;
-}
+  padding: 0;
 
-#result-main {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  textarea {
-    width: 100%;
+  #content {
+    padding: 0;
   }
-}
-
-#content {
-  display: flex;
-  flex-direction: column;
-  z-index: auto !important;
-}
-
-.expanded_view {
-  z-index: auto !important;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  padding: 0 !important;
-}
-
-.expanded_view .page {
-  margin: 0 auto;
-  border: none;
-}
-
-#help_dialog table {
-  border-collapse: separate;
-  border-spacing: 5px;
-}
-
-.rt-td.hidden {
-  display: block;
-}
-
-.actual_output {
-  white-space: normal !important;
-}
-
-#image_container {
-  position: relative;
 }

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -19,7 +19,7 @@
   <div id='mobile_menu'>
     <a id='menu_icon'></a>
   </div>
-  <div id='wrapper' class='wrapper_flex'>
+  <div id='wrapper' class='flex-col'>
     <nav id='menus'>
       <div id='menus_child'>
         <%= render partial: 'layouts/header' %>
@@ -35,7 +35,7 @@
       <span id='ellipsis'></span>
     </div>
 
-    <section id='content'>
+    <section id='content' class='flex-col'>
       <%= render partial: 'shared/flash_message' %>
       <%= render partial: 'layouts/noscript'%>
       <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -49,7 +49,7 @@
 
 <aside class='dialog' id='help_dialog' style='display:none'>
   <h2><%=t('results.keybinding.keyboard_help')%></h2>
-  <table class="help_table">
+  <table class="shortcuts-table">
     <tr>
       <td><kbd>Alt</kbd> + <kbd>Enter/return</kbd></td>
       <td><%=t('results.keybinding.toggle_compact')%></td>
@@ -127,7 +127,7 @@
 
 <div id='criterion_incomplete_error' class='error hidden'></div>
 
-<div id='result-main'></div>
+<div id='result-main' class='flex-col'></div>
 
 <!-- Annotation pane-->
 <div id='annotation_holder'></div>

--- a/app/views/results/view_marks.html.erb
+++ b/app/views/results/view_marks.html.erb
@@ -69,7 +69,7 @@
                        current_pr: @current_pr} %>
 <% end %>
 
-<div id='result-main'></div>
+<div id='result-main' class='flex-col'></div>
 
 <!-- Annotation pane-->
 <div id='annotation_holder'></div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is part of an ongoing effort to remove ad-hoc css in MarkUs.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: I removed the ad-hoc css from `results.scss`. I also changed the way we handle "fullscreen" mode in the Results/edit page to use the [Fullscreen API](), simplifying the CSS and Javascript a little.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in both Firefox and Chrome.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

1. As a result of this PR, MarkUs no longer uses localStorage to keep track of whether the grader is in fullscreen mode when going from one submission to the next. In a future PR, we'll no longer do a full page refresh when going from one submission to the next, so this should no longer be an issue.
2. While I've tested this on (the latest versions of) Firefox and Chrome, the Fullscreen API may not be compatible with other browsers. In the future, we could look into using a library like [Fscreen](https://github.com/rafgraph/fscreen).

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
