### PR TITLE
autotest: Add guard for add_feedback_data helper.

### DIFF
--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -308,6 +308,8 @@ module AutomatedTestsHelper
     # Gets the feedback file data from the autotester for the TestRun with autotest_test_id = +test_id+
     # and adds it to the +results+ hash.
     def add_feedback_data(results, settings_id, test_id)
+      return if results['test_groups'].blank?
+
       results['test_groups'].each do |result|
         next if result['feedback'].nil?
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The tests are currently failing on master, see e.g. https://travis-ci.org/github/MarkUsProject/Markus/builds/772464462.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added an additional check in the `AutomatedTestsHelper`'s `add_feedback_data` method to fix this.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran the tests to ensure they pass.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

We missed this in #5225; the second-last commit had the failing tests, but the last commit, marked `[ci skip]`, had the green checkmark. That commit had Hound and coveralls passing, but didn't have the TravisCI check.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
