### PR TITLE
Added Hyperlink Button to URL preview

### DIFF
--- a/app/assets/javascripts/Components/Modals/submission_url_submit_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_url_submit_modal.jsx
@@ -16,11 +16,11 @@ class SubmitUrlUploadModal extends React.Component {
 
   onSubmit = event => {
     event.preventDefault();
+    this.props.onSubmit(this.state.newUrl, this.state.newUrlText);
     this.setState({
       newUrl: "",
       newUrlText: "",
     });
-    this.props.onSubmit(this.state.newUrl, this.state.newUrlText);
   };
 
   handleUrlChange = event => {

--- a/app/assets/javascripts/Components/Modals/submission_url_submit_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_url_submit_modal.jsx
@@ -16,6 +16,10 @@ class SubmitUrlUploadModal extends React.Component {
 
   onSubmit = event => {
     event.preventDefault();
+    this.setState({
+      newUrl: "",
+      newUrlText: "",
+    });
     this.props.onSubmit(this.state.newUrl, this.state.newUrlText);
   };
 

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -5,6 +5,7 @@ export class URLViewer extends React.Component {
     super(props);
     this.state = {
       url: "",
+      isInvalidUrl: false
     };
   }
 
@@ -32,18 +33,16 @@ export class URLViewer extends React.Component {
             this.configureGoogleDrivePreview(url);
             break;
           default:
-            this.setDefaultState();
+            this.setState({url: ""});
         }
       }
+      this.setState({isInvalidUrl: false});
     } catch (e) {
-      this.setDefaultState();
+      this.setState({
+        url: "",
+        isInvalidUrl: true
+      });
     }
-  };
-
-  setDefaultState = () => {
-    this.setState({
-      url: "",
-    });
   };
 
   configureGoogleDrivePreview = url => {
@@ -71,29 +70,31 @@ export class URLViewer extends React.Component {
     return false;
   };
 
-  renderLinkDisplay = () => {
-    return (
-      <div className="link-bar">
-        <a className="link-display" href={this.props.externalUrl} target="_blank">{this.props.externalUrl}</a>
-      </div>
-    )
+  renderPreviewDisplay = () => {
+    if (this.state.url !== "") {
+      return (
+        <iframe className="url-display" src={this.state.url} allowFullScreen>
+          There was an error trying to preview this link
+        </iframe>
+      )
+    } else {
+      return "Preview display for this URL is not supported";
+    }
   }
 
   render() {
-    if (this.state.url !== "") {
-      return (
-        <div className="url-container">
-          {this.renderLinkDisplay()}
-          <div className="display-area">
-            <iframe className="url-display" src={this.state.url} allowFullScreen>
-              <pre>{this.props.externalUrl}</pre>
-            </iframe>
-          </div>
-        </div>
-      );
+    if (this.state.isInvalidUrl) {
+      return <pre>{this.props.externalUrl}</pre>
     } else {
       return (
-        <div className="url-container">{this.renderLinkDisplay()}</div>
+        <div className="url-container">
+          <div className="link-bar">
+            <a className="link-display" href={this.props.externalUrl} target="_blank">{this.props.externalUrl}</a>
+          </div>
+          <div className="display-area">
+            {this.renderPreviewDisplay()}
+          </div>
+        </div>
       )
     }
   }

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -5,7 +5,7 @@ export class URLViewer extends React.Component {
     super(props);
     this.state = {
       url: "",
-      isInvalidUrl: false
+      embeddedURL: ""
     };
   }
 
@@ -13,8 +13,8 @@ export class URLViewer extends React.Component {
     this.configDisplay();
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.externalUrl !== this.props.externalUrl) {
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps !== this.props) {
       this.configDisplay();
     }
   }
@@ -33,14 +33,14 @@ export class URLViewer extends React.Component {
             this.configureGoogleDrivePreview(url);
             break;
           default:
-            this.setState({url: ""});
+            this.setState({embeddedURL: ""});
         }
       }
-      this.setState({isInvalidUrl: false});
+      this.setState({url: this.props.externalUrl});
     } catch (e) {
       this.setState({
         url: "",
-        isInvalidUrl: true
+        embeddedURL: ""
       });
     }
   };
@@ -53,7 +53,7 @@ export class URLViewer extends React.Component {
       url.pathname = url.pathname.replace(/(\/[^\/]+)$/, "/preview");
     }
     this.setState({
-      url: url.toString(),
+      embeddedURL: url.toString(),
     });
   };
 
@@ -62,7 +62,7 @@ export class URLViewer extends React.Component {
       const match = res.html.match(/src="(\S+)"/);
       if (match.length === 2) {
         this.setState({
-          url: match[1],
+          embeddedURL: match[1],
         });
         return true;
       }
@@ -71,31 +71,32 @@ export class URLViewer extends React.Component {
   };
 
   renderPreviewDisplay = () => {
-    if (this.state.url !== "") {
+    if (this.state.embeddedURL !== "") {
       return (
-        <iframe className="url-display" src={this.state.url} allowFullScreen>
-          {I18n.t("submissions.url_display_error")}
+        <iframe className="url-display" src={this.state.embeddedURL} allowFullScreen>
+          <div className="url-message-display">{I18n.t("submissions.url_display_error")}</div>
         </iframe>
       )
-    } else {
-      return I18n.t("submissions.unsupported_url", { host: "sample.com"} );
+    } else if (this.state.url !== "") {
+      const url_host = new URL(this.props.externalUrl).hostname;
+      return <div className="url-message-display">{I18n.t("submissions.unsupported_url", { host: url_host} )}</div>
     }
   }
 
   render() {
-    if (this.state.isInvalidUrl) {
-      return <pre>{this.props.externalUrl}</pre>
-    } else {
+    if (this.state.url !== "") {
       return (
         <div className="url-container">
           <div className="link-bar">
-            <a className="link-display" href={this.props.externalUrl} target="_blank">{this.props.externalUrl}</a>
+            <a className="link-display" href={this.state.url} target="_blank">{this.state.url}</a>
           </div>
           <div className="display-area">
             {this.renderPreviewDisplay()}
           </div>
         </div>
       )
+    } else {
+      return <div className="url-message-display">{this.props.externalUrl}</div>
     }
   }
 }

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -74,11 +74,11 @@ export class URLViewer extends React.Component {
     if (this.state.url !== "") {
       return (
         <iframe className="url-display" src={this.state.url} allowFullScreen>
-          There was an error trying to preview this link
+          {I18n.t("submissions.url_display_error")}
         </iframe>
       )
     } else {
-      return "Preview display for this URL is not supported";
+      return I18n.t("submissions.unsupported_url", { host: "sample.com"} );
     }
   }
 

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -5,7 +5,7 @@ export class URLViewer extends React.Component {
     super(props);
     this.state = {
       url: "",
-      embeddedURL: ""
+      embeddedURL: "",
     };
   }
 
@@ -40,7 +40,7 @@ export class URLViewer extends React.Component {
     } catch (e) {
       this.setState({
         url: "",
-        embeddedURL: ""
+        embeddedURL: "",
       });
     }
   };
@@ -76,27 +76,31 @@ export class URLViewer extends React.Component {
         <iframe className="url-display" src={this.state.embeddedURL} allowFullScreen>
           <div className="url-message-display">{I18n.t("submissions.url_display_error")}</div>
         </iframe>
-      )
+      );
     } else if (this.state.url !== "") {
       const url_host = new URL(this.props.externalUrl).hostname;
-      return <div className="url-message-display">{I18n.t("submissions.unsupported_url", { host: url_host} )}</div>
+      return (
+        <div className="url-message-display">
+          {I18n.t("submissions.unsupported_url", {host: url_host})}
+        </div>
+      );
     }
-  }
+  };
 
   render() {
     if (this.state.url !== "") {
       return (
         <div className="url-container">
           <div className="link-bar">
-            <a className="link-display" href={this.state.url} target="_blank">{this.state.url}</a>
+            <a className="link-display" href={this.state.url} target="_blank">
+              {this.state.url}
+            </a>
           </div>
-          <div className="display-area">
-            {this.renderPreviewDisplay()}
-          </div>
+          <div className="display-area">{this.renderPreviewDisplay()}</div>
         </div>
-      )
+      );
     } else {
-      return <div className="url-message-display">{this.props.externalUrl}</div>
+      return <div className="url-message-display">{this.props.externalUrl}</div>;
     }
   }
 }

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -13,8 +13,8 @@ export class URLViewer extends React.Component {
     this.configDisplay();
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps !== this.props) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.externalUrl !== this.props.externalUrl) {
       this.configDisplay();
     }
   }

--- a/app/assets/javascripts/Components/Result/url_viewer.jsx
+++ b/app/assets/javascripts/Components/Result/url_viewer.jsx
@@ -71,17 +71,30 @@ export class URLViewer extends React.Component {
     return false;
   };
 
+  renderLinkDisplay = () => {
+    return (
+      <div className="link-bar">
+        <a className="link-display" href={this.props.externalUrl} target="_blank">{this.props.externalUrl}</a>
+      </div>
+    )
+  }
+
   render() {
     if (this.state.url !== "") {
       return (
         <div className="url-container">
-          <iframe className="url-display" src={this.state.url} allowFullScreen>
-            <pre>{this.props.externalUrl}</pre>
-          </iframe>
+          {this.renderLinkDisplay()}
+          <div className="display-area">
+            <iframe className="url-display" src={this.state.url} allowFullScreen>
+              <pre>{this.props.externalUrl}</pre>
+            </iframe>
+          </div>
         </div>
       );
     } else {
-      return <pre>{this.props.externalUrl}</pre>;
+      return (
+        <div className="url-container">{this.renderLinkDisplay()}</div>
+      )
     }
   }
 }

--- a/app/assets/stylesheets/common/_url_viewer.scss
+++ b/app/assets/stylesheets/common/_url_viewer.scss
@@ -27,3 +27,9 @@
   word-wrap: break-word;
 }
 
+.url-message-display {
+  box-sizing: border-box;
+  font: 14px/20px $mono-fonts;
+  padding: 10px;
+}
+

--- a/app/assets/stylesheets/common/_url_viewer.scss
+++ b/app/assets/stylesheets/common/_url_viewer.scss
@@ -8,3 +8,21 @@
   height: 100%;
   width: 100%;
 }
+
+.display-area {
+  display: flex;
+  height: auto;
+}
+
+.link-bar {
+  background-color: $background-support;
+  border: thin solid $sub-menu;
+  padding: 5px;
+  width: inherit;
+}
+
+.link-display {
+  width: inherit;
+  word-wrap: break-word;
+}
+

--- a/app/assets/stylesheets/common/_url_viewer.scss
+++ b/app/assets/stylesheets/common/_url_viewer.scss
@@ -1,6 +1,8 @@
 .url-container {
   height: 595px;
   width: inherit;
+  display: flex;
+  flex-flow: column wrap;
 }
 
 .url-display {
@@ -10,13 +12,12 @@
 }
 
 .display-area {
-  display: flex;
-  height: auto;
+  flex-grow: 2;
 }
 
 .link-bar {
-  background-color: $background-support;
-  border: thin solid $sub-menu;
+  border: thin solid $primary-three;
+  box-sizing: border-box;
   padding: 5px;
   width: inherit;
 }

--- a/app/assets/stylesheets/common/_url_viewer.scss
+++ b/app/assets/stylesheets/common/_url_viewer.scss
@@ -1,8 +1,8 @@
 .url-container {
-  height: 595px;
-  width: inherit;
   display: flex;
   flex-flow: column wrap;
+  height: 595px;
+  width: inherit;
 }
 
 .url-display {
@@ -32,4 +32,3 @@
   font: 14px/20px $mono-fonts;
   padding: 10px;
 }
-

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -5,7 +5,7 @@ en:
       across_all_submission_files: Click on the filename to jump to the annotation.
       common: Common Annotations
       include_in_download: Include Annotations
-      include_in_download_warning: 'Warning: Annotations on PDFs and URLs are not currently downloaded.'
+      include_in_download_warning: 'Warning: Annotations on PDFs are not currently downloaded.'
       placeholder: Markdown and basic LaTeX syntax are supported.
       remark_flag: remark
       select_an_area: You must select an area on the image to annotate.

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -5,7 +5,7 @@ en:
       across_all_submission_files: Click on the filename to jump to the annotation.
       common: Common Annotations
       include_in_download: Include Annotations
-      include_in_download_warning: 'Warning: Annotations on PDFs are not currently downloaded.'
+      include_in_download_warning: 'Warning: Annotations on PDFs and URLs are not currently downloaded.'
       placeholder: Markdown and basic LaTeX syntax are supported.
       remark_flag: remark
       select_an_area: You must select an area on the image to annotate.

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -87,3 +87,5 @@ en:
     submission_summary: Submission Report
     successfully_changed: Successfully updated %{changed} results.
     unrelease_marks: Unrelease Marks
+    unsupported_url: Previews from %{host} are not supported and cannot be displayed
+    url_display_error: There was an error trying to display a preview for this URL


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request adds an important add on to the url uploader, that is the ability to see links uploaded from a markusurl file and be able to visit the link in a new tab. To do this, minor changes were also made to the layout of the `url_viewer`


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Added a bar that shows a clickable text of the entire URL. Clicking the link opens it in a new page.   
- Reworked layout of `url_viewer` to be adjustable according to the length of the url.
- Fixed minor bug that did not reset url modal content after submitting
- Added error messages for unsupported and/or broken URLs


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Manual testing of the feature was done to ensure no additional features were broken by the `url_viewer` rework. Several types of links were uploaded and viewed to ensure that the the proper messages were being displayed and the appropriate link was shown. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
