### PR TITLE
bugfix: fix ta grades view

### DIFF
--- a/app/controllers/grade_entry_forms_controller.rb
+++ b/app/controllers/grade_entry_forms_controller.rb
@@ -148,7 +148,7 @@ class GradeEntryFormsController < ApplicationController
                              .pluck_to_hash(*student_pluck_attrs)
       grades = current_role.grade_entry_students
                            .where(grade_entry_form: grade_entry_form)
-                           .joins(role: :end_user)
+                           .joins(:grades)
                            .pluck(:id, 'grades.grade_entry_item_id', 'grades.grade')
                            .group_by { |x| x[0] }
     end

--- a/spec/controllers/grade_entry_forms_controller_spec.rb
+++ b/spec/controllers/grade_entry_forms_controller_spec.rb
@@ -580,7 +580,7 @@ describe GradeEntryFormsController do
         expect(response.parsed_body['data'].length).to be > 0
       end
       it 'returns all student data' do
-        expect(response.parsed_body['data'].length).to eq Student.count
+        expect(response.parsed_body['data'].length).to eq course.students.count
       end
       it 'returns correct fields' do
         data_fields << grade_entry_form_with_data.grade_entry_items.first.id.to_s

--- a/spec/controllers/grade_entry_forms_controller_spec.rb
+++ b/spec/controllers/grade_entry_forms_controller_spec.rb
@@ -567,16 +567,24 @@ describe GradeEntryFormsController do
     end
   end
 
-  describe '#populate_grade_table' do
+  describe '#populate_grades_table' do
     before(:each) do
       get_as role, :populate_grades_table, params: { course_id: course.id, id: grade_entry_form_with_data.id }
     end
     context 'an instructor' do
+      let(:data_fields) { %w[_id released_to_student user_name first_name last_name hidden section_id] }
       it 'returns a 200 response' do
         expect(response.status).to eq 200
       end
       it 'returns data' do
         expect(response.parsed_body['data'].length).to be > 0
+      end
+      it 'returns all student data' do
+        expect(response.parsed_body['data'].length).to eq Student.count
+      end
+      it 'returns correct fields' do
+        data_fields << grade_entry_form_with_data.grade_entry_items.first.id.to_s
+        expect(response.parsed_body['data'][0].keys).to match_array(data_fields)
       end
     end
     context 'a TA' do
@@ -594,11 +602,20 @@ describe GradeEntryFormsController do
           grade_entry_form_with_data.grade_entry_students.joins(role: :end_user).find_by('users.user_name': 'c8shosta')
         end
         let!(:grade_entry_student_ta) { create(:grade_entry_student_ta, ta: role, grade_entry_student: student) }
-        context 'who has not been assigned a student' do
-          it 'returns data' do
-            get_as role, :populate_grades_table, params: { course_id: course.id, id: grade_entry_form_with_data.id }
-            expect(response.parsed_body['data'].length).to be > 0
-          end
+        it 'returns data' do
+          get_as role, :populate_grades_table, params: { course_id: course.id, id: grade_entry_form_with_data.id }
+          expect(response.parsed_body['data'].length).to be > 0
+        end
+        it 'returns the number of students assigned to the ta' do
+          get_as role, :populate_grades_table, params: { course_id: course.id, id: grade_entry_form_with_data.id }
+          expect(response.parsed_body['data'].length).to eq role.grade_entry_students.count
+        end
+        it 'returns the correct set of students' do
+          get_as role, :populate_grades_table, params: { course_id: course.id, id: grade_entry_form_with_data.id }
+          students = role.grade_entry_students
+                         .where(grade_entry_form: grade_entry_form_with_data)
+                         .joins(role: :end_user).pluck('users.user_name')
+          expect(response.parsed_body['data'].map { |stu| stu['user_name'] }).to match_array(students)
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the TA view for grades on grade entry forms does load due to an incorrect query. This change fixes that query and re-enables the TA view for grades on GEFs 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Corrects query on grade entry forms `populate_grades_table` method for TAs and adds tests for `populate_grades_table` method


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested via the web view to ensure the grade table loads properly

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes.