### PR TITLE
Updated .import gem to use upsert_all instead

### DIFF
--- a/app/models/grade_entry_form.rb
+++ b/app/models/grade_entry_form.rb
@@ -181,9 +181,9 @@ class GradeEntryForm < Assessment
         end
       end
     end
-    Grade.import updated_grades,
-                 on_duplicate_key_update: { conflict_target: [:grade_entry_item_id, :grade_entry_student_id],
-                                            columns: [:grade] }
+    unless updated_grades.empty?
+      Grade.upsert_all(updated_grades, unique_by: [:grade_entry_item_id, :grade_entry_student_id])
+    end
     GradeEntryStudent.refresh_total_grades(updated_grades.map { |h| h[:grade_entry_student_id] })
     result
   end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
Rails 6 recently introduced bulk inserts/upserts so I updated this code to accommodate that.
<!--- If it fixes an open issue, please link to the issue here. -->
#5280 

## Your Changes
<!--- Describe your changes here. -->
**Description**
I replaced the .import call with a .upsert_all instead in the method `from_csv`


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
I ran the spec test suite and the specific file that grades this file separately as well. Secondly, I triggered the UI element that calls the method I changed, that being `from_csv`. I downloaded a sample grades file, then uploaded it **successfully** into the _grades_ section of a new assignment that I created. All rspec tests passed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

