### PR TITLE
Fix starter file change warning

### DIFF
--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -289,10 +289,12 @@ class StarterFileManager extends React.Component {
             disabled={!this.state.files.length}
           >
             {Object.entries(this.state.files).map( (data, index) => {
-              const {id, name} = data[1];
-              return (
-                <option value={id} key={id}>{index + 1}: {name}</option>
-              );
+              const {id, name, files} = data[1];
+              if (!!files.length) {
+                return (
+                  <option value={id} key={id}>{index + 1}: {name}</option>
+                );
+              }
             })}
           </select>
         </label>
@@ -316,11 +318,13 @@ class StarterFileManager extends React.Component {
                     >
                       <option value={`${row.original.section_id}_`}/>
                       {Object.entries(this.state.files).map( (data, index) => {
-                        const {id, name} = data[1];
-                        const value = `${row.original.section_id}_${id}`;
-                        return (
-                          <option value={value} key={id}>{index + 1}: {name}</option>
-                        );
+                        const {id, name, files} = data[1];
+                        if (!!files.length) {
+                          const value = `${row.original.section_id}_${id}`;
+                          return (
+                            <option value={value} key={id}>{index + 1}: {name}</option>
+                          );
+                        }
                       })}
                     </select>
                   );
@@ -362,7 +366,7 @@ class StarterFileManager extends React.Component {
              }
             }
           ]}
-          data={this.state.files}
+          data={this.state.files.filter(data => !!data.files.length)}
         />
       )
     }

--- a/app/controllers/api/starter_file_groups_controller.rb
+++ b/app/controllers/api/starter_file_groups_controller.rb
@@ -81,7 +81,7 @@ module Api
       end
       file_path = File.join(starter_file_group.path, params[:filename])
       File.write(file_path, content, mode: 'wb')
-      update_entries_and_warn(starter_file_group)
+      update_entries_and_warn(starter_file_group, params[:filename])
       render 'shared/http_status',
              locals: { code: '201', message: HttpStatusHelper::ERROR_CODE['message']['201'] },
              status: 201
@@ -101,7 +101,7 @@ module Api
 
       folder_path = File.join(starter_file_group.path, params[:folder_path])
       FileUtils.mkdir_p(folder_path)
-      update_entries_and_warn(starter_file_group)
+      update_entries_and_warn(starter_file_group, params[:folder_path])
       render 'shared/http_status',
              locals: { code: '201', message: HttpStatusHelper::ERROR_CODE['message']['201'] },
              status: 201
@@ -120,7 +120,7 @@ module Api
       end
       file_path = File.join(starter_file_group.path, params[:filename])
       File.delete(file_path)
-      update_entries_and_warn(starter_file_group)
+      update_entries_and_warn(starter_file_group, params[:filename])
       render 'shared/http_status',
              locals: { code: '200', message: HttpStatusHelper::ERROR_CODE['message']['200'] },
              status: 200
@@ -140,7 +140,7 @@ module Api
 
       folder_path = File.join(starter_file_group.path, params[:folder_path])
       FileUtils.rm_rf(folder_path)
-      update_entries_and_warn(starter_file_group)
+      update_entries_and_warn(starter_file_group, params[:folder_path])
       render 'shared/http_status',
              locals: { code: '200', message: HttpStatusHelper::ERROR_CODE['message']['200'] },
              status: 200
@@ -168,8 +168,8 @@ module Api
 
     # Update starter file entries for +starter_file_group+ and set the starter_file_changed
     # attribute to true for all groupings affected by the change.
-    def update_entries_and_warn(starter_file_group)
-      starter_file_group.warn_affected_groupings
+    def update_entries_and_warn(starter_file_group, modified_path)
+      starter_file_group.warn_affected_groupings(modified_paths: [modified_path])
       starter_file_group.assignment.assignment_properties.update!(starter_file_updated_at: Time.current)
       starter_file_group.update_entries
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -404,11 +404,9 @@ class AssignmentsController < ApplicationController
 
   def update_starter_file
     assignment = Assignment.find(params[:id])
-    all_changed = false
     success = true
     ApplicationRecord.transaction do
       assignment.assignment_properties.update!(starter_file_assignment_params)
-      all_changed = assignment.assignment_properties.saved_changes?
       params[:sections].each do |section_params|
         Section.find_by(id: section_params[:section_id])
                &.update_starter_file_group(assignment.id, section_params[:group_id])
@@ -416,7 +414,6 @@ class AssignmentsController < ApplicationController
       starter_file_group_params.each do |group_params|
         starter_file_group = assignment.starter_file_groups.find_by(id: group_params[:id])
         starter_file_group.update!(group_params)
-        all_changed ||= starter_file_group.saved_changes? || assignment.assignment_properties.saved_changes?
       end
       assignment.assignment_properties.update!(starter_file_updated_at: Time.current)
     rescue ActiveRecord::RecordInvalid => e
@@ -432,8 +429,6 @@ class AssignmentsController < ApplicationController
       flash_message(:success, I18n.t('flash.actions.update.success',
                                      resource_name: I18n.t('assignments.starter_file.title')))
     end
-    # mark all groupings with starter files that were changed as changed
-    assignment.groupings.update_all(starter_file_changed: true) if success && all_changed
   end
 
   def download_starter_file_mappings

--- a/app/controllers/starter_file_groups_controller.rb
+++ b/app/controllers/starter_file_groups_controller.rb
@@ -82,7 +82,7 @@ class StarterFileGroupsController < ApplicationController
     else
       all_paths = [params[:path]]
     end
-    starter_file_group.warn_affected_groupings
+    starter_file_group.warn_affected_groupings(modified_paths: all_paths)
     assignment.assignment_properties.update!(starter_file_updated_at: Time.current) unless all_paths.empty?
     starter_file_group.update_entries
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -888,7 +888,8 @@ class Assignment < Assessment
 
   def default_starter_file_group
     default = starter_file_groups.find_by(id: self.default_starter_file_group_id)
-    default.nil? ? starter_file_groups.order(:id).first : default
+    # if no default, pick the first starter file group that has at least one entry
+    default.nil? ? starter_file_groups.joins(:starter_file_entries).order(:id).first : default
   end
 
   def starter_file_mappings

--- a/app/models/assignment_properties.rb
+++ b/app/models/assignment_properties.rb
@@ -56,6 +56,7 @@ class AssignmentProperties < ApplicationRecord
   validates_presence_of :start_time, if: :is_timed
   validate :start_before_due, if: :is_timed
   validate :not_timed_and_scanned
+  validate :default_starter_group_not_empty
 
   STARTER_FILE_TYPES = %w[simple sections shuffle group].freeze
 
@@ -130,5 +131,11 @@ class AssignmentProperties < ApplicationRecord
   def not_timed_and_scanned
     msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.is_timed.not_scanned')
     errors.add(:base, msg) if is_timed && scanned_exam
+  end
+
+  def default_starter_group_not_empty
+    default_sfgroup = StarterFileGroup.find_by(id: default_starter_file_group_id)
+    msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.default_starter_file_group_id.is_empty')
+    errors.add(:base, msg) if default_sfgroup && default_sfgroup.starter_file_entries.empty?
   end
 end

--- a/app/models/assignment_properties.rb
+++ b/app/models/assignment_properties.rb
@@ -137,7 +137,7 @@ class AssignmentProperties < ApplicationRecord
   def default_starter_group_not_empty
     default_sfgroup = StarterFileGroup.find_by(id: default_starter_file_group_id)
     msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.default_starter_file_group_id.is_empty')
-    errors.add(:base, msg) if default_sfgroup && default_sfgroup.starter_file_entries.empty?
+    errors.add(:base, msg) if default_sfgroup&.starter_file_entries&.empty?
   end
 
   # Warn groupings that are affected by a change in starter_file_type. If the type changed to/from 'shuffle' then this

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -4,6 +4,7 @@ class Section < ApplicationRecord
   has_many :section_due_dates
   has_many :section_starter_file_groups
   has_many :starter_file_groups, through: :section_starter_file_groups
+  validate :starter_group_not_empty
 
   # Returns true when students are part of this section
   def has_students?
@@ -38,5 +39,12 @@ class Section < ApplicationRecord
             .where('users.section_id': self.id)
             .where(assessment_id: assessment_id)
             .update_all(starter_file_changed: true)
+  end
+
+  def starter_group_not_empty
+    starter_file_groups.each do |sfgroup|
+      msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.default_starter_file_group_id.is_empty')
+      errors.add(:base, msg) if sfgroup && sfgroup.starter_file_entries.empty?
+    end
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -44,7 +44,7 @@ class Section < ApplicationRecord
   def starter_group_not_empty
     starter_file_groups.each do |sfgroup|
       msg = I18n.t('activerecord.errors.models.assignment_properties.attributes.default_starter_file_group_id.is_empty')
-      errors.add(:base, msg) if sfgroup && sfgroup.starter_file_entries.empty?
+      errors.add(:base, msg) if sfgroup&.starter_file_entries&.empty?
     end
   end
 end

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -70,7 +70,10 @@ class StarterFileGroup < ApplicationRecord
   end
 
   # Set starter_file_changed true for all groupings that have changed starter files based on
-  # whether starter file entries have changed.
+  # whether starter file entries have changed. Use +assignment.starter_file_type+ to determine which groupings to
+  # warn based on the starter file type.
+  # If +assignment.starter_file_type+ == 'shuffle' and +modified_paths+ is not nil, only update the groupings
+  # that have an existing starter file entry at a path in +modified_paths+.
   def warn_affected_groupings(modified_paths: nil)
     case assignment.starter_file_type
     when 'simple'

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -10,8 +10,9 @@ class StarterFileGroup < ApplicationRecord
   after_create_commit :create_dir
   before_validation :sanitize_rename_entry
   before_destroy :update_default
-  before_destroy -> { warn_affected_groupings(modified_paths: self.starter_file_entries.pluck(:path)) }, prepend: true
+  before_destroy :warn_all, prepend: true
   after_save :update_timestamp
+  after_save :warn_all, if: -> { saved_change_to_entry_rename? || saved_change_to_use_rename? }
 
   validates_exclusion_of :entry_rename, in: %w[.. .]
   validates_presence_of :entry_rename, if: -> { self.use_rename }
@@ -113,5 +114,9 @@ class StarterFileGroup < ApplicationRecord
 
   def update_timestamp
     assignment.assignment_properties.update(starter_file_updated_at: Time.current)
+  end
+
+  def warn_all
+    warn_affected_groupings(modified_paths: self.starter_file_entries.pluck(:path))
   end
 end

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -54,7 +54,14 @@ class StarterFileGroup < ApplicationRecord
     to_delete = entry_paths - fs_entry_paths
     to_add = fs_entry_paths - entry_paths
     starter_file_entries.where(path: to_delete).destroy_all unless to_delete.empty?
-    StarterFileEntry.upsert_all(to_add.map { |p| { starter_file_group_id: self.id, path: p } }) unless to_add.empty?
+    unless to_add.empty?
+      entries = StarterFileEntry.upsert_all(to_add.map { |p| { starter_file_group_id: self.id, path: p } })
+    end
+    if starter_file_entries.empty?
+      assignment.update!(default_starter_file_group_id: nil) if assignment.default_starter_file_group_id == self.id
+      section_starter_file_groups.destroy_all
+    end
+    entries
   end
 
   def should_rename

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -82,11 +82,13 @@ class StarterFileGroup < ApplicationRecord
       affected_groupings = assignment.groupings.joins(:accepted_students).where('users.section_id': sections.ids)
     when 'shuffle'
       modified_entry_paths = modified_paths&.map { |m| m.split(File::Separator)&.first }
-      affected_groupings = assignment.groupings.left_outer_joins(:starter_file_entries)
-                                               .where('starter_file_entries.path': [nil, *modified_entry_paths])
+      affected_groupings = assignment.groupings
+                                     .left_outer_joins(:starter_file_entries)
+                                     .where('starter_file_entries.path': [nil, *modified_entry_paths])
     when 'group'
-      affected_groupings = assignment.groupings.left_outer_joins(:starter_file_entries)
-                                               .where('starter_file_entries.id': [nil, *self.starter_file_entries.ids])
+      affected_groupings = assignment.groupings
+                                     .left_outer_joins(:starter_file_entries)
+                                     .where('starter_file_entries.id': [nil, *self.starter_file_entries.ids])
     else
       raise "starter_file_type is invalid: #{assignment.starter_file_type}"
     end

--- a/config/locales/models/assignments/en.yml
+++ b/config/locales/models/assignments/en.yml
@@ -41,6 +41,8 @@ en:
               not_scanned: scanned_exam and is_timed cannot both be true
             start_time:
               before_due_date: must be before due date
+            default_starter_file_group_id:
+              is_empty: must contain at least one entry
     models:
       assignment:
         one: Assignment

--- a/config/locales/models/assignments/es.yml
+++ b/config/locales/models/assignments/es.yml
@@ -41,6 +41,8 @@ es:
               not_scanned: UPDATE ME
             start_time:
               before_due_date: UPDATE ME
+            default_starter_file_group_id:
+              is_empty: UPDATE ME
     models:
       assignment:
         one: Proyect

--- a/config/locales/models/assignments/fr.yml
+++ b/config/locales/models/assignments/fr.yml
@@ -41,6 +41,8 @@ fr:
               not_scanned: UPDATE ME
             start_time:
               before_due_date: UPDATE ME
+            default_starter_file_group_id:
+              is_empty: UPDATE ME
     models:
       assignment:
         one: Projet

--- a/config/locales/models/assignments/pt.yml
+++ b/config/locales/models/assignments/pt.yml
@@ -41,6 +41,8 @@ pt:
               not_scanned: UPDATE ME
             start_time:
               before_due_date: UPDATE ME
+            default_starter_file_group_id:
+              is_empty: UPDATE ME
     models:
       assignment:
         one: Projeto


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The rules governing when students get warned if their starter files have changed were incorrect. In some cases, students would get warned even if their starter files had not changed, in other cases, the students were not warned if the starter files had changed. This PR makes sure that students are warned that starter files changed under the following conditions:

When a file is added/removed/updated in a starter file group:
- `starter_file_type == 'simple'`: all groupings for the given assignment get warned
- `starter_file_type == 'sections'`: all groupings that have students in a section that is associated with the changed starter file group get warned
- `starter_file_type == 'shuffle'`: all groupings that are assigned a starter file entry that is affected by the file change are warned. Additionally, all groupings without any associated starter file entries get warned (in the case that they were created before the starter files were assigned).
- `starter_file_type == 'group'`: all groupings that are assigned a starter file entry from the updated starter file group are warned. Additionally, all groupings without any associated starter file entries get warned (in the case that they were created before the starter files were assigned).

When a starter file group is destroyed:
- all groupings that are assigned a starter file entry from the updated starter file group are warned

When the starter file type is changed or the default starter file group has changed:
- if the `starter_file_type` was changed to/from 'shuffle': warn all groupings for the given assignment
- otherwise: warn all groupings without any associated starter file entries (all other groupings will keep the same starter files)

When `entry_rename` or `use_rename` is changed:
- all groupings that are assigned a starter file entry that is affected by the name change are warned. Additionally, all groupings without any associated starter file entries get warned (in the case that they were created before the starter files were assigned).

Additional changes:

- do not allow starter file groups with no files to be assigned to groupings

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

see above

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [ ] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [ ] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)
