### PR TITLE
assignments: handle remarks in get_num_marked.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 - Allow for multiple custom validation messages (#5194)
 - Add ability to hold shift to select a range of values in checkbox tables (#5182)
 - Fix bug where creating an annotation or switching results reset the selected file (#5200)
+- Fix bug in Assignment#get_num_marked that caused it to double-count remark and original results (#5205)
 
 ## [v1.11.5]
 - Account for percentage deductions when calculating total marks after deleting a criterion (#5176)

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -13,5 +13,10 @@ FactoryBot.define do
         released_to_students { true }
       end
     end
+
+    factory :remark_result do
+      marking_state { Result::MARKING_STATES[:incomplete] }
+      remark_request_submitted_at { Time.current }
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes Assignment#get_num_marked so that it correctly counts
groupings with remark requests. Previously, when a grouping submitted a
remark request, both the original and remark result would be counted,
rather than just the remark result. The cause was the same error as
noted in #5063: joining groupings on :current_result doesn't limit to
one result per grouping.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
The root fix is the creation of a new method Assignment#current_results,
which uses a more sophisticated db query to retrive one current result
per grouping.

This commit also simplifies the code for calculating the number of
marked submissions for a grader when graders are assigned to criteria.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Added some new tests that involve remark requests. Also tested this on a running server (we actually have this problem from our seed data, which includes submitted remark requests).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

After this PR is merged in, we should review other places where we're doing a `joins(:current_result)`, or accessing `current_result`s in bulk for an assignment. I suspect the change to the `Assignment#current_results` method can make it useful in other places beyond the fix in this PR. Incidentally, the method already existed, but wasn't being used anywhere.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
