### PR TITLE
Issue 5607

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Fix bug for menu icon not working on mobile devices / smaller screens (#5607)
 - Remove unmaintained locales (#5727)
 - Fix bug for "Delete Group" button generating an invalid path (#5768)
 - Update wiki urls to point to https://github.com/MarkUsProject/Wiki (#5781)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [unreleased]
-- Fix bug for menu icon not working on mobile devices / smaller screens (#5607)
+- Fix bug for menu icon not working on mobile devices / smaller screens (#5818)
 - Remove unmaintained locales (#5727)
 - Fix bug for "Delete Group" button generating an invalid path (#5768)
 - Update wiki urls to point to https://github.com/MarkUsProject/Wiki (#5781)

--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -32,6 +32,6 @@ function initMenu() {
     }
   };
 }
-window.addEventListener("onload", () => {
+window.addEventListener("DOMContentLoaded", () => {
   initMenu();
 });

--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -32,6 +32,8 @@ function initMenu() {
     }
   };
 }
+// using addEventListener as opposed to direct assignment so that event listeners added elsewhere
+// don't get overridden
 window.addEventListener("DOMContentLoaded", () => {
   initMenu();
 });

--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -32,7 +32,6 @@ function initMenu() {
     }
   };
 }
-
-window.onload = () => {
+window.addEventListener("onload", () => {
   initMenu();
-};
+});

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -18,6 +18,8 @@
   <% end %>
 <% end %>
 <%= javascript_tag nonce: true do %>
+  // using addEventListener as opposed to direct assignment so that event listeners added elsewhere
+  // don't get overridden
   window.addEventListener("DOMContentLoaded", function () {
     Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
       elem.addEventListener("click", function(e) {

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -18,11 +18,11 @@
   <% end %>
 <% end %>
 <%= javascript_tag nonce: true do %>
-  window.onload = function () {
-    Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
-      elem.addEventListener("click", function(e) {
-        e.target.parentElement.style.display = 'none';
-      })
-    })
-  }
+  window.addEventListener('onload', function () {
+  Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
+  elem.addEventListener("click", function(e) {
+  e.target.parentElement.style.display = 'none';
+  })
+  })
+  })
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 <% end %>
 <%= javascript_tag nonce: true do %>
-  window.addEventListener("onload", function () {
+  window.addEventListener("DOMContentLoaded", function () {
     Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
       elem.addEventListener("click", function(e) {
         e.target.parentElement.style.display = 'none';

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 <% end %>
 <%= javascript_tag nonce: true do %>
-  window.addEventListener('onload', function () {
+  window.addEventListener("onload", function () {
   Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
   elem.addEventListener("click", function(e) {
   e.target.parentElement.style.display = 'none';

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -19,10 +19,10 @@
 <% end %>
 <%= javascript_tag nonce: true do %>
   window.addEventListener("onload", function () {
-  Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
-  elem.addEventListener("click", function(e) {
-  e.target.parentElement.style.display = 'none';
-  })
-  })
+    Array.from(document.getElementsByClassName('hide-flash')).forEach(function (elem) {
+      elem.addEventListener("click", function(e) {
+        e.target.parentElement.style.display = 'none';
+      })
+    })
   })
 <% end %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/MarkUsProject/Markus/issues/5607 issue of mobile menu/navigation bar not working. 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
The two files concerned by this commit both had an assignment to window.onload. This caused one of them to override the other. The fix is to add to window.onload instead of assigning. 

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I have performed manual testing using the latest version of google chrome on icognito mode (i.e. with no site data/cache). I used google developer tools to switch to several mobile devices, as well as resizing the desktop browser window to hit the size limit of the appearance of the navgation bar. In both case I was able to open/collapse the menu and use its menu items. There were no visible UI discrepancies. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
