### PR TITLE
Make sure shown annotation categories are consistent

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 - Replace non-UTF8 characters in text file preview (#5156)
 - Rollback group creation if error is raised when creating a group for a working-alone student (#5169)
 - Prevent deletion/modification of annotation texts associated with a result with a pending remark request (#5170)
+- Ensure that graders are shown the correct annotation categories (#5181)
 
 ## [v1.11.4]
 - Override defaultSortMethod for react-table to put null/undefined values at bottom (#5159)

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -11,8 +11,8 @@ class AnnotationCategoriesController < ApplicationController
 
   def index
     @assignment = Assignment.find(params[:assignment_id])
-    @annotation_categories = @assignment.annotation_categories.order(:position)
-                                        .includes(:assignment, :annotation_texts)
+    @annotation_categories = AnnotationCategory.visible_categories(@assignment, current_user)
+                                               .includes(:assignment, :annotation_texts)
     respond_to do |format|
       format.html
       format.json {

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -91,20 +91,8 @@ class ResultsController < ApplicationController
 
         # Annotation categories
         if current_user.admin? || current_user.ta?
-          if current_user.ta? && assignment.assign_graders_to_criteria
-            visible = current_user.criterion_ta_associations
-                                  .joins(:criterion)
-                                  .where('criteria.type': 'FlexibleCriterion')
-                                  .pluck(:criterion_id) + [nil]
-            annotation_categories = assignment.annotation_categories
-                                              .order(:position)
-                                              .includes(:annotation_texts)
-                                              .where('annotation_categories.flexible_criterion_id': visible)
-          else
-            annotation_categories = assignment.annotation_categories
-                                              .order(:position)
-                                              .includes(:annotation_texts)
-          end
+          annotation_categories = AnnotationCategory.visible_categories(assignment, current_user)
+                                                    .includes(:annotation_texts)
           data[:annotation_categories] = annotation_categories.map do |category|
             name_extension = category.flexible_criterion_id.nil? ? '' : " [#{category.flexible_criterion.name}]"
             {

--- a/app/models/annotation_category.rb
+++ b/app/models/annotation_category.rb
@@ -145,4 +145,20 @@ class AnnotationCategory < ApplicationRecord
       end
     end
   end
+
+  # Return all visible annotation categories associated with +assignment+ for +user+.
+  #
+  # This will return all annotation categories for admins and no admin categories for students.
+  # If graders are assigned annotation categories, then only return assigned categories, otherwise
+  # treat graders the same as admins.
+  def self.visible_categories(assignment, user)
+    return AnnotationCategory.none unless user.ta? || user.admin?
+
+    if user.ta? && assignment.assign_graders_to_criteria
+      visible = user.criterion_ta_associations.joins(:criterion).pluck(:criterion_id) + [nil]
+      assignment.annotation_categories.order(:position).where('annotation_categories.flexible_criterion_id': visible)
+    else
+      assignment.annotation_categories.order(:position)
+    end
+  end
 end

--- a/spec/models/annotation_category_spec.rb
+++ b/spec/models/annotation_category_spec.rb
@@ -280,4 +280,58 @@ describe AnnotationCategory do
       expect { assignment.annotation_categories.destroy_all }.to_not raise_error
     end
   end
+  describe '.visible_categories' do
+    let(:assignment) { create :assignment }
+    let(:criterion) { create :flexible_criterion, assignment: assignment }
+    let(:criterion2) { create :flexible_criterion, assignment: assignment }
+    let!(:annotation_category) { create :annotation_category, assignment: assignment, flexible_criterion: criterion }
+    let!(:annotation_category2) { create :annotation_category, assignment: assignment, flexible_criterion: criterion2 }
+    let!(:annotation_category3) { create :annotation_category, assignment: assignment }
+
+    shared_examples 'visible category for admin and student' do
+      context 'an admin user' do
+        let(:user) { create :admin }
+        it 'should return all three annotation categories' do
+          category_ids = AnnotationCategory.ids
+          expect(AnnotationCategory.visible_categories(assignment, user).ids).to contain_exactly(*category_ids)
+        end
+      end
+      context 'a student user' do
+        let(:user) { create :student }
+        it 'should return no annotation categories' do
+          expect(AnnotationCategory.visible_categories(assignment, user)).to be_empty
+        end
+      end
+    end
+    context 'criteria are assigned to graders' do
+      before { assignment.assignment_properties.update!(assign_graders_to_criteria: true) }
+      include_examples 'visible category for admin and student'
+      context 'a grader user' do
+        let(:user) { create :ta }
+        context 'not assigned to any criteria' do
+          it 'should return only the unassociated annotation category' do
+            ids = AnnotationCategory.visible_categories(assignment, user).ids
+            expect(ids).to contain_exactly(*annotation_category3.id)
+          end
+        end
+        context 'assigned to one of the associated criteria' do
+          before { create :criterion_ta_association, ta: user, criterion: criterion }
+          it 'should return the unassociated annotation category and the one assigned to the grader' do
+            expected_ids = [annotation_category.id, annotation_category3.id]
+            expect(AnnotationCategory.visible_categories(assignment, user).ids).to contain_exactly(*expected_ids)
+          end
+        end
+      end
+    end
+    context 'criteria are not assigned to graders' do
+      include_examples 'visible category for admin and student'
+      context 'a grader user' do
+        let(:user) { create :ta }
+        it 'should return all three annotation categories' do
+          category_ids = AnnotationCategory.ids
+          expect(AnnotationCategory.visible_categories(assignment, user).ids).to contain_exactly(*category_ids)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A grader that had been assigned criteria to grade should only be able to see annotation categories that are associated with the assigned criteria (or annotation categories not assigned to any criteria). 

This behaviour is correct in `ResultsController.show` but not in `AnnotationCategoriesController.index`. This PR adds a new model method that both of these controller methods can use to keep the behaviour consistent.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- added model method
- referenced it from two controller methods
- added tests

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
