### PR TITLE
Fixed Grace Token Deductions to Use Display Name

### DIFF
--- a/app/assets/javascripts/Components/Result/summary_panel.jsx
+++ b/app/assets/javascripts/Components/Result/summary_panel.jsx
@@ -253,7 +253,7 @@ export class SummaryPanel extends React.Component {
     } else {
       let rows = this.props.graceTokenDeductions.flatMap(d => {
         return [
-          <tr key={d["users.user_name"]}>
+          <tr key={d["users.user_name"]} align="left">
             <th colSpan={2}>
               {`${d["users.user_name"]} - (${d["users.display_name"]})`}
             </th>

--- a/app/assets/javascripts/Components/Result/summary_panel.jsx
+++ b/app/assets/javascripts/Components/Result/summary_panel.jsx
@@ -253,7 +253,7 @@ export class SummaryPanel extends React.Component {
     } else {
       let rows = this.props.graceTokenDeductions.flatMap(d => {
         return [
-          <tr key={d["users.user_name"]} align="left">
+          <tr key={d["users.user_name"]}>
             <th colSpan={2}>
               {`${d["users.user_name"]} - (${d["users.display_name"]})`}
             </th>

--- a/app/assets/javascripts/Components/Result/summary_panel.jsx
+++ b/app/assets/javascripts/Components/Result/summary_panel.jsx
@@ -255,7 +255,7 @@ export class SummaryPanel extends React.Component {
         return [
           <tr key={d["users.user_name"]}>
             <th colSpan={2}>
-              {`${d["users.user_name"]} - (${d["users.first_name"]} ${d["users.last_name"]})`}
+              {`${d["users.user_name"]} - (${d["users.display_name"]})`}
             </th>
           </tr>,
           <tr key={d["users.user_name"] + "-deduction"}>

--- a/app/assets/javascripts/Components/Result/summary_panel.jsx
+++ b/app/assets/javascripts/Components/Result/summary_panel.jsx
@@ -254,9 +254,7 @@ export class SummaryPanel extends React.Component {
       let rows = this.props.graceTokenDeductions.flatMap(d => {
         return [
           <tr key={d["users.user_name"]}>
-            <th colSpan={2}>
-              {`${d["users.user_name"]} - (${d["users.display_name"]})`}
-            </th>
+            <th colSpan={2}>{`${d["users.user_name"]} - (${d["users.display_name"]})`}</th>
           </tr>,
           <tr key={d["users.user_name"] + "-deduction"}>
             <td>

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -209,7 +209,7 @@ class ResultsController < ApplicationController
                       .grace_period_deductions
                       .joins(membership: :user)
                       .where('users.user_name': current_user.user_name)
-                      .pluck_to_hash(:id, :deduction, 'users.user_name', 'users.display_name')  
+                      .pluck_to_hash(:id, :deduction, 'users.user_name', 'users.display_name')
         else
           data[:grace_token_deductions] =
             submission.grouping

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -203,7 +203,13 @@ class ResultsController < ApplicationController
           data[:grace_token_deductions] = []
         elsif current_user.ta? && assignment.anonymize_groups
           data[:grace_token_deductions] = []
-
+        elsif current_user.student?
+          data[:grace_token_deductions] =
+            submission.grouping
+                      .grace_period_deductions
+                      .joins(membership: :user)
+                      .where('users.user_name': current_user.user_name)
+                      .pluck_to_hash(:id, :deduction, 'users.user_name', 'users.display_name')  
         else
           data[:grace_token_deductions] =
             submission.grouping

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -207,9 +207,9 @@ class ResultsController < ApplicationController
         else
           data[:grace_token_deductions] =
             submission.grouping
-              .grace_period_deductions
-              .joins(membership: :user)
-              .pluck_to_hash(:id, :deduction, 'users.user_name', 'users.first_name', 'users.last_name')
+                      .grace_period_deductions
+                      .joins(membership: :user)
+                      .pluck_to_hash(:id, :deduction, 'users.user_name', 'users.display_name')
         end
 
         # Totals

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -482,9 +482,7 @@ describe ResultsController do
   shared_examples 'showing json data' do |is_student|
     let(:student2) do
       partner = create(:student, grace_credits: 2)
-      StudentMembership.create(user: partner,
-                               membership_status: StudentMembership::STATUSES[:accepted],
-                               grouping: grouping)
+      create(:accepted_student_membership, user: partner, grouping: grouping)
       partner
     end
     subject do

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -479,10 +479,10 @@ describe ResultsController do
     end
 
     context 'showing json data' do
-      let(:student2) do 
+      let(:student2) do
         partner = create(:student, grace_credits: 2)
-        StudentMembership.create(user: partner, 
-                                 membership_status: StudentMembership::STATUSES[:accepted], 
+        StudentMembership.create(user: partner,
+                                 membership_status: StudentMembership::STATUSES[:accepted],
                                  grouping: grouping)
         partner
       end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request fixes an issue whereby the results page which displays grace token deductions would show a user's first and last name in parentheses as opposed to their display name. 
In addition, the grace token deductions display for students was changed so that students can no longer see the grace token deductions for other group members (they can only see their own).

Resolves #5610

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Changed grace token deductions summary display to show a student's display name rather than their first and last name. 
- When logged in as a student, changed grace token deductions summary display to show only that student's deductions.
- Added tests for changes as well as basic tests for other data provided from  the `results_contoller`'s `show` method.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Manual testing was done to ensure the appropriate display name was shown. In addition, this testing was done whilst logged in as an admin, grader, and student roles to ensure only the relevant grace token deductions were being shown for a specific user (i.e. students could only see their own grace token deductions whilst admins and graders can see every group member's deductions). 
This was further supplemented by adding rspec tests which checked that the appropriate data was being sent given the user who is currently logged in. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
