### PR TITLE
One-Time Annotations Table

### DIFF
--- a/app/assets/javascripts/Components/Modals/create_modify_annotation_panel_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/create_modify_annotation_panel_modal.jsx
@@ -184,7 +184,7 @@ class CreateModifyAnnotationPanel extends React.Component {
     ];
     this.props.categories.forEach((category) => {
       options.push(
-        <option key ={category.id} value={category.id}>{category.annotation_category_name}</option>
+        <option key={category.id} value={category.id}>{category.annotation_category_name}</option>
       );
     });
 

--- a/app/assets/javascripts/Components/Modals/create_modify_annotation_panel_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/create_modify_annotation_panel_modal.jsx
@@ -180,11 +180,11 @@ class CreateModifyAnnotationPanel extends React.Component {
 
   render() {
     let options = [
-      <option value="">{I18n.t("annotation_categories.one_time_only")}</option>,
+      <option key="one_time_annotation" value="">{I18n.t("annotation_categories.one_time_only")}</option>,
     ];
     this.props.categories.forEach((category) => {
       options.push(
-        <option value={category.id}>{category.annotation_category_name}</option>
+        <option key ={category.id} value={category.id}>{category.annotation_category_name}</option>
       );
     });
 

--- a/app/assets/javascripts/Components/one_time_annotations_table.jsx
+++ b/app/assets/javascripts/Components/one_time_annotations_table.jsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import {render} from 'react-dom';
+
+import ReactTable from 'react-table';
+import CreateModifyAnnotationPanel from './Modals/create_modify_annotation_panel_modal';
+
+const INITIAL_ANNOTATION_MODAL_STATE = {
+  show: false,
+  onSubmit: null,
+  title: '',
+  content: '',
+  categoryId: '',
+  isNew: true,
+  changeOneOption: false,
+};
+class OneTimeAnnotationsTable extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      data: [],
+      annotationModal: INITIAL_ANNOTATION_MODAL_STATE,
+      loading: true
+    };
+  }
+
+  componentDidMount()  {
+    this.fetchData();
+  }
+
+  fetchData = () => {
+    $.ajax({
+      url: Routes.uncategorized_annotations_assignment_annotation_categories_path(this.props.assignment_id),
+      dataType: 'json',
+    }).then(res => {
+      this.setState({
+        data: res,
+        loading: false
+      });
+    });
+  };
+
+  refreshAnnotations = () => {
+    $.ajax({
+      url: Routes.uncategorized_annotations_assignment_annotation_categories_path(this.props.assignment_id),
+      dataType: 'json',
+    }).then(res => {
+      this.setState({
+        data: res,
+        loading: false
+      })
+    });
+  };
+
+  editAnnotation = (annot_id, content) => {
+    let onSubmit = (formData) => {
+      return ($.ajax({
+        url: Routes.update_annotation_text_assignment_annotation_categories_path(this.props.assignment_id)+ '?id=' + annot_id,
+        data:{ ...formData },
+        method: "PUT",
+        remote: true,
+        dataType: "json",
+      }).always(() =>
+        {
+          this.setState({
+            annotationModal: INITIAL_ANNOTATION_MODAL_STATE
+          })
+          this.refreshAnnotations();
+        }
+      ));
+    };
+
+
+    let category_id = '';
+    let deduction = '';
+
+    this.setState({
+      annotationModal: {
+        ...this.state.annotationModal,
+        show: true,
+        content: content,
+        category_id,
+        isNew: false,
+        changeOneOption: category_id && !deduction,
+        onSubmit,
+        title: I18n.t("helpers.submit.create", {
+          model: I18n.t("activerecord.models.annotation.one"),
+        }),
+      },
+    });
+  };
+
+  removeAnnotation = (annot_id, result_id) => {
+    $.ajax({
+      url: Routes.destroy_annotation_text_assignment_annotation_categories_path(this.props.assignment_id)+ '?id=' + annot_id,
+      method: 'delete',
+      data: {
+        result_id: result_id
+      },
+      remote: true,
+      dataType: 'json'
+    }).always(() =>
+      {
+      this.refreshAnnotations()
+      });
+  };
+
+  columns = [
+    {
+      Header: I18n.t('activerecord.models.group.one'),
+      accessor: 'group_name',
+      id: 'group_name',
+      Cell: row => {
+        let remove_button = <a
+        href="#"
+        className="remove-icon"
+        title={I18n.t('delete')}
+        onClick={() => this.removeAnnotation(row.original.id, row.original.result_id)}
+      />
+        if (row.original.result_id) {
+          const path = Routes.edit_assignment_submission_result_path(
+            this.props.assignment_id,
+            row.original.submission_id,
+            row.original.result_id
+          );
+          return (
+            <div>
+            {remove_button}
+            <a className ="alignright" href={path}>{row.original.group_name}</a>
+          </div>
+          );
+        } else {
+          return (
+            <div>
+            {remove_button}
+            <span className="alignright">
+              {row.original.group_name}
+            </span>
+          </div>
+          );
+        }
+      },
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          // Check group name
+          if (row._original.group_name.includes(filter.value)) {
+            return true;
+          }
+        } else {
+          return true;
+        }
+      }
+    },
+    {
+      Header:  I18n. t('activerecord.attributes.annotation_text.creator'),
+      accessor: 'creator',
+      id: 'creator',
+      Cell: row => {
+        return <span>{row.original.creator}</span>;
+      },
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          if (row._original.creator.includes(filter.value)) {
+            return true;
+          }
+        } else {
+          return true;
+        }
+      }
+    },
+    {
+      Header: I18n. t('annotations.last_edited_by'),
+      accessor: 'last_editor',
+      id: 'last_editor',
+      Cell: row => {
+        return <span>{row.original.last_editor}</span>;
+      },
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          if (row._original.last_editor.includes(filter.value)) {
+            return true;
+          }
+        } else {
+          return true;
+        }
+      }
+    },
+    {
+      Header: I18n. t('activerecord.models.annotation_text.one'),
+      accessor: 'content',
+      id: 'content',
+      Cell: row => {
+        let edit_button = <a
+        href="#"
+        className="edit-icon"
+        title={I18n.t('edit')}
+        onClick={() => this.editAnnotation(row.original.id, row.original.content)}
+      />
+
+        return (
+          <div>
+          <div dangerouslySetInnerHTML={{__html: marked(row.original.content, {sanitize: true})}}/>
+          <div className={"alignright"}>{edit_button}</div>
+        </div>
+        );
+      },
+      filterMethod: (filter, row) => {
+        if (filter.value) {
+          if (row._original.content.includes(filter.value)) {
+            return true;
+          }
+        } else {
+          return true;
+        }
+      }
+    }
+  ];
+
+  render() {
+    return [
+      <ReactTable
+          key="one_time_annotations_table"
+          data={this.state.data}
+          columns={this.columns}
+          filterable
+          defaultSorted={[{id: 'group_name'}]}
+          loading={this.state.loading}
+        />,
+      <CreateModifyAnnotationPanel
+          key="modify_modal"
+          categories={[]}
+          onRequestClose={() =>
+            this.setState({
+              annotationModal: INITIAL_ANNOTATION_MODAL_STATE
+            })
+          }
+          is_reviewer={false}
+          assignment_id={this.props.assignment_id}
+          {...this.state.annotationModal}
+        />
+    ];
+    }
+}
+
+export function makeOneTimeAnnotationsTable(elem, props) {
+    render(<OneTimeAnnotationsTable {...props} />, elem);
+  }

--- a/app/assets/javascripts/Components/one_time_annotations_table.jsx
+++ b/app/assets/javascripts/Components/one_time_annotations_table.jsx
@@ -89,16 +89,13 @@ class OneTimeAnnotationsTable extends React.Component {
     });
   };
 
-  removeAnnotation = (annot_id, result_id) => {
+  removeAnnotation = (annot_id) => {
     $.ajax({
       url: Routes.destroy_annotation_text_assignment_annotation_categories_path(this.props.assignment_id)+ '?id=' + annot_id,
       method: 'delete',
-      data: {
-        result_id: result_id
-      },
       remote: true,
-      dataType: 'json'
-    }).always(() =>
+      dataType: 'script'
+    }).then(() =>
       {
       this.refreshAnnotations()
       });
@@ -224,6 +221,7 @@ class OneTimeAnnotationsTable extends React.Component {
           filterable
           defaultSorted={[{id: 'group_name'}]}
           loading={this.state.loading}
+          noDataText={I18n. t('annotations.empty_uncategorized')}
         />,
       <CreateModifyAnnotationPanel
           key="modify_modal"

--- a/app/assets/javascripts/Components/one_time_annotations_table.jsx
+++ b/app/assets/javascripts/Components/one_time_annotations_table.jsx
@@ -39,48 +39,29 @@ class OneTimeAnnotationsTable extends React.Component {
     });
   };
 
-  refreshAnnotations = () => {
-    $.ajax({
-      url: Routes.uncategorized_annotations_assignment_annotation_categories_path(this.props.assignment_id),
-      dataType: 'json',
-    }).then(res => {
-      this.setState({
-        data: res,
-        loading: false
-      })
-    });
-  };
-
   editAnnotation = (annot_id, content) => {
     let onSubmit = (formData) => {
       return ($.ajax({
-        url: Routes.update_annotation_text_assignment_annotation_categories_path(this.props.assignment_id)+ '?id=' + annot_id,
-        data:{ ...formData },
+        url: Routes.update_annotation_text_assignment_annotation_categories_path(this.props.assignment_id),
+        data:{ ...formData, id: annot_id },
         method: "PUT",
         remote: true,
         dataType: "json",
-      }).always(() =>
-        {
+      }).always(() => {
           this.setState({
-            annotationModal: INITIAL_ANNOTATION_MODAL_STATE
-          })
-          this.refreshAnnotations();
+            annotationModal: INITIAL_ANNOTATION_MODAL_STATE,
+          });
+          this.fetchData();
         }
       ));
     };
-
-
-    let category_id = '';
-    let deduction = '';
 
     this.setState({
       annotationModal: {
         ...this.state.annotationModal,
         show: true,
         content: content,
-        category_id,
         isNew: false,
-        changeOneOption: category_id && !deduction,
         onSubmit,
         title: I18n.t("helpers.submit.create", {
           model: I18n.t("activerecord.models.annotation.one"),
@@ -91,14 +72,12 @@ class OneTimeAnnotationsTable extends React.Component {
 
   removeAnnotation = (annot_id) => {
     $.ajax({
-      url: Routes.destroy_annotation_text_assignment_annotation_categories_path(this.props.assignment_id)+ '?id=' + annot_id,
+      url: Routes.destroy_annotation_text_assignment_annotation_categories_path(this.props.assignment_id),
+      data: { id: annot_id },
       method: 'delete',
       remote: true,
       dataType: 'script'
-    }).then(() =>
-      {
-      this.refreshAnnotations()
-      });
+    }).then(() => this.fetchData());
   };
 
   columns = [
@@ -108,11 +87,10 @@ class OneTimeAnnotationsTable extends React.Component {
       id: 'group_name',
       Cell: row => {
         let remove_button = <a
-        href="#"
-        className="remove-icon"
-        title={I18n.t('delete')}
-        onClick={() => this.removeAnnotation(row.original.id, row.original.result_id)}
-      />
+          href="#"
+          className="remove-icon"
+          title={I18n.t('delete')}
+          onClick={() => this.removeAnnotation(row.original.id, row.original.result_id)}/>;
         if (row.original.result_id) {
           const path = Routes.edit_assignment_submission_result_path(
             this.props.assignment_id,
@@ -121,34 +99,32 @@ class OneTimeAnnotationsTable extends React.Component {
           );
           return (
             <div>
-            {remove_button}
-            <a className ="alignright" href={path}>{row.original.group_name}</a>
-          </div>
+              {remove_button}
+              <a className="alignright" href={path}>{row.original.group_name}</a>
+            </div>
           );
         } else {
           return (
             <div>
-            {remove_button}
-            <span className="alignright">
-              {row.original.group_name}
-            </span>
-          </div>
+              {remove_button}
+              <span className="alignright">
+                {row.original.group_name}
+              </span>
+            </div>
           );
         }
       },
       filterMethod: (filter, row) => {
         if (filter.value) {
           // Check group name
-          if (row._original.group_name.includes(filter.value)) {
-            return true;
-          }
+          return row._original.group_name.includes(filter.value);
         } else {
           return true;
         }
       }
     },
     {
-      Header:  I18n. t('activerecord.attributes.annotation_text.creator'),
+      Header:  I18n.t('activerecord.attributes.annotation_text.creator'),
       accessor: 'creator',
       id: 'creator',
       Cell: row => {
@@ -156,16 +132,14 @@ class OneTimeAnnotationsTable extends React.Component {
       },
       filterMethod: (filter, row) => {
         if (filter.value) {
-          if (row._original.creator.includes(filter.value)) {
-            return true;
-          }
+          return row._original.creator.includes(filter.value);
         } else {
           return true;
         }
       }
     },
     {
-      Header: I18n. t('annotations.last_edited_by'),
+      Header: I18n.t('annotations.last_edited_by'),
       accessor: 'last_editor',
       id: 'last_editor',
       Cell: row => {
@@ -173,16 +147,14 @@ class OneTimeAnnotationsTable extends React.Component {
       },
       filterMethod: (filter, row) => {
         if (filter.value) {
-          if (row._original.last_editor.includes(filter.value)) {
-            return true;
-          }
+          return row._original.last_editor.includes(filter.value);
         } else {
           return true;
         }
       }
     },
     {
-      Header: I18n. t('activerecord.models.annotation_text.one'),
+      Header: I18n.t('activerecord.models.annotation_text.one'),
       accessor: 'content',
       id: 'content',
       Cell: row => {
@@ -195,16 +167,14 @@ class OneTimeAnnotationsTable extends React.Component {
 
         return (
           <div>
-          <div dangerouslySetInnerHTML={{__html: marked(row.original.content, {sanitize: true})}}/>
-          <div className={"alignright"}>{edit_button}</div>
-        </div>
+            <div dangerouslySetInnerHTML={{__html: marked(row.original.content, {sanitize: true})}}/>
+            <div className={"alignright"}>{edit_button}</div>
+          </div>
         );
       },
       filterMethod: (filter, row) => {
         if (filter.value) {
-          if (row._original.content.includes(filter.value)) {
-            return true;
-          }
+          return row._original.content.includes(filter.value);
         } else {
           return true;
         }
@@ -215,28 +185,24 @@ class OneTimeAnnotationsTable extends React.Component {
   render() {
     return [
       <ReactTable
-          key="one_time_annotations_table"
-          data={this.state.data}
-          columns={this.columns}
-          filterable
-          defaultSorted={[{id: 'group_name'}]}
-          loading={this.state.loading}
-          noDataText={I18n. t('annotations.empty_uncategorized')}
-        />,
+        key="one_time_annotations_table"
+        data={this.state.data}
+        columns={this.columns}
+        filterable
+        defaultSorted={[{id: 'group_name'}]}
+        loading={this.state.loading}
+        noDataText={I18n. t('annotations.empty_uncategorized')}
+      />,
       <CreateModifyAnnotationPanel
-          key="modify_modal"
-          categories={[]}
-          onRequestClose={() =>
-            this.setState({
-              annotationModal: INITIAL_ANNOTATION_MODAL_STATE
-            })
-          }
-          is_reviewer={false}
-          assignment_id={this.props.assignment_id}
-          {...this.state.annotationModal}
-        />
+        key="modify_modal"
+        categories={[]}
+        onRequestClose={() => this.setState({annotationModal: INITIAL_ANNOTATION_MODAL_STATE})}
+        is_reviewer={false}
+        assignment_id={this.props.assignment_id}
+        {...this.state.annotationModal}
+      />
     ];
-    }
+  }
 }
 
 export function makeOneTimeAnnotationsTable(elem, props) {

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -288,7 +288,8 @@ class AnnotationCategoriesController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     @texts = annotation_text_data(nil)
     respond_to do |format|
-      format.js
+      format.js { }
+      format.json { render json: @texts }
       format.csv do
         data = MarkusCsv.generate(
           @texts

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -288,7 +288,7 @@ class AnnotationCategoriesController < ApplicationController
     @assignment = Assignment.find(params[:assignment_id])
     @texts = annotation_text_data(nil)
     respond_to do |format|
-      format.js { }
+      format.js {}
       format.json { render json: @texts }
       format.csv do
         data = MarkusCsv.generate(

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -76,6 +76,8 @@ import { makeStudentTable } from 'javascripts/Components/student_table';
 window.makeStudentTable = makeStudentTable;
 import { makeAssignmentSummaryTable } from 'javascripts/Components/assignment_summary_table';
 window.makeAssignmentSummaryTable = makeAssignmentSummaryTable;
+import { makeOneTimeAnnotationsTable } from 'javascripts/Components/one_time_annotations_table';
+window.makeOneTimeAnnotationsTable = makeOneTimeAnnotationsTable;
 import { makeExamScanLogTable } from 'javascripts/Components/exam_scan_log_table';
 window.makeExamScanLogTable = makeExamScanLogTable;
 import { makeMarksSpreadsheet } from 'javascripts/Components/marks_spreadsheet';

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -4,8 +4,7 @@ class AnnotationText < ApplicationRecord
   belongs_to :last_editor, class_name: 'User', foreign_key: :last_editor_id, optional: true
 
   after_update :update_mark_deductions,
-               if: :should_have_deduction?,
-               unless: ->(t) { t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
+               unless: ->(t) { t.annotation_category.nil? or t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }
 

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -4,7 +4,8 @@ class AnnotationText < ApplicationRecord
   belongs_to :last_editor, class_name: 'User', foreign_key: :last_editor_id, optional: true
 
   after_update :update_mark_deductions,
-               unless: ->(t) { t.annotation_category.nil? or t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
+               unless: ->(t) { t.annotation_category.nil? ||
+                               t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }
 

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -4,6 +4,7 @@ class AnnotationText < ApplicationRecord
   belongs_to :last_editor, class_name: 'User', foreign_key: :last_editor_id, optional: true
 
   after_update :update_mark_deductions,
+               if: :should_have_deduction?,
                unless: ->(t) { t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -5,7 +5,7 @@ class AnnotationText < ApplicationRecord
 
   after_update :update_mark_deductions,
                unless: ->(t) {
-                  t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
+                          t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
                        }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -5,7 +5,7 @@ class AnnotationText < ApplicationRecord
 
   after_update :update_mark_deductions,
                unless: ->(t) {
-                         t.annotation_category.nil? || 
+                         t.annotation_category.nil? ||
                          t.annotation_category.changes_to_save.key?('flexible_criterion_id')
                        }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -5,8 +5,8 @@ class AnnotationText < ApplicationRecord
 
   after_update :update_mark_deductions,
                unless: ->(t) {
-                 t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
-                }
+                  t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
+                       }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }
 

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -5,7 +5,8 @@ class AnnotationText < ApplicationRecord
 
   after_update :update_mark_deductions,
                unless: ->(t) {
-                          t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
+                         t.annotation_category.nil? || 
+                         t.annotation_category.changes_to_save.key?('flexible_criterion_id')
                        }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }

--- a/app/models/annotation_text.rb
+++ b/app/models/annotation_text.rb
@@ -4,8 +4,9 @@ class AnnotationText < ApplicationRecord
   belongs_to :last_editor, class_name: 'User', foreign_key: :last_editor_id, optional: true
 
   after_update :update_mark_deductions,
-               unless: ->(t) { t.annotation_category.nil? ||
-                               t.annotation_category.changes_to_save.key?('flexible_criterion_id') }
+               unless: ->(t) {
+                 t.annotation_category.nil? || t.annotation_category.changes_to_save.key?('flexible_criterion_id')
+                }
   before_update :check_if_released, unless: ->(t) { t.deduction.nil? }
   before_destroy :check_if_released, unless: ->(t) { t.deduction.nil? }
 

--- a/app/views/annotation_categories/_uncategorized_annotations_list.html.erb
+++ b/app/views/annotation_categories/_uncategorized_annotations_list.html.erb
@@ -11,15 +11,5 @@
                   class: 'button' %>
       </div>
   </div>
-
-  <% if texts.empty? %>
-    <p>
-      <%= t('annotations.empty_uncategorized') %>
-    </p>
-  <% else %>
-    <ul id='annotation_list' class='block-list'>
-      <%= render partial: 'annotation_text',
-                 collection: texts %>
-    </ul>
-  <% end %>
+  <div id='one_time_annotations_table'></div>
 </div>

--- a/app/views/annotation_categories/uncategorized_annotations.js.erb
+++ b/app/views/annotation_categories/uncategorized_annotations.js.erb
@@ -2,3 +2,9 @@ $('#annotation_list_holder').replaceWith(
   "<%= escape_javascript(render partial: 'uncategorized_annotations_list',
                                 locals: { texts: @texts }).html_safe %>");
 reloadDOM();
+makeOneTimeAnnotationsTable(
+  document.getElementById('one_time_annotations_table'),
+  {
+    assignment_id: <%= @assignment.id %>
+  }
+);

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -439,7 +439,7 @@ describe AnnotationCategoriesController do
         get_as user, :uncategorized_annotations, params: { assignment_id: assignment.id }
         expect(assigns['texts'].first['id']).to eq uncategorized_text.id
         delete_as user, :destroy_annotation_text,
-               params: { assignment_id: assignment.id,
+                  params: { assignment_id: assignment.id,
                          id: uncategorized_text.id,
                          format: :js }
 

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -440,8 +440,8 @@ describe AnnotationCategoriesController do
         expect(assigns['texts'].first['id']).to eq uncategorized_text.id
         delete_as user, :destroy_annotation_text,
                   params: { assignment_id: assignment.id,
-                         id: uncategorized_text.id,
-                         format: :js }
+                            id: uncategorized_text.id,
+                            format: :js }
 
         get_as user, :uncategorized_annotations, params: { assignment_id: assignment.id }
         expect(assigns['texts']).to eq []

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -431,7 +431,7 @@ describe AnnotationCategoriesController do
         create(:text_annotation, annotation_text: text, result: assignment_result)
         other_grouping = assignment.groupings.where.not(id: assignment_result.grouping.id).first
         create(:text_annotation, annotation_text: different_text, result: other_grouping.current_result)
-        expected_keys = %w(group_name creator last_editor content assignment_id result_id submission_id id)
+        expected_keys = %w[group_name creator last_editor content assignment_id result_id submission_id id]
         get_as user, :uncategorized_annotations, format: 'json', params: { assignment_id: assignment.id }
         data = JSON.parse(response.body)
         expect(data.first.keys).to match_array expected_keys

--- a/spec/controllers/annotation_categories_controller_spec.rb
+++ b/spec/controllers/annotation_categories_controller_spec.rb
@@ -423,7 +423,7 @@ describe AnnotationCategoriesController do
 
       it 'is not empty when responding to json format and uncategorized annotations exist' do
         create(:text_annotation, annotation_text: text, result: assignment_result)
-        get_as user, :uncategorized_annotations, :format => :json, params: { assignment_id: assignment.id }
+        get_as user, :uncategorized_annotations, format: 'json', params: { assignment_id: assignment.id }
         expect(JSON.parse(response.body)).not_to be_empty
       end
 
@@ -431,17 +431,8 @@ describe AnnotationCategoriesController do
         create(:text_annotation, annotation_text: text, result: assignment_result)
         other_grouping = assignment.groupings.where.not(id: assignment_result.grouping.id).first
         create(:text_annotation, annotation_text: different_text, result: other_grouping.current_result)
-        expected_keys = [
-          'group_name',
-          'creator',
-          'last_editor',
-          'content',
-          'assignment_id',
-          'result_id',
-          'submission_id',
-          'id'
-        ]
-        get_as user, :uncategorized_annotations, :format => :json, params: { assignment_id: assignment.id }
+        expected_keys = %w(group_name creator last_editor content assignment_id result_id submission_id id)
+        get_as user, :uncategorized_annotations, format: 'json', params: { assignment_id: assignment.id }
         data = JSON.parse(response.body)
         expect(data.first.keys).to match_array expected_keys
         expect(data.second.keys).to match_array expected_keys
@@ -449,7 +440,7 @@ describe AnnotationCategoriesController do
 
       it 'has correct data when responding to json format and uncategorized annotation exists' do
         create(:text_annotation, annotation_text: text2, result: assignment_result)
-        get_as user, :uncategorized_annotations, :format => :json, params: { assignment_id: assignment.id }
+        get_as user, :uncategorized_annotations, format: 'json', params: { assignment_id: assignment.id }
         data = JSON.parse(response.body)
         expect(data.first['group_name']).to eq(assignment.groupings.first.group.group_name)
         expect(data.first['creator']).to eq(text2.creator.user_name)
@@ -457,7 +448,7 @@ describe AnnotationCategoriesController do
         expect(data.first['content']).to eq(text2.content)
         expect(data.first['assignment_id']).to eq(assignment.id)
         expect(data.first['result_id']).to eq(assignment_result.id)
-        expect(data.first['submission_id']).to eq(assignment.groupings.first.group.id)
+        expect(data.first['submission_id']).to eq(assignment.groupings.first.current_result.submission_id)
         expect(data.first['id']).to eq(text2.id)
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
![image](https://user-images.githubusercontent.com/53841219/109590794-9b2fea80-7ada-11eb-9105-33a3c64f4cfb.png)

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request changed how the one time annotations data was displayed. Now, when the "One Time Only Annotations" link is pressed, a table is rendered. 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
First step: Wrote out the code in React for the One_Time_Annotations component
Second step: Added a json format response for uncategorized_annotations in annoation_categories_controller.rb
Third Step: Changed what DOM elements were rendered so the table would render, instead of what was rendered before 
Fourth Step: Added test cases for update_annotation_text and destroy_annotation_text to test these methods with an uncategorized annotation

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 


- [x] New feature (non-breaking change which adds functionality)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Added test cases to annotation_categories_controller_spec.rb as well as testing the Edit/Delete and filter functions on my local server


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->



