### PR TITLE
bugfix: cancel remark requests should pass result_id to the results_controller, not assignment_id

### DIFF
--- a/app/views/results/student/no_remark_result.html.erb
+++ b/app/views/results/student/no_remark_result.html.erb
@@ -36,7 +36,7 @@
       <%= link_to t('results.remark.cancel'),
                   { controller: 'results',
                     action: 'cancel_remark_request',
-                    id: @assignment.id,
+                    id: @result.id,
                     submission_id: @submission.id },
                   class: 'button',
                   data: { confirm: t('results.remark.cancel_confirm') },


### PR DESCRIPTION


<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix: the cancel remark request button was sending @assignment_id to the results controller instead of @result_id. This resulted in a 404 when the result with id == assignment.id was in a different course than the assignment.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Just a one line change to use result.id instead of assignment.id for cancelling remarks.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested in the web view with courses and students.


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
