### PR TITLE
js-routes: Allow precompilation of routes.js file in development.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -76,3 +76,6 @@ coverage/
 
 # nbconvert python files
 **/nbconvertvenv/
+
+# If this file is pre-generated, for Windows and WSL 2 (see Wiki docker setup instructions)
+app/javascript/routes.js

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ dump.rdb
 yarn-debug.log*
 .yarn-integrity
 yarn-error.log
+# If this file is pre-generated, for Windows and WSL 2 (see Wiki docker setup instructions)
+app/javascript/routes.js
 
 # simplecov gem
 coverage/

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -47,7 +47,7 @@ window.Jcrop = Jcrop;
 import { Chart } from 'chart.js';
 import 'javascripts/chart_config';
 
-window.Routes = require('routes.js.erb');
+window.Routes = require('routes');
 
 // Override react-table defaultSortMethod
 import { defaultSort } from 'javascripts/Components/Helpers/table_helpers';

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -34,7 +34,6 @@ default: &default
     - .woff2
 
   extensions:
-    - .erb
     - .mjs
     - .js
     - .jsx
@@ -49,6 +48,7 @@ default: &default
     - .gif
     - .jpeg
     - .jpg
+    - .js.erb
 
 development:
   <<: *default


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It looks like running MarkUs with Docker on WSL 2 runs into a webpacker compilation error:

```
Uncaught Error: Module build failed (from ./node_modules/rails-erb-loader/index.js):
Error: rails-erb-loader failed with code: 1
    at ChildProcess.<anonymous> (/app/node_modules/rails-erb-loader/index.js:128:16)
    at ChildProcess.emit (events.js:314:20)
    at maybeClose (internal/child_process.js:1022:16)
    at Socket.<anonymous> (internal/child_process.js:444:11)
    at Socket.emit (events.js:314:20)
    at Pipe.<anonymous> (net.js:675:12)
    erb application-b86bd25d2c8459646289.js:12001
```

I tried out various approaches in https://github.com/usabilityhub/rails-erb-loader/issues/63 but didn't find one that worked (setting `DISABLE_SPRING` to `1`, using `bundle exec`). When I inspect the webpack-dev-server output I see some permission errors associated with running rails, which `rails-erb-loader` does in a separate process.

```
webpacker_1  | Rails Error: Unable to access log file. Please ensure that /app/log/development.log exists and is writable (ie, make it writable for user and group: chmod 0664 /app/log/development.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
webpacker_1  | Traceback (most recent call last):
webpacker_1  |  60: from bin/rails:9:in `<main>'
...
webpacker_1  |   3: from /app/config/initializers/bullet.rb:6:in `<top (required)>'
webpacker_1  |   2: from /bundle/gems/bullet-6.1.4/lib/bullet.rb:128:in `bullet_logger='
webpacker_1  |   1: from /bundle/gems/bullet-6.1.4/lib/bullet.rb:128:in `open'
webpacker_1  | /bundle/gems/bullet-6.1.4/lib/bullet.rb:128:in `initialize': Permission denied @ rb_sysopen - /app/log/bullet.log (Errno::EACCES)
```

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: I've introduced a workaround to precompile the js-routes file by doing `rails js:routes`, which generates `app/javascript/routes.js`. If present, this file will be imported by `application.js` instead of `routes.js.erb`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Other (please specify): Development setup change


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

I verified that this allows webpacker to compile all of the required assets, so MarkUs can actually run!

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

I changed the extension `.erb` to `.js.erb` to allow webpacker to find `routes.js.erb`. We don't have any other assets that use the `.erb` extension (e.g., `.css.erb`), but if we ever do want that, we'll need to add them separately to the extensions list in `webpacker.config`. But I think it's best to limit our use of `rails-erb-loader` until we can figure out the root cause of this WSL issue.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)

I'm updating https://github.com/MarkUsProject/Markus/wiki/Developer-Guide--Set-Up-With-Docker to include setup instructions for WSL 2, and will include the js routes precompilation step for this platform.
