### PR TITLE
Removing misleading server time text, and associated route, controller method, and test.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Fix bug where additional test tokens were added after every save (#5064)
 - Fix bug where latex files were rendered with character escape sequences displayed (#5073)
 - Fix bug where grader permission for creating annotations were not properly set (#5078)
+- Removed server_time information in submissions_controller.rb and server_time? from submission_policy.rb (#5071)
 
 ## [v1.11.1]
 - Fix bug where duplicate marks can get created because of concurrent requests (#5018)
@@ -371,4 +372,3 @@
 - Fixed annotation_category bug, and average calculation bug (c6conley)
 - Closing #402 (c6conley)
 - Add version and patch level information to MarkUs (g9jerboa)
-- Removed server_time information in submissions_controller.rb and server_time? from submission_policy.rb (choyuji3)

--- a/Changelog.md
+++ b/Changelog.md
@@ -371,3 +371,4 @@
 - Fixed annotation_category bug, and average calculation bug (c6conley)
 - Closing #402 (c6conley)
 - Add version and patch level information to MarkUs (g9jerboa)
+- Removed server_time information in submissions_controller.rb and server_time? from submission_policy.rb (choyuji3)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -604,11 +604,6 @@ class SubmissionsController < ApplicationController
               filename: "#{assignment.short_identifier}_repo_list.csv"
   end
 
-  # This action is called periodically from file_manager.
-  def server_time
-    render plain: l(Time.current)
-  end
-
   def set_result_marking_state
     if !params.key?(:groupings) || params[:groupings].empty?
       flash_now(:error, t('groups.select_a_group'))

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -9,10 +9,6 @@ class SubmissionPolicy < ApplicationPolicy
     check?(:manage_submissions?, user)
   end
 
-  def server_time?
-    true
-  end
-
   def file_manager?
     user.student?
   end

--- a/app/views/submissions/file_manager.html.erb
+++ b/app/views/submissions/file_manager.html.erb
@@ -19,15 +19,6 @@
           enableSubdirs: <%= allowed_to? :manage_subdirectories? %>,
           starterFileChanged: <%= @grouping.starter_file_changed %>
         });
-
-      window.setInterval(() => {
-        $.get({
-          url: '<%= server_time_assignment_submissions_path(@assignment.id) %>',
-          success: function(data) {
-            document.getElementById('current_time').innerHTML = data;
-          }
-        });
-      }, 60000);
     });
   </script>
 <% end %>
@@ -35,11 +26,6 @@
 <% content_for :title do %>
     <%= t('submissions.student.file_manager',
           short_identifier: sanitize(@assignment.short_identifier)) %>
-<% end %>
-
-<% content_for :additional_headings do %>
-  <strong><%= t('submissions.student.server_time') %></strong>:
-  <span id='current_time'><%= l(Time.current)%></span>
 <% end %>
 
 <div id='file_manager'></div>

--- a/config/locales/policies/en.yml
+++ b/config/locales/policies/en.yml
@@ -115,7 +115,6 @@ en:
         manage?: You do not have permission to manage submissions.
         manage_files?: You do not have permission to manage files for this group.
         manage_subdirectories?: You do not have permission to create subdirectories.
-        server_time?: You do not have permission to view the server time.
         view_files?: You do not have permission to view files.
       ta:
         manage_assessments?: You do not have permission to manage assessments.

--- a/config/locales/policies/es.yml
+++ b/config/locales/policies/es.yml
@@ -115,7 +115,6 @@ es:
         manage?: UPDATE ME.
         manage_files?: UPDATE ME.
         manage_subdirectories?: UPDATE ME.
-        server_time?: UPDATE ME.
         view_files?: UPDATE ME.
       ta:
         manage_assessments?: UPDATE ME.

--- a/config/locales/policies/fr.yml
+++ b/config/locales/policies/fr.yml
@@ -115,7 +115,6 @@ fr:
         manage?: UPDATE ME.
         manage_files?: UPDATE ME.
         manage_subdirectories?: Vous n'êtes pas autorisé à créer, supprimer ou modifier des dossiers.
-        server_time?: UPDATE ME.
         view_files?: UPDATE ME.
       ta:
         manage_assessments?: UPDATE ME.

--- a/config/locales/policies/pt.yml
+++ b/config/locales/policies/pt.yml
@@ -115,7 +115,6 @@ pt:
         manage?: UPDATE ME.
         manage_files?: UPDATE ME.
         manage_subdirectories?: UPDATE ME.
-        server_time?: UPDATE ME.
         view_files?: UPDATE ME.
       ta:
         manage_assessments?: UPDATE ME.

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -75,7 +75,6 @@ en:
       no_revision_available: No revision available.
       no_submission: You have not submitted any work yet.
       select_file: Select a file to view
-      server_time: Server Time
       version_control_warning: Submitting files here overrides any changes made using version control. Make sure you have worked on the most recent files before submitting.
     successfully_changed: Successfully updated %{changed} results.
     unrelease_marks: Unrelease Marks

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -73,7 +73,6 @@ es:
       no_revision_available: No existe ninguna revisión disponible.
       no_submission: Usted no ha enviado ninguna entrega todavía
       select_file: UPDATE ME!
-      server_time: Tiempo Servidor
       version_control_warning: Entregar archivos aquí reescribe todos los cambios realizados usando version control. Asegúrese que haya trabajado en los archivos más recientes antes de realizar la entrega.
     successfully_changed: "%{changed} resultados han sido actualizados exitosamente"
     unrelease_marks: Ocultar Notas

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -67,7 +67,6 @@ fr:
       no_revision_available: Aucune révision disponible.
       no_submission: Vous n'avez encore rien envoyé
       select_file: UPDATE ME!
-      server_time: Heure du serveur
       version_control_warning: Envoi de fichiers ici annule les modifications apportées à l'aide de contrôle de version. Assurez-vous que vous avez travaillé sur les fichiers les plus récents avant de soumettre.
     successfully_changed: Les %{changed} résultats ont été mis à jour.
     unrelease_marks: Cacher les notes

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -71,7 +71,6 @@ pt:
       no_revision_available: Nenhuma revisão disponível.
       no_submission: Você não tem nenhum envio ainda.
       select_file: UPDATE ME!
-      server_time: Data servidor
       version_control_warning: Submetendo arquivos aqui substitui todas as mudanças feitas usando o controle de versão. Certifique-se de que você trabalhou nos arquivos mais recentes antes de enviar.
     successfully_changed: "%{changed} resultados atualizados."
     unrelease_marks: Esconder notas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,7 +210,6 @@ Rails.application.routes.draw do
         get 'replace_files'
         get 'delete_files'
         post 'update_files'
-        get 'server_time'
         get 'download'
         post 'zip_groupings_files'
         get 'download_zipped_file'

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -18,18 +18,6 @@ describe SubmissionPolicy do
     end
   end
 
-  describe_rule :server_time? do
-    succeed 'user is an admin' do
-      let(:user) { create(:admin) }
-    end
-    succeed 'user is a ta' do
-      let(:user) { create(:ta) }
-    end
-    succeed 'user is a student' do
-      let(:user) { create(:student) }
-    end
-  end
-
   describe_rule :file_manager? do
     failed 'user is an admin' do
       let(:user) { create(:admin) }

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -581,14 +581,6 @@ describe 'An Assignment' do
         )
       end
 
-      it 'routes GET server_time properly' do
-        expect(get: sub_path + '/server_time').to route_to(
-          controller: sub_ctrl,
-          action: 'server_time',
-          assignment_id: assignment.id.to_s
-        )
-      end
-
       it 'routes GET download properly' do
         expect(get: sub_path + '/download').to route_to(
           controller: sub_ctrl,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
I am removing the misleading "Server time" information under the student assignment "Submissions" tab and the corresponding javascript, route, and controller method.

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request removes some unnecessary information (server time) because it is updated through polling only.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
I removed an ajax request and its corresponding partial which displayed the local server time, along with the matching route and controller method.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I manually tested this by logging in as a student, going to an assignment, then clicking the submissions tab.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
~Should I modify the yml in any way (for the localizations)?~ Turns out I should.

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [ ]  I have updated the Changelog.md file.
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->