### PR TITLE
responders: Fix configuration for responders gem

### DIFF
--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -43,4 +43,9 @@ class InstructorsController < ApplicationController
   def end_user_params
     params.require(:role).require(:end_user).permit(:user_name)
   end
+
+  def flash_interpolation_options
+    { resource_name: @role.end_user&.user_name.blank? ? @role.model_name.human : @role.user_name,
+      errors: @role.errors.full_messages.join('; ') }
+  end
 end

--- a/config/initializers/responders.rb
+++ b/config/initializers/responders.rb
@@ -1,4 +1,4 @@
 # Configuration for the 'responders' gem
 
 Rails.application.config.app_generators.scaffold_controller :responders_controller
-Responders::FlashResponder.flash_keys = [:success, :failure]
+Responders::FlashResponder.flash_keys = [:success, :error]

--- a/spec/controllers/instructors_controller_spec.rb
+++ b/spec/controllers/instructors_controller_spec.rb
@@ -49,6 +49,10 @@ describe InstructorsController do
           instructor
           expect { subject }.not_to(change { Instructor.count })
         end
+        it 'should display an error message' do
+          subject
+          expect(flash[:error]).not_to be_empty
+        end
       end
     end
     context '#update' do
@@ -75,6 +79,10 @@ describe InstructorsController do
           old_user = role.end_user
           subject
           expect(role.reload.end_user).to eq(old_user)
+        end
+        it 'should display an error message' do
+          subject
+          expect(flash[:error]).not_to be_empty
         end
       end
     end

--- a/spec/controllers/tas_controller_spec.rb
+++ b/spec/controllers/tas_controller_spec.rb
@@ -157,6 +157,9 @@ describe TasController do
       it 'should not create a Ta' do
         expect(Ta.count).to eq(0)
       end
+      it 'should display an error message' do
+        expect(flash[:error]).not_to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Error flash messages from the responders gem weren't being displayed properly due to a configuration issue. The default responder error flash is `:failure`, the but rest of MarkUs uses `:error`.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Updated the configuration.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Checked that error flash messages display properly when using `respond_with`, e.g. on the "Create Student" form.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
