### PR TITLE
groups: Ensure student 'Delete Group' button has correct path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - Remove unmaintained locales (#5727)
+- Fix bug for "Delete Group" button generating an invalid path (#5768)
 
 ## [v2.0.5]
 - Add ability to annotate notebook (jupyter and Rmd) submissions (#5749)

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -205,7 +205,7 @@
             @grouping.accepted_students.size == 1 &&
             @grouping.extension.nil? %>
             <%= button_to t('helpers.submit.delete', model: Group.model_name.human),
-                          course_assignment_group_path(@current_course.id, @assignment.id),
+                          course_assignment_group_path(@current_course.id, @assignment.id, @grouping.id),
                           method: :delete,
                           data: { confirm: t('groups.student_interface.confirm_delete_group') }
             %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current code for the student interface Delete Group button calls a path helper as follows: `course_assignment_group_path(@current_course.id, @assignment.id)`. This omits an `:id` argument, which is automatically filled in as the `@assignment.id`. For example, `DELETE courses/1/assignments/10/groups/10`.

The `GroupsController` ignores the `:id` parameter so this previously wasn't an issue, but now that we're doing stricter URL checking and model associations, this `:id` is used to look up a grouping, which doesn't necessarily belong to the assignment, or even part of the same course, resulting in a 404 error.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fix the path helper.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually in the UI (the bug is in the view file).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

Even though I fixed the `:id` parameter, it's still not being used in the controller method. We can change this if we move the method into a `Groupings` controller in the future.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
