### PR TITLE
bugfix: ensure penalty periods are ordered correctly

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -4,6 +4,9 @@ class Period < ApplicationRecord
   validates_numericality_of :hours, greater_than: 0
   validates_numericality_of :deduction, greater_than_or_equal_to: 0, if: :check_deduction
   validates_numericality_of :interval, greater_than: 0, if: :check_interval
+  # Order by id to ensure consistent ordering of periods.
+  # TODO: change this to order by created_at or add explicit ordering in the database.
+  default_scope { order(id: :asc) }
 
   before_create -> { self.submission_rule_type = submission_rule.type }
 

--- a/app/views/assignments/_read.html.erb
+++ b/app/views/assignments/_read.html.erb
@@ -46,7 +46,7 @@
         <% acc = 0 %>
         <% if @assignment.submission_rule.type == "GracePeriodSubmissionRule" %>
           <% remaining_credits = @grouping.available_grace_credits %>
-          <% @assignment.submission_rule.periods.order(:id).each do |p| %>
+          <% @assignment.submission_rule.periods.each do |p| %>
             <% unless remaining_credits <= 0 %>
               <% acc += p.hours %>
               <% remaining_credits -= 1 %>
@@ -64,7 +64,7 @@
             <strong>
               <%= t('penalty_period_submission_rules.deadline_html') %>:
             </strong>
-            <% @assignment.submission_rule.periods.order(:id).each { |p| acc += p.hours } %>
+            <% @assignment.submission_rule.periods.each { |p| acc += p.hours } %>
             <% if @grouping.nil? %>
               <%= I18n.l(@assignment.section_due_date(@current_role.try(:section)) + acc.hours) %>
             <% else %>
@@ -84,8 +84,8 @@
             </li>
           <% end %>
         <% elsif @assignment.submission_rule.type == "PenaltyDecayPeriodSubmissionRule" %>
-          <% @assignment.submission_rule.periods.order(:id).each do |p| %>
-            <% if p == @assignment.submission_rule.periods.order(:id).first %>
+          <% @assignment.submission_rule.periods.each do |p| %>
+            <% if p == @assignment.submission_rule.periods.first %>
               <li><%= t('penalty_decay_period_submission_rules.details_message_first',
                         deduction: p.deduction, interval: p.interval, hours: p.hours) %> </li>
             <% else %>
@@ -95,7 +95,7 @@
           <% end %>
         <% elsif @assignment.submission_rule.type == "PenaltyPeriodSubmissionRule" %>
           <% deduction = hours = 0 %>
-          <% @assignment.submission_rule.periods.order(:id).each do |p| %>
+          <% @assignment.submission_rule.periods.each do |p| %>
             <% deduction += p.deduction %>
             <% hours += p.hours %>
             <li><%= t('penalty_period_submission_rules.details_message',

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -42,4 +42,14 @@ describe Period do
     it { is_expected.not_to validate_numericality_of(:interval) }
     include_examples 'has a course'
   end
+
+  context 'Multiple penalty decay periods' do
+    let(:rule) { create :penalty_period_submission_rule }
+    let!(:period) { create :period, id: 2, submission_rule: rule }
+    let!(:period2) { create :period, id: 3, deduction: 0.25, interval: 0.25, hours: 0.25, submission_rule: rule }
+    let!(:period3) { create :period, id: 1, deduction: 1, interval: 1, hours: 10, submission_rule: rule }
+    it 'returns the periods in order' do
+      expect(rule.reload.periods).to eq [period3, period, period2]
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes reported issues with penalty periods being returned in an incorrect order, which impacts both instructors adding penalty periods and marks given using penalty periods.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Adds default_scope order by ID to periods, to ensure they are always ordered in the same way. Also removes explicit ordering from assignments/_read view, because the same ordering is now on the model

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Added test for checking ordering of periods. Also manually tested in the web interface, especially the assignments/_read view. 


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->