### PR TITLE
exam-templates: Fix controller redirect routes and file paths

### DIFF
--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -36,7 +36,7 @@ class ExamTemplatesController < ApplicationController
         flash_message(:error, t('exam_templates.create.failure'))
       end
     end
-    redirect_to course_assignment_path(current_course, assignment)
+    redirect_to course_assignment_exam_templates_path(current_course, assignment)
   end
 
   def download
@@ -76,7 +76,7 @@ class ExamTemplatesController < ApplicationController
         flash_message(:error, t('exam_templates.update.failure'))
       end
     end
-    redirect_to course_assignment_path(current_course, assignment)
+    redirect_to course_assignment_exam_templates_path(current_course, assignment)
   end
 
   def generate
@@ -139,7 +139,7 @@ class ExamTemplatesController < ApplicationController
       exam_template.crop_height = nil
     end
     exam_template.save
-    redirect_to course_assignment_exam_templates_path(current_course, exam_template.assignment, exam_template)
+    redirect_to course_assignment_exam_templates_path(current_course, exam_template.assignment)
   end
 
   def split
@@ -148,7 +148,7 @@ class ExamTemplatesController < ApplicationController
     unless split_exam.nil?
       if split_exam.content_type != 'application/pdf'
         flash_message(:error, t('exam_templates.split.invalid'))
-        redirect_to course_assignment_path(current_course, exam_template.assignment)
+        redirect_to course_assignment_exam_templates_path(current_course, exam_template.assignment)
       else
         current_job = exam_template.split_pdf(split_exam.path, split_exam.original_filename, current_role)
         session[:job_id] = current_job.job_id
@@ -156,7 +156,7 @@ class ExamTemplatesController < ApplicationController
       end
     else
       flash_message(:error, t('exam_templates.split.missing'))
-      redirect_to course_assignment_path(current_course, exam_template.assignment)
+      redirect_to course_assignment_exam_templates_path(current_course, exam_template.assignment)
     end
   end
 
@@ -167,7 +167,7 @@ class ExamTemplatesController < ApplicationController
     else
       flash_message(:failure, t('exam_templates.delete.failure'))
     end
-    redirect_to course_assignment_path(current_course, exam_template.assignment)
+    redirect_to course_assignment_exam_templates_path(current_course, exam_template.assignment)
   end
 
   def view_logs

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -910,6 +910,10 @@ class Assignment < Assessment
     File.join(autotest_path, TestRun::SPECS_FILE)
   end
 
+  def scanned_exams_path
+    File.join(Settings.scanned_exams.path, course.name, short_identifier)
+  end
+
   # Retrieve current grader data.
   def current_grader_data
     ta_counts = self.criterion_ta_associations.group(:ta_id).count

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -29,8 +29,7 @@ class ExamTemplate < ApplicationRecord
     name_input = attributes[:name]
     exam_template_name = name_input.blank? ? File.basename(attributes[:filename].tr(' ', '_'), '.pdf') : name_input
     template_path = File.join(
-      Settings.scanned_exams.path,
-      assignment_name,
+      assignment.scanned_exams_path,
       exam_template_name
     )
     FileUtils.mkdir_p template_path unless Dir.exists? template_path
@@ -63,14 +62,8 @@ class ExamTemplate < ApplicationRecord
   # Replace an ExamTemplate with the correct file
   def replace_with_file(blob, attributes={})
     return unless attributes.key? :assessment_id
-    assignment_name = Assignment.find(attributes[:assessment_id]).short_identifier
-    template_path = File.join(
-      Settings.scanned_exams.path,
-      assignment_name,
-      self.name
-    )
 
-    File.open(File.join(template_path, attributes[:new_filename].tr(' ', '_')), 'wb') do |f|
+    File.open(File.join(base_bath, attributes[:new_filename].tr(' ', '_')), 'wb') do |f|
       f.write blob
     end
 
@@ -238,7 +231,7 @@ class ExamTemplate < ApplicationRecord
   end
 
   def base_path
-    File.join Settings.scanned_exams.path, self.course.name, assignment.short_identifier, self.name
+    File.join self.assignment.scanned_exams_path, self.name
   end
 
   def num_cover_fields
@@ -292,13 +285,11 @@ class ExamTemplate < ApplicationRecord
     if self.name_changed?
       assignment_name = self.assignment.short_identifier
       old_directory_name = File.join(
-        Settings.scanned_exams.path,
-        assignment_name,
+        self.assignment.scanned_exams_path,
         name_was
       )
       new_directory_name = File.join(
-        Settings.scanned_exams.path,
-        assignment_name,
+        self.assignment.scanned_exams_path,
         name
       )
       File.rename old_directory_name, new_directory_name


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. There were a few places in `ExamTemplate` where the path wasn't using the course name.
2. The exam template controller routes were redirecting to `course_assignment_path` (which we don't actually support for instructors). 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

1. Centralized exam template path into an `Assignmetn` helper.
2. Changed redirects to `course_assignment_exam_templates_path` (which I'm pretty sure is the existing behaviour, since it brings users just back to the exam templates settings page).

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Manual testing in the UI. Re-seeded the database (which had an error before).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
