### PR TITLE
Remove inline javascript in scanned exam view

### DIFF
--- a/app/views/exam_templates/_student_info.html.erb
+++ b/app/views/exam_templates/_student_info.html.erb
@@ -1,10 +1,19 @@
+<%= content_for :head do %>
+  <%= javascript_tag nonce: true do %>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.getElementById('automatic_parsing').addEventListener('change', () => {
+        toggle_cover_page(<%= exam_template.id %>, <%= exam_template.cover_fields.split(',') %>);
+      })
+    })
+  <% end %>
+<% end %>
+
 <%= form_for [@assignment, exam_template],
              url: add_fields_assignment_exam_template_path(id: exam_template.id) do |f| %>
 
   <p>
     <%= check_box_tag :automatic_parsing, true,
-                      exam_template.automatic_parsing,
-                      onchange: "toggle_cover_page(#{exam_template.id}, #{exam_template.cover_fields.split(',')}); return true;" %>
+                      exam_template.automatic_parsing %>
     <%= t('exam_templates.parsing.general') %><br>
   </p>
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Inline javascript in scanned exam view is rejected by CSP.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- rewrote onchange handler as an event listener

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->


### Required documentation changes (if applicable)
