### PR TITLE
starter files: Remove spurious warning when only starter_files_after_due is updated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Added the ability to submit URLs (#5822)
 - Allow TAs to download grades for students they've been assigned to grade (#5793)
 - Fix bugs when submitting and cancelling remark requests (#5838)
+- Do not trigger starter file changed timestamp when only starter_files_after_due assignment setting is changed (#5845)
 
 ## [v2.0.5]
 - Add ability to annotate notebook (jupyter and Rmd) submissions (#5749)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -433,17 +433,19 @@ class AssignmentsController < ApplicationController
     success = true
     ApplicationRecord.transaction do
       assignment.assignment_properties.update!(starter_file_assignment_params)
-      all_changed = assignment.assignment_properties.saved_changes?
-      params[:sections].each do |section_params|
+      all_changed =
+        assignment.assignment_properties.saved_change_to_starter_file_type? ||
+        assignment.assignment_properties.saved_change_to_default_starter_file_group_id?
+      params[:sections]&.each do |section_params|
         Section.find_by(id: section_params[:section_id])
                &.update_starter_file_group(assignment.id, section_params[:group_id])
       end
       starter_file_group_params.each do |group_params|
         starter_file_group = assignment.starter_file_groups.find_by(id: group_params[:id])
         starter_file_group.update!(group_params)
-        all_changed ||= starter_file_group.saved_changes? || assignment.assignment_properties.saved_changes?
+        all_changed ||= starter_file_group.saved_changes?
       end
-      assignment.assignment_properties.update!(starter_file_updated_at: Time.current)
+      assignment.assignment_properties.update!(starter_file_updated_at: Time.current) if all_changed
     rescue ActiveRecord::RecordInvalid, StandardError => e
       flash_message(:error, e.message)
       success = false

--- a/app/models/starter_file_group.rb
+++ b/app/models/starter_file_group.rb
@@ -106,7 +106,7 @@ class StarterFileGroup < ApplicationRecord
   end
 
   def update_timestamp
-    assignment.assignment_properties.update(starter_file_updated_at: Time.current)
+    assignment.assignment_properties.update(starter_file_updated_at: Time.current) if saved_changes?
   end
 
   def set_name


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We use the assignment `starter_file_updated_at` and grouping `starter_file_changed` attributes to report when starter files for an assignment were last changed, and whether a student/group should download a new version of the files.

These attributes are currently being updated from the `AssignmentsController#update_starter_file` route even when the only thing that's changed is `starter_files_after_due`. However, this attribute doesn't affect the contents of the starter files themselves, only whether they are available to students after the due date of an assignment has passed. So when this field is updated, we should not update the above attributes, as doing so may mislead students into thinking that they need to download a fresh set of starter files, when in reality nothing has changed.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Updated the controller method to not update the attributes if the only thing that's changed is `starter_files_after_due`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI, and added some additional tests.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
