### PR TITLE
controllers: Fix deprecation warning from including .js.erb extension

### DIFF
--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -202,7 +202,7 @@ class AutomatedTestsController < ApplicationController
       else
         @current_job = AutotestSpecsJob.perform_later(request.protocol + request.host_with_port, assignment)
         session[:job_id] = @current_job.job_id
-        render 'shared/_poll_job.js.erb'
+        render 'shared/_poll_job'
       end
     else
       head :unprocessable_entity

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -92,7 +92,7 @@ class ExamTemplatesController < ApplicationController
     session[:job_id] = current_job.job_id
 
     respond_to do |format|
-      format.js { render 'exam_templates/_poll_generate_job.js.erb' }
+      format.js { render 'exam_templates/_poll_generate_job' }
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -296,7 +296,7 @@ class GroupsController < ApplicationController
     end
 
     respond_to do |format|
-      format.js { render 'shared/_poll_job.js.erb' }
+      format.js { render 'shared/_poll_job' }
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -150,7 +150,7 @@ class SubmissionsController < ApplicationController
     session[:job_id] = @current_job.job_id
 
     respond_to do |format|
-      format.js { render 'shared/_poll_job.js.erb' }
+      format.js { render 'shared/_poll_job' }
     end
   end
 
@@ -196,7 +196,7 @@ class SubmissionsController < ApplicationController
                      assignment_identifier: assignment.short_identifier)
       flash_now(:error, error)
     end
-    render 'shared/_poll_job.js.erb'
+    render 'shared/_poll_job'
   end
 
   def run_tests
@@ -584,7 +584,7 @@ class SubmissionsController < ApplicationController
     @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id)
     session[:job_id] = @current_job.job_id
 
-    render 'shared/_poll_job.js.erb'
+    render 'shared/_poll_job'
   end
 
   # download a zip file previously prepared by calling the

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -960,7 +960,7 @@ describe SubmissionsController do
                     params: { course_id: course.id, assignment_id: @assignment.id,
                               override: true, groupings: ([] << @assignment.groupings).flatten }
 
-            expect(response).to render_template(partial: 'shared/_poll_job.js.erb')
+            expect(response).to render_template(partial: 'shared/_poll_job')
           end
 
           it 'should succeed if it is after the section due date' do
@@ -976,7 +976,7 @@ describe SubmissionsController do
                     params: { course_id: course.id, assignment_id: @assignment.id,
                               override: true, groupings: ([] << @assignment.groupings).flatten }
 
-            expect(response).to render_template(partial: 'shared/_poll_job.js.erb')
+            expect(response).to render_template(partial: 'shared/_poll_job')
           end
         end
 
@@ -1000,7 +1000,7 @@ describe SubmissionsController do
                     params: { course_id: course.id, assignment_id: @assignment.id,
                               override: true, groupings: ([] << @assignment.groupings).flatten }
 
-            expect(response).to render_template(partial: 'shared/_poll_job.js.erb')
+            expect(response).to render_template(partial: 'shared/_poll_job')
           end
 
           it 'should succeed if it is after the global due date' do
@@ -1016,7 +1016,7 @@ describe SubmissionsController do
                     params: { course_id: course.id, assignment_id: @assignment.id,
                               override: true, groupings: ([] << @assignment.groupings).flatten }
 
-            expect(response).to render_template(partial: 'shared/_poll_job.js.erb')
+            expect(response).to render_template(partial: 'shared/_poll_job')
           end
         end
       end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Rails has deprecated [rendering templates with '.' in the name](https://github.com/rails/rails/pull/39164).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fix template names that included a `.` (all were uses of `shared/_poll_job.js.erb`). We can juse remove the extension (the file will be found anyway).

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested to make sure that the view gets rendered correctly from these controller methods, and ran suite.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
