### PR TITLE
criteria: Support Markdown in descriptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Support rendering of Markdown in criterion descriptions (#5500)
 
 ## [v1.13.0]
 - Modify Result.get_total_extra_marks to differentiate between having extra marks that sum to zero and

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -209,7 +209,10 @@ class CheckboxCriterionInput extends React.Component {
               this.props.oldMark
             })`}</div>
           )}
-          <div className="criterion-description">{this.props.description}</div>
+          <div
+            className="criterion-description"
+            dangerouslySetInnerHTML={{__html: safe_marked(this.props.description)}}
+          />
         </div>
       </li>
     );
@@ -369,7 +372,10 @@ class FlexibleCriterionInput extends React.Component {
             {this.props.bonus && ` (${I18n.t("activerecord.attributes.criterion.bonus")})`}
             {this.deleteManualMarkLink()}
           </div>
-          <div className="criterion-description">{this.props.description}</div>
+          <div
+            className="criterion-description"
+            dangerouslySetInnerHTML={{__html: safe_marked(this.props.description)}}
+          />
           <span className="mark">
             {markElement}
             &nbsp;/&nbsp;
@@ -424,8 +430,8 @@ class RubricCriterionInput extends React.Component {
         className={`rubric-level ${selectedClass} ${oldMarkClass}`}
       >
         <td className="level-description">
-          <strong>{level.name}</strong>&nbsp;
-          {level.description}
+          <strong>{level.name}</strong>
+          <span dangerouslySetInnerHTML={{__html: safe_marked(level.description)}} />
         </td>
         <td className={"mark"}>
           {levelMark}

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -55,7 +55,7 @@
   padding: 0;
   width: 100%;
 
-  li {
+  > li {
     border-bottom: 1px solid $background-support;
     display: inline-block;
     padding: 5px;

--- a/app/views/checkbox_criteria/_criterion_editor.html.erb
+++ b/app/views/checkbox_criteria/_criterion_editor.html.erb
@@ -60,6 +60,6 @@
 <% unless criterion.description.blank? %>
   <h3><%= t(:preview) %></h3>
   <div>
-    <%= sanitize(criterion.description) %>
+    <%= markdown(criterion.description) %>
   </div>
 <% end %>

--- a/app/views/flexible_criteria/_criterion_editor.html.erb
+++ b/app/views/flexible_criteria/_criterion_editor.html.erb
@@ -57,6 +57,6 @@
 <% unless criterion.description.blank? %>
   <h3><%= t(:preview) %></h3>
   <div>
-    <%= sanitize(criterion.description) %>
+    <%= markdown(criterion.description) %>
   </div>
 <% end %>

--- a/config/locales/views/criteria/en.yml
+++ b/config/locales/views/criteria/en.yml
@@ -5,7 +5,7 @@ en:
     answer_yes: 'Yes'
   criteria:
     checkbox: Checkbox
-    description_hint: You may use simple HTML tags in this field. Save changes to see a preview.
+    description_hint: You may use Markdown in this field. Save changes to see a preview.
     editing_criteria: Editing criteria
     errors:
       invalid_format: 'The following criteria had invalid format:'

--- a/config/locales/views/criteria/es.yml
+++ b/config/locales/views/criteria/es.yml
@@ -5,7 +5,7 @@ es:
     answer_yes: Sí
   criteria:
     checkbox: Caja de Selección
-    description_hint: Usted puede usar etiquetas HTML simples en este campo. Guarde los cambios para ver una vista preliminar.
+    description_hint: Usted puede usar Markdown en este campo. Guarde los cambios para ver una vista preliminar.
     editing_criteria: Editando los criterios de calificación
     errors:
       invalid_format: 'Los siguientes criterios de calificación tenían un formato inválido:'

--- a/config/locales/views/criteria/fr.yml
+++ b/config/locales/views/criteria/fr.yml
@@ -5,7 +5,7 @@ fr:
     answer_yes: Oui
   criteria:
     checkbox: Checkbox
-    description_hint: Vous avez la possibilité d'utiliser des tags HTML simples dans ce champ. Pour un aperçu, sauvegardez.
+    description_hint: Vous avez la possibilité d'utiliser Markdown dans ce champ. Pour un aperçu, sauvegardez.
     editing_criteria: Édition des critères
     errors:
       invalid_format: 'Les critères suivants a un format non valide:'

--- a/config/locales/views/criteria/pt.yml
+++ b/config/locales/views/criteria/pt.yml
@@ -5,7 +5,7 @@ pt:
     answer_yes: Sim
   criteria:
     checkbox: Caixa de seleção
-    description_hint: Você pode usar tags simples de HTML no campo. Salve as alterações para vizualizar.
+    description_hint: Você pode usar Markdown no campo. Salve as alterações para vizualizar.
     editing_criteria: Editando critério
     errors:
       invalid_format: 'Os seguintes critérios deveriam formato inválido:'


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #5495 (simple HTML tags were not rendering in grading view, despite message in UI saying they were supported).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: I've modified the front end so that criterion and level descriptions support Markdown syntax (which is the syntax we've adopted for annotations and assessment descriptions). Changed the criterion UI to say that we support Markdown, but not simple HTML tags.

*Comment*: the Javascript library `marked` we're using for Markdown rendering also supports simple HTML tags, but the Ruby Markdown renderer doesn't, with the options we're setting. So it's possible for an instructor to input HTML tags for a criterion description and have them render properly in the grading view, but not in the "Preview" for the criterion. But we should discourage use of HTML tags and encourage people to just use Markdown.

Updated screenshots based on the issue:

![image](https://user-images.githubusercontent.com/3333115/133545627-c8e5e0f0-f737-4e61-85d1-6d880873aebb.png)

![image](https://user-images.githubusercontent.com/3333115/133545688-a5ab835d-191c-4245-b32d-1103c57f83bf.png)


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI for all three criterion types.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)

Modify criterion documentation to say that the descriptions support Markdown syntax.