### PR TITLE
Fix Flaky Tests in Assignment Download When Comparing Arrays

### DIFF
--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1346,8 +1346,8 @@ describe AssignmentsController do
           subject
           tags = read_file_from_zip(response.body, 'tags.yml')
           tags = tags.map(&:symbolize_keys)
-          expect(tags).to eq([{ name: tag1.name, description: tag1.description },
-                              { name: tag2.name, description: tag2.description }])
+          expect(tags).to match_array([{ name: tag1.name, description: tag1.description },
+                                       { name: tag2.name, description: tag2.description }])
         end
 
         it 'should contain a peer review tags file' do
@@ -1553,7 +1553,7 @@ describe AssignmentsController do
                                                  .map(&:symbolize_keys)
         expected_annotation_text = [{ content: 'Sunt optio.' }, { content: 'Quibusdam ut ipsa.' },
                                     { content: 'Earum voluptate.' }, { content: 'Saepe.' }, { content: 'Non eum.' }]
-        expect(uploaded_annotation_text).to eq(expected_annotation_text)
+        expect(uploaded_annotation_text).to match_array(expected_annotation_text)
       end
 
       it 'properly uploads all the automated test files for an assignment' do
@@ -1687,7 +1687,7 @@ describe AssignmentsController do
         expected_tags = [{ name: tag1.name, description: tag1.description },
                          { name: tag2.name, description: tag2.description },
                          { name: tag3.name, description: tag3.description }]
-        expect(uploaded_tags).to eq(expected_tags)
+        expect(uploaded_tags).to match_array(expected_tags)
       end
 
       it 'copies over annotations' do
@@ -1735,7 +1735,7 @@ describe AssignmentsController do
             files_and_dirs: starter_group2_files
           }
         ]
-        expect(uploaded_starter_files).to eq(expected_starter_files)
+        expect(uploaded_starter_files).to match_array(expected_starter_files)
       end
     end
 
@@ -1802,7 +1802,7 @@ describe AssignmentsController do
                                       .map(&:symbolize_keys)
         expected = [{ filename: assignment_file1.filename },
                     { filename: assignment_file2.filename }]
-        expect(received).to eq(expected)
+        expect(received).to match_array(expected)
       end
 
       it 'copies over automated tests' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As seen in some [test runs](https://github.com/MarkUsProject/Markus/runs/5056235855?check_suite_focus=true), sometimes copy assignment tests that involve comparing two arrays will fail because the order in which items can appear can sometimes differ from what was expected (when in reality array order should not matter for these tests). 


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Replaced `eq` calls with `match_array` when comparing two arrays in copy assignment tests

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I have reran the changed tests locally and on the CI server both of which have passed. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
