### PR TITLE
string interpolation

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -659,9 +659,23 @@ class SubmissionsController < ApplicationController
       changed = if assignment.is_peer_review?
                   set_pr_release_on_results(groupings, release)
                 else
-                  set_release_on_results(groupings, release)
+                  begin
+                    Result.set_release_on_results(groupings, release)
+                  rescue StandardError => e
+                    error_message, group_names = e.message.split
+                    if error_message == 'no_submission'
+                      flash_now(:error, I18n.t('submissions.errors.no_submission', group_name: group_names))
+                    elsif error_message == 'not_complete'
+                      flash_now(:error, t('submissions.errors.not_complete', group_name: group_names))
+                    elsif error_message == 'not_complete_unrelease'
+                      flash_now(:error, t('submissions.errors.not_complete_unrelease', group_name: group_names))
+                    end
+                  end
                 end
-
+      if changed.is_a? Array
+        # Changed will only be an array if an error message flashed
+        changed = 0
+      end
       if changed > 0
         assignment.update_remark_request_count
 

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -14,45 +14,6 @@ module SubmissionsHelper
     end
   end
 
-  # Release or unrelease the submissions of a set of groupings.
-  def set_release_on_results(groupings, release)
-    without_submissions = groupings.where.not(id: groupings.joins(:current_submission_used))
-
-    if without_submissions.present?
-      group_names = without_submissions.joins(:group).pluck(:group_name).join(', ')
-      flash_now(:error, I18n.t('submissions.errors.no_submission', group_name: group_names))
-      groupings = groupings.where.not(id: without_submissions.ids)
-    end
-
-    without_complete_result = groupings.joins(:current_result)
-                                       .where.not('results.marking_state': Result::MARKING_STATES[:complete])
-
-    if without_complete_result.present?
-      group_names = without_complete_result.joins(:group).pluck(:group_name).join(', ')
-      if release
-        flash_now(:error, t('submissions.errors.not_complete', group_name: group_names))
-      else
-        flash_now(:error, t('submissions.errors.not_complete_unrelease', group_name: group_names))
-      end
-      groupings = groupings.where.not(id: without_complete_result.ids)
-    end
-
-    result = Result.where(id: groupings.joins(:current_result).pluck('results.id'))
-                   .update_all(released_to_students: release)
-
-    if release
-      groupings.includes(:accepted_students).each do |grouping|
-        grouping.accepted_students.each do |student|
-          if student.receives_results_emails?
-            NotificationMailer.with(user: student, grouping: grouping).release_email.deliver_later
-          end
-        end
-      end
-    end
-
-    result
-  end
-
   def get_file_info(file_name, file, course_id, assignment_id, revision_identifier,
                     path, grouping_id, url_submit: false)
     return if Repository.get_class.internal_file_names.include? file_name

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -37,6 +37,45 @@ class Result < ApplicationRecord
     end
   end
 
+  # Release or unrelease the submissions of a set of groupings.
+  def self.set_release_on_results(groupings, release)
+    without_submissions = groupings.where.not(id: groupings.joins(:current_submission_used))
+
+    if without_submissions.present?
+      group_names = without_submissions.joins(:group).pluck(:group_name).join(', ')
+      groupings = groupings.where.not(id: without_submissions.ids)
+      raise StandardError, "no_submission #{group_names}"
+    end
+
+    without_complete_result = groupings.joins(:current_result)
+                                       .where.not('results.marking_state': Result::MARKING_STATES[:complete])
+
+    if without_complete_result.present?
+      group_names = without_complete_result.joins(:group).pluck(:group_name).join(', ')
+      groupings = groupings.where.not(id: without_complete_result.ids)
+      if release
+        raise StandardError, "not_complete #{group_names}"
+      else
+        raise StandardError, "not_complete_unrelease #{group_names}"
+      end
+    end
+
+    result = Result.where(id: groupings.joins(:current_result).pluck('results.id'))
+                   .update_all(released_to_students: release)
+
+    if release
+      groupings.includes(:accepted_students).find_each do |grouping|
+        grouping.accepted_students.each do |student|
+          if student.receives_results_emails?
+            NotificationMailer.with(user: student, grouping: grouping).release_email.deliver_later
+          end
+        end
+      end
+    end
+
+    result
+  end
+
   # Calculate the total mark for this submission
   def get_total_mark
     user_visibility = is_a_review? ? :peer_visible : :ta_visible

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -165,4 +165,16 @@ describe Result do
       end
     end
   end
+
+  describe '.set_release_on_results' do
+    let!(:assignment) { create :assignment_with_criteria_and_results }
+    it 'should raise StandardError with message not_complete error if result has not been completed' do
+      result = assignment.ungraded_submission_results[0]
+      expect { result.set_release_on_results(grouping, true) }.to raise_error(StandardError)
+    end
+    it 'should raise a StandardError with message no_submission error if the grouping does not have a submission' do
+      grouping = assignment.unassigned_groupings[0]
+      expect { Result.set_release_on_results(grouping, true) }.to raise_error(StandardError)
+    end
+  end
 end


### PR DESCRIPTION
Migrated the set_release_on_results from submissions_controller to a class method of result.rb and added testing.

## Motivation and Context
This helps group related code together and adds testing for the migrated method.


## Your Changes
**Description**:
I first copy-pasted the method over. Then I changed how it was called so it references the class. Then I realized there were scope issues with the flashing of the error message so I changed the original method to raise an error and then inside submissions_controller the error is caught and the message is read in order to determine what type of error it is.

I also added some basic testing for the function.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->
- [x] Refactoring (internal change to codebase, without changing functionality)
- [x] Test update (change that modifies or updates tests only)


## Testing
I ran the rspec suite and manually tested the feature to make sure the error flashed. I also added new testing.


## Questions and Comments (if applicable)
I'm not 100% sure my rspec tests are amazing. I also think that there might be a better way to handle the error, but I could not figure out what that is.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes.

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
