### PR TITLE
react-table: Change defaultSortMethod to handle null/undefined values.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - Support Markdown syntax for assessment messages (#5135)
 - Remove controller-specific css files (#5136)
 - Replace non-UTF8 characters in text file preview (#5156)
+- Override defaultSortMethod for react-table to put null/undefined values at bottom (#5157)
 
 ## [v1.11.3]
 - Fix easyModal overlay bug (#5117)

--- a/app/assets/javascripts/Components/Helpers/table_helpers.jsx
+++ b/app/assets/javascripts/Components/Helpers/table_helpers.jsx
@@ -5,6 +5,32 @@ import React from "react";
  * Provides generic helper functions for react tables
 */
 
+export function defaultSort(a, b) {
+  // Sort values, putting undefined/nulls below all other values.
+  // Based on react-table v6 defaultSortMethod (https://github.com/tannerlinsley/react-table/tree/v6/),
+  // but not string-based.
+  if ((a === undefined || a === null) && (b === undefined || b === null)) {
+    return 0;
+  } else if (a === undefined || a === null) {
+    return -1;
+  } else if (b === undefined || b === null) {
+    return 1;
+  } else {
+    // force any string values to lowercase
+    a = typeof a === 'string' ? a.toLowerCase() : a
+    b = typeof b === 'string' ? b.toLowerCase() : b
+    // Return either 1 or -1 to indicate a sort priority
+    if (a > b) {
+      return 1;
+    }
+    if (a < b) {
+      return -1;
+    }
+    // returning 0, undefined or any falsey value will use subsequent sorts or
+    // the index as a tiebreaker
+    return 0;
+  }
+}
 
 export function stringFilter(filter, row) {
   /** Case insensitive, locale aware, string filter function */

--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from 'react-dom';
-import {markingStateColumn} from "./Helpers/table_helpers";
+import {defaultSort, markingStateColumn} from "./Helpers/table_helpers";
 
 import ReactTable from 'react-table';
 

--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from 'react-dom';
-import {defaultSort, markingStateColumn} from "./Helpers/table_helpers";
+import {markingStateColumn} from "./Helpers/table_helpers";
 
 import ReactTable from 'react-table';
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -49,6 +49,11 @@ import 'javascripts/chart_config';
 
 window.Routes = require('routes.js.erb');
 
+// Override react-table defaultSortMethod
+import { defaultSort } from 'javascripts/Components/Helpers/table_helpers';
+import { ReactTableDefaults } from 'react-table';
+Object.assign(ReactTableDefaults, { defaultSortMethod: defaultSort });
+
 // assets with side-effects only
 import 'javascripts/help-system';
 import 'javascripts/layouts';


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, numeric columns (e.g., marks in summary table) conflate `0` and blank (`null`/`undefined`) values when sorting. This makes it harder to find blank entries.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Override `react-table`'s default sort method to explicitly make `null` and `undefined` values less than all other values.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the web interface for both numeric and non-numeric columns.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
