### PR TITLE
file-upload: Fix unzip label in file upload dialog

### DIFF
--- a/app/assets/javascripts/Components/Modals/file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/file_upload_modal.jsx
@@ -47,6 +47,7 @@ class FileUploadModal extends React.Component {
               <label htmlFor='unzip'>
                 <input
                   type={'checkbox'}
+                  id={'unzip'}
                   name={'unzip'}
                   checked={this.state.unzip}
                   onChange={this.toggleUnzip}

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -42,6 +42,7 @@ class SubmissionFileUploadModal extends React.Component {
               <label htmlFor='unzip'>
                 <input
                   type={'checkbox'}
+                  id={'unzip'}
                   name={'unzip'}
                   checked={this.state.unzip}
                   onChange={this.toggleUnzip}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the file upload dialog, the label for the unzip checkbox option isn't properly linked to the input.

![image](https://user-images.githubusercontent.com/3333115/109362000-0fbc1c80-7882-11eb-9481-516bdd319350.png)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added the right `id` attribute to the input to link the labels.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested in the web interface.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
