### PR TITLE
chart-js: Fix registering scales for DataChart component

### DIFF
--- a/app/assets/javascripts/Components/Helpers/data_chart.jsx
+++ b/app/assets/javascripts/Components/Helpers/data_chart.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import {render} from "react-dom";
 import {Bar} from "react-chartjs-2";
 
+import {Chart, registerables} from "chart.js";
+Chart.register(...registerables);
+
 export class DataChart extends React.Component {
   static defaultProps = {
     legend: true,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After doing the chart.js (#5626) and react-chartjs-2 (#5624) updates, we need to register `Chart` elements everywhere we import `Chart`. (See [here](https://www.chartjs.org/docs/latest/getting-started/integration.html#bundlers-webpack-rollup-etc).)

Without this registering, there was a runtime error when the `DataChart` component was used (e.g., Results view -> Summary tab -> Marks Chart modal).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added the registering code to where we import `Chart` from `chart.js` in the `DataChart` component file.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ensure the `DataChart` component loads properly in the UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
