### PR TITLE
assessments: Fix bug in User#visible_assessments for students in a section

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Add test results download modal for assignment summary (#5561)
 - Improve accessibility of exam templates page (#5607)
 - Fix display bug with infinitely expanding chart in student results view for grade entry form (#5612)
+- Fix bug in User#visible_assessments for students in a section (#5634)
 
 ## [v1.13.3]
 - Display multiple feedback files returned by the autotester (#5524)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,15 +289,19 @@ class User < ApplicationRecord
   # only the assessment with the given id, if it is visible to the current user.
   # If it is not visible, returns an empty collection.
   def visible_assessments(assessment_type: nil, assessment_id: nil)
-    assessments = Assessment.where(is_hidden: false, type: assessment_type || Assessment.type)
+    assessments = Assessment.where(type: assessment_type || Assessment.type)
+    assessments = assessments.where(id: assessment_id) if assessment_id
     if self.section_id
-      assessments = Assessment.left_outer_joins(:assessment_section_properties)
-                              .where('assessment_section_properties.section_id': [self.section_id, nil])
+      assessments = assessments.left_outer_joins(:assessment_section_properties)
+                               .where(
+                                 'assessment_section_properties.section_id': [self.section_id, nil]
+                               )
       assessments = assessments.where('assessment_section_properties.is_hidden': false)
                                .or(assessments.where('assessment_section_properties.is_hidden': nil,
                                                      'assessments.is_hidden': false))
+    else
+      assessments = assessments.where(is_hidden: false)
     end
-    return assessments.where(id: assessment_id) if assessment_id
     assessments
   end
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, `User#visible_assessments` has a bug where if a student is in a section, then the `assessment_type` parameter is ignored. This causes assessments to be duplicated in the student assessment selector dropdown.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the bug in `User#visible_assessments`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Added some additional test cases, and manually verified that the student assessment dropdown only shows assessments once (under either assignments or grade entry forms).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
