### PR TITLE
Removed consideration of due date from scanned exam

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 - Display error messages on group csv upload when there are invalid group names (#5952)
 - Created a new admin role (#5956)
 - Added a bulk upload of end users to admin users page (#5959)
+- Removed consideration of due date from scanned exam (#5964)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/collect_submissions_modal.jsx
@@ -26,6 +26,17 @@ class CollectSubmissionsModal extends React.Component {
     this.setState({override: event.target.checked});
   };
 
+  warningText = () => {
+    let label_text = I18n.t("submissions.collect.results_loss_warning");
+    if (this.props.isScannedExam) {
+      label_text = label_text.concat(
+        " ",
+        I18n.t("submissions.collect.scanned_exam_latest_warning")
+      );
+    }
+    return label_text;
+  };
+
   render() {
     return (
       <Modal
@@ -36,7 +47,7 @@ class CollectSubmissionsModal extends React.Component {
         <h2>{I18n.t("submissions.collect.submit")}</h2>
         <form onSubmit={this.onSubmit}>
           <div className={"modal-container-vertical"}>
-            <p>{I18n.t("submissions.collect.results_loss_warning")}</p>
+            <p>{this.warningText()}</p>
             <p>
               <label>
                 <input type="checkbox" name="override" onChange={this.handleOverrideChange} />

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -338,6 +338,7 @@ class RawSubmissionTable extends React.Component {
         />
         <CollectSubmissionsModal
           isOpen={this.state.showModal}
+          isScannedExam={this.props.is_scanned_exam}
           onRequestClose={() => {
             this.setState({showModal: false});
           }}

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -24,7 +24,11 @@ class SubmissionsJob < ApplicationJob
       m_logger.log("Now collecting: #{assignment.short_identifier} for grouping: " +
                    grouping.id.to_s)
       if options[:revision_identifier].nil?
-        time = options[:collection_dates]&.fetch(grouping.id, nil) || grouping.collection_date
+        time = if assignment.scanned_exam?
+                 Time.current
+               else
+                 options[:collection_dates]&.fetch(grouping.id, nil) || grouping.collection_date
+               end
         new_submission = Submission.create_by_timestamp(grouping, time)
       else
         new_submission = Submission.create_by_revision_identifier(grouping, options[:revision_identifier])

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -23,7 +23,6 @@ class SubmissionsJob < ApplicationJob
     groupings.each do |grouping|
       m_logger.log("Now collecting: #{assignment.short_identifier} for grouping: " +
                    grouping.id.to_s)
-
       if !assignment.scanned_exam? && options[:revision_identifier].nil?
         time = options[:collection_dates]&.fetch(grouping.id, nil) || grouping.collection_date
         new_submission = Submission.create_by_timestamp(grouping, time)

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -23,16 +23,17 @@ class SubmissionsJob < ApplicationJob
     groupings.each do |grouping|
       m_logger.log("Now collecting: #{assignment.short_identifier} for grouping: " +
                    grouping.id.to_s)
-      if assignment.scanned_exam? && options[:revision_identifier].nil?
-        options[:revision_identifier] = grouping.group.access_repo do |repo|
-          repo.get_latest_revision.revision_identifier.to_s
-        end
-      end
-      if options[:revision_identifier].nil?
+
+      if !assignment.scanned_exam? && options[:revision_identifier].nil?
         time = options[:collection_dates]&.fetch(grouping.id, nil) || grouping.collection_date
         new_submission = Submission.create_by_timestamp(grouping, time)
       else
-        new_submission = Submission.create_by_revision_identifier(grouping, options[:revision_identifier])
+        revision_id = if assignment.scanned_exam? && options[:revision_identifier].nil?
+                        grouping.group.access_repo { |repo| repo.get_latest_revision.revision_identifier.to_s }
+                      else
+                        options[:revision_identifier]
+                      end
+        new_submission = Submission.create_by_revision_identifier(grouping, revision_id)
       end
 
       if assignment.submission_rule.is_a? GracePeriodSubmissionRule

--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -24,9 +24,11 @@ class SubmissionsJob < ApplicationJob
       m_logger.log("Now collecting: #{assignment.short_identifier} for grouping: " +
                    grouping.id.to_s)
       if assignment.scanned_exam? && options[:revision_identifier].nil?
-        latest_revision = grouping.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
-        new_submission = Submission.create_by_revision_identifier(grouping, latest_revision)
-      elsif options[:revision_identifier].nil?
+        options[:revision_identifier] = grouping.group.access_repo do |repo|
+          repo.get_latest_revision.revision_identifier.to_s
+        end
+      end
+      if options[:revision_identifier].nil?
         time = options[:collection_dates]&.fetch(grouping.id, nil) || grouping.collection_date
         new_submission = Submission.create_by_timestamp(grouping, time)
       else

--- a/app/views/submissions/browse.html.erb
+++ b/app/views/submissions/browse.html.erb
@@ -8,6 +8,7 @@
           show_grace_tokens: <%= @assignment.submission_rule.type == 'GracePeriodSubmissionRule' %>,
           show_sections: <%= @current_course.sections.exists? %>,
           is_timed: <%= @assignment.is_timed %>,
+          is_scanned_exam: <%= @assignment.scanned_exam? %>,
           can_collect: <%= allowed_to? :manage? %>,
           can_run_tests: <%= allowed_to?(:view_test_options?, @assignment) %>,
           defaultFiltered: [{ id: '<%= params[:filter_by] %>', value: '<%= params[:filter_value] %>' }]

--- a/config/locales/views/exam_templates/en.yml
+++ b/config/locales/views/exam_templates/en.yml
@@ -67,9 +67,8 @@ en:
         individual submissions. Any errors with the upload process will be displayed in the Uploaded Scans Log.
       </p> <h3>Finalizing Submissions</h3> <p>
         After you have ensured all scanned files have been uploaded and all QR code parsing errors have been fixed,
-        you must collect submissions in order to begin grading. To do this, first change the due date of the assignment
-        to the current time. Then, go to the "Submissions" tab and select all rows. Finally, press "Collect
-        Submissions". Grading can then begin as normal.
+        you must collect submissions in order to begin grading. To do this, go to the "Submissions" tab and select all
+        rows. Finally, press "Collect Submissions". Grading can then begin as normal.
       </p> <h3>Matching test papers to students</h3> <p>
         After submissions have been finalized, navigate to the "groups" tab of this assignment. Click on the "Assign
         Scans" link beside the first group and begin matching each test paper to a student.

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -14,6 +14,7 @@ en:
       submit: Collect Submissions
       this_revision: Collect and Grade This Revision
       undo_results_loss_warning: 'This operation will undo the previous Collect All Submissions operation. This should only be done if the previous Collect All Submissions operation was done in error. WARNING: All grading work done since the previous Collect All Submissions operation will be lost.'
+      latest_scanned_exam_warning: For scanned exams, the latest submitted file version for each selected group is identified regardless of the due date.
     commit_date: Submission Date
     download_zipped_file:
       file_missing: No file named %{zip_file} found. Please try preparing this file for download again.

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -11,10 +11,10 @@ en:
       overwrite_warning: Collecting and grading this revision will overwrite any previous collections/grading done for this group on this assignment.  Are you sure you want to do this?
       progress: "%{count}/%{size} submissions collected"
       results_loss_warning: This action identifies the file version for each selected group that meets the assignment due date and/or late penalty, and creates the views for grading each selected group.
+      scanned_exam_latest_warning: For scanned exams, the latest submitted file version for each selected group is used regardless of the due date.
       submit: Collect Submissions
       this_revision: Collect and Grade This Revision
       undo_results_loss_warning: 'This operation will undo the previous Collect All Submissions operation. This should only be done if the previous Collect All Submissions operation was done in error. WARNING: All grading work done since the previous Collect All Submissions operation will be lost.'
-      latest_scanned_exam_warning: For scanned exams, the latest submitted file version for each selected group is identified regardless of the due date.
     commit_date: Submission Date
     download_zipped_file:
       file_missing: No file named %{zip_file} found. Please try preparing this file for download again.

--- a/spec/jobs/submissions_job_spec.rb
+++ b/spec/jobs/submissions_job_spec.rb
@@ -70,7 +70,7 @@ describe SubmissionsJob do
     end
     let(:revision_ids) do
       groupings.map do |g|
-        [g.id, g.group.access_repo { |repo| repo.get_latest_revision.revision_identifier.to_s }]
+        [g.id, g.group.access_repo { |repo| repo.get_all_revisions.first.revision_identifier.to_s }]
       end.to_h
     end
     context 'when a revision id exists in the repo for the group' do

--- a/spec/jobs/submissions_job_spec.rb
+++ b/spec/jobs/submissions_job_spec.rb
@@ -1,5 +1,5 @@
 describe SubmissionsJob do
-  let(:assignment) { create :assignment }
+  let(:assignment) { create :assignment, due_date: Time.zone.parse('2010-02-10 15:30:45') }
   let(:groupings) { create_list(:grouping_with_inviter, 3, assignment: assignment) }
 
   context 'when running as a background job' do
@@ -89,15 +89,27 @@ describe SubmissionsJob do
   end
   context 'when creating a submission for a scanned exam' do
     let(:assignment) { create :assignment_for_scanned_exam }
-    before :each do
-      groupings.each { |g| submit_file_at_time(g.assignment, g.group, 'test', 1.hour.ago.to_s, 'test.txt', 'aaa') }
-      SubmissionsJob.perform_now(groupings)
+    context 'when a submission exists before the collection date' do
+      it 'collects the latest revision' do
+        groupings.each { |g| submit_file_at_time(g.assignment, g.group, 'test', 1.hour.ago.to_s, 'test.txt', 'aaa') }
+        SubmissionsJob.perform_now(groupings)
+        groupings.each do |g|
+          g.reload
+          latest_revision = g.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
+          expect(g.current_submission_used.revision_identifier).to eq latest_revision.to_s
+        end
+      end
     end
-    it 'collects the latest revision' do
-      groupings.each do |g|
-        g.reload
-        latest_revision = g.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
-        expect(g.current_submission_used.revision_identifier).to eq latest_revision.to_s
+    context 'when a submission exists after the collection date' do
+      it 'collects the latest revision' do
+        groupings.each do |g|
+          submit_file_at_time(g.assignment, g.group, 'test', 1.hour.from_now.to_s, 'test.txt', 'aaa')
+        end
+        SubmissionsJob.perform_now(groupings)
+        groupings.each do |g|
+          g.reload
+          expect(g.current_submission_used).to be_nil
+        end
       end
     end
   end

--- a/spec/jobs/submissions_job_spec.rb
+++ b/spec/jobs/submissions_job_spec.rb
@@ -34,6 +34,16 @@ describe SubmissionsJob do
           expect(g.reload.current_submission_used.revision_identifier).to be_nil
         end
       end
+      context 'when the assignment is a scanned exam' do
+        let(:assignment) { create :assignment_for_scanned_exam }
+        it 'collects the latest revision' do
+          groupings.each do |g|
+            g.reload
+            latest_revision = g.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
+            expect(g.current_submission_used.revision_identifier).to eq latest_revision.to_s
+          end
+        end
+      end
     end
     context 'when a submission exists before the given collection date' do
       let(:collection_dates) { groupings.map { |g| [g.id, 1.hour.ago] }.to_h }
@@ -52,6 +62,16 @@ describe SubmissionsJob do
       it 'collects a nil revision' do
         groupings.each do |g|
           expect(g.reload.current_submission_used.revision_identifier).to be_nil
+        end
+      end
+      context 'when the assignment is a scanned exam' do
+        let(:assignment) { create :assignment_for_scanned_exam }
+        it 'collects the latest revision' do
+          groupings.each do |g|
+            g.reload
+            latest_revision = g.group.access_repo { |repo| repo.get_latest_revision.revision_identifier }
+            expect(g.current_submission_used.revision_identifier).to eq latest_revision.to_s
+          end
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After implementing PR #5839, one thing that users found confusing was changing the due date before collecting scanned exam submissions. This pull request makes changes so that users need not worry about changing the due date when collecting scanned exams.


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Created submissions only from latest revision for scanned exams in SubmissionJob (overriden if a specific revision is specified)
- Removed mention of changing due date in scanned exam homepage
- Refactored revision id submission job test to use the earliest submission id and to be a shared example (for use in new tests)
- Changed collect submission warning modal for scanned exams to explain new behaviour
- Added rspec tests for changes

This change makes the following UI change:
![collect submission warning](https://user-images.githubusercontent.com/37222075/165636790-a0b89d5d-a60d-4249-9ed8-137e4b5b5b9e.png)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [x] I have made changes to the documentation and linked to that pull request below. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
https://github.com/MarkUsProject/Wiki/pull/111