### PR TITLE
Remove class methods

### DIFF
--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -1,10 +1,6 @@
 class CheckboxCriterion < Criterion
   DEFAULT_MAX_MARK = 1
 
-  def self.symbol
-    :checkbox
-  end
-
   def update_assigned_groups_count
     result = []
     tas.each do |ta|

--- a/app/models/flexible_criterion.rb
+++ b/app/models/flexible_criterion.rb
@@ -12,10 +12,6 @@ class FlexibleCriterion < Criterion
     end
   end
 
-  def self.symbol
-    :flexible
-  end
-
   def update_assigned_groups_count
     result = []
     tas.each do |ta|

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -6,10 +6,6 @@ class RubricCriterion < Criterion
 
   DEFAULT_MAX_MARK = 4
 
-  def self.symbol
-    :rubric
-  end
-
   # Checks whether the passed in param's level_attributes have unique name and marks.
   # Skips the uniqueness validation if true.
   def update_levels(levels_attributes)

--- a/app/models/rubric_criterion.rb
+++ b/app/models/rubric_criterion.rb
@@ -5,7 +5,6 @@ class RubricCriterion < Criterion
   validates :levels, presence: true
 
   DEFAULT_MAX_MARK = 4
-
   # Checks whether the passed in param's level_attributes have unique name and marks.
   # Skips the uniqueness validation if true.
   def update_levels(levels_attributes)

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -163,6 +163,7 @@ Robert Burke
 Robert Tan
 Ryan Spring
 Samuel Gougeon
+Samuel Weiss
 Sean Budning
 Seung Hoon Lee
 Severin Gehwolf


### PR DESCRIPTION
## Motivation and Context
This removes the symbol methods from CheckboxCriterion and FlexibleCriterion. The PR was made in order to clean up the code. 

## Your Changes
I removed the class method symbol from Checkbox Criterion and FlexibleCriterion. I was also told to remove it from RubricCriterion but found it was either already removed or not present.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)



## Testing
I launched Markus and took a look around to make sure nothing was broken and did not spot anything. Then I ran the test suite.

## Questions and Comments (if applicable)
I don't 100% understand why I deleted a class method instead of replacing it. My guess is that it is just unnecessary code and could be accounted for by inheritance?


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
