### PR TITLE
Tag edit modal should close only when cancel button is clicked

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 - Improve accessibility of exam templates page (#5607)
 - Fix display bug with infinitely expanding chart in student results view for grade entry form (#5612)
 - Fix bug in User#visible_assessments for students in a section (#5634)
+- Fixed bug where tag edit modal closed whenever it is clicked (#5652)
 
 ## [v1.13.3]
 - Display multiple feedback files returned by the autotester (#5524)

--- a/app/views/tags/_edit.html.erb
+++ b/app/views/tags/_edit.html.erb
@@ -23,7 +23,7 @@
                    name: 'submit',
                    data: { disable_with: t(:working) },
                    class: 'button' %>
-      <input type='reset' value='<%= t(:cancel) %>'/>
+      <input type='reset' id='edit-tag-dialog-cancel' value='<%= t(:cancel) %>'/>
     </section>
   <% end %>
 </div>

--- a/app/views/tags/_edit_dialog.js.erb
+++ b/app/views/tags/_edit_dialog.js.erb
@@ -1,7 +1,7 @@
 $('#edit_tags_dialog').html("<%= escape_javascript(render('tags/edit')) %>");
 modal_edit.open();
 $(function() {
-  $('#edit_tags_dialog').click(function(e) {
+  $('#edit_tags_dialog :reset').click(function(e) {
     modal_edit.close();
     e.preventDefault();
   })

--- a/app/views/tags/_edit_dialog.js.erb
+++ b/app/views/tags/_edit_dialog.js.erb
@@ -1,7 +1,7 @@
 $('#edit_tags_dialog').html("<%= escape_javascript(render('tags/edit')) %>");
 modal_edit.open();
 $(function() {
-  $('#edit_tags_dialog :reset').click(function(e) {
+  $('#edit-tag-dialog-cancel').click(function(e) {
     modal_edit.close();
     e.preventDefault();
   })


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- tag edit modal should close when the cancel button is clicked, not when any part of the modal is clicked

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- update jquery selector

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
