### PR TITLE
timed-assessments: Improve student UI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Combine all python dependencies (#5358)
 - Rename "Tags/Notes" tab on grading page to "Submission Info", and move membership information to the tab (#5380)
 - Remove delete link from TA table (#5407)
+- Improve student UI for timed assessments (#5417) 
 
 ## [v1.12.5]
 - Fix bugs in grading view when switching between submissions (#5400)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -47,7 +47,11 @@ class AssignmentsController < ApplicationController
       flash_message(:warning, I18n.t('assignments.starter_file.changed_warning')) if @grouping.starter_file_changed
       if @assignment.is_timed && !@grouping.start_time.nil? && !@grouping.past_collection_date?
         flash_message(:note, I18n.t('assignments.timed.started_message_html'))
-        flash_message(:note, I18n.t('assignments.timed.starter_file_prompt'))
+        unless @assignment.starter_file_updated_at.nil?
+          flash_message(:note, I18n.t('assignments.timed.starter_file_prompt'))
+        end
+      elsif @assignment.is_timed && @grouping.start_time.nil? && @grouping.past_collection_date?
+        flash_message(:warning, I18n.t('assignments.timed.past_end_time'))
       end
       set_repo_vars(@assignment, @grouping)
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -706,11 +706,15 @@ class SubmissionsController < ApplicationController
   # Used in update_files and file_manager actions.
   # Requires @grouping, @assignment, and @missing_assignment_files variables to be set.
   def flash_file_manager_messages
-    if @assignment.is_timed
-      flash_message(:notice, I18n.t('assignments.timed.time_until_due_warning', due_date: I18n.l(@grouping.due_date)))
-    elsif @assignment.submission_rule.can_collect_now?(@grouping.section)
+    if @assignment.is_timed && @grouping.start_time.nil? && @grouping.past_collection_date?
       flash_message(:warning,
-                    @assignment.submission_rule.class.human_attribute_name(:after_collection_message))
+                    I18n.t('assignments.timed.past_end_time') + ' ' + I18n.t('submissions.past_collection_time'))
+    elsif @assignment.is_timed && !@grouping.start_time.nil? && !@assignment.grouping_past_due_date?(@grouping)
+      flash_message(:notice, I18n.t('assignments.timed.time_until_due_warning', due_date: I18n.l(@grouping.due_date)))
+    elsif @grouping.past_collection_date?
+      flash_message(:warning,
+                    @assignment.submission_rule.class.human_attribute_name(:after_collection_message) + ' ' +
+                      I18n.t('submissions.past_collection_time'))
     elsif @assignment.grouping_past_due_date?(@grouping)
       flash_message(:warning, @assignment.submission_rule.overtime_message(@grouping))
     end

--- a/app/models/submission_rule.rb
+++ b/app/models/submission_rule.rb
@@ -19,13 +19,6 @@ class SubmissionRule < ApplicationRecord
      GracePeriodSubmissionRule]
   end
 
-  def can_collect_now?(section = nil)
-    reset_collection_time if @can_collect_now.nil?
-    section_id = section.nil? ? 0 : section.id
-    return @can_collect_now[section_id] unless @can_collect_now[section_id].nil?
-    @can_collect_now[section_id] = Time.current >= get_collection_time(section)
-  end
-
   def can_collect_all_now?
     return @can_collect_all_now unless @can_collect_all_now.nil?
     @can_collect_all_now = Time.current >= assignment.latest_due_date
@@ -84,7 +77,6 @@ class SubmissionRule < ApplicationRecord
   def reset_collection_time
     @get_collection_time = Array.new
     @get_global_collection_time = nil
-    @can_collect_now = Array.new
     @can_collect_all_now = nil
   end
 

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -4,7 +4,7 @@ class AssignmentPolicy < ApplicationPolicy
   alias_rule :summary?, to: :view?
   alias_rule :stop_batch_tests?, :batch_runs?, :stop_test?, to: :manage_tests?
   alias_rule :refresh_graph?, :view_summary?, :download?, :upload?, to: :admin?
-  alias_rule :show?, :peer_review?, :start_timed_assignment?, to: :student?
+  alias_rule :show?, :peer_review?, to: :student?
 
   def index?
     true
@@ -73,5 +73,16 @@ class AssignmentPolicy < ApplicationPolicy
 
   def manage_tests?
     check?(:manage?, with: AutomatedTestPolicy)
+  end
+
+  def start_timed_assignment?
+    user.student? && (
+      (check?(:not_yet_in_group?) &&
+        record.section_start_time(user.section) < Time.current &&
+        record.section_due_date(user.section) > Time.current &&
+        record.group_max == 1) ||
+      (!check?(:not_yet_in_group?) &&
+        check?(:start_timed_assignment?, user.accepted_grouping_for(record.id), with: GroupingPolicy))
+    )
   end
 end

--- a/app/views/assignments/_timed_due_info.html.erb
+++ b/app/views/assignments/_timed_due_info.html.erb
@@ -1,13 +1,4 @@
 <% due_date = @assignment.section_due_date(@current_user&.section) %>
-<h3><%= I18n.t('activerecord.models.timed_assignment.one') %></h3>
-<p>
-  <strong><%= I18n.t('assignments.timed.start_time_instructions') %></strong>
-  <%= I18n.l @assignment.section_start_time(@current_user&.section) %>
-<p>
-  <strong><%= I18n.t('assignments.timed.end_time_instructions') %></strong>
-  <%= I18n.l due_date %>
-</p>
-<%= render partial: 'timed_due_message', locals: { assignment: @assignment, grouping: @grouping } %>
 <p>
   <% duration = @assignment.duration + (@grouping&.extension&.time_delta || 0)
      parts = AssignmentProperties.duration_parts(duration)
@@ -23,3 +14,12 @@
     <%= I18n.t('assignments.timed.duration_extension_info', extension_string: extension_string) %>
   <% end %>
 </p>
+<p>
+  <strong><%= I18n.t('assignments.timed.start_time_instructions') %></strong>
+  <%= I18n.l @assignment.section_start_time(@current_user&.section) %>
+<p>
+  <strong><%= I18n.t('assignments.timed.end_time_instructions') %></strong>
+  <%= I18n.l due_date %>
+</p>
+<h3><%= I18n.t('assignments.timed.details_heading') %></h3>
+<%= render partial: 'timed_due_message', locals: { assignment: @assignment, grouping: @grouping } %>

--- a/app/views/assignments/_timed_due_message.html.erb
+++ b/app/views/assignments/_timed_due_message.html.erb
@@ -31,22 +31,18 @@
                    duration_string: duration_string, extension_string: extension_string) %>
       <% end %>
     </p>
-    <% if grouping.nil? || allowed_to?(:start_timed_assignment?, grouping) %>
-      <%= form_with url: start_timed_assignment_assignment_path(assignment.id), method: 'put', local: true do |f| %>
-        <%= f.submit I18n.t('assignments.timed.start_button'),
-                     disabled: grouping.nil? && assignment.group_max != 1,
-                     data: { confirm: t('assignments.timed.start_confirmation') } %>
-      <% end %>
+  <% end %>
+  <% unless simple %>
+    <%= form_with url: start_timed_assignment_assignment_path(assignment.id), method: 'put', local: true do |f| %>
+      <%= f.submit I18n.t('assignments.timed.start_button'),
+                   disabled: !allowed_to?(:start_timed_assignment?, assignment),
+                   data: { confirm: t('assignments.timed.start_confirmation') } %>
     <% end %>
   <% end %>
 <% else %>
-  <% if Time.current < grouping.due_date %>
-    <p>
-      <%= t('assignments.timed.after_start_instructions_html',
-                 start_time: I18n.l(grouping.start_time),
-                 due_date: I18n.l(grouping.due_date)) %>
-    </p>
-  <% else %>
-    <p><%= I18n.t('assignments.timed.past_due_date') %></p>
-  <% end %>
+  <p><strong><%= I18n.t('assignments.timed.started_on') %></strong> <%= I18n.l(grouping.start_time) %></p>
+  <p>
+    <strong><%= Assignment.human_attribute_name(:due_date) %></strong>:
+    <%= I18n.l(grouping.due_date) %>
+  </p>
 <% end %>

--- a/config/locales/models/submission_rules/en.yml
+++ b/config/locales/models/submission_rules/en.yml
@@ -3,22 +3,22 @@ en:
   activerecord:
     attributes:
       grace_period_submission_rule:
-        after_collection_message: The maximum grace period has passed for this assignment. Any changes will be recorded, but not graded.
+        after_collection_message: The maximum grace period has passed for this assignment.
         commit_after_collection_message: The due date for this assignment, plus the maximum grace period, has passed. Your changes have been recorded, but will not be included in the grading.
         description: You may submit up to a set time past the due date, provided you have enough remaining grace credits to do so.
         form_description: Automatically deduct grace credits
       no_late_submission_rule:
-        after_collection_message: The due date for this assignment has passed. Only what was submitted before the due date will be graded.
+        after_collection_message: The due date for this assignment has passed.
         commit_after_collection_message: The due date for this assignment has passed. Your changes have been recorded, but will not be included in the grading.
         description: No late submissions are accepted.
         form_description: Accept no late submissions
       penalty_decay_period_submission_rule:
-        after_collection_message: The maximum late penalty period has passed for this assignment. Any changes will be recorded, but not graded.
+        after_collection_message: The maximum late penalty period has passed for this assignment.
         commit_after_collection_message: The due date for this assignment, plus the maximum late penalty period, has passed. Your changes have been recorded, but will not be included in the grading.
         description: You are able to submit up to a set time past the due date, but with the appropriate percentage deducted from your final grade.
         form_description: Use penalty decay formula
       penalty_period_submission_rule:
-        after_collection_message: The maximum late penalty period has passed for this assignment. Any changes will be recorded, but not graded.
+        after_collection_message: The maximum late penalty period has passed for this assignment.
         commit_after_collection_message: The due date for this assignment, plus the maximum late penalty period, has passed. Your changes have been recorded, but will not be included in the grading.
         description: You are able to submit up to a set time past the due date, but with the appropriate percentage deducted from your final grade.
         form_description: Set manual penalty periods

--- a/config/locales/models/submission_rules/es.yml
+++ b/config/locales/models/submission_rules/es.yml
@@ -3,7 +3,7 @@ es:
   activerecord:
     attributes:
       grace_period_submission_rule:
-        after_collection_message: El número máximo de períodos de aplazamiento de gracia ha pasado para este proyecto. Cualquier cambio realizado será guardado pero no calificado.
+        after_collection_message: El número máximo de períodos de aplazamiento de gracia ha pasado para este proyecto.
         commit_after_collection_message: El último plazo de entrega para este proyecto, más el número máximo de días de gracia permitidos ha pasado. Sus cambios han sido guardados, pero no serán incluídos en el proceso de calificación.
         form_description: Deducir automáticamente los créditos de aplazamiento de gracia
       no_late_submission_rule:
@@ -11,12 +11,12 @@ es:
         description: No se aplicaran penalidades a proyectos entregados tardíamente
         form_description: No se aceptan entregas tardías
       penalty_decay_period_submission_rule:
-        after_collection_message: El número máximo de horas de penalidad han pasado para este proyecto. Cualquier cambio realizado será guardado, pero no calificado.
+        after_collection_message: El número máximo de horas de penalidad han pasado para este proyecto.
         commit_after_collection_message: El último plazo para este proyecto, más el número máximo de horas de penalidad permitidas han pasado. Sus cambios han sido guardados, pero no serán incluídos en el proceso de calificación.
         description: Usted puede enviar hasta %{penalty_decay_period_limit} hora(s) después del último plazo, pero el porcentaje respectivo será deducido de su resultado final
         form_description: Usar la Fórmula de Decaimiento de la Penalidad
       penalty_period_submission_rule:
-        after_collection_message: El número máximo de horas de penalidad han pasado para este proyecto. Cualquier cambio realizado será guardado, pero no calificado.
+        after_collection_message: El número máximo de horas de penalidad han pasado para este proyecto.
         commit_after_collection_message: El último plazo para este proyecto, más el número máximo de horas de penalidad permitidas han pasado. Sus cambios han sido guardados, pero no serán incluídos en el proceso de calificación.
         description: Usted puede enviar archivos hasta %{penalty_period_limit} hora(s) después del último plazo, pero el porcentaje respectivo será deducido de su resultado final
         form_description: Usar la Fórmula de Penalidad

--- a/config/locales/models/submission_rules/fr.yml
+++ b/config/locales/models/submission_rules/fr.yml
@@ -3,21 +3,21 @@ fr:
   activerecord:
     attributes:
       grace_period_submission_rule:
-        after_collection_message: Le nombre maximum de périodes de grâce sont passées pour ce projet. Tout changement sera enregistré mais non évalué.
+        after_collection_message: Le nombre maximum de périodes de grâce sont passées pour ce projet.
         commit_after_collection_message: La date de retour pour ce projet, plus le maximum de jour de grâce autorisés sont passés. Vos changements ont été enregistrés, mais ne seront pas inclus dans l'évaluation.
         form_description: Déduire automatiquement les crédits de grâce
       no_late_submission_rule:
-        after_collection_message: La date de retour pour ce projet est passée. Seront évalués les fichiers qui étaient dans votre répertoire à la date de retour.
+        after_collection_message: La date de retour pour ce projet est passée.
         commit_after_collection_message: La date de retour pour ce projet est passée. Vos changements ont été enregistrés, mais ils ne seront pas inclus pour l'évaluation.
         description: Aucune pénalité ne sera appliquée aux projets en retard.
         form_description: N'accepter aucun retard
       penalty_decay_period_submission_rule:
-        after_collection_message: Le nombre maximal d'heures de pénalité est passé pour ce projet. Tout changement sera enregistré mais non évalué.
+        after_collection_message: Le nombre maximal d'heures de pénalité est passé pour ce projet.
         commit_after_collection_message: La date de retour pour ce projet et le nombre maximum d'heures de retard sont passés. Vos changements ont été enregistrés, mais ne seront pas inclus dans l'évaluation.
         description: Vous pouvez envoyer votre travail jusqu'à %{penalty_period_limit} heure(s) après la date de retour, mais vous aurez une pénalité sur votre note finale.
         form_description: Utiliser une pénalité dépendant du retard
       penalty_period_submission_rule:
-        after_collection_message: Le nombre maximal de périodes de pénalité est passé pour ce projet. Tout changement sera enregistré mais non évalué.
+        after_collection_message: Le nombre maximal de périodes de pénalité est passé pour ce projet.
         commit_after_collection_message: La date de retour et la période de pénalité maximale sont dépassées pour ce projet. Vos changements ont été enregistrés, mais ne seront pas inclus dans l'évaluation.
         description: Vous pouvez envoyer votre travail jusqu'à %{penalty_period_limit} heure(s) après la date de retour et vous aurez le pourcentage adéquat déduit de votre note finale.
         form_description: Activer les pénalités

--- a/config/locales/models/submission_rules/pt.yml
+++ b/config/locales/models/submission_rules/pt.yml
@@ -3,21 +3,21 @@ pt:
   activerecord:
     attributes:
       grace_period_submission_rule:
-        after_collection_message: O número máximo de períodos de tolerância já passou para esse projeto. Quaisquer alterações serão gravadas, mas não classificados.
+        after_collection_message: O número máximo de períodos de tolerância já passou para esse projeto.
         commit_after_collection_message: A data de entrega para este projeto, além do número máximo de dias de tolerância, já passou. Suas alterações foram registrados, mas não vai ser incluído na classificação.
         form_description: Deduzir automaticamente créditos de período de tolerância
       no_late_submission_rule:
-        after_collection_message: A data de entrega para este projeto já passou. Só o que estava em sua pasta na data de entrega será avaliado
+        after_collection_message: A data de entrega para este projeto já passou.
         commit_after_collection_message: A data de entrega para este projeto já passou. Suas alterações foram registradas, mas não serão incluídas na classificação
         description: Não aceitar nenhuma entrega atrasada.
         form_description: Não aceitar nenhuma entrega atrasada
       penalty_decay_period_submission_rule:
-        after_collection_message: O número máximo de horas de penalização passou para este projeto. Quaisquer alterações serão gravadas, mas não classificados.
+        after_collection_message: O número máximo de horas de penalização passou para este projeto.
         commit_after_collection_message: A data de entrega para este projeto, além do número máximo de horas de penalização permitidos, já passou. Suas alterações foram registrados, mas não vai ser incluído na classificação.
         description: Você pode enviar até %{penalty_decay_period_limit} hora(s) após a data de entrega, mas terá a percentagem adequada deduzida do seu resultado final
         form_description: Usar fórmula de decaimento de penalidade
       penalty_period_submission_rule:
-        after_collection_message: O número maximo de penalidades foi atingido nesse projeto. Qualquer alteração sera salva, mas não avaliada.
+        after_collection_message: O número maximo de penalidades foi atingido nesse projeto.
         commit_after_collection_message: A data de entrega para esse projeto, mais o número maximo de penalidades no período, foram atingidos. Suas alterações foram salvas, mas não sera incluido na sua nota.
         description: Você pode submeter até %{penalty_period_limit} hora(s) depois do prazo, mas tera uma porcentagem deduzida do resultado final
         form_description: Usar fórmula de penalidade

--- a/config/locales/views/assignments/en.yml
+++ b/config/locales/views/assignments/en.yml
@@ -54,22 +54,22 @@ en:
       upload_confirmation: The starter files for this assignment have changed since you last downloaded them. Are you sure you want to continue?
       use_original_filename: Use original filename
     timed:
-      after_start_instructions_html: This assessment is due before <strong>%{due_date}</strong> without penalty.<br/><strong>(started %{start_time})</strong>.
-      before_start_instructions: Once this timed assessment has been started, you will have %{duration_string} to complete it without penalty.
-      before_start_instructions_extension: Once this timed assessment has been started, you will have %{duration_string} to complete it without penalty (this includes a duration extension of %{extension_string}).
-      before_start_time: This timed assessment is not available yet.
+      before_start_instructions: Once you start this timed assessment, you will have %{duration_string} to complete it without penalty.
+      before_start_instructions_extension: Once you start this timed assessment, you will have %{duration_string} to complete it without penalty (this includes a duration extension of %{extension_string}).
+      before_start_time: This timed assessment is not available to start yet.
+      details_heading: Start this assessment
       duration_extension_info: "(this includes a duration extension of %{extension_string})"
       end_time: Students may start this assessment before
       end_time_instructions: 'You must start this timed assessment before: '
       modal_current_duration: 'This will extend the current duration for this group. The current duration is: %{duration}.'
-      past_due_date: This timed assessment is now over.
-      past_end_time: This timed assessment is no longer available.
+      past_end_time: Unfortunately, you did not start this timed assessment within the allowed time window, and it is now over.
       start_button: Start
       start_confirmation: You are about to start a timed assessment. You cannot undo this action. Click OK to continue.
       start_end_time_instructions: You may start this timed assessment any time between %{start_time} and %{end_time}.
       start_time: Students may start this assessment after
       start_time_instructions: 'You may start this timed assessment after: '
       started_message_html: "<strong>You have started this assessment.</strong>"
+      started_on: 'You started on:'
       starter_file_prompt: Click below to download the starter files for this assessment.
       time_until_due_warning: This assessment is due before %{due_date} without penalty.
     upload_file_requirement: The list of uploaded files does not match the required files for this assignment.

--- a/config/locales/views/assignments/es.yml
+++ b/config/locales/views/assignments/es.yml
@@ -54,21 +54,21 @@ es:
       upload_confirmation: UPDATE ME
       use_original_filename: UPDATE ME
     timed:
-      after_start_instructions_html: UPDATE ME %{start_time} %{due_date}
       before_start_instructions: UPDATE ME %{duration_string}
       before_start_instructions_extension: UPDATE ME %{duration_string} %{extension_string}
       before_start_time: UPDATE ME
+      details_heading: UPDATE ME
       duration_extension_info: UPDATE ME %{extension_string}
       end_time: UPDATE ME
       end_time_instructions: UPDATE ME
       modal_current_duration: UPDATE ME
-      past_due_date: UPDATE ME
       past_end_time: UPDATE ME
       start_button: UPDATE ME
       start_confirmation: UPDATE ME
       start_end_time_instructions: UPDATE ME
       start_time_instructions: UPDATE ME
       started_message_html: UPDATE ME
+      started_on: UPDATE ME
       starter_file_prompt: UPDATE ME
       time_until_due_warning: UPDATE ME %{due_date}
     upload_file_requirement: La lista de archivos entregados no coincide con los archivos necesarios para este proyecto.

--- a/config/locales/views/assignments/fr.yml
+++ b/config/locales/views/assignments/fr.yml
@@ -54,21 +54,21 @@ fr:
       upload_confirmation: UPDATE ME
       use_original_filename: UPDATE ME
     timed:
-      after_start_instructions_html: UPDATE ME %{start_time} %{due_date}
       before_start_instructions: UPDATE ME %{duration_string}
       before_start_instructions_extension: UPDATE ME %{duration_string} %{extension_string}
       before_start_time: UPDATE ME
+      details_heading: UPDATE ME
       duration_extension_info: UPDATE ME %{extension_string}
       end_time: Heure de fin
       end_time_instructions: UPDATE ME
       modal_current_duration: UPDATE ME
-      past_due_date: UPDATE ME
       past_end_time: UPDATE ME
       start_button: UPDATE ME
       start_confirmation: UPDATE ME
       start_end_time_instructions: UPDATE ME
       start_time_instructions: UPDATE ME
       started_message_html: UPDATE ME
+      started_on: UPDATE ME
       starter_file_prompt: UPDATE ME
       time_until_due_warning: UPDATE ME %{due_date}
     upload_file_requirement: La liste des fichiers téléchargés ne correspond pas aux fichiers d'affectation nécessaire

--- a/config/locales/views/assignments/pt.yml
+++ b/config/locales/views/assignments/pt.yml
@@ -54,21 +54,21 @@ pt:
       upload_confirmation: UPDATE ME
       use_original_filename: UPDATE ME
     timed:
-      after_start_instructions_html: UPDATE ME %{start_time} %{due_date}
       before_start_instructions: UPDATE ME %{duration_string}
       before_start_instructions_extension: UPDATE ME %{duration_string} %{extension_string}
       before_start_time: UPDATE ME
+      details_heading: UPDATE ME
       duration_extension_info: UPDATE ME %{extension_string}
       end_time: UPDATE ME
       end_time_instructions: UPDATE ME
       modal_current_duration: UPDATE ME
-      past_due_date: UPDATE ME
       past_end_time: UPDATE ME
       start_button: UPDATE ME
       start_confirmation: UPDATE ME
       start_end_time_instructions: UPDATE ME
       start_time_instructions: UPDATE ME
       started_message_html: UPDATE ME
+      started_on: UPDATE ME
       starter_file_prompt: UPDATE ME
       time_until_due_warning: UPDATE ME %{due_date}
     upload_file_requirement: A lista de arquivos carregados não coincide com os arquivos de atribuição necessária

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -39,6 +39,7 @@ en:
 
       Are you sure you want to proceed?
     no_files_available: No files available
+    past_collection_time: Any changes you make to your submitted files will be recorded, but not graded.
     release_marks: Release Marks
     repo_browser:
       client_time: 'commit:'

--- a/config/locales/views/submissions/es.yml
+++ b/config/locales/views/submissions/es.yml
@@ -38,6 +38,7 @@ es:
 
       ¿Está seguro/a de querer proceder?
     no_files_available: No existen archivos disponibles
+    past_collection_time: Cualquier cambio realizado será guardado pero no calificado.
     release_marks: Publicar Notas
     repo_browser:
       client_time: 'commit:'

--- a/config/locales/views/submissions/fr.yml
+++ b/config/locales/views/submissions/fr.yml
@@ -33,6 +33,7 @@ fr:
 
       Êtes-vous sûr de vouloir continuer?
     no_files_available: Aucun fichier disponible
+    past_collection_time: Tout changement sera enregistré mais non évalué.
     release_marks: Montrer les notes
     repo_browser:
       client_time: 'commit:'

--- a/config/locales/views/submissions/pt.yml
+++ b/config/locales/views/submissions/pt.yml
@@ -37,6 +37,7 @@ pt:
 
       Tem certeza que deseja continuar?
     no_files_available: Nenhum arquivo disponível
+    past_collection_time: Quaisquer alterações serão gravadas, mas não classificados.
     release_marks: Mostrar notas
     repo_browser:
       client_time: 'commit:'

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -71,22 +71,22 @@ describe AssignmentsController do
         end
         context 'when the group_max is > 1' do
           let(:assignment) { create :timed_assignment, assignment_properties_attributes: { group_max: 2 } }
-          it 'should respond with 400' do
-            expect(response).to have_http_status 400
+          it 'should respond with 403' do
+            expect(response).to have_http_status 403
           end
         end
       end
     end
     context 'as an admin' do
       let(:user) { create :admin }
-      it 'should respond with 400' do
+      it 'should respond with 403' do
         put_as user, :start_timed_assignment, params: { id: assignment.id }
         expect(response).to have_http_status 403
       end
     end
     context 'as an grader' do
       let(:user) { create :ta }
-      it 'should respond with 400' do
+      it 'should respond with 403' do
         put_as user, :start_timed_assignment, params: { id: assignment.id }
         expect(response).to have_http_status 403
       end

--- a/spec/factories/groupings.rb
+++ b/spec/factories/groupings.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :grouping do
     association :group
     association :assignment
+    start_time { nil }
 
     factory :grouping_with_inviter do
       transient do

--- a/spec/models/submission_rule_spec.rb
+++ b/spec/models/submission_rule_spec.rb
@@ -10,12 +10,6 @@ shared_examples 'due_date_calculations' do |assignment_past, section_past, secti
     section_due_date_str = assignment_due_date_str
   end
 
-  context '#can_collect_now?(section)' do
-    it "should return #{section_past}" do
-      expect(assignment.submission_rule.can_collect_now?(section)).to eq(section_past)
-    end
-  end
-
   context '#can_collect_all_now?' do
     it "should return #{assignment_past && section_past}" do
       expect(assignment.submission_rule.can_collect_all_now?).to eq(assignment_past && section_past)

--- a/spec/policies/assignment_policy_spec.rb
+++ b/spec/policies/assignment_policy_spec.rb
@@ -214,4 +214,52 @@ describe AssignmentPolicy do
       let(:user) { create(:student) }
     end
   end
+
+  describe_rule :start_timed_assignment? do
+    let(:user) { create :student }
+    let(:due_date) { 2.hours.from_now }
+    let(:start_time) { 2.hours.ago }
+    let(:assignment) do
+      create :timed_assignment,
+             due_date: due_date,
+             assignment_properties_attributes: { start_time: start_time }
+    end
+
+    context 'when the student is not in a group yet' do
+      failed 'when before the start time' do
+        let(:start_time) { 1.hour.from_now }
+      end
+      succeed 'when between the start and end time'
+      failed 'when between the start and end time, but the student must work in a group' do
+        before { assignment.assignment_properties.update(group_max: 2) }
+      end
+      failed 'when after the end time' do
+        let(:due_date) { 1.hour.ago }
+      end
+      failed 'when after the end time but within a penalty period' do
+        let(:due_date) { 1.hour.ago }
+        before do
+          rule = create :penalty_period_submission_rule, assignment: assignment
+          create :period, hours: 2, submission_rule: rule
+        end
+      end
+    end
+    context 'when the student is in a group' do
+      let(:grouping_start_time) { nil }
+      let!(:grouping) do
+        create :grouping_with_inviter, inviter: user, assignment: assignment, start_time: grouping_start_time
+      end
+
+      failed 'when before the start time' do
+        let(:start_time) { 1.hour.from_now }
+      end
+      succeed 'when between the start and end time and the group has not started'
+      failed 'when between the start and end time and the group has already started' do
+        let(:grouping_start_time) { Time.current }
+      end
+      failed 'when after the end time' do
+        let(:due_date) { 1.hour.ago }
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want to improve the messaging for timed assessments to make it clearer to students when they can start the assessment, and when it's over (and they can no longer submit files for grading).

This PR fixes #5177 and fixes #5187.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

1. Display flash message on assessment page when the last possible time to start the assessment has passed.
2. Always show the button to start the timed assessment, but keep it disabled when the student can't start the assessment (making it more obvious they cannot start it).
3. Update the `AssignmentPolicy#start_timed_assignment?` policy to be more restrictive.
4. Update the flash messages on the `submissions/file_manager` student view to indicate when the start window has passed, when in the late period, or when the final due date has passed.

![image](https://user-images.githubusercontent.com/3333115/127248329-b2beb74f-20fa-49b8-a37f-512b9ad94437.png)


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Refactoring (internal change to codebase, without changing functionality)
- [x] Other (please specify): UI updates


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Checked the UI on various stages of the timed assessment: before the window, during the window but before starting, after starting but before the due date, after the due date, and after the window without having started at all.

Checked that the `start_timed_assessment` route responds with a 403 when the student attempts to start the timed assessment outside of the window (by manually enabling the "Start" button).

Added additional tests for the policy change.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

Removed newly-unused `SubmissionRule#can_collect_now?` method. There might be other unused code in that section we can remove in the future.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
