### PR TITLE
csp: Add 'nonce: true' option to js files for AutomatedTestsController#student_interface

### DIFF
--- a/app/views/automated_tests/student_interface.html.erb
+++ b/app/views/automated_tests/student_interface.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, t('automated_tests.title') %>
 <%= stylesheet_link_tag 'result_main' %>
 <%= stylesheet_pack_tag 'result' %>
-<%= javascript_include_tag 'mathjax' %>
-<%= javascript_pack_tag 'result' %>
-<%= javascript_include_tag 'Results/main' %>
+<%= javascript_include_tag 'mathjax', nonce: true %>
+<%= javascript_pack_tag 'result', nonce: true %>
+<%= javascript_include_tag 'Results/main', nonce: true %>
 
 <% if @assignment.enable_student_tests && !@grouping.nil? %>
   <p>


### PR DESCRIPTION
…r#student_interface

<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Enabling content security policies (#5186) requires using the `nonce: true` option for all Javascript files to be loaded. These were missing in the `AutomatedTestsController#student_interface` view when new includes were added in #5209, causing the page to not load feedback files properly.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added the `nonce: true` option to the Javascript includes.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ensured that feedback files load properly for student-run tests in the `student_interface` view.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
