### PR TITLE
test: Fix flaky i18n in test

### DIFF
--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -34,7 +34,7 @@ describe Grouping do
     end
 
     it 'displays Empty Group since no students in the group' do
-      expect(grouping.get_all_students_in_group).to eq('Empty Group')
+      expect(grouping.get_all_students_in_group).to eq(I18n.t('groups.empty'))
     end
 
     it 'creates a subdirectory in the repo for the grouping\'s assignment' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An existing `grouping_spec.rb` test hard-coded an English string rather than using `I18n`, causing the test to be flaky depending on how the current locale was set in other tests.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Modified the test to use `I18n.t` instead.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Test update (change that modifies or updates tests only)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran the tests to ensure they pass.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
