### PR TITLE
Add Copy Clipboard Button to Fileviewer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - Modify Result.get_total_extra_marks to differentiate between having extra marks that sum to zero and
   having no extra marks (#5220)
 - remove counter caches (#5222)
+- Add copy to clipboard button for code submission files in Results view (#5223)
 
 ## [v1.12.0]
 - Remove annotations context menu from peer assignments view (#5116)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 - Modify Result.get_total_extra_marks to differentiate between having extra marks that sum to zero and
   having no extra marks (#5220)
 - remove counter caches (#5222)
-- Add copy to clipboard button for code submission files in Results view (#5223)
+- Add copy to clipboard button for plaintext submission files in Results view (#5223)
 
 ## [v1.12.0]
 - Remove annotations context menu from peer assignments view (#5116)

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -63,22 +63,23 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   var original_commands = dp.sh.Toolbar.Commands;
 
   // Get rid of some commands and add font size commands
-  delete original_commands.ViewSource;
+  delete original_commands['ViewSource'];
   delete original_commands['PrintSource'];
   delete original_commands['ExpandSource'];
 
   original_commands.CopyToClipboard = {
     label: I18n.t('results.copy_text'),
     func: function() {
+      const code = document.getElementById('code');
       navigator.clipboard.writeText(code.textContent).then(() => {
-          let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
-          original_commands.CopyToClipboard.label = '✔ ' + I18n.t('results.copy_text');
-          //update id attribute with new label
-          let id = document.createAttribute('id');
-          id.value = original_commands.CopyToClipboard.label;
-          copy_code.setAttributeNode(id);
-          copy_code.innerText = original_commands.CopyToClipboard.label;
-        });
+        // update id attribute with new label
+        let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
+        original_commands.CopyToClipboard.label = '✔ ' + I18n.t('results.copy_text');
+        let id = document.createAttribute('id');
+        id.value = original_commands.CopyToClipboard.label;
+        copy_code.setAttributeNode(id);
+        copy_code.innerText = original_commands.CopyToClipboard.label;
+      });
     }
   };
 

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -63,7 +63,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   var original_commands = dp.sh.Toolbar.Commands;
 
   // Get rid of some commands and add font size commands
-  delete original_commands['ViewSource'];
+  delete original_commands.ViewSource;
   delete original_commands['PrintSource'];
   delete original_commands['ExpandSource'];
 
@@ -84,7 +84,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
         id.value = original_commands.CopyToClipboard.label;
         copy_code.setAttributeNode(id);
         copy_code.innerText = original_commands.CopyToClipboard.label;
-      };
+      }
       text.remove();
     }
   };

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -66,9 +66,9 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   delete original_commands['PrintSource'];
   delete original_commands['ExpandSource'];
 
-  original_commands['CopyToClipboard'] = {
+  original_commands.CopyToClipboard = {
     label: 'copy code to clipboard',
-    func: function(highlighter) {
+    func: function() {
       //this is a work-around, selecting the pre element with jQuery wasn't working 
       const text = document.createElement('textarea');
       text.textContent = code.textContent;
@@ -76,7 +76,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
       text.select();
       success = document.execCommand('copy');
       if (success) {
-        alert("Code is copied to clipboard");
+        alert('Code is copied to clipboard');
       }
       text.remove();
     }

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -63,9 +63,25 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   var original_commands = dp.sh.Toolbar.Commands;
 
   // Get rid of some commands and add font size commands
-  delete original_commands['CopyToClipboard'];
   delete original_commands['PrintSource'];
   delete original_commands['ExpandSource'];
+
+  original_commands['CopyToClipboard'] = {
+    label: 'copy code to clipboard',
+    func: function(highlighter) {
+      //this is a work-around, selecting the pre element wasn't working 
+      const text = document.createElement('textarea');
+      text.textContent = code.textContent;
+      document.body.append(text);
+      text.select();
+      success = document.execCommand('copy');
+      if (success)
+      {
+        alert("Code is copied to clipboard");
+      }
+      text.remove();
+    }
+  };
 
   original_commands["BoostCode"] = {
     label: '+A',

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -69,7 +69,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   original_commands['CopyToClipboard'] = {
     label: 'copy code to clipboard',
     func: function(highlighter) {
-      //this is a work-around, selecting the pre element wasn't working 
+      //this is a work-around, selecting the pre element with jQuery wasn't working 
       const text = document.createElement('textarea');
       text.textContent = code.textContent;
       document.body.append(text);

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -63,21 +63,28 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   var original_commands = dp.sh.Toolbar.Commands;
 
   // Get rid of some commands and add font size commands
+  delete original_commands['ViewSource'];
   delete original_commands['PrintSource'];
   delete original_commands['ExpandSource'];
 
   original_commands.CopyToClipboard = {
     label: 'copy code to clipboard',
     func: function() {
-      //this is a work-around, selecting the pre element with jQuery wasn't working 
+      //this is a work-around, selecting the pre element with jQuery wasn't working
       const text = document.createElement('textarea');
       text.textContent = code.textContent;
       document.body.append(text);
       text.select();
       success = document.execCommand('copy');
       if (success) {
-        alert('Code is copied to clipboard');
-      }
+        let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
+        original_commands.CopyToClipboard.label = '✔ copy code to clipboard';
+        //update id attribute with new label
+        let id = document.createAttribute('id');
+        id.value = original_commands.CopyToClipboard.label;
+        copy_code.setAttributeNode(id);
+        copy_code.innerText = original_commands.CopyToClipboard.label;
+      };
       text.remove();
     }
   };
@@ -115,8 +122,11 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
       let [name, {label}] = entry;
       let tool = document.createElement('a');
       let href = document.createAttribute('href');
+      let id = document.createAttribute('id');
       href.value = '#';
+      id.value = label;
       tool.setAttributeNode(href);
+      tool.setAttributeNode(id);
       tool.addEventListener('click', (e) => {
         dp.sh.Toolbar.Command(name, e.target);
         e.preventDefault();

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -68,24 +68,17 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   delete original_commands['ExpandSource'];
 
   original_commands.CopyToClipboard = {
-    label: 'copy code to clipboard',
+    label: I18n.t('results.copy_text'),
     func: function() {
-      //this is a work-around, selecting the pre element with jQuery wasn't working
-      const text = document.createElement('textarea');
-      text.textContent = code.textContent;
-      document.body.append(text);
-      text.select();
-      success = document.execCommand('copy');
-      if (success) {
-        let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
-        original_commands.CopyToClipboard.label = '✔ copy code to clipboard';
-        //update id attribute with new label
-        let id = document.createAttribute('id');
-        id.value = original_commands.CopyToClipboard.label;
-        copy_code.setAttributeNode(id);
-        copy_code.innerText = original_commands.CopyToClipboard.label;
-      }
-      text.remove();
+      navigator.clipboard.writeText(code.textContent).then(res => {
+          let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
+          original_commands.CopyToClipboard.label = '✔ ' + I18n.t('results.copy_text');
+          //update id attribute with new label
+          let id = document.createAttribute('id');
+          id.value = original_commands.CopyToClipboard.label;
+          copy_code.setAttributeNode(id);
+          copy_code.innerText = original_commands.CopyToClipboard.label;
+        })
     }
   };
 

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -75,8 +75,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
       document.body.append(text);
       text.select();
       success = document.execCommand('copy');
-      if (success)
-      {
+      if (success) {
         alert("Code is copied to clipboard");
       }
       text.remove();

--- a/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
+++ b/app/assets/javascripts/SourceCodeGlower/SyntaxHighlighter1p5Adapter.js
@@ -70,7 +70,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
   original_commands.CopyToClipboard = {
     label: I18n.t('results.copy_text'),
     func: function() {
-      navigator.clipboard.writeText(code.textContent).then(res => {
+      navigator.clipboard.writeText(code.textContent).then(() => {
           let copy_code = document.getElementById(original_commands.CopyToClipboard.label);
           original_commands.CopyToClipboard.label = '✔ ' + I18n.t('results.copy_text');
           //update id attribute with new label
@@ -78,7 +78,7 @@ SyntaxHighlighter1p5Adapter.prototype.applyMods = function() {
           id.value = original_commands.CopyToClipboard.label;
           copy_code.setAttributeNode(id);
           copy_code.innerText = original_commands.CopyToClipboard.label;
-        })
+        });
     }
   };
 

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -20,6 +20,7 @@ en:
     cancel_override: Revert to automatic deductions
     cant_display_image: Image cannot be displayed. Click on the Download button to download the file instead.
     collapse_all: Collapse All
+    copy_text: copy text to clipboard
     criterion_incomplete_error: Unable to change marking status to complete because not every criterion has been given a mark.
     current_mark: Current mark
     current_rotation: Current rotation (Clockwise) = %{rotation}°

--- a/config/locales/views/results/es.yml
+++ b/config/locales/views/results/es.yml
@@ -17,6 +17,7 @@ es:
     cancel_override: UPDATE ME!
     cant_display_image: La imagen no puede ser mostrada. Si usted trata de ver un archivo en formato pdf, por favor asegurese de habilitar el soporte para pdf. De click en el botón de descargas para descargar el archivo.
     collapse_all: Reducir todos
+    copy_text: UPDATE ME!
     criterion_incomplete_error: Usted no puede marcar el estado de calificación como completo. No todas las notas han sido insertadas. Revise los criterios de calificación y asegúrese que cada uno de ellos tenga su nota correspondiente.
     current_mark: UPDATE ME!
     current_rotation: UPDATE ME!

--- a/config/locales/views/results/fr.yml
+++ b/config/locales/views/results/fr.yml
@@ -17,6 +17,7 @@ fr:
     cancel_override: UPDATE ME!
     cant_display_image: L'image ne peut pas être affichée. Si vous essayez d'afficher un PDF, vérifiez que l'option permettant d'afficher les PDF est activée. Vous pouvez télécharger manuellement le fichier.
     collapse_all: Cacher toutes
+    copy_text: UPDATE ME!
     criterion_incomplete_error: Note non remplie, mais état fixé comme terminé.
     current_mark: UPDATE ME!
     current_rotation: UPDATE ME!

--- a/config/locales/views/results/pt.yml
+++ b/config/locales/views/results/pt.yml
@@ -17,6 +17,7 @@ pt:
     cancel_override: UPDATE ME!
     cant_display_image: Imagem não pode ser mostrada. Se estiver tentando ver um arquivo pdf, por favor verifique se você ligou o suporte à pdfs. Clique no botão de download para baixar o arquivo
     collapse_all: Agrupar todos
+    copy_text: UPDATE ME!
     criterion_incomplete_error: Impossível alterar status das notas para completo, notas estão faltando. Verifique a rúbrica de notas e tenha certeza que cada critério recebeu uma nota.
     current_mark: UPDATE ME!
     current_rotation: UPDATE ME!


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
![image](https://user-images.githubusercontent.com/53841219/116006635-1349f680-a5da-11eb-8a4d-594dbbf7e43f.png)


## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request resolves #1810 (allow for graders to copy code to clipboard by clicking a button).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
The default "CopytoClipboard" command in SyntaxHighlighter1p5Adapter.js was not working (was not copying code in Google Chrome and Microsoft Edge, but sent alert that code was copied) so I redefined the corresponding function. 
I had to use a work-around though since I was not successful at selecting the pre DOM element (attempted to use Selection and Range objects, but it didn't work) . Work around involved creating a new textArea element, copying content to it, selecting it for copying and then removing element.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 
- [x] New feature (non-breaking change which adds functionality)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
- Tested through MarkUs UI primarily
- Tested on Microsoft Edge and Google Chrome browsers


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls.  <!-- (check after opening pull request) -->

