### PR TITLE
seed: Remove old autotest api key file when creating new TestServer user

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -26,7 +26,11 @@ namespace :db do
   desc 'Add a local TestServer account'
   # this task depends on :environment and :seed
   task(:test_servers => :environment) do
-    puts 'Populate database with TestServers'
+    puts 'Populate database with TestServer user'
+
+    # Remove old autotest API key file
+    FileUtils.rm_f(AutomatedTestsHelper::AutotestApi::AUTOTEST_KEY_FILE)
+
     [[Settings.autotest.server_host, 'Test', 'Server1']]
         .each do |server|
       TestServer.create(user_name: server[0], first_name: server[1], last_name: server[2], hidden: true)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When running the `markus:setup_autotest` rails task, if the autotest API key file is present (`AutomatedTestsHelper::AutotestApi::AUTOTEST_KEY_FILE`), the task resets credentials, assuming the test server user's API key is the same. But if we reset the database (`rails db:reset`), the test server user is recreated, and its API key is reset. This results in an authorization failure when making the `reset_credentials` request to the autotest client.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Delete the saved autotest API key file when resetting the `TestServer` user.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran `rails db:setup_autotest`, then `rails db:reset`, and then `rails db:setup_autotest` again, and ensured the final task succeeds without getting an authorization failure.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
