### PR TITLE
test-tokens: calculate before save test tokens properly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Render .ipynb submission files as html (#5032)
 - Add option to view a binary file as plain text while grading (#5033)
 - Fix bug where a remarked submission wasn't being shown in the course summary (#5063)
+- Fix bug where additional test tokens were added after every save (#5064)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1240,14 +1240,14 @@ class Assignment < Assessment
   end
 
   def update_assigned_tokens
-    difference = assignment_properties.tokens_per_period -
-        (assignment_properties.tokens_per_period_before_last_save || 0)
-    if difference == 0
-      return
-    end
-    groupings.each do |g|
-      g.test_tokens = [g.test_tokens + difference, 0].max
-      g.save
+    old, new = assignment_properties.saved_change_to_tokens_per_period || [0,0]
+    difference = new - old
+    unless difference.zero?
+      max_tokens = assignment_properties.tokens_per_period
+      groupings.each do |g|
+        g.test_tokens = [[g.test_tokens + difference, 0].max, max_tokens].min
+        g.save
+      end
     end
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1240,7 +1240,7 @@ class Assignment < Assessment
   end
 
   def update_assigned_tokens
-    old, new = assignment_properties.saved_change_to_tokens_per_period || [0,0]
+    old, new = assignment_properties.saved_change_to_tokens_per_period || [0, 0]
     difference = new - old
     unless difference.zero?
       max_tokens = assignment_properties.tokens_per_period

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -435,30 +435,31 @@ describe Grouping do
     end
 
     describe '#update_assigned_tokens' do
-      before :each do
-        @assignment = FactoryBot.create(:assignment, assignment_properties_attributes: { token_start_date: 1.day.ago,
-                                                                                         tokens_per_period: 6 })
-        @group = FactoryBot.create(:group)
-        @grouping = Grouping.create(group: @group, assignment: @assignment, test_tokens: 5)
-        @assignment.groupings << @grouping # TODO: why the bidirectional association is not automatically created?
+      let(:assignment) do
+        create :assignment, assignment_properties_attributes: { token_start_date: 1.day.ago, tokens_per_period: 6 }
       end
+      let!(:grouping) { create :grouping, assignment: assignment, test_tokens: 5 }
+
+      before { assignment.reload }
 
       it 'updates token count properly when it is being increased' do
-        @assignment.tokens_per_period = 9
-        @assignment.save
-        expect(@grouping.test_tokens).to eq(8)
+        assignment.update!(tokens_per_period: 9)
+        expect(grouping.reload.test_tokens).to eq(8)
       end
 
       it 'updates token count properly when it is being decreased' do
-        @assignment.tokens_per_period = 3
-        @assignment.save
-        expect(@grouping.test_tokens).to eq(2)
+        assignment.update!(tokens_per_period: 3)
+        expect(grouping.reload.test_tokens).to eq(2)
       end
 
       it 'does not allow token count to go below 0' do
-        @assignment.tokens_per_period = 0
-        @assignment.save
-        expect(@grouping.test_tokens).to eq(0)
+        assignment.update!(tokens_per_period: 0)
+        expect(grouping.reload.test_tokens).to eq(0)
+      end
+
+      it 'does not update tokens when there is no change' do
+        assignment.update!(tokens_per_period: 6)
+        expect(grouping.reload.test_tokens).to eq(5)
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`attribute_before_last_save` returns `nil` if the attribute in question did not change. This meant that every time the assignment object was saved without updating the `tokens_per_period` value, each grouping got an additional `tokens_per_period` tokens.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

Use `saved_change_to_attribute` instead so that we can better differentiate between a new object and no change to the given attribute.

Also add a check to make sure a groupings tokens can never exceed the maximum.

Added tests and cleaned up old tests for this method.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Added a test to check that the grouping tokens don't change if the `tokens_per_period` does not change.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
