### PR TITLE
a11y: Improvements to layouts and login page

### DIFF
--- a/app/assets/stylesheets/common/_icons.scss
+++ b/app/assets/stylesheets/common/_icons.scss
@@ -119,6 +119,11 @@
   font-weight: bolder;
 }
 
+.switch-role::before {
+  content: asset_url('icons/group_go.png');
+  padding-right: 5px;
+  vertical-align: text-top;
+}
 
 // Icons for react-json-schema-forms
 .btn-danger::after {

--- a/app/assets/stylesheets/common/_login.scss
+++ b/app/assets/stylesheets/common/_login.scss
@@ -9,11 +9,11 @@
   box-shadow: 0 3px 0 0 $primary-two;
   height: auto;
   left: 50%;
-  margin-left: -180px;
-  margin-top: -200px;
+  margin-left: -250px;
+  margin-top: -250px;
   position: absolute;
   top: 50%;
-  width: 360px;
+  width: 500px;
 
   /* Mobile friendly! */
   @include breakpoint(tiny) {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,18 +15,17 @@
       </span>
       <% if @current_user.admin? || (session[:real_uid] &&
               User.find_by_id(session[:real_uid]).admin?) %>
-        <%= link_to image_tag('icons/group_go.png',
-                              alt: t('main.role_switch.switch_role'),
-                              title: t('main.role_switch.switch_role'),
-                              id: 'switch_role_icon'),
+        <%= link_to t('main.role_switch.switch_role'),
                     role_switch_main_index_path,
-                    remote: true %>
+                    remote: true,
+                    class: 'button inline-button switch-role' %>
       <% end %>
 
       <%= link_to(t('main.log_out'),
                   logout_main_index_path,
                   id: 'logout_link',
-                  method: :post) unless
+                  method: :post,
+                  class: 'button inline-button') unless
             Settings.logout_redirect == 'NONE' %>
 
       <% if Settings.remote_user_auth &&

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,6 +1,6 @@
 <ul class='main'>
   <li id='logo'>
-    <a href='<%= root_url %>' id='logo-img'></a>
+    <a href='<%= root_url %>' id='logo-img' aria-label='<%= t('menu.dashboard') %>'></a>
   </li>
 
   <% if @current_user.admin? %>

--- a/app/views/layouts/assignment_content.html.erb
+++ b/app/views/layouts/assignment_content.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name.titleize %></title>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name.titleize %></title>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title>Oh no!</title>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head>
+<html lang="<%= I18n.locale %>">
   <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
   <style>
     @media (prefers-color-scheme: dark) {

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name %></title>

--- a/app/views/layouts/no_menu_header.html.erb
+++ b/app/views/layouts/no_menu_header.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name %></title>

--- a/app/views/layouts/plain.html.erb
+++ b/app/views/layouts/plain.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title>Test Result: <%= @test_result.filename %></title>

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <%= render partial: 'layouts/head' %>
   <title><%= t(:markus) %> - <%= controller.action_name.titleize %></title>

--- a/app/views/main/_role_switch_content.html.erb
+++ b/app/views/main/_role_switch_content.html.erb
@@ -8,8 +8,8 @@
     <%= text_field_tag 'effective_user_login',
                        nil,
                        placeholder: t('main.role_switch.log_in_as'),
-                       autocorrect: 'off',
-                       tabindex: 10 %>
+                       'aria-label': t('main.role_switch.log_in_as'),
+                       autocorrect: 'off' %>
 
     <%
       # For REMOTE_USER we have no way to check a password, so don't
@@ -19,17 +19,15 @@
       <%= password_field_tag 'admin_password',
                              nil,
                              placeholder: t('main.role_switch.admin_password'),
-                             tabindex: 20,
+                             'aria-label': t('main.role_switch.admin_password'),
                              autocomplete: 'off' %>
     <% end %>
 
     <section class='dialog-actions'>
       <%= submit_tag t('main.log_in'),
-                     data: { disable_with: t('main.logging_in') },
-                     tabindex: 100 %>
+                     data: { disable_with: t('main.logging_in') } %>
       <%= button_tag t(:cancel),
-                     id: 'role-switch-modal-cancel',
-                     tabindex: 110 %>
+                     id: 'role-switch-modal-cancel' %>
     </section>
   <% end %>
 </div>

--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -2,12 +2,12 @@
   <%= javascript_include_tag 'cookies_eu', nonce: true %>
 <% end %>
 
-<div class='login'>
+<main class='login'>
   <div class='login-image'></div>
 
-  <p class='login-course'>
+  <h1 class='login-course'>
     <%= Settings.course_name %>
-  </p>
+  </h1>
 
   <div class='login-error'>
     <%= render 'shared/flash_message' %>
@@ -20,25 +20,24 @@
          end %>
       <%= text_field_tag 'user_login',
                          nil,
-                         tabindex: 1,
                          placeholder: User.human_attribute_name(:user_name),
+                         'aria-label': User.human_attribute_name(:user_name),
                          autocorrect: 'off',
                          autocapitalize: 'off',
                          autofocus: user_login == '',
                          value: user_login %>
       <%= password_field_tag 'user_password',
                              nil,
-                             tabindex: 2,
                              placeholder: t('main.password'),
+                             'aria-label': t('main.password'),
                              autofocus: user_login != '',
                              autocomplete: 'off' %>
       <div class='submit'>
         <%= submit_tag t('main.log_in'),
-                       data: { disable_with: t('main.logging_in') },
-                       tabindex: 3 %>
+                       data: { disable_with: t('main.logging_in') } %>
       </div>
     <% end %>
   </div>
-</div>
+</main>
 
 <%= render 'cookies_eu/consent_banner' %>

--- a/app/views/main/remote_user_auth_login_fail.html.erb
+++ b/app/views/main/remote_user_auth_login_fail.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset='UTF-8'>
   <meta http-equiv='X-UA-Compatible' content='IE=Edge'>

--- a/app/views/shared/http_status.html.erb
+++ b/app/views/shared/http_status.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset='UTF-8'>
   <meta http-equiv='X-UA-Compatible' content='IE=Edge'>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Accessibility is important! I started doing a preliminary review of accessibility using the [WAVE browser extension](https://wave.webaim.org/extension/).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed some accessibility issues on the login path, switch role ("login as") modal, and page layouts.

1. Use heading on login page.
2. Remove redundant `tabindex` attributes.
3. Made the "switch role" icon a proper button, with label.
4. Added the `lang` attribute to `html` elements in the layouts.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Other (please specify): UI improvements (accessibility)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested teh UI changes in Firefox and Chrome.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
