### PR TITLE
results: Enable word wrapping for test name table cell

### DIFF
--- a/app/assets/javascripts/Components/test_run_table.jsx
+++ b/app/assets/javascripts/Components/test_run_table.jsx
@@ -301,7 +301,7 @@ class TestGroupResultTable extends React.Component {
           pivotBy={["test_group_name"]}
           getTdProps={(state, rowInfo) => {
             if (rowInfo) {
-              let className = `test-result-${rowInfo.row["test_status"]}`;
+              let className = `-wrap test-result-${rowInfo.row["test_status"]}`;
               if (
                 !rowInfo.aggregated &&
                 (!this.state.show_output || !rowInfo.original["test_results.output"])

--- a/app/assets/stylesheets/common/core.scss
+++ b/app/assets/stylesheets/common/core.scss
@@ -354,6 +354,11 @@ th.required::after {
     padding-right: 22px;
   }
 
+  .rt-td.-wrap,
+  .rt-th.-wrap {
+    white-space: initial;
+  }
+
   &.auto-overflow {
     .rt-thead,
     .rt-tbody {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

react-table does not allow line wrapping in table cells, instead hiding overflow using ellipses. Normally this is fine, but with test results the "Test Name" field can be fairly long, at least in the Python tester where the test name is concatenated with the docstring of the test. This means that these test descriptions are truncated, which isn't helpful when viewing the results.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added a new `-wrap` react-table cell class to enable line wrapping, and applied it to the "Test Name" test result table cell.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): UI change

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI with a long test name:

![image](https://user-images.githubusercontent.com/3333115/134103618-5a02631e-294c-4546-96d7-53fdd1a9ac74.png)

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
