### PR TITLE
deps: Downgrade pdfjs-dist to v2.6.347.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mime-types": "^2.1.34",
     "moment": "^2.29.1",
     "mousetrap": "^1.6.5",
-    "pdfjs-dist": "^2.12.313",
+    "pdfjs-dist": "2.6.347",
     "postcss-preset-env": "^6.7.0",
     "prop-types": "^15.8.0",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5237,10 +5237,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@^2.12.313:
-  version "2.12.313"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.12.313.tgz#62f2273737bb956267ae2e02cdfaddcb1099819c"
-  integrity sha512-1x6iXO4Qnv6Eb+YFdN5JdUzt4pAkxSp3aLAYPX93eQCyg/m7QFzXVWJHJVtoW48CI8HCXju4dSkhQZwoheL5mA==
+pdfjs-dist@2.6.347:
+  version "2.6.347"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.6.347.tgz#f257ed66e83be900cd0fd28524a2187fb9e25cd5"
+  integrity sha512-QC+h7hG2su9v/nU1wEI3SnpPIrqJODL7GTDFvR74ANKGq1AFJW16PH8VWnhpiTi9YcLSFV9xLeWSgq+ckHLdVQ==
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

pdfjs [v2.7.570](https://github.com/mozilla/pdf.js/releases/tag/v2.7.570) (and later) requires that the parent container of a PDFViewer be absolutely positioned, which doesn't (easily) work with our setup. This currently causes an error to the thrown when viewing PDF files in MarkUs.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Reverted the upgrade from #5703 until we can spend more time fixing the styling and layout of the parent container.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested the PDF views in the MarkUs web interface.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have fixed any Hound bot comments. <!-- (check after opening pull request) -->