### PR TITLE
autotest: Move autotest specs.json into database

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,6 +2,8 @@ require 'csv'
 
 # Represents an assignment where students submit work to be graded
 class Assignment < Assessment
+  include AutomatedTestsHelper
+
   MIN_PEER_REVIEWS_PER_GROUP = 1
 
   validates :due_date, presence: true
@@ -961,10 +963,6 @@ class Assignment < Assessment
     end.compact
   end
 
-  def autotest_settings_file
-    File.join(autotest_path, TestRun::SPECS_FILE)
-  end
-
   def scanned_exams_path
     File.join(Settings.scanned_exams.path, course.name, short_identifier)
   end
@@ -1231,12 +1229,11 @@ class Assignment < Assessment
   end
 
   # Writes all of this assignment's automated test files to the +zip_dir+ in +zip_file+. Also writes
-  # the tester settings specified in this assignment's properties and spec file to the json file at
+  # the tester settings specified in this assignment's properties to the json file at
   # +specs_file_path+ in the +zip_file+.
   def automated_test_config_to_zip(zip_file, zip_dir, specs_file_path)
     self.add_test_files_to_zip(zip_file, zip_dir)
-    test_specs_path = self.autotest_settings_file
-    test_specs = File.exist?(test_specs_path) ? JSON.parse(File.read(test_specs_path)) : {}
+    test_specs = autotest_settings_for(self)
     test_specs['testers']&.each do |tester_info|
       tester_info['test_data']&.each do |test_info|
         test_info['extra_info']&.delete('test_group_id')

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -116,7 +116,7 @@ class Course < ApplicationRecord
     autotest_setting = AutotestSetting.find_or_create_by!(url: url)
     if autotest_setting.id != self.autotest_setting&.id
       self.update!(autotest_setting_id: autotest_setting.id)
-      AssignmentProperties.where(assessment_id: self.assignments.ids).update_all(autotest_settings_id: nil)
+      AssignmentProperties.where(assessment_id: self.assignments.ids).update_all(remote_autotest_settings_id: nil)
     end
   end
 end

--- a/app/models/test_group.rb
+++ b/app/models/test_group.rb
@@ -10,4 +10,15 @@ class TestGroup < ApplicationRecord
   validates :name, presence: true
   validates :display_output, presence: true
   validate :courses_should_match
+
+  def to_json(*_args)
+    result = self.autotest_settings
+    result['extra_info'] = {
+      'name' => name,
+      'display_output' => display_output,
+      'test_group_id' => id,
+      'criterion' => criterion&.name
+    }
+    result
+  end
 end

--- a/config/locales/views/automated_tests/en.yml
+++ b/config/locales/views/automated_tests/en.yml
@@ -11,7 +11,7 @@ en:
     need_group_for_test: You must have a group to run tests.
     need_one_file: You must submit at least one file in order to run tests.
     need_submission: Submissions must be collected before tests are run. Not all selected groupings had tests run.
-    no_criteria: Unable to find a criterion of type "%{type}" and name "%{name}".
+    no_criteria: Unable to find a criterion with name "%{name}".
     no_results: No test results to display
     results:
       extra_malformed: "Malformed results discarded by server: \n%{extra}\n"

--- a/db/data/autotest_files/custom/specs.json
+++ b/db/data/autotest_files/custom/specs.json
@@ -12,7 +12,7 @@
           ],
           "timeout": 30,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Custom Test Group"
           }
         }

--- a/db/data/autotest_files/haskell/specs.json
+++ b/db/data/autotest_files/haskell/specs.json
@@ -14,7 +14,7 @@
           "test_timeout": 10,
           "test_cases": 100,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Haskell Test Group"
           }
         }

--- a/db/data/autotest_files/java/specs.json
+++ b/db/data/autotest_files/java/specs.json
@@ -8,7 +8,7 @@
           "category": ["instructor"],
           "timeout": 30,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Java Test Group 1"
           }
         },
@@ -17,7 +17,7 @@
           "category": ["instructor"],
           "timeout": 30,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Java Test Group 2"
           }
         }

--- a/db/data/autotest_files/jupyter/specs.json
+++ b/db/data/autotest_files/jupyter/specs.json
@@ -17,7 +17,7 @@
             "instructor"
           ],
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Python Test Group"
           }
         }
@@ -43,7 +43,7 @@
             "instructor"
           ],
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Jupyter Test Group"
           }
         }

--- a/db/data/autotest_files/py/specs.json
+++ b/db/data/autotest_files/py/specs.json
@@ -14,7 +14,7 @@
           "tester": "unittest",
           "output_verbosity": 2,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Python Test Group 1"
           }
         },
@@ -25,7 +25,7 @@
           "tester": "pytest",
           "output_verbosity": "short",
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Python Test Group 2"
           }
         }

--- a/db/data/autotest_files/pyta/specs.json
+++ b/db/data/autotest_files/pyta/specs.json
@@ -15,7 +15,7 @@
           ],
           "timeout": 30,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "PyTA Test Group"
           }
         }

--- a/db/data/autotest_files/r/specs.json
+++ b/db/data/autotest_files/r/specs.json
@@ -15,7 +15,7 @@
           ],
           "extra_info":
           {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "R Test Group",
             "display_output": "instructors"
           },

--- a/db/data/autotest_files/racket/specs.json
+++ b/db/data/autotest_files/racket/specs.json
@@ -15,7 +15,7 @@
           ],
           "timeout": 30,
           "extra_info": {
-            "criterion": "FlexibleCriterion:criterion",
+            "criterion": "criterion",
             "name": "Racket Test Group"
           }
         }

--- a/db/migrate/20220321145827_add_json_autotest_settings.rb
+++ b/db/migrate/20220321145827_add_json_autotest_settings.rb
@@ -1,0 +1,7 @@
+class AddJsonAutotestSettings < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :assignment_properties, :autotest_settings_id, :remote_autotest_settings_id
+    add_column :assignment_properties, :autotest_settings, :json
+    add_column :test_groups, :autotest_settings, :json, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_06_065135) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_21_145827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -135,9 +135,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_06_065135) do
     t.string "starter_file_type", default: "simple", null: false
     t.datetime "starter_file_updated_at", precision: nil
     t.bigint "default_starter_file_group_id"
-    t.integer "autotest_settings_id"
+    t.integer "remote_autotest_settings_id"
     t.boolean "starter_files_after_due", default: true, null: false
     t.boolean "url_submit", default: false, null: false
+    t.json "autotest_settings"
     t.index ["assessment_id"], name: "index_assignment_properties_on_assessment_id", unique: true
     t.index ["default_starter_file_group_id"], name: "index_assignment_properties_on_default_starter_file_group_id"
   end
@@ -599,6 +600,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_06_065135) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "assessment_id", null: false
+    t.json "autotest_settings", default: {}, null: false
     t.index ["assessment_id"], name: "index_test_groups_on_assessment_id"
     t.index ["criterion_id"], name: "index_test_groups_on_criterion_id"
   end

--- a/lib/tasks/autotest.rake
+++ b/lib/tasks/autotest.rake
@@ -79,7 +79,6 @@ class AutotestSetup
 
     # copy test scripts and specs files into the destination directory
     FileUtils.cp @test_scripts, test_file_destination
-    FileUtils.cp @specs_file, @assignment.autotest_path
   end
 
   def create_marking_scheme
@@ -133,6 +132,9 @@ class AutotestSetup
     @assignment.reload
     Assignment.transaction do
       update_test_groups_from_specs(@assignment, @specs_data)
+
+      # Manually associate one of the test groups with the assignment's criterion
+      @assignment.test_groups.order(:name).first.update(criterion: @assignment.criteria.first)
     end
   end
 end

--- a/spec/factories/test_groups.rb
+++ b/spec/factories/test_groups.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :test_group do
     association :assignment
     sequence(:name) { |n| "Test Group #{n}" }
+
+    after :create do |test_group|
+      test_group.update!(autotest_settings: { 'extra_info' => { 'test_group_id' => test_group.id } })
+    end
   end
 end

--- a/spec/fixtures/files/assignments/sample-timed-assessment-good/automated-test-config-files/automated-test-specs.json
+++ b/spec/fixtures/files/assignments/sample-timed-assessment-good/automated-test-config-files/automated-test-specs.json
@@ -18,7 +18,7 @@
           "tester": "unittest",
           "output_verbosity": 2,
           "extra_info": {
-            "criterion": "CheckboxCriterion:Optimal",
+            "criterion": "Optimal",
             "name": "Python Test Group 1"
           }
         }

--- a/spec/jobs/autotest_cancel_job_spec.rb
+++ b/spec/jobs/autotest_cancel_job_spec.rb
@@ -18,7 +18,7 @@ describe AutotestCancelJob do
   describe '#perform' do
     subject { described_class.perform_now(assignment.id, test_run_ids) }
     context 'tests are set up for an assignment' do
-      let(:assignment) { create :assignment, assignment_properties_attributes: { autotest_settings_id: 10 } }
+      let(:assignment) { create :assignment, assignment_properties_attributes: { remote_autotest_settings_id: 10 } }
       before { test_runs.each_with_index { |t, i| t.update!(autotest_test_id: i + 1) } }
       it 'should send an api request to the autotester' do
         expect_any_instance_of(AutotestCancelJob).to receive(:send_request!) do |_job, net_obj, uri|

--- a/spec/jobs/autotest_results_job_spec.rb
+++ b/spec/jobs/autotest_results_job_spec.rb
@@ -44,7 +44,7 @@ describe AutotestResultsJob do
     end
     subject { described_class.perform_now }
     context 'tests are set up for an assignment' do
-      let(:assignment) { create :assignment, assignment_properties_attributes: { autotest_settings_id: 10 } }
+      let(:assignment) { create :assignment, assignment_properties_attributes: { remote_autotest_settings_id: 10 } }
       let(:dummy_return) { Net::HTTPSuccess.new(1.0, '200', 'OK') }
       let(:body) { '{}' }
       before { allow(dummy_return).to receive(:body) { body } }

--- a/spec/jobs/autotest_run_job_spec.rb
+++ b/spec/jobs/autotest_run_job_spec.rb
@@ -28,7 +28,7 @@ describe AutotestRunJob do
       described_class.perform_now(host_with_port, user.id, assignment.id, groups.map(&:id), collected: collected)
     end
     context 'tests are set up for an assignment' do
-      let(:assignment) { create :assignment, assignment_properties_attributes: { autotest_settings_id: 10 } }
+      let(:assignment) { create :assignment, assignment_properties_attributes: { remote_autotest_settings_id: 10 } }
       let(:dummy_return) { OpenStruct.new(body: { 'test_ids' => (1..n_groups).to_a }.to_json) }
       before do
         allow_any_instance_of(AutotestRunJob).to receive(:send_request!).and_return(dummy_return)

--- a/spec/jobs/autotest_specs_job_spec.rb
+++ b/spec/jobs/autotest_specs_job_spec.rb
@@ -37,10 +37,10 @@ describe AutotestSpecsJob do
         end
         subject
       end
-      it 'should update the autotest_settings_id' do
+      it 'should update the remote_autotest_settings_id' do
         allow_any_instance_of(AutotestSpecsJob).to receive(:send_request!).and_return(dummy_return)
         subject
-        expect(assignment.autotest_settings_id).to eq 43
+        expect(assignment.remote_autotest_settings_id).to eq 43
       end
     end
 
@@ -48,10 +48,9 @@ describe AutotestSpecsJob do
       subject { described_class.perform_now(host_with_port, assignment) }
       before do
         allow(File).to receive(:read).and_return("123456789\n")
-        allow(File).to receive(:read).with(assignment.autotest_settings_file).and_return('{}')
       end
       context 'tests are set up for an assignment' do
-        let(:assignment) { create :assignment, assignment_properties_attributes: { autotest_settings_id: 10 } }
+        let(:assignment) { create :assignment, assignment_properties_attributes: { remote_autotest_settings_id: 10 } }
         it 'should send an api request to the autotester' do
           expect_any_instance_of(AutotestSpecsJob).to receive(:send_request!) do |_job, net_obj, uri|
             expect(net_obj.instance_of?(Net::HTTP::Put)).to be true

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -37,11 +37,12 @@ describe Course do
       end
       context 'when assignments exist for the course' do
         before do
-          create_list :assignment, 3, course: course, assignment_properties_attributes: { autotest_settings_id: 1 }
+          create_list :assignment, 3, course: course,
+                                      assignment_properties_attributes: { remote_autotest_settings_id: 1 }
         end
-        it 'should reset the autotest_settings_id for all assignments' do
+        it 'should reset the remote_autotest_settings_id for all assignments' do
           course.update_autotest_url(url)
-          expect(course.assignments.pluck(:autotest_settings_id).compact).to be_empty
+          expect(course.assignments.pluck(:remote_autotest_settings_id).compact).to be_empty
         end
       end
     end
@@ -56,11 +57,12 @@ describe Course do
       end
       context 'when assignments exist for the course' do
         before do
-          create_list :assignment, 3, course: course, assignment_properties_attributes: { autotest_settings_id: 1 }
+          create_list :assignment, 3, course: course,
+                                      assignment_properties_attributes: { remote_autotest_settings_id: 1 }
         end
-        it 'should not reset the autotest_settings_id for all assignments' do
+        it 'should not reset the remote_autotest_settings_id for all assignments' do
           course.update_autotest_url(url)
-          expect(course.assignments.pluck(:autotest_settings_id).to_set).to contain_exactly(1)
+          expect(course.assignments.pluck(:remote_autotest_settings_id).to_set).to contain_exactly(1)
         end
       end
       context 'when the autotest setting is changed' do
@@ -70,11 +72,12 @@ describe Course do
         end
         context 'when assignments exist for the course' do
           before do
-            create_list :assignment, 3, course: course, assignment_properties_attributes: { autotest_settings_id: 1 }
+            create_list :assignment, 3, course: course,
+                                        assignment_properties_attributes: { remote_autotest_settings_id: 1 }
           end
-          it 'should reset the autotest_settings_id for all assignments' do
+          it 'should reset the remote_autotest_settings_id for all assignments' do
             course.update_autotest_url('http://example.com/other')
-            expect(course.assignments.pluck(:autotest_settings_id).compact).to be_empty
+            expect(course.assignments.pluck(:remote_autotest_settings_id).compact).to be_empty
           end
         end
       end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to #5523, this PR moves assignment autotest settings out from the `specs.json` file and into the database.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added new [json columns](https://edgeguides.rubyonrails.org/active_record_postgresql.html#json-and-jsonb) to the `assignment_properties` and `test_groups` tables. The column for `assignment_properties` stores the settings for each tester, with references to the corresponding `TestGroup` ids; the column for `test_groups` stores the settings specific to that test group. The "criterion" field also now stores just the criterion name and not the criterion type.

To help maintain backwards compatiblity, the new helper method `autotest_settings_for` uses these values to reconstruct the full JSON data that used to be stored in `specs.json`. This is both used in MarkUs controller routes for managing autotest settings, and sending these settings to the autotest server.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI, and updated existing test cases.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

In the future, would be good to:

1. Validate the JSON values against the schema from the autotest server, e.g. using [json-schema](https://github.com/voxpupuli/json-schema).
2. Update autotester schema to not require the `extra_info` field in test group settings. The only data in this field that the autotester needs is the test group id; the other fields are MarkUs-specific.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
