### PR TITLE
allow annotations on remarks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Fix bug for rubric criteria level's mark update where one of the marks = an old mark (#5854)
 - Upgrade to Rails 7 (#5885)
 - Fix bug when downloading all automated test files where the files were saved to a sub directory (#5864)
+- Allow adding annotations to remark requests (#5900)
 
 ## [v2.0.8]
 - Fix bug where "run tests" grader permission was not working for submission table (#5860)

--- a/app/assets/javascripts/Components/Result/left_pane.jsx
+++ b/app/assets/javascripts/Components/Result/left_pane.jsx
@@ -86,11 +86,7 @@ export class LeftPane extends React.Component {
             assignment_id={this.props.assignment_id}
             grouping_id={this.props.grouping_id}
             revision_identifier={this.props.revision_identifier}
-            show_annotation_manager={
-              !this.props.released_to_students &&
-              !this.props.remark_submitted &&
-              !this.props.is_reviewer
-            }
+            show_annotation_manager={!this.props.released_to_students && !this.props.is_reviewer}
             canDownload={this.props.is_reviewer === undefined ? undefined : !this.props.is_reviewer}
             fileData={this.props.submission_files}
             annotation_categories={this.props.annotation_categories}

--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -232,7 +232,7 @@ class FlexibleCriterionInput extends React.Component {
   listDeductions = () => {
     let label = I18n.t("annotations.list_deductions");
     let deductiveAnnotations = this.props.annotations.filter(a => {
-      return !!a.deduction && a.criterion_id === this.props.id;
+      return !!a.deduction && a.criterion_id === this.props.id && !a.is_remark;
     });
 
     if (deductiveAnnotations.length === 0) {

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -132,12 +132,7 @@ class Result extends React.Component {
 
   /* Interaction with external components/libraries */
   updateContextMenu = () => {
-    if (
-      this.state.released_to_students ||
-      this.state.remark_submitted ||
-      this.props.role === "Student"
-    )
-      return;
+    if (this.state.released_to_students || this.props.role === "Student") return;
 
     window.annotation_context_menu.setup(
       Routes.course_annotations_path,

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -29,7 +29,7 @@ class Annotation < ApplicationRecord
 
   def modify_mark_with_deduction
     criterion = self.annotation_text.annotation_category.flexible_criterion
-    self.result.marks.find_or_create_by(criterion: criterion).update_deduction
+    self.result.marks.find_or_create_by(criterion: criterion).update_deduction unless self.is_remark
   end
 
   def get_data(include_creator: false)
@@ -63,6 +63,9 @@ class Annotation < ApplicationRecord
   # check if the submission file is associated with a remark result or a released result
   def check_if_released
     annotation_results = result.submission.results
+
+    return if is_remark && annotation_results.where.not(remark_request_submitted_at: nil)
+                                             .where('results.released_to_students': false)
 
     return if annotation_results.where('results.released_to_students': true).empty? &&
               annotation_results.where.not(remark_request_submitted_at: nil).empty?

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -33,8 +33,8 @@ describe Annotation do
         grouping.current_submission_used.make_remark_result
         grouping.current_result
       end
-      it 'should prevent it being created' do
-        expect { create :text_annotation, result: result }.to raise_error(ActiveRecord::RecordNotSaved)
+      it 'should allow it to be created' do
+        expect { create :text_annotation, result: result, is_remark: true }.not_to raise_error
       end
     end
     context 'with a released result' do
@@ -59,8 +59,12 @@ describe Annotation do
         grouping.current_submission_used.make_remark_result
         annotation
       end
-      it 'should prevent it being destroyed' do
+      it 'should prevent a pre-existing annotation from being destroyed' do
         expect { annotation.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      end
+      it 'should allow a remark annotation to destroyed' do
+        annotation.update!(is_remark: true)
+        expect { annotation.destroy! }.not_to raise_error
       end
     end
     context 'with a released result' do
@@ -114,6 +118,26 @@ describe Annotation do
              annotation_text: annotation_text,
              result: result)
       expect(new_flex.marks.first.mark).to eq 0.67
+    end
+
+    context 'with a remark request' do
+      let(:annotation) do
+        grouping = assignment.groupings.first
+        grouping.current_result.update!(released_to_students: true)
+        grouping.current_submission_used.make_remark_result
+        grouping.current_submission_used.update!(remark_request: 'remark request', remark_request_timestamp: Time.now)
+        grouping.current_submission_used.get_original_result.update!(released_to_students: false)
+        annotation = create(:text_annotation, annotation_text: annotation_text, result: grouping.current_result,
+                                              is_remark: true)
+        annotation
+      end
+      it 'does not update a mark after creation' do
+        expect(mark.mark).to eq 2.0
+      end
+      it 'does not update a mark after destruction' do
+        annotation.destroy!
+        expect(mark.mark).to eq 2.0
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows graders and instructors to add annotations to remark requests. For this PR, old annotations cannot be removed, and new deductive annotations do not actually affect remark grades. Resolves #5671

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Modified result react components to display annotation tools on remark requests. Also modified checks around annotation creation, destruction, and mark updating for the use cases above.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update (change that modifies or updates tests only)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I tested this change manually in the web interface, and also added tests for creation, destruction, and marking changes on remark annotations,

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Future discussion/PR todos: potentially changing the color of remark annotations to differentiate them from other annotations. Integrate more deeply between original marks and remarks. 

## Checklist
Test run: https://github.com/MarkUsProject/Markus/runs/5504888246
- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [x] I have made changes to the documentation and linked to that pull request below. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
https://github.com/MarkUsProject/Wiki/pull/96