### PR TITLE
user: Fix flaky locale test and change locale on setting update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,7 @@ class UsersController < ApplicationController
   def update_settings
     user = current_user
     user.update!(settings_params)
+    I18n.locale = user.locale if user.saved_change_to_attribute? :locale
     update_success
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,20 @@
 describe UsersController do
   let(:admin) { create :admin }
 
+  shared_examples 'change locale' do
+    describe 'change locale in settings' do
+      before { I18n.locale = :en }
+
+      it 'updates locale' do
+        locale = 'es'
+        patch_as user, 'update_settings', params: { 'user': { 'locale': locale } }
+
+        expect(user.reload.locale).to eq locale
+        expect(I18n.locale).to eq locale.to_sym
+      end
+    end
+  end
+
   describe 'GET settings' do
     before { get_as admin, :settings }
     it 'should respond with success' do
@@ -12,6 +26,7 @@ describe UsersController do
   end
 
   describe 'User is an admin' do
+    let(:user) { admin }
     describe '#reset_api_key' do
       it 'responds with a success' do
         post_as admin, :reset_api_key
@@ -25,76 +40,45 @@ describe UsersController do
       end
     end
 
-    describe 'Change locale' do
-      it 'updates locale for admin' do
-        locale = 'es'
-        expect(I18n.locale).to eq I18n.default_locale
-        patch_as admin,
-                 'update_settings',
-                 params: { 'user': { 'locale': locale } }
-
-        @controller = MainController.new
-        get 'check_timeout'
-
-        expect(admin.reload.locale).to eq locale
-        expect(I18n.locale).to eq locale.to_sym
-      end
-    end
+    include_examples 'change locale'
   end
 
   describe 'User is a TA' do
-    let(:ta) { create :ta }
+    let(:user) { create :ta }
 
     describe 'change display name in settings' do
       it 'updates student display_name' do
         display_name = 'First Last'
-        patch_as ta,
+        patch_as user,
                  'update_settings',
                  params: { 'user': { 'display_name': display_name } }
-        expect(ta.reload.display_name).to eq display_name
+        expect(user.reload.display_name).to eq display_name
       end
     end
 
-    describe 'change locale in settings' do
-      after(:each) do
-        I18n.locale = :en
-      end
-
-      it 'updates locale for student' do
-        locale = 'es'
-        expect(I18n.locale).to eq I18n.default_locale
-        patch_as ta,
-                 'update_settings',
-                 params: { 'user': { 'locale': locale } }
-
-        @controller = MainController.new
-        get 'check_timeout'
-
-        expect(ta.reload.locale).to eq locale
-        expect(I18n.locale).to eq locale.to_sym
-      end
-    end
+    include_examples 'change locale'
   end
 
   describe 'User is a Student' do
     include ERB::Util
+    let(:user) { create(:student, user_name: 'c6stenha') }
     RSpec.shared_examples 'changing particular mailer settings' do
       it 'can be enabled in settings' do
-        student.update!(setting => false)
-        patch_as student,
+        user.update!(setting => false)
+        patch_as user,
                  'update_settings',
                  params: { user: { setting => true, other_setting => true } }
-        student.reload
-        expect(student[setting]).to be true
+        user.reload
+        expect(user[setting]).to be true
       end
 
       it 'can be disabled in settings' do
-        student.update!(setting => true)
-        patch_as student,
+        user.update!(setting => true)
+        patch_as user,
                  'update_settings',
                  params: { user: { setting => false, other_setting => true } }
-        student.reload
-        expect(student[setting]).to be false
+        user.reload
+        expect(user[setting]).to be false
       end
     end
 
@@ -102,7 +86,6 @@ describe UsersController do
       # Authenticate user is not timed out, and is a student.
       let(:setting) { 'receives_results_emails' }
       let(:other_setting) { 'receives_invite_emails' }
-      let(:student) { create(:student, user_name: 'c6stenha') }
 
       include_examples 'changing particular mailer settings'
     end
@@ -111,14 +94,12 @@ describe UsersController do
       # Authenticate user is not timed out, and is a student.
       let(:setting) { 'receives_invite_emails' }
       let(:other_setting) { 'receives_results_emails' }
-      let(:student) { create(:student, user_name: 'c6stenha') }
 
       include_examples 'changing particular mailer settings'
     end
     describe 'changing any setting' do
-      let(:student) { create(:student, user_name: 'c6stenha') }
       it 'redirects back to settings' do
-        patch_as student,
+        patch_as user,
                  'update_settings',
                  params: { 'user': { 'receives_invite_emails': false, 'receives_results_emails': true } }
         expect(response).to redirect_to(settings_users_path)
@@ -126,53 +107,30 @@ describe UsersController do
     end
 
     describe 'change display name in settings' do
-      let(:student) { create(:student, user_name: 'c6stenha') }
       it 'updates student display_name' do
         display_name = 'First Last'
-        patch_as student,
+        patch_as user,
                  'update_settings',
                  params: { 'user': { 'display_name': display_name } }
-        expect(student.reload.display_name).to eq display_name
+        expect(user.reload.display_name).to eq display_name
       end
     end
 
     describe 'change time zone in settings' do
-      let(:student) { create(:student, user_name: 'c6stenha') }
       it 'updates time zone for student' do
         time_zone = 'Pacific Time (US & Canada)'
-        patch_as student,
+        patch_as user,
                  'update_settings',
                  params: { 'user': { 'time_zone': time_zone } }
-        expect(student.reload.time_zone).to eq time_zone
+        expect(user.reload.time_zone).to eq time_zone
       end
     end
 
-    describe 'change locale in settings' do
-      let(:student) { create(:student, user_name: 'c6stenha') }
-
-      after(:each) do
-        I18n.locale = :en
-      end
-
-      it 'updates locale for student' do
-        locale = 'es'
-        expect(I18n.locale).to eq I18n.default_locale
-        patch_as student,
-                 'update_settings',
-                 params: { 'user': { 'locale': locale } }
-
-        @controller = MainController.new
-        get 'check_timeout'
-
-        expect(student.reload.locale).to eq locale
-        expect(I18n.locale).to eq locale.to_sym
-      end
-    end
+    include_examples 'change locale'
 
     describe '#reset_api_key' do
-      let(:student) { create(:student) }
       it 'cannot reset their api key' do
-        post_as student, :reset_api_key
+        post_as user, :reset_api_key
         expect(response).to have_http_status(:forbidden)
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is currently a flaky test in `user_controllers_spec.rb:65` (`I18n.locale` wasn't being set properly). While fixing this, I noticed a small bug in the `UsersController#update_settings` method, which didn't change `I18n.locale` even when the user changed this setting.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the test setup and modified `UsersController#update_settings` to change `I18n.locale`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran the tests locally a few times, always passed. Checked in the UI that after changing the locale setting, the flash message that's rendered is in the updated locale, rather than the previous locale

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
