### PR TITLE
Fixed TODO in remove_extra_mark regarding AJAX data formatting

### DIFF
--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -470,11 +470,11 @@ class Result extends React.Component {
 
     $.ajax({
       url: Routes.remove_extra_mark_assignment_submission_result_path(
-        this.state.assignment_id, this.state.submission_id,
+        this.state.assignment_id, this.state.submission_id, this.state.result_id
         // TODO: Fix this route so that the id refers to a Result rather than ExtraMark.
-        id
       ),
-      method: 'POST',
+      method: 'DELETE',
+      data: {extra_mark_id: id}
     }).then(this.fetchData)
   };
 

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -471,7 +471,6 @@ class Result extends React.Component {
     $.ajax({
       url: Routes.remove_extra_mark_assignment_submission_result_path(
         this.state.assignment_id, this.state.submission_id, this.state.result_id
-        // TODO: Fix this route so that the id refers to a Result rather than ExtraMark.
       ),
       method: 'DELETE',
       data: {extra_mark_id: id}

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -653,8 +653,8 @@ class ResultsController < ApplicationController
   end
 
   def remove_extra_mark
-    extra_mark = ExtraMark.find(params[:id])
-    result = extra_mark.result
+    result = Result.find(params[:id])
+    extra_mark = ExtraMark.find(params[:extra_mark_id])
 
     extra_mark.destroy
     result.update_total_mark

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -654,7 +654,7 @@ class ResultsController < ApplicationController
 
   def remove_extra_mark
     result = Result.find(params[:id])
-    extra_mark = ExtraMark.find(params[:extra_mark_id])
+    extra_mark = result.extra_marks.find(params[:extra_mark_id])
 
     extra_mark.destroy
     result.update_total_mark

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,7 @@ Rails.application.routes.draw do
           post 'add_extra_mark'
           delete 'delete_grace_period_deduction'
           get 'next_grouping'
-          post 'remove_extra_mark'
+          delete 'remove_extra_mark'
           patch 'revert_to_automatic_deductions'
           post 'set_released_to_students'
           post 'update_overall_comment'

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -365,8 +365,9 @@ describe ResultsController do
         extra_mark = create(:extra_mark_points, result: submission.get_latest_result)
         submission.get_latest_result.update_total_mark
         @old_mark = submission.get_latest_result.total_mark
-        post :remove_extra_mark, params: { assignment_id: assignment.id, submission_id: submission.id,
-                                           id: extra_mark.id }, xhr: true
+        delete :remove_extra_mark, params: { assignment_id: assignment.id, submission_id: submission.id,
+                                             id: submission.get_latest_result.id,
+                                             extra_mark_id: extra_mark.id }, xhr: true
       end
       test_no_flash
       it { expect(response).to have_http_status(:success) }

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -737,8 +737,8 @@ describe 'An Assignment' do
           )
         end
 
-        it 'routes POST remove_extra_mark properly' do
-          expect(post: res_path + '/1/remove_extra_mark').to route_to(
+        it 'routes DELETE remove_extra_mark properly' do
+          expect(delete: res_path + '/1/remove_extra_mark').to route_to(
             controller: res_ctrl,
             action: 'remove_extra_mark',
             id: '1',


### PR DESCRIPTION
## Motivation and Context
This PR fixed the TODO on line 474 in `app/assets/javascripts/Components/Result/result.jsx`

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
 I fixed the ajax request's data to use `result.id` as opposed to the `extra_mark.id`, and instead passed that in as the `data` parameter. I also updated the controller in accordance with these changes. Secondly, this PR also changed the HTTPS request type from a `POST` to `DELETE`. Lastly, I updated all the `rspec` cases to accommodate these changes. 


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update (change that modifies or updates tests only)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I tested this change through the UI by making an extra mark on a user's submission for a dummy assignment and then deleted it **successfully**. Secondly, I ran the `rpsec` test suite, and all tests **passed**.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->