### PR TITLE
Remove starter file timestamp

### DIFF
--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -464,12 +464,6 @@ class Grouping < ApplicationRecord
     self.update!(starter_file_changed: false)
   end
 
-  def changed_starter_file_at?(revision)
-    revision.tree_at_path(assignment.repository_folder, with_attrs: true).values.any? do |obj|
-      self.starter_file_timestamp.nil? || self.starter_file_timestamp < obj.last_modified_date
-    end
-  end
-
   # Returns a list of missing assignment (required) files.
   # A repo revision can be passed directly if the caller already opened the repo.
   def missing_assignment_files(revision = nil)
@@ -766,7 +760,6 @@ class Grouping < ApplicationRecord
         unless group_repo.commit(txn)
           raise I18n.t('repo.assignment_dir_creation_error', short_identifier: assignment.short_identifier)
         end
-        self.update!(starter_file_timestamp: group_repo.get_latest_revision.server_timestamp)
       end
     end
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -66,8 +66,6 @@ class Submission < ApplicationRecord
           # populate the submission with no files instead of raising an exception
           raise ActiveRecord::Rollback
         end
-        # if starter files exist, check if the student did not change the starter files
-        new_submission.is_empty = !grouping.changed_starter_file_at?(revision)
       end
       new_submission.save!
       new_submission

--- a/db/migrate/20210730132238_remove_grouping_starter_file_timestamp.rb
+++ b/db/migrate/20210730132238_remove_grouping_starter_file_timestamp.rb
@@ -1,0 +1,5 @@
+class RemoveGroupingStarterFileTimestamp < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :groupings, :starter_file_timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_201409) do
+ActiveRecord::Schema.define(version: 2021_07_30_132238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -278,7 +278,6 @@ ActiveRecord::Schema.define(version: 2021_06_17_201409) do
     t.integer "test_tokens", default: 0, null: false
     t.bigint "assessment_id", null: false
     t.datetime "start_time"
-    t.datetime "starter_file_timestamp"
     t.boolean "starter_file_changed", default: false, null: false
     t.index ["assessment_id", "group_id"], name: "groupings_u1", unique: true
   end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -1425,19 +1425,6 @@ describe Grouping do
       expect(grouping.reload.starter_file_entries.pluck(:path)).to contain_exactly('q2.txt', 'q1')
     end
   end
-  describe '#changed_starter_file_at?' do
-    let(:grouping) { create :grouping }
-    it 'should return false if no changes have been made' do
-      revision = grouping.group.access_repo(&:get_latest_revision)
-      expect(grouping.changed_starter_file_at?(revision)).to be false
-    end
-    it 'should return true if changes have been made' do
-      submit_time = 10.seconds.from_now
-      submit_file_at_time(grouping.assignment, grouping.group, 'test', submit_time.to_s, 'my_file', 'Hello, World!')
-      revision = grouping.group.access_repo(&:get_latest_revision)
-      expect(grouping.changed_starter_file_at?(revision)).to be true
-    end
-  end
   describe '#access_repo' do
     let(:grouping) { create :grouping }
     it 'should make sure the assignment folder exists' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Starter file timestamps were used to help determine if files had been added after the starter files were sent to the repo. BUT, we are not sending starter files to the repo anymore, any changes made to the repo must be made by the student (or other user). Because of this, we can just check if there are any files in the repo instead of comparing their commit time to a timestamp.

This is also the simplest way to resolve a bug that was caused by setting the submissions.is_empty column value incorrectly when an assignment did not have any starter files. 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- remove groupings.starter_file_timestamp column and all uses

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

- removed unused tests

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Required documentation changes (if applicable)
