### PR TITLE
assessments: Support Markdown syntax for assessment messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Display assignment totals on the grade summary table rounded up to 2 decimal places (#5123)
 - Added a delete button to notes dialog under an results edit view and removed user_can_modify under note model,
   removed Notes#user_can_modify and replaced instances of usage with NotePolicy (#5128)
+- Support Markdown syntax for assessment messages (#5135)
 
 ## [v1.11.3]
 - Fix easyModal overlay bug (#5117)

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -6,7 +6,7 @@
 
 <div class='block-content'>
   <% if @assignment.message %>
-    <p><%= @assignment.message %></p>
+    <%= markdown @assignment.message %>
   <% end %>
   <% if @assignment.is_timed %>
     <%= render partial: 'timed_due_info' %>

--- a/app/views/grade_entry_forms/student_interface.html.erb
+++ b/app/views/grade_entry_forms/student_interface.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, t('grade_entry_forms.students.title') + ' ' + @grade_entry_form.short_identifier %>
 
 <% unless @grade_entry_form.message.blank? %>
-  <p><%= "#{@grade_entry_form.message}" %></p>
+  <%= markdown @grade_entry_form.message %>
 <% end %>
 
 <% if @grade_entry_form.grade_entry_items.empty? %>

--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -17,7 +17,7 @@
   </p>
   <div id="remark_request">
     <h3><%= Assignment.human_attribute_name(:remark_message) %></h3>
-    <%= @assignment.remark_message %>
+    <%= markdown @assignment.remark_message %>
     <h3><%= Submission.human_attribute_name(:submitted_remark) %></h3>
     <div id="remark_request_text">
       <%= markdown(@submission.remark_request) %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently assessment messages are limited to one paragraph. However, instructors may want to provide more detailed instructions (this has proved to be fairly common for timed assessments). The simplest way to do this is support Markdown syntax for these messages, which we use in other places in MarkUs already (and has the added benefit of allowing richer formatting than just multiple paragraphs).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Render assessment messages using markdown.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested that markdown syntax in messages renders correctly in the web interface.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
