### PR TITLE
cleanup role migration and add uniqueness constraints

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -16,7 +16,7 @@ class Assessment < ApplicationRecord
   # Look in lib/validators/* for more info
   validates :due_date, date: true
 
-  validates_uniqueness_of :short_identifier, case_sensitive: true, scope: :course_id
+  validates_uniqueness_of :short_identifier, scope: :course_id
   validates_presence_of :short_identifier
   validate :short_identifier_unchanged, on: :update
   validates_presence_of :description

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -16,7 +16,7 @@ class Assessment < ApplicationRecord
   # Look in lib/validators/* for more info
   validates :due_date, date: true
 
-  validates_uniqueness_of :short_identifier, case_sensitive: true
+  validates_uniqueness_of :short_identifier, case_sensitive: true, scope: :course_id
   validates_presence_of :short_identifier
   validate :short_identifier_unchanged, on: :update
   validates_presence_of :description

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,9 +11,9 @@ class Course < ApplicationRecord
   validates :name, format: { with: /\A[a-zA-Z0-9\-_]+\z/,
                              message: 'name must only contain alphanumeric, hyphen, or '\
                                       'underscore' }
-  validates :display_name, format: { with: /\A[a-zA-Z0-9\-_ ]+\z/,
-                                     message: 'display_name must only contain alphanumeric, hyphen, '\
-                                              'space, or underscore' }
+
+  # Note rails provides built-in sanitization via active record.
+  validates_presence_of :display_name
 
   # Returns an output file for controller to handle.
   def get_assignment_list(file_format)

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -153,7 +153,7 @@ class ExamTemplate < ApplicationRecord
         group = Group.find_or_create_by(
           group_name: "#{self.name}_paper_#{exam_num}",
           repo_name: "#{self.name}_paper_#{exam_num}",
-          course: self.assignment
+          course: self.assignment.course
         )
         split_page.update(status: 'FIXED', exam_page_number: page_num, group: group)
         # This creates both a new grouping and a new folder in the group repository

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,7 +1,8 @@
 class Section < ApplicationRecord
-  validates :name, presence: true, uniqueness: true, allow_blank: false,
+  validates :name, presence: true, allow_blank: false,
                    format: { with: /\A[a-zA-Z0-9\-_ ]+\z/,
                              message: 'user_name must be alphanumeric, hyphen, whitespace, or underscore' }
+  validates_uniqueness_of :name, scope: :course_id
   has_many :students
   has_many :assessment_section_properties, class_name: 'AssessmentSectionProperties'
   has_many :section_starter_file_groups

--- a/db/migrate/20211013190449_create_roles.rb
+++ b/db/migrate/20211013190449_create_roles.rb
@@ -18,22 +18,22 @@ class CreateRoles < ActiveRecord::Migration[6.1]
     remove_column :users, :receives_results_emails, :boolean
     remove_column :users, :receives_invite_emails, :boolean
 
-    add_reference :grader_permissions, :role, foreign_key: true
-    remove_reference :grader_permissions, :user, type: :integer
+    add_reference :grader_permissions, :role, foreign_key: true, null: false
+    remove_reference :grader_permissions, :user, type: :integer, null: false
 
-    add_reference :grade_entry_students, :role, foreign_key:true
+    add_reference :grade_entry_students, :role, foreign_key: true, null: false
     remove_reference :grade_entry_students, :user
 
-    add_reference :memberships, :role, foreign_key: true
-    remove_reference :memberships, :user, foreign_key: true
+    add_reference :memberships, :role, foreign_key: true, null: false
+    remove_reference :memberships, :user, foreign_key: true, null: false
 
-    add_reference :test_runs, :role, foreign_key: true
-    remove_reference :test_runs, :user, foreign_key: true
+    add_reference :test_runs, :role, foreign_key: true, null: false
+    remove_reference :test_runs, :user, foreign_key: true, null: false
 
     remove_reference :tags, :user, foreign_key: true
-    add_reference :tags, :role, foreign_key: true
+    add_reference :tags, :role, foreign_key: true, null: false
 
     remove_reference :split_pdf_logs, :user, foreign_key: true
-    add_reference :split_pdf_logs, :role, foreign_key: true
+    add_reference :split_pdf_logs, :role, foreign_key: true, null: false
   end
 end

--- a/db/migrate/20211126223421_add_uniqueness_for_courses.rb
+++ b/db/migrate/20211126223421_add_uniqueness_for_courses.rb
@@ -1,0 +1,6 @@
+class AddUniquenessForCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_index :sections, [:name, :course_id], unique: true
+    add_index :assessments, [:short_identifier, :course_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_29_164912) do
+ActiveRecord::Schema.define(version: 2021_11_26_223421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2021_10_29_164912) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "course_id", null: false
     t.index ["course_id"], name: "index_assessments_on_course_id"
+    t.index ["short_identifier", "course_id"], name: "index_assessments_on_short_identifier_and_course_id", unique: true
     t.index ["type", "short_identifier"], name: "index_assessments_on_type_and_short_identifier"
   end
 
@@ -450,6 +451,7 @@ ActiveRecord::Schema.define(version: 2021_10_29_164912) do
     t.datetime "updated_at"
     t.bigint "course_id", null: false
     t.index ["course_id"], name: "index_sections_on_course_id"
+    t.index ["name", "course_id"], name: "index_sections_on_name_and_course_id", unique: true
   end
 
   create_table "sessions", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,6 @@ Rake::Task['db:admin'].invoke
 Rake::Task['db:tas'].invoke
 Rake::Task['db:test_servers'].invoke
 Rake::Task['db:users'].invoke
-Rake::Task['db:courses'].invoke
 Rake::Task['db:assignments'].invoke
 Rake::Task['db:grade_entry_forms'].invoke
 Rake::Task['db:groups'].invoke

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -49,7 +49,7 @@ describe Assignment do
       end
 
       it 'should require case sensitive unique value for short_identifier' do
-        expect(@assignment).to validate_uniqueness_of(:short_identifier)
+        expect(@assignment).to validate_uniqueness_of(:short_identifier).scoped_to(:course_id)
       end
       it 'should have a nil parent_assignment by default' do
         expect(@assignment.parent_assignment).to be_nil

--- a/spec/models/grade_entry_form_spec.rb
+++ b/spec/models/grade_entry_form_spec.rb
@@ -16,7 +16,7 @@ describe GradeEntryForm do
 
   describe 'uniqueness validation' do
     subject { create :grade_entry_form }
-    it { is_expected.to validate_uniqueness_of(:short_identifier) }
+    it { is_expected.to validate_uniqueness_of(:short_identifier).scoped_to(:course_id) }
   end
 
   describe '#max_mark' do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -246,7 +246,7 @@ describe Role do
         end
         let(:peer_review_section) do
           create :assessment_section_properties, section: new_section,
-                 assessment: peer_review, is_hidden: true
+                                                 assessment: peer_review, is_hidden: true
         end
         it 'does appear hidden' do
           assessment_section_properties_hidden

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -2,7 +2,7 @@ describe Section do
   context 'validations' do
     subject { build :section }
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).scoped_to(:course_id) }
     it { is_expected.to have_many(:students) }
     it { is_expected.to have_many(:assessment_section_properties) }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds uniqueness constraints to section name and assessment short identifier. it also updates the role table creation migration for backwards compatibility, and some other cleanup, as well as fixing tests for role#visible_assessments 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- adds uniqueness constraints on section name and assessment short identifier scoped to course
- removes constraints on course display_name
- updates role table for backwards compatibility
- addresses typo and double invocation of courses rake task


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Updated tests for assignment, grade entry form, section, to validate uniqueness and ran all relevant tests. 


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->


### Required documentation changes (if applicable)
