### PR TITLE
Course summary table account for multiple results

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Use Fullscreen API for grading in "fullscreen mode" (#5036)
 - Render .ipynb submission files as html (#5032)
 - Add option to view a binary file as plain text while grading (#5033)
+- Fix bug where a remarked submission wasn't being shown in the course summary (#5063)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)

--- a/app/helpers/course_summaries_helper.rb
+++ b/app/helpers/course_summaries_helper.rb
@@ -27,6 +27,7 @@ module CourseSummariesHelper
 
     assignment_grades = students.joins(accepted_groupings: :current_result)
                                 .where('results.released_to_students': released)
+                                .order(:'results.created_at')
                                 .pluck('users.id', 'groupings.assessment_id', 'results.total_mark')
     assignment_grades.each do |student_id, assessment_id, mark|
       max_mark = @max_marks[assessment_id]

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -43,6 +43,31 @@ FactoryBot.define do
     end
   end
 
+  factory :assignment_with_criteria_and_results_with_remark, parent: :assignment do
+    after(:create) do |a|
+      3.times { create(:flexible_criterion, assignment: a) }
+      3.times { create(:grouping_with_inviter_and_submission, assignment: a) }
+      a.groupings.each_with_index do |grouping, i|
+        result = grouping.current_result
+        result.marks.each do |mark|
+          mark.update(mark: mark.criterion.max_mark - 1)
+        end
+        result.update_total_mark
+        result.update!(marking_state: Result::MARKING_STATES[:complete], created_at: 1.minute.ago)
+        if i.zero?
+          grouping.current_submission_used.make_remark_result
+          remark_result = grouping.current_submission_used.current_result
+          remark_result.marks.each do |mark|
+            mark.update!(mark: mark.criterion.max_mark)
+          end
+          remark_result.update_total_mark
+          remark_result.update!(marking_state: Result::MARKING_STATES[:complete])
+        end
+      end
+      a.update_results_stats
+    end
+  end
+
   factory :assignment_with_deductive_annotations, parent: :assignment do
     # This factory creates an assignment with three groupings that each have a result.
     # The assignment has a flexible_criterion with a max_mark of 3.0.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Including a `has_one` relationship in a join in an activerecord query does not in fact limit the result to one row.
This means that all `Result` objects, not just the most recent, was included in a query result. Furthermore, since the earlier `Result` was later in the list, it was parsed second, meaning the earlier `Result` overrode the later `Result`.

Resolves #5062 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- add an explicit ordering so that the later result is processed last. 

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
