### PR TITLE
criteria: Change level mark input step from 0.1 to 0.01

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@
 - Display multiple feedback files returned by the autotester (#5524)
 - Add workaround for CSP rules in Safari (#5526)
 - Display smaller error message when nbconvert fails to avoid a cookie overflow (#5510)
+- Change level mark input field to accept change increments of 0.01 (#5546)
+
 
 ## [v1.13.2]
 - Ensure "Create all groups" button uses existing repos if they already exist (#5504)

--- a/app/views/rubric_criteria/_rubric_criterion_level.html.erb
+++ b/app/views/rubric_criteria/_rubric_criterion_level.html.erb
@@ -15,7 +15,7 @@
     <%= level_form.label :name, Level.human_attribute_name(:name), class: 'required' %>
     <%= level_form.text_field :name, required: true %>
     <%= level_form.label :mark, class: 'required' %>
-    <%= level_form.number_field :mark, step: 0.1, required: true %>
+    <%= level_form.number_field :mark, step: 0.01, required: true %>
     <%= level_form.label :description, Level.human_attribute_name(:description),
                          class: 'description' %>
     <%= level_form.text_area :description, cols: 50, rows: 5 %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, each rubric criterion level's mark number field has a `step`  attribute of `0.1`. This prevents users from setting mark values of up to two decimal places (e.g., `1.25`), or changing an uploaded level mark with two decimal places to a mark with 1 or 0 decimal places.

Fixes #5521.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Changed the `step` attribute of this field to `0.01`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually in the UI that we can switch level marks between values of 0, 1, and 2 decimal places.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [x] I have described any required documentation changes below. <!-- (delete this checklist item if not applicable) -->


### Required documentation changes (if applicable)

Document that level marks can be specified up to two decimal places.