### PR TITLE
Removed assignment due date from the grade distribution graph in Admin page

### DIFF
--- a/app/views/assignments/_assignment_info_summary.html.erb
+++ b/app/views/assignments/_assignment_info_summary.html.erb
@@ -1,7 +1,3 @@
-<p>
-  <%= "#{Assignment.human_attribute_name(:due_date)}: #{l(assignment.due_date)}" %>
-</p>
-
 <% if assignment.outstanding_remark_request_count && assignment.outstanding_remark_request_count > 0%>
   <p>
     <%= link_to t(:outstanding_remark_request,

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -129,6 +129,7 @@ Michael Lumbroso
 Michael Margel
 Mike Conley
 Mike Gunderloy
+Mike Kang
 Mike Stewart
 Mike Wu
 Mina Almasry


### PR DESCRIPTION
In admin page: removed assignment due date from the grade distribution graph.

## Motivation and Context
This information is redundant because the assignment due date is displayed in the assessments table on the admin dashboard already.


## Your Changes
Deletion of the due date data in View.


- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
Manually tested the code.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
None