### PR TITLE
results: Fix file selector switching in results.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@
 - Show informative error message if an uploaded criteria yaml file did not contain a "type" key (#5184)
 - Allow for multiple custom validation messages (#5194)
 - Add ability to hold shift to select a range of values in checkbox tables (#5182)
+- Fix bug where creating an annotation or switching results reset the selected file (#5200)
 
 ## [v1.11.5]
 - Account for percentage deductions when calculating total marks after deleting a criterion (#5176)

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -557,28 +557,30 @@ class Result extends React.Component {
         this.state.assignment_id, this.state.submission_id, this.state.result_id
       );
 
-      $.ajax({
-        url: url,
-        data: {
-          direction: direction
-        }
-      }).then((result) => {
-        if (!result.next_result || !result.next_grouping) {
-          alert(I18n.t('results.no_results_in_direction'));
-          return;
-        }
+      this.setState({loading: true}, () => {
+        $.ajax({
+          url: url,
+          data: {
+            direction: direction
+          }
+        }).then((result) => {
+          if (!result.next_result || !result.next_grouping) {
+            alert(I18n.t('results.no_results_in_direction'));
+            return;
+          }
 
-        const result_obj = {
-          result_id: result.next_result.id,
-          submission_id: result.next_result.submission_id,
-          grouping_id: result.next_grouping.id,
-        };
-        this.setState(prevState => ({...prevState, ...result_obj}));
-        let new_url = Routes.edit_assignment_submission_result_url(
-          this.state.assignment_id, this.state.submission_id, this.state.result_id
-        );
-        history.pushState({}, document.title, new_url)
-      })
+          const result_obj = {
+            result_id: result.next_result.id,
+            submission_id: result.next_result.submission_id,
+            grouping_id: result.next_grouping.id,
+          };
+          this.setState(prevState => ({...prevState, ...result_obj}));
+          let new_url = Routes.edit_assignment_submission_result_url(
+            this.state.assignment_id, this.state.submission_id, this.state.result_id
+          );
+          history.pushState({}, document.title, new_url)
+        });
+      });
     }
   }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes a few different issues following the changes from #5082.

1. After creating/updating an annotation, the submission file was switching to the
   first file.
2. When switching results, the submission file was switching to the
   first file (even when the new result had a file with the same name as
   the currently selected file).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Updated the logic for when the `selectedFile` for the fileviewer is computed. Previously, it was being recomputed using `getFirstFile` whenever an annotation was created, or when the result was switched.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested this in the UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
