### PR TITLE
modal: Fix bug where easyModal overlay covered the modal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Fix bug where zip files with too many entries could not be uploaded (#5080)
 - Add button to assignment's annotations tab to allow instructor to download one time annotations (#5088)
 - Removed AssignmentStats table (#5089)
+- Fix easyModal overlay bug (#5117)
 
 ## [v1.11.2]
 - Fix bug where newlines were being added to files in zip archives (#5030)

--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -18,7 +18,8 @@ export class ModalMarkus {
         // z-index values set by browser extensions. See issue #3212.
         'zIndex': function () {
           return 100;
-        }
+        },
+        overlayParent: '#content'
       });
     this.$elem.find('.make_div_clickable, [type=reset]').click(() => {
       // Set callbacks for buttons to close the modal.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was a bug in the results page where the MarkusModal dialogs were covered by the overlay.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fix the bug by making the overlay parent the `#content` div.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Checked that the overlay no longer covers the modals. The `react-modal` modals are unaffected.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
