### PR TITLE
Issue-5172: Adding a link between grading view and repository

### DIFF
--- a/app/assets/javascripts/Components/Result/right_pane.jsx
+++ b/app/assets/javascripts/Components/Result/right_pane.jsx
@@ -65,6 +65,9 @@ export class RightPane extends React.Component {
              removeTag={this.props.removeTag}
              newNote={this.props.newNote}
              role={this.props.role}
+             assignment_id={this.props.assignment_id}
+             submission_id={this.props.submission_id}
+             result_id={this.props.result_id}
            />
          </TabPanel>
         }

--- a/app/assets/javascripts/Components/Result/right_pane.jsx
+++ b/app/assets/javascripts/Components/Result/right_pane.jsx
@@ -66,8 +66,7 @@ export class RightPane extends React.Component {
              newNote={this.props.newNote}
              role={this.props.role}
              assignment_id={this.props.assignment_id}
-             submission_id={this.props.submission_id}
-             result_id={this.props.result_id}
+             submission_id={this.props.grouping_id}
            />
          </TabPanel>
         }

--- a/app/assets/javascripts/Components/Result/right_pane.jsx
+++ b/app/assets/javascripts/Components/Result/right_pane.jsx
@@ -66,7 +66,7 @@ export class RightPane extends React.Component {
              newNote={this.props.newNote}
              role={this.props.role}
              assignment_id={this.props.assignment_id}
-             submission_id={this.props.grouping_id}
+             grouping_id={this.props.grouping_id}
            />
          </TabPanel>
         }

--- a/app/assets/javascripts/Components/Result/tags_panel.jsx
+++ b/app/assets/javascripts/Components/Result/tags_panel.jsx
@@ -64,7 +64,7 @@ export class TagsPanel extends React.Component {
           </a>
         </p>
         <h4>{I18n.t('submissions.repo_browser.repository')}</h4>
-        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
+        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.grouping_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
       </div>
     );
   }

--- a/app/assets/javascripts/Components/Result/tags_panel.jsx
+++ b/app/assets/javascripts/Components/Result/tags_panel.jsx
@@ -63,8 +63,9 @@ export class TagsPanel extends React.Component {
             {I18n.t('activerecord.models.note.other')} ({this.props.notes_count})
           </a>
         </p>
-        <h4>{"Links"}</h4>
-        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id, this.props.result_id)}> This is a link</a>
+        <h4>{I18n.t('submissions.repo_browser.repository')}</h4>
+        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id,
+          this.props.result_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
       </div>
     );
   }

--- a/app/assets/javascripts/Components/Result/tags_panel.jsx
+++ b/app/assets/javascripts/Components/Result/tags_panel.jsx
@@ -64,8 +64,7 @@ export class TagsPanel extends React.Component {
           </a>
         </p>
         <h4>{I18n.t('submissions.repo_browser.repository')}</h4>
-        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id,
-          this.props.result_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
+        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
       </div>
     );
   }

--- a/app/assets/javascripts/Components/Result/tags_panel.jsx
+++ b/app/assets/javascripts/Components/Result/tags_panel.jsx
@@ -59,8 +59,8 @@ export class TagsPanel extends React.Component {
             {I18n.t('activerecord.models.note.other')} ({this.props.notes_count})
           </a>
         </p>
-        <h4>{I18n.t('submissions.repo_browser.repository')}</h4>
-        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.grouping_id)}> {I18n.t('groups.student_interface.url_group_repository')}</a>
+        <h4>{I18n.t('other_info')}</h4>
+        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.grouping_id)}> {I18n.t('results.view_group_repo')}</a>
       </div>
     );
   }

--- a/app/assets/javascripts/Components/Result/tags_panel.jsx
+++ b/app/assets/javascripts/Components/Result/tags_panel.jsx
@@ -63,6 +63,8 @@ export class TagsPanel extends React.Component {
             {I18n.t('activerecord.models.note.other')} ({this.props.notes_count})
           </a>
         </p>
+        <h4>{"Links"}</h4>
+        <a href={Routes.repo_browser_assignment_submission_path(this.props.assignment_id, this.props.submission_id, this.props.result_id)}> This is a link</a>
       </div>
     );
   }

--- a/config/locales/common/en.yml
+++ b/config/locales/common/en.yml
@@ -15,6 +15,7 @@ en:
   filter_by: Filter by %{name}
   help: Help
   markus: MarkUs
+  other_info: Other Info
   please_wait: Please wait…
   preview: Preview
   save: Save

--- a/config/locales/common/es.yml
+++ b/config/locales/common/es.yml
@@ -14,6 +14,7 @@ es:
   filter_by: UPDATE ME
   help: Ayuda
   markus: MarkUs
+  other_info: UPDATE ME
   please_wait: Por favor espere…
   preview: Vista previa
   save: Guardar

--- a/config/locales/common/fr.yml
+++ b/config/locales/common/fr.yml
@@ -14,6 +14,7 @@ fr:
   filter_by: UPDATE ME
   help: Aide
   markus: MarkUs
+  other_info: UPDATE ME
   please_wait: Merci de patienter…
   preview: Prévisualisation
   save: Sauvegarder

--- a/config/locales/common/pt.yml
+++ b/config/locales/common/pt.yml
@@ -14,6 +14,7 @@ pt:
   filter_by: UPDATE ME
   help: Ajuda
   markus: MarkUs
+  other_info: UPDATE ME
   please_wait: Aguarde por favor…
   preview: Prever
   save: Salvar

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -71,6 +71,7 @@ en:
     subtotal: Subtotal
     summary: Summary
     total_extra_marks: Total Extra Marks
+    view_group_repo: View group repository
     your_mark: Your Mark
     zoom_in_image: Zoom in
     zoom_out_image: Zoom out

--- a/config/locales/views/results/es.yml
+++ b/config/locales/views/results/es.yml
@@ -66,6 +66,7 @@ es:
     subtotal: Subtotal
     summary: Resumen
     total_extra_marks: Notas Adicionales Totales
+    view_group_repo: UPDATE ME!
     your_mark: Su Nota
     zoom_in_image: UPDATE ME!
     zoom_out_image: UPDATE ME!

--- a/config/locales/views/results/fr.yml
+++ b/config/locales/views/results/fr.yml
@@ -66,6 +66,7 @@ fr:
     subtotal: Sous-total
     summary: Récapitulatif
     total_extra_marks: Total Notes Supplémentaires
+    view_group_repo: UPDATE ME!
     your_mark: Votre Note
     zoom_in_image: UPDATE ME!
     zoom_out_image: UPDATE ME!

--- a/config/locales/views/results/pt.yml
+++ b/config/locales/views/results/pt.yml
@@ -66,6 +66,7 @@ pt:
     subtotal: Subtotal
     summary: Resumo
     total_extra_marks: Nota extra total
+    view_group_repo: UPDATE ME!
     your_mark: Sua Nota
     zoom_in_image: UPDATE ME!
     zoom_out_image: UPDATE ME!


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This link was added to make navigating between the two views more convenient. (resolve Issue #5172 )

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
I added a header and a link in the tag/notes tab of the grading view that links to the group repository. (link and header names use I18n) I also passed assignment_id and submission_id as props from right_pane to tags_panel, so that I could create the link.
![image](https://user-images.githubusercontent.com/73006103/122958271-b3a96680-d350-11eb-92e2-5a84fa0d9f28.png)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I tested my link on different assignments and groups.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
