### PR TITLE
results: Show correct feedback files when switching results

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Fix bug in User#visible_assessments for students in a section (#5634)
 - Fixed bug where tag edit modal closed whenever it is clicked (#5652)
 - Fix bug where the datetime selector wasn't being shown for peer review assessments (#5659)
+- Fix bug in displaying associated feedback files when switching between results (#5676)
 
 ## [v1.13.3]
 - Display multiple feedback files returned by the autotester (#5524)

--- a/app/assets/javascripts/Components/Result/feedback_file_panel.jsx
+++ b/app/assets/javascripts/Components/Result/feedback_file_panel.jsx
@@ -5,16 +5,24 @@ import {lookup} from "mime-types";
 export class FeedbackFilePanel extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      selectedFile: props.feedbackFiles ? props.feedbackFiles[0].id : null,
-    };
+    if (props.loading) {
+      this.state = {selectedFile: null};
+    } else {
+      this.state = {
+        selectedFile: props.feedbackFiles.length > 0 ? props.feedbackFiles[0].id : null,
+      };
+    }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.feedbackFiles.find(file => file.id === this.state.selectedFile)) {
-      this.setState({
-        selectedFile: nextProps.feedbackFiles ? nextProps.feedbackFiles[0].id : null,
-      });
+  static getDerivedStateFromProps(props, state) {
+    if (props.loading && state.selectedFile !== null) {
+      return {selectedFile: null};
+    } else if (!props.feedbackFiles.find(file => file.id === state.selectedFile)) {
+      return {
+        selectedFile: props.feedbackFiles.length > 0 ? props.feedbackFiles[0].id : null,
+      };
+    } else {
+      return null;
     }
   }
 
@@ -23,6 +31,10 @@ export class FeedbackFilePanel extends React.Component {
   };
 
   render() {
+    if (this.props.loading) {
+      return "";
+    }
+
     let feedbackSelector;
     if (this.props.feedbackFiles) {
       feedbackSelector = (

--- a/app/assets/javascripts/Components/Result/file_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/file_viewer.jsx
@@ -40,7 +40,12 @@ export class FileViewer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!this.props.result_id && prevProps.selectedFile !== this.props.selectedFile) {
+    if (
+      !this.props.result_id &&
+      (prevProps.selectedFile !== this.props.selectedFile ||
+        prevProps.submission_id !== this.props.submission_id ||
+        prevProps.selectedFileURL !== this.props.selectedFileURL)
+    ) {
       this.set_submission_file("");
     }
   }

--- a/app/assets/javascripts/Components/Result/left_pane.jsx
+++ b/app/assets/javascripts/Components/Result/left_pane.jsx
@@ -16,17 +16,40 @@ export class LeftPane extends React.Component {
     this.submissionFilePanel = React.createRef();
   }
 
-  disableRemarkPanel = () => {
-    if (this.props.is_reviewer || !this.props.allow_remarks) {
+  static getDerivedStateFromProps(props, state) {
+    // Reset selected tab state if props are changed and a tab becomes disabled.
+    // Affected tabs are "Test Results" (tabIndex 2), "Feedback Files" (tabIndex 3),
+    // and "Remark Request" (tabIndex 4).
+    if (
+      (state.tabIndex === 2 && LeftPane.disableTestResultsPanel(props)) ||
+      (state.tabIndex === 3 && LeftPane.disableFeedbackFilesPanel(props)) ||
+      (state.tabIndex === 4 && LeftPane.disableRemarkPanel(props))
+    ) {
+      return {tabIndex: 0};
+    } else {
+      return null;
+    }
+  }
+
+  static disableTestResultsPanel(props) {
+    return props.is_reviewer || !props.enable_test;
+  }
+
+  static disableFeedbackFilesPanel(props) {
+    return props.is_reviewer || props.feedback_files.length === 0;
+  }
+
+  static disableRemarkPanel(props) {
+    if (props.is_reviewer || !props.allow_remarks) {
       return true;
-    } else if (this.props.student_view) {
+    } else if (props.student_view) {
       return false;
-    } else if (this.props.remark_submitted) {
+    } else if (props.remark_submitted) {
       return false;
     } else {
       return true;
     }
-  };
+  }
 
   // Display a given file. Used to changes files from the annotations panel.
   selectFile = (file, submission_file_id, focus_line, annotation_focus) => {
@@ -45,13 +68,13 @@ export class LeftPane extends React.Component {
         <TabList>
           <Tab>{I18n.t("activerecord.attributes.submission.submission_files")}</Tab>
           <Tab>{I18n.t("activerecord.models.annotation.other")}</Tab>
-          <Tab disabled={this.props.is_reviewer || !this.props.enable_test}>
+          <Tab disabled={LeftPane.disableTestResultsPanel(this.props)}>
             {I18n.t("activerecord.models.test_result.other")}
           </Tab>
-          <Tab disabled={this.props.is_reviewer || this.props.feedback_files.length === 0}>
+          <Tab disabled={LeftPane.disableFeedbackFilesPanel(this.props)}>
             {I18n.t("activerecord.attributes.submission.feedback_files")}
           </Tab>
-          <Tab disabled={this.disableRemarkPanel()}>
+          <Tab disabled={LeftPane.disableRemarkPanel(this.props)}>
             {I18n.t("activerecord.attributes.submission.submitted_remark")}
           </Tab>
         </TabList>
@@ -135,6 +158,7 @@ export class LeftPane extends React.Component {
             assignment_id={this.props.assignment_id}
             feedbackFiles={this.props.feedback_files}
             submission_id={this.props.submission_id}
+            loading={this.props.loading}
           />
         </TabPanel>
         <TabPanel>

--- a/lib/tasks/marks.rake
+++ b/lib/tasks/marks.rake
@@ -28,8 +28,8 @@ namespace :db do
 
     feedback_files = submission_ids.flat_map do |sid|
       attrs = { submission_id: sid, created_at: Time.current, updated_at: Time.current }
-      [attrs.merge(filename: 'humanfb.txt', mime_type: 'text', file_content: text1),
-       attrs.merge(filename: 'machinefb.txt', mime_type: 'text', file_content: text2),
+      [attrs.merge(filename: 'humanfb.txt', mime_type: 'text', file_content: "#{sid}\n#{text1}"),
+       attrs.merge(filename: 'machinefb.txt', mime_type: 'text', file_content: "#{sid}\n#{text2}"),
        attrs.merge(filename: 'imagefb.png', mime_type: 'image/png', file_content: image)]
     end
     FeedbackFile.insert_all feedback_files


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An instructor reported that when they were grading and were on the "Feedback Files" tab and switched to the next group, the feedback file did not update (i.e., showed the feedback file from the previous submission).

Note: this *doesn't* affect feedback files shown as part of test results.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: This PR has a couple of related fixes.

1. To address the problem, I updated the `FileViewer`'s `componentDidUpdate` method to trigger an update when switching groups.
2. Pass a `loading` prop down from the root result component down to the `FeedbackFilesPanel` and updated its `render` method, so that it doesn't attempt to display feedback files when the new data is being loaded. Without this, there was an annoying "flash" of the old feedback file before displaying the new feedback file.
    - I also changed the (deprecated) `componentWillReceiveProps` Component method into [`getDerivedStateFromProps`](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops).
3. I also tested cases when one submission had feedback files but the next one didn't (this is likely rare, but possible). In this case, we don't show the "FeedbackFiles" tab at all, so I added a fix to reset the selected tab index back to the submission files tab. (Previous, an error was raised.)
4. Related to (3), I also fixed a logical error in the `FeedbackFilePanel`'s state setting, changing `props.feedbackFiles` (as a boolean check) to `props.feedbackFiles.length > 0`.

Finally, I updated the seed data so that different submissions actually get different (text) feedback files, making it easier to detect this error in the development environment.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually through the web interface.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

In the future, it would be good to improve the look and feel of the "loading" state of each of the result components, from the top level all the way down to things like the fileviewer.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
