### PR TITLE
results: Eagerly render all result tabs (so that they only mount once)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Upgrade to Rails 7 (#5885)
 - Modified login to allow admin users to login via the UI (#5897)
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)
+- Ensure tabs in result view do not reload when switching between them (#5910)
 
 ## [v2.0.9]
 - Fix bug when downloading all automated test files where the files were saved to a sub directory (#5864)

--- a/app/assets/javascripts/Components/Result/left_pane.jsx
+++ b/app/assets/javascripts/Components/Result/left_pane.jsx
@@ -117,7 +117,7 @@ export class LeftPane extends React.Component {
             />
           </div>
         </TabPanel>
-        <TabPanel>
+        <TabPanel forceRender={!LeftPane.disableTestResultsPanel(this.props)}>
           <div id="testviewer">
             {/* student results page (with instructor tests released) does not need the button */}
             {!this.props.student_view && (
@@ -151,7 +151,7 @@ export class LeftPane extends React.Component {
             />
           </div>
         </TabPanel>
-        <TabPanel>
+        <TabPanel forceRender={!LeftPane.disableFeedbackFilesPanel(this.props)}>
           <FeedbackFilePanel
             assignment_id={this.props.assignment_id}
             feedbackFiles={this.props.feedback_files}
@@ -160,7 +160,7 @@ export class LeftPane extends React.Component {
             loading={this.props.loading}
           />
         </TabPanel>
-        <TabPanel>
+        <TabPanel forceRender={!LeftPane.disableRemarkPanel(this.props)}>
           <div id="remark_request_tab">
             <RemarkPanel
               result_id={this.props.result_id}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes #5603. The issue was that by default the react-tabs library we use to display tabs triggers a React component mount/unmount every time tabs are switched. In the case of the remark request form, this caused previous text to be lost after switching away from the tab.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Use the [`forceRender`](https://github.com/reactjs/react-tabs#forcerender-boolean) prop to ensure remark request tab is loaded just once on initial page load.

I did the same for the test runs and feedback files tabs---they do trigger additional requests to fetch their data, which also makes loading those tabs a bit faster.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (internal change to codebase, without changing functionality)
- [ ] Test update (change that modifies or updates tests only)
- [ ] Other (please specify):


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the web interface.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

In the future, could do a cached lazy loading of tabs as described by https://github.com/reactjs/react-tabs/issues/126#issuecomment-466240855

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
