### PR TITLE
Fix flaky tests that fail when run first

### DIFF
--- a/spec/controllers/api/assignments_controller_spec.rb
+++ b/spec/controllers/api/assignments_controller_spec.rb
@@ -144,7 +144,7 @@ describe Api::AssignmentsController do
       end
       context 'requesting a non-existant assignment' do
         it 'should respond with 404' do
-          get :show, params: { id: 9999 }
+          get :show, params: { id: -1 }
           expect(response.status).to eq(404)
         end
       end
@@ -254,7 +254,7 @@ describe Api::AssignmentsController do
       end
       it 'should not update an assignment that does not exist' do
         new_desc = assignment.description + 'more!'
-        put :update, params: { id: 1, description: new_desc }
+        put :update, params: { id: -1, description: new_desc }
         expect(response.status).to eq(404)
       end
     end
@@ -300,7 +300,7 @@ describe Api::AssignmentsController do
         it('should be successful') { expect(response.status).to eq 200 }
       end
       it 'should fail if the assignment does not exist' do
-        get :test_specs, params: { id: 1 }
+        get :test_specs, params: { id: -1 }
         expect(response.status).to eq 404
       end
     end
@@ -342,7 +342,7 @@ describe Api::AssignmentsController do
         it('should not be successful') { expect(response.status).to eq 422 }
       end
       it 'should fail if the assignment does not exist' do
-        post :update_test_specs, params: { id: 1, specs: '123' }
+        post :update_test_specs, params: { id: -1, specs: '123' }
         expect(response.status).to eq 404
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These tests fail occasionally when run first (assignment.id==1). This changes the test to ensure that no object can possibly exist with the given id (no negative ids). 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- make ids negative (where id no object should be found)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Test update (change that modifies or updates tests only)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Required documentation changes (if applicable)
