### PR TITLE
Fixed automated test zip file folder download to not make a subfolder

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,6 @@
 - Remove group name displayed attribute from assignment properties table (#5834)
 - Replace uses of first name and last name attributes with display name (#5844)
 - Upgrade to Rails 7 (#5885)
-
-## [v2.0.9]
 - Fix bug when downloading all automated test files where the files were saved to a sub directory (#5864)
 
 ## [v2.0.8]

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
 - Upgrade to Rails 7 (#5885)
 
 ## [v2.0.9]
-- Fix bug when downloading all automated test files where the files were saved to a sub directory
+- Fix bug when downloading all automated test files where the files were saved to a sub directory (#5864)
 
 ## [v2.0.8]
 - Fix bug where "run tests" grader permission was not working for submission table (#5860)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
 - Replace uses of first name and last name attributes with display name (#5844)
 - Upgrade to Rails 7 (#5885)
 
+## [v2.0.9]
+- Fix bug when downloading all automated test files where the files were saved to a sub directory
+
 ## [v2.0.8]
 - Fix bug where "run tests" grader permission was not working for submission table (#5860)
 - Fix bug for replacing exam template files (#5863)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1221,7 +1221,7 @@ class Assignment < Assessment
     zip_path = File.join('tmp', zip_name + '.zip')
     FileUtils.rm_rf zip_path
     Zip::File.open(zip_path, create: true) do |zip_file|
-      add_test_files_to_zip(zip_file, zip_name)
+      self.add_test_files_to_zip(zip_file, '')
     end
     zip_path
   end
@@ -1245,10 +1245,10 @@ class Assignment < Assessment
 
   private
 
-  def add_test_files_to_zip(zip_file, zip_name)
+  def add_test_files_to_zip(zip_file, zip_base_dir)
     files_dir = Pathname.new self.autotest_files_dir
     self.autotest_files.map do |file|
-      path = File.join zip_name, file
+      path = zip_base_dir.empty? ? file : File.join(zip_base_dir, file)
       abs_path = files_dir.join(file)
       if abs_path.directory?
         zip_file.mkdir(path)

--- a/spec/controllers/automated_tests_controller_spec.rb
+++ b/spec/controllers/automated_tests_controller_spec.rb
@@ -129,40 +129,43 @@ describe AutomatedTestsController do
     end
     context 'GET download_files' do
       subject { get_as role, :download_files, params: params }
-      before :each do
-        create_automated_test(assignment)
-      end
-      after :each do
-        # Clear uploaded autotest files to prepare for next test
-        FileUtils.rm_rf(assignment.autotest_files_dir)
-        FileUtils.rm_f(assignment.autotest_settings_file)
-      end
+      let(:content) { response.body }
+      it_behaves_like 'zip file download'
       it 'should be successful' do
         subject
         expect(response.status).to eq(200)
       end
-      it 'should receive the appropriate files' do
-        subject
-        received_content = []
-        Zip::InputStream.open(StringIO.new(response.body)) do |io|
-          while (entry = io.get_next_entry)
-            received_content << {
-              name: entry.name,
-              file_content: entry.get_input_stream.read
-            }
-          end
+      context 'non empty automated test files' do
+        before :each do
+          create_automated_test(assignment)
         end
-        expected_content = [{
-          name: File.join('Helpers', 'test_helpers.py'),
-          file_content: "def initialize_tests()\n\treturn True"
-        }, {
-          name: 'tests.py',
-          file_content: "def sample_test()\n\tassert True == True"
-        }, {
-          name: File.join('Helpers', ''),
-          file_content: ''
-        }]
-        expect(received_content).to match_array(expected_content)
+        after :each do
+          # Clear uploaded autotest files to prepare for next test
+          FileUtils.rm_rf(assignment.autotest_files_dir)
+          FileUtils.rm_f(assignment.autotest_settings_file)
+        end
+        it 'should receive the appropriate files' do
+          subject
+          received_content = []
+          Zip::InputStream.open(StringIO.new(content)) do |io|
+            while (entry = io.get_next_entry)
+              unless entry.name_is_directory?
+                received_content << {
+                  name: entry.name,
+                  file_content: entry.get_input_stream.read
+                }
+              end
+            end
+          end
+          expected_content = [{
+            name: File.join('Helpers', 'test_helpers.py'),
+            file_content: "def initialize_tests()\n\treturn True"
+          }, {
+            name: 'tests.py',
+            file_content: "def sample_test()\n\tassert True == True"
+          }]
+          expect(received_content).to match_array(expected_content)
+        end
       end
     end
     context 'POST upload_files' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
Fixed a small bug that created automated test files files in a sub folder as opposed to straight to a zip file when downloading all test files. 

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves a minor issue where after downloading all automated test files and re uploading them, the automated test files would be in a sub folder which caused some inconveniences. This pull request aims to resolve that inconvenience by saving the automated test files straight to the zip folder as opposed to putting them in a sub folder. 


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Fixed bug that made `add_test_files_to_zip` unable to accept an empty relative path
- Changed `zip_automated_test_files` to save files to empty relative path (i.e. straight to zip folder root) rather than to a sub directory. 


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Manual testing of the feature was done. That is, automated test files were downloaded from an assignment and verified to ensure that the files were saved straight to the zip file and not in a sub directory. 


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
