### PR TITLE
Rename file manager

### DIFF
--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -62,7 +62,7 @@ en:
       remark_requested: Remark Requested
     status: Status
     student:
-      file_manager: "%{short_identifier}: File Manager"
+      file_manager: "%{short_identifier}: Submissions"
       files_submitted:
         one: One file submitted
         other: "%{count} files submitted"

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -98,6 +98,7 @@ Jesse Riemann
 Jiahui Xu
 Joel Burford
 Joey Perry
+Jonathan Chen
 Jordan Saleh
 Joseph Mate
 Joseph Maté


### PR DESCRIPTION
Under the students submissions page, File Manager was changed to display Submissions. Also added my name to the markus-contributors.txt file


## Motivation and Context
Pull request is required in order to edit what is displayed in the student submissions page (change from "File Manager" to "Submissions").


## Your Changes
**Description**:
I modified the config/locales/views/submissions/en.yml file. I changed the submissions.student.file_manager key so now it will display the assignment short_identifier and then Submissions (e.g. A3 Submissions).
I did a quick search and found that the submissions.student.file_manager key was not used in other places.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
Reloaded the student submissions page with different student accounts to see it says Submissions. 


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->


### Required documentation changes (if applicable)
