### PR TITLE
Make sure downloadable test specs file is portable between assignments and instances

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Ensure that downloadable test specs file is portable between assignments and instances (#5469)
 
 ## [v1.13.0]
 - Modify Result.get_total_extra_marks to differentiate between having extra marks that sum to zero and

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -41,42 +41,42 @@ module AutomatedTestsHelper
     criteria_map = assignment.ta_criteria.pluck(:type, :name, :id).map do |type, name, id_|
       ["#{type}:#{name}", id_]
     end.to_h
-    test_specs['testers']&.each do |tester_specs|
-      next if tester_specs['test_data'].nil?
-
-      tester_specs['test_data']&.each do |test_group_specs|
-        test_group_specs['extra_info'] ||= {}
-        extra_data_specs = test_group_specs['extra_info']
-        test_group_id = extra_data_specs['test_group_id']
-        display_output = extra_data_specs['display_output'] || TestGroup.display_outputs.keys.first
-        test_group_name = extra_data_specs['name'] || TestGroup.model_name.human
-        criterion_id = nil
-        unless extra_data_specs['criterion'].nil?
-          criterion_id = criteria_map[extra_data_specs['criterion']]
-          if criterion_id.nil?
-            type, name = extra_data_specs['criterion'].split(':')
-            flash_message(:warning, I18n.t('automated_tests.no_criteria', type: type, name: name))
+    ApplicationRecord.transaction do
+      test_specs['testers']&.each do |tester_specs|
+        tester_specs['test_data']&.each do |test_group_specs|
+          test_group_specs['extra_info'] ||= {}
+          extra_data_specs = test_group_specs['extra_info']
+          test_group_id = extra_data_specs['test_group_id']
+          display_output = extra_data_specs['display_output'] || TestGroup.display_outputs.keys.first
+          test_group_name = extra_data_specs['name'] || TestGroup.model_name.human
+          criterion_id = nil
+          unless extra_data_specs['criterion'].nil?
+            criterion_id = criteria_map[extra_data_specs['criterion']]
+            if criterion_id.nil?
+              type, name = extra_data_specs['criterion'].split(':')
+              flash_message(:warning, I18n.t('automated_tests.no_criteria', type: type, name: name))
+            end
           end
+          fields = { assignment: assignment, name: test_group_name, display_output: display_output,
+                     criterion_id: criterion_id }
+          if test_group_id.nil?
+            test_group = TestGroup.create!(fields)
+            test_group_id = test_group.id
+            extra_data_specs['test_group_id'] = test_group_id # update specs to contain new id
+          else
+            test_group = TestGroup.find(test_group_id)
+            test_group.update!(fields)
+          end
+          test_group_ids << test_group_id
         end
-        fields = { assignment: assignment, name: test_group_name, display_output: display_output,
-                   criterion_id: criterion_id }
-        if test_group_id.nil?
-          test_group = TestGroup.create!(fields)
-          test_group_id = test_group.id
-          extra_data_specs['test_group_id'] = test_group_id # update specs to contain new id
-        else
-          test_group = TestGroup.find(test_group_id)
-          test_group.update!(fields)
-        end
-        test_group_ids << test_group_id
       end
+      # delete test groups that are not in the autotest specs
+      deleted_test_groups = TestGroup.where(assignment: assignment)
+      unless test_group_ids.empty?
+        deleted_test_groups = deleted_test_groups.where.not(id: test_group_ids)
+      end
+      deleted_test_groups.delete_all
     end
-    # delete test groups that are not in the autotest specs
-    deleted_test_groups = TestGroup.where(assignment: assignment)
-    unless test_group_ids.empty?
-      deleted_test_groups = deleted_test_groups.where.not(id: test_group_ids)
-    end
-    deleted_test_groups.delete_all
   ensure
     # save modified specs
     File.open(test_specs_path, 'w') { |f| f.write test_specs.to_json }

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -53,6 +53,10 @@ module AutomatedTestsHelper
         criterion_id = nil
         unless extra_data_specs['criterion'].nil?
           criterion_id = criteria_map[extra_data_specs['criterion']]
+          if criterion_id.nil?
+            type, name = extra_data_specs['criterion'].split(':')
+            flash_message(:warning, I18n.t('automated_tests.no_criteria', type: type, name: name))
+          end
         end
         fields = { assignment: assignment, name: test_group_name, display_output: display_output,
                    criterion_id: criterion_id }

--- a/config/locales/views/automated_tests/en.yml
+++ b/config/locales/views/automated_tests/en.yml
@@ -12,6 +12,7 @@ en:
     need_group_for_test: You must have a group to run tests.
     need_one_file: You must submit at least one file in order to run tests.
     need_submission: Submissions must be collected before tests are run. Not all selected groupings had tests run.
+    no_criteria: Unable to find a criterion of type "%{type}" and name "%{name}".
     no_results: No test results to display
     results:
       extra_malformed: "Malformed results discarded by server: \n%{extra}\n"

--- a/config/locales/views/automated_tests/es.yml
+++ b/config/locales/views/automated_tests/es.yml
@@ -12,6 +12,7 @@ es:
     need_group_for_test: Usted debe tener un grupo para lanzar la prueba
     need_one_file: Usted necesita al menos un archivo en la entrega para poder ejecutar las pruebas.
     need_submission: Las entregas deben ser recolectadas antes de ejecutar las pruebas. No todas las agrupaciones seleccionadas tuvieron sus pruebas respectivas ejecutadas.
+    no_criteria: UPDATE ME "%{type}" "%{name}".
     no_results: UPDATE ME
     results:
       extra_malformed: "UPDATE ME \n%{extra}\n"

--- a/config/locales/views/automated_tests/fr.yml
+++ b/config/locales/views/automated_tests/fr.yml
@@ -12,6 +12,7 @@ fr:
     need_group_for_test: UPDATE ME
     need_one_file: Vous devez avoir au moins un fichier envoyé pour exécuter un test.
     need_submission: Les soumissions doivent être recueillies avant que les tests sont exécutés. Tous les tests n'ont pas été exécuté.
+    no_criteria: UPDATE ME "%{type}" "%{name}".
     no_results: Aucun résultats
     results:
       extra_malformed: "Resultats mal formés: \n%{extra}\n"

--- a/config/locales/views/automated_tests/pt.yml
+++ b/config/locales/views/automated_tests/pt.yml
@@ -12,6 +12,7 @@ pt:
     need_group_for_test: Você precisa possuir um grupo para executar os testes.
     need_one_file: Você precisa de pelo menos um arquivo enviado para executar os testes.
     need_submission: As inscrições devem ser recolhidos antes dos testes são executados. Nem todos os agrupamentos seleccionados tiveram testes executados.
+    no_criteria: UPDATE ME "%{type}" "%{name}".
     no_results: UPDATE ME
     results:
       extra_malformed: "UPDATE ME \n%{extra}\n"

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -203,6 +203,12 @@ describe AutomatedTestsController do
         it 'should respond with a success' do
           expect(response.status).to eq 200
         end
+        context "when there is a test_group_id specified" do
+          let(:content) { { testers: [{ test_data: [{ extra_info:{ test_group_id:10 } }] }] }.to_json }
+          it 'should remove the test_group_id' do
+            expect(JSON.parse(response.body)['testers'].first['test_data'].first['extra_info']).to eq({})
+          end
+        end
       end
       context 'when the file does not exist' do
         before :each do
@@ -229,7 +235,7 @@ describe AutomatedTestsController do
       context 'a valid json file' do
         let(:file) { fixture_file_upload 'automated_tests/valid_json.json' }
         it 'should upload the file content' do
-          expect(File.read(assignment.autotest_settings_file)).to eq file.read
+          expect(File.read(assignment.autotest_settings_file)).to eq file.read.strip
         end
         it 'should return a success http status' do
           expect(response.status).to eq 200

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -203,8 +203,8 @@ describe AutomatedTestsController do
         it 'should respond with a success' do
           expect(response.status).to eq 200
         end
-        context "when there is a test_group_id specified" do
-          let(:content) { { testers: [{ test_data: [{ extra_info:{ test_group_id:10 } }] }] }.to_json }
+        context 'when there is a test_group_id specified' do
+          let(:content) { { testers: [{ test_data: [{ extra_info: { test_group_id: 10 } }] }] }.to_json }
           it 'should remove the test_group_id' do
             expect(JSON.parse(response.body)['testers'].first['test_data'].first['extra_info']).to eq({})
           end

--- a/spec/helpers/automated_tests_helper_spec.rb
+++ b/spec/helpers/automated_tests_helper_spec.rb
@@ -1,0 +1,55 @@
+describe AutomatedTestsHelper do
+  include ApplicationHelper
+  describe '.update_test_groups_from_specs' do
+    let(:assignment) { create :assignment }
+    let(:test_group) { build :test_group, assignment: assignment }
+    let(:criterion) { build :flexible_criterion, assignment: assignment }
+    let(:criterion_key) { "#{criterion.type}:#{criterion.name}" }
+    let(:specs) do
+      { 'testers' =>  [
+          {
+              'test_data' => [{
+                                  'extra_info' => {
+                                      'test_group_id' => test_group.id,
+                                      'criterion' => criterion_key
+                                  }
+                              }]
+          }]
+      }
+    end
+    subject { update_test_groups_from_specs assignment, specs }
+    before { allow(AutomatedTestsHelper).to receive(:flash_message) }
+    context 'when the test group exists' do
+      before { test_group.save }
+      it 'should not create a new test group' do
+        expect { subject }.not_to change { TestGroup.count }
+      end
+      it 'should use the test group id' do
+        subject
+        expect(specs['testers'][0]['test_data'][0]['extra_info']['test_group_id']).to eq test_group.id
+      end
+    end
+    context 'when the test group does not exist' do
+      it 'should create a new test group' do
+        expect { subject }.to change { TestGroup.count }.from(0).to(1)
+      end
+      it 'should use the newly created test group' do
+        subject
+        expect(specs['testers'][0]['test_data'][0]['extra_info']['test_group_id']).to eq TestGroup.first.id
+      end
+    end
+    context 'when the criterion exists' do
+      before { criterion.save }
+      it 'should use the criterion' do
+        subject
+        expect(TestGroup.first.criterion).to eq criterion
+      end
+    end
+    context 'when the criterion does not exist' do
+      before { subject }
+      it 'should not set the criterion on the test group' do
+        expect(TestGroup.first.criterion).to be_nil
+      end
+    end
+  end
+end

--- a/spec/helpers/automated_tests_helper_spec.rb
+++ b/spec/helpers/automated_tests_helper_spec.rb
@@ -6,23 +6,23 @@ describe AutomatedTestsHelper do
     let(:criterion) { build :flexible_criterion, assignment: assignment }
     let(:criterion_key) { "#{criterion.type}:#{criterion.name}" }
     let(:specs) do
-      { 'testers' =>  [
-          {
-              'test_data' => [{
-                                  'extra_info' => {
-                                      'test_group_id' => test_group.id,
-                                      'criterion' => criterion_key
-                                  }
-                              }]
+      { 'testers' => [
+        {
+          'test_data' => [{
+            'extra_info' => {
+              'test_group_id' => test_group.id,
+              'criterion' => criterion_key
+            }
           }]
-      }
+        }
+      ] }
     end
     subject { update_test_groups_from_specs assignment, specs }
     before { allow(AutomatedTestsHelper).to receive(:flash_message) }
     context 'when the test group exists' do
       before { test_group.save }
       it 'should not create a new test group' do
-        expect { subject }.not_to change { TestGroup.count }
+        expect { subject }.not_to(change { TestGroup.count })
       end
       it 'should use the test group id' do
         subject


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Test spec files could be downloaded but contained unique ids for criteria and test groups that only made sense in the context of the assignment that they were downloaded from. This meant that these files could not be used to (easily) move test settings between assignments.

This PR removes/replaces those ids so that these spec files can be used to move settings in this way. 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- spec file now identifies criteria based on type and name (instead of id)
- test group ids are not downloaded as part of the spec file (new test groups will be created when re-uploaded)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
