### PR TITLE
fix bug with section starter files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Allow TAs to download grades for students they've been assigned to grade (#5793)
 - Fix bugs when submitting and cancelling remark requests (#5838)
 - Do not trigger starter file changed timestamp when only starter_files_after_due assignment setting is changed (#5845)
+- Fix bugs in starter files when assigning by section (#5846)
 
 ## [v2.0.5]
 - Add ability to annotate notebook (jupyter and Rmd) submissions (#5749)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -446,8 +446,8 @@ class Grouping < ApplicationRecord
     when 'simple'
       assignment.default_starter_file_group&.starter_file_entries || []
     when 'sections'
-      return inviter.section&.starter_file_group_for(assignment)&.starter_file_entries || [] unless inviter.nil?
-      assignment.default_starter_file_group&.starter_file_entries || []
+      section = inviter&.section&.starter_file_group_for(assignment) || assignment.default_starter_file_group
+      section&.starter_file_entries || []
     when 'shuffle'
       assignment.starter_file_groups.includes(:starter_file_entries).map do |g|
         # If this grouping has previous starter files, try to choose an entry with the same path as before

--- a/app/models/student_membership.rb
+++ b/app/models/student_membership.rb
@@ -26,6 +26,7 @@ class StudentMembership < Membership
 
   after_save :update_repo_permissions_after_save
   after_create :update_repo_permissions_after_create
+  after_create :reset_starter_files_after_create
   after_destroy :update_repo_permissions_after_destroy
 
   def must_be_valid_student
@@ -80,5 +81,10 @@ class StudentMembership < Membership
 
     errors.add(:base, :memberships_not_unique)
     throw(:abort)
+  end
+
+  def reset_starter_files_after_create
+    return unless self.inviter? && grouping.assignment.assignment_properties&.starter_file_type == 'sections'
+    grouping.reset_starter_file_entries
   end
 end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -1350,6 +1350,23 @@ describe Grouping do
         entries = ssfg.starter_file_group.starter_file_entries
         expect(grouping.select_starter_file_entries).to contain_exactly(*entries)
       end
+
+      context 'when the grouping\'s inviter does not belong to a section' do
+        it 'should return the entries from the default starter file group' do
+          entries = assignment.default_starter_file_group.starter_file_entries
+          student2 = create :student
+          grouping_without_section = create :grouping_with_inviter, inviter: student2, assignment: assignment
+          expect(grouping_without_section.select_starter_file_entries).to contain_exactly(*entries)
+        end
+      end
+
+      context 'when the grouping does not have an inviter' do
+        it 'should return the entries from the default starter file group' do
+          entries = assignment.default_starter_file_group.starter_file_entries
+          grouping_without_inviter = create :grouping, assignment: assignment
+          expect(grouping_without_inviter.select_starter_file_entries).to contain_exactly(*entries)
+        end
+      end
     end
     context 'when starter_file_type is shuffle' do
       let(:starter_file_type) { 'shuffle' }

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -1422,6 +1422,56 @@ describe Grouping do
         end
       end
     end
+
+    context 'when a grouping is created' do
+      let(:grouping_without_inviter) { build :grouping, assignment: assignment }
+      let(:inviter) { create :inviter_student_membership, grouping: grouping_without_inviter }
+
+      it 'is called' do
+        expect(grouping_without_inviter).to receive(:reset_starter_file_entries)
+
+        grouping_without_inviter.save!
+      end
+
+      context 'when the grouping gets an inviter' do
+        before do
+          assignment.assignment_properties.update!(starter_file_type: starter_file_type)
+          grouping_without_inviter.save!
+        end
+
+        context 'when starter files are always assigned from the same single group' do
+          let(:starter_file_type) { 'simple' }
+          it 'is not called' do
+            expect(grouping_without_inviter).to_not receive(:reset_starter_file_entries)
+            inviter
+          end
+        end
+
+        context 'when starter files are assigned by section' do
+          let(:starter_file_type) { 'sections' }
+          it 'is called' do
+            expect(grouping_without_inviter).to receive(:reset_starter_file_entries)
+            inviter
+          end
+        end
+
+        context 'when starter files are assigned a random file from each group' do
+          let(:starter_file_type) { 'shuffle' }
+          it 'is not called' do
+            expect(grouping_without_inviter).to_not receive(:reset_starter_file_entries)
+            inviter
+          end
+        end
+
+        context 'when starter files are assigned from a random group' do
+          let(:starter_file_type) { 'group' }
+          it 'is not called' do
+            expect(grouping_without_inviter).to_not receive(:reset_starter_file_entries)
+            inviter
+          end
+        end
+      end
+    end
   end
   describe '#reset_starter_file_entries' do
     let(:assignment) { create :assignment }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes two issues with student starter files not being correctly assigned based on sections:

1. When a student first visits the timed assessment page (and MarkUs creates a "working alone" group for the student), the default starter file group is assigned, rather than the starter file group for the section.
2. If a student does not belong to a section, no files get assigned, rather than the default starter file group.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the bugs.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

New tests c/o @david-yz-liu and a callback on creation of student memberships

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes.
- [x] I have updated the Changelog.md file. 
