### PR TITLE
criteria: Report error when rubric yml does not have levels key.

### DIFF
--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -128,7 +128,7 @@ class RubricCriterion < Criterion
     attrs[:ta_visible] = criterion_yml[1]['ta_visible'] unless criterion_yml[1]['ta_visible'].nil?
     attrs[:peer_visible] = criterion_yml[1]['peer_visible'] unless criterion_yml[1]['peer_visible'].nil?
     attrs[:bonus] = criterion_yml[1]['bonus'] unless criterion_yml[1]['bonus'].nil?
-    criterion_yml[1]['levels'].each do |level_name, level_yml|
+    (criterion_yml[1]['levels'] || []).each do |level_name, level_yml|
       attrs[:levels_attributes] << {
         name: level_name,
         description: level_yml['description'],

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -787,6 +787,7 @@ describe CriteriaController do
     end
     let(:mixed_file) { fixture_file_upload('criteria/upload_yml_mixed.yaml', 'text/yaml') }
     let(:invalid_mixed_file) { fixture_file_upload('criteria/upload_yml_mixed_invalid.yaml', 'text/yaml') }
+    let(:missing_levels_file) { fixture_file_upload('criteria/upload_yml_missing_levels.yaml', 'text/yaml') }
     let(:empty_file) { fixture_file_upload('empty_file', 'text/yaml') }
     let(:test_upload_download_file) { fixture_file_upload('criteria/criteria_upload_download.yaml', 'text/yaml') }
     let(:expected_download) { fixture_file_upload('criteria/download_yml_output.yaml', 'text/yaml') }
@@ -954,6 +955,14 @@ describe CriteriaController do
         post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: invalid_mixed_file }
 
         expect(assignment.criteria.pluck(:name)).not_to include('cr40', 'cr50')
+      end
+
+      it 'does not create rubric criteria when levels are missing' do
+        post_as admin, :upload, params: { assignment_id: assignment.id, upload_file: missing_levels_file }
+
+        expect(assignment.criteria.where(name: %w[no_levels empty_levels])).to be_empty
+        expect(flash[:error].map { |f| extract_text f })
+          .to eq([I18n.t('criteria.errors.invalid_format') + ' no_levels, empty_levels'].map { |f| extract_text f })
       end
 
       it 'does not create criteria that have both visibility options set to false' do

--- a/spec/fixtures/files/criteria/upload_yml_missing_levels.yaml
+++ b/spec/fixtures/files/criteria/upload_yml_missing_levels.yaml
@@ -1,0 +1,7 @@
+no_levels:
+  type: rubric
+  max_mark: 5.0
+empty_levels:
+  type: rubric
+  max_mark: 5.0
+  levels: []


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, an uncaught runtime error occurred when a user uploaded a criterion yml file with a rubric criterion that had no `levels` key.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Modified the code so that if the levels key isn't present, no levels are associated with the rubric. Because we have a validation on `RubricCriterion` that requires at least one level, the resulting object is invalid, and MarkUs reports this back to the user in a flash message.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Added a test for this, and tested in the UI by uploading a YML file with the levels attribute missing.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
