### PR TITLE
resque: Added web monitoring for Resque queues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Modified login to allow admin users to login via the UI (#5897)
 - Fix bug where admins viewing the admin page were not redirected properly when timed out (#5909)
 - Added a list of courses to manage for new markus administration view (#5907)
+- Added Resque monitoring views for admin users (#5919)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/app/views/admin/main_admin/index.html.erb
+++ b/app/views/admin/main_admin/index.html.erb
@@ -1,1 +1,3 @@
 <% content_for :title, t('markus_administration') %>
+
+<%= link_to t('resque.dashboard'), admin_resque_path, target: :_blank, rel: 'noopener' %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -54,8 +54,9 @@ data:
 # Find translate calls
 search:
   ## Paths or `File.find` patterns to search in:
-  # paths:
-  #   - app/
+  paths:
+    - app/
+    - config/initializers/
 
   ## Root directories for relative keys resolution.
   # relative_roots:

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,14 @@
+require 'resque/server'
+
+# Modify Resque::Server class to add (manual) authentication
+Rails.application.config.after_initialize do
+  Resque::Server.class_eval do
+    include SessionHandler
+
+    before do
+      unless real_user&.admin_user?
+        halt 403, I18n.t(:forbidden)
+      end
+    end
+  end
+end

--- a/config/locales/common/en.yml
+++ b/config/locales/common/en.yml
@@ -13,6 +13,7 @@ en:
   encoding: Encoding
   file: File
   filter_by: Filter by %{name}
+  forbidden: Forbidden
   help: Help
   markus: MarkUs
   not_applicable: N/A

--- a/config/locales/views/resque/en.yml
+++ b/config/locales/views/resque/en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  resque:
+    dashboard: Resque dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'resque/server'
+
 Rails.application.routes.draw do
   # Install the default routes as the lowest priority.
   root controller: 'main', action: 'login', via: [:post, :get]
@@ -77,6 +79,8 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :courses, only: [:index]
     get '/', controller: 'main_admin', action: 'index'
+
+    mount Resque::Server.new, at: '/resque', as: 'resque'
   end
 
   resources :courses, only: [:show, :index] do

--- a/spec/requests/admin/resque_spec.rb
+++ b/spec/requests/admin/resque_spec.rb
@@ -1,0 +1,58 @@
+describe 'Resque dashboard authorization', type: :request do
+  context 'when the user is not authenticated' do
+    it 'returns a 403 status code' do
+      get '/admin/resque'
+      expect(response).to have_http_status :forbidden
+    end
+  end
+
+  context 'when the user is authenticated and an admin' do
+    before do
+      allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:auth_type)
+                                                                             .and_return('local')
+    end
+
+    context 'and is an admin' do
+      let(:user) { create(:admin_user) }
+      it 'returns a 200 status code' do
+        # TODO: Change this to first login using a POST request, rather than mocking session.
+        #   It seems that currently the session isn't persisted across two separate requests.
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:real_user_name)
+                                                                               .and_return(user.user_name)
+        get '/admin/resque'
+        expect(response).to have_http_status :redirect
+        expect(response).to redirect_to('/admin/resque/overview')
+      end
+    end
+
+    context 'and is an instructor' do
+      let(:user) { create(:instructor) }
+      it 'returns a 200 status code' do
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:real_user_name)
+                                                                               .and_return(user.user_name)
+        get '/admin/resque'
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context 'and is a TA' do
+      let(:user) { create(:ta) }
+      it 'returns a 200 status code' do
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:real_user_name)
+                                                                               .and_return(user.user_name)
+        get '/admin/resque'
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context 'and is a student' do
+      let(:user) { create(:student) }
+      it 'returns a 200 status code' do
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:real_user_name)
+                                                                               .and_return(user.user_name)
+        get '/admin/resque'
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows us to take advantage of Resque's [front end](https://github.com/resque/resque#the-front-end) to display some monitoring information for the queues (Admin users only).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Mounted `Resque::Server` at the `/admin/resque` route, and made it accessible to admin users only. Since the Resque server doesn't do any authentication by default, I also modified the class in a new initializer (`config/initializers/resque.rb`) to do this authentication, and added some tests.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested (in web browser) that the Resque server is accessible at the specified route, and only to admin users. Also added some authentication tests.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [ ] I have made changes to the documentation and linked to that pull request below. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
