### PR TITLE
flash: Fix display of flash messages for criterion and annotation category creation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Added course visibility status to admin courses list (#5924)
 - Added ability for instructors to edit course visibility (#5925)
 - Fix bugs when handling remark requests with deductive annotations (#5926)
+- Fix display of flash messages when creating criteria and annotations (#5949)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/app/assets/javascripts/ajax_events.js
+++ b/app/assets/javascripts/ajax_events.js
@@ -1,10 +1,5 @@
 const FLASH_KEYS = ["notice", "warning", "success", "error"];
 
-export function setUpCallbacks(elem) {
-  elem.addEventListener("ajax:complete", renderFlash);
-  elem.addEventListener("ajax:beforeSend", hideFlash);
-}
-
 /*
  * Display flash messages sent in response to an AJAX request.
  * If a message key is in the X-Message-Discard header, hide

--- a/app/controllers/annotation_categories_controller.rb
+++ b/app/controllers/annotation_categories_controller.rb
@@ -82,7 +82,7 @@ class AnnotationCategoriesController < ApplicationController
     @assignment = @annotation_category.assignment
     if @annotation_category.update(annotation_category_params)
       flash_message(:success, t('.success'))
-      render 'show', assignment_id: @assignment.id, id: @annotation_category.id
+      @annotation_texts = annotation_text_data(record)
     else
       respond_with @annotation_category, render: { body: nil, status: :bad_request }
     end

--- a/app/views/annotation_categories/insert_new_annotation_category.js.erb
+++ b/app/views/annotation_categories/insert_new_annotation_category.js.erb
@@ -1,4 +1,3 @@
-$('#add_annotation_category').remove();
 $('#annotation_category_pane_list').append(
   "<%= escape_javascript(render partial: 'annotation_category',
                                 locals: { annotation_category: @annotation_category }).html_safe %>");

--- a/app/views/annotation_categories/new.js.erb
+++ b/app/views/annotation_categories/new.js.erb
@@ -5,5 +5,8 @@
   let new_category_form = document.getElementById('add_annotation_category');
   new_category_form.getElementsByTagName('input')[0].focus();
 
-  ajax_events.setUpCallbacks(new_category_form);
+  new_category_form.addEventListener('ajax:success', (event) => {
+    ajax_events.renderFlash(event, event.detail[2]);
+    $('#add_annotation_category').remove()
+  });
 })();

--- a/app/views/annotation_categories/show.js.erb
+++ b/app/views/annotation_categories/show.js.erb
@@ -3,5 +3,3 @@ $('#annotation_list_holder').replaceWith(
                                 locals: { annotation_texts: @annotation_texts,
                                           annotation_category: @annotation_category }).html_safe %>");
 reloadDOM();
-ajax_events.setUpCallbacks(document.getElementById('delete_annotation_category'));
-ajax_events.setUpCallbacks(document.getElementsByClassName('edit_annotation_category')[0]);

--- a/app/views/annotation_categories/update.js.erb
+++ b/app/views/annotation_categories/update.js.erb
@@ -2,6 +2,5 @@ $('#annotation_category_' + <%= @annotation_category.id %>).replaceWith(
   "<%= escape_javascript(render partial: 'annotation_category',
                                 locals: { annotation_category: @annotation_category }).html_safe %>");
 
-document.getElementById('current_annotation_category').innerHTML =
-  "<%= escape_javascript(render partial: 'annotation_category_edit',
-                                locals: { annotation_category: @annotation_category }).html_safe %>";
+document.getElementById('annotation_list').innerHTML =
+  "<%= escape_javascript(render partial: 'annotation_text', collection: @annotation_texts).html_safe %>";

--- a/app/views/criteria/create.js.erb
+++ b/app/views/criteria/create.js.erb
@@ -1,8 +1,6 @@
 $('#criteria_pane_list').append("<%= escape_javascript(render partial: 'criteria/criterion',
                                                                    locals: { criterion: @criterion }) %>");
 
-$('#new_criterion').remove();
-
 document.getElementById('editing_pane_menu').innerHTML =
   "<%= escape_javascript(render partial: "#{@criterion.class.to_s.tableize}/criterion_editor",
                                 locals: { criterion: @criterion }) %>";

--- a/app/views/criteria/new.js.erb
+++ b/app/views/criteria/new.js.erb
@@ -16,3 +16,8 @@ $(document).ready(function() {
     }
   });
 });
+
+document.getElementById('new_criterion').addEventListener('ajax:success', event => {
+  ajax_events.renderFlash(event, event.detail[2]);
+  $('#new_criterion').remove();
+})

--- a/app/views/criteria/update.js.erb
+++ b/app/views/criteria/update.js.erb
@@ -11,9 +11,9 @@ document.getElementById('visibility_indicator_<%= @criterion.class %><%= @criter
   <% end %>;
 // Update the general max_mark accounting for all ta visible criteria
 document.getElementById('criteria_total_max_mark').innerHTML = '<%= @criterion.assignment.max_mark %>';
-// Update editing pane
-document.getElementById('editing_pane_menu').innerHTML =
-  '<%= escape_javascript(render partial: "#{@criterion.class.to_s.tableize}/criterion_editor",
-                                locals: { criterion: @criterion }) %>';
-
-<%= render partial: 'event_listeners' %>
+// Levels need to be re-rendered because their order may change
+<% if @criterion.is_a? RubricCriterion %>
+  document.getElementById('rubric-criteria-levels').innerHTML =
+    '<%= escape_javascript(render partial: "rubric_criteria/rubric_criterion_levels",
+                                  locals: { criterion: @criterion }) %>';
+<% end %>

--- a/app/views/rubric_criteria/_criterion_editor.html.erb
+++ b/app/views/rubric_criteria/_criterion_editor.html.erb
@@ -59,10 +59,9 @@
     <p><%= f.submit t(:save), data: { disable_with: t('working') } %></p>
   </div>
 
-  <div class='rubric-criteria-levels'>
+  <div id='rubric-criteria-levels' class='rubric-criteria-levels'>
     <%= render partial: 'rubric_criteria/rubric_criterion_levels',
-               locals: { criterion: criterion,
-                         f: f } %>
+               locals: { criterion: criterion } %>
   </div>
 
 <% end %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When creating criteria and annotation categories, flash messages were not being displayed because the form objects that triggered the request were removed from the DOM.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Made changes by manually attaching a callback for `ajax:success` to these specific forms to display the flash messages and then remove the form.

This problem affects the other forms in criteria and annotations page, but I haven't fixed those since in the future we'll probably change them into React components.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI. Verified that success and error flash messages appear when creating criteria and annotation categories.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
