### PR TITLE
Don't get realpath for symlink in git repos hooks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Remove unmaintained locales (#5727)
 - Fix bug where repository access files were not taking multiple courses into account (#5734)
 - Fix bug where sections and grace credits could not be updated from the student edit view (#5739)
+- Fix bug where git hooks were not finding the correct file containing the maximum file size for a given course (#5744)
 
 ## [v2.0.2]
 - Fix bug in displaying feedback files for test results (#5719)

--- a/lib/repo/git_hooks/multihook.py
+++ b/lib/repo/git_hooks/multihook.py
@@ -7,7 +7,7 @@ import sys
 if __name__ == '__main__':
 
     hook_type = os.path.basename(__file__)
-    real_dir = os.path.dirname(os.path.realpath(__file__))
+    real_dir = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(real_dir, 'max_file_size')) as f:
         max_file_size = f.read().strip()
     hooks_dir = os.path.join(real_dir, '{}.d'.format(hook_type))


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`os.path.realpath` resolves the file to the target of a symlinked file. In this case though we want to get the path to the symlink itself so that the max_file_size to the specific course in question can be used.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Required documentation changes (if applicable)
