### PR TITLE
Added redirect for students and TAs

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,9 +25,6 @@ class CoursesController < ApplicationController
   def edit; end
 
   def update
-    if current_role.student? || current_role.ta?
-      raise status => 403
-    end
     @current_course.update(params.require(:course).permit(:is_hidden))
     respond_with @current_course, location: -> { edit_course_path(@current_course) }
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,13 +25,16 @@ class CoursesController < ApplicationController
   def edit; end
 
   def update
+    if current_role.student? || current_role.ta?
+      raise status => 403
+    end
     @current_course.update(params.require(:course).permit(:is_hidden))
     respond_with @current_course, location: -> { edit_course_path(@current_course) }
   end
 
   def show
     if current_role.student? || current_role.ta?
-      redirect_to root_url
+      redirect_to course_assignments_path(@current_course.id)
     elsif current_role.instructor?
       @assignments = @current_course.assignments
       @grade_entry_forms = @current_course.grade_entry_forms

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -36,6 +36,10 @@ class CoursesController < ApplicationController
     respond_with(@current_course)
   end
 
+  def user_not_authorized
+    redirect_to root_url
+  end
+
   # Sets current_user to nil, which clears a role switch session (see role_switch)
   def clear_role_switch_session
     MarkusLogger.instance.log("Instructor '#{session[:real_user_name]}' logged out from '#{session[:user_name]}'.")

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -30,14 +30,14 @@ class CoursesController < ApplicationController
   end
 
   def show
-    @assignments = @current_course.assignments
-    @grade_entry_forms = @current_course.grade_entry_forms
-    @current_assignment = @current_course.get_current_assignment
-    respond_with(@current_course)
-  end
-
-  def user_not_authorized
-    redirect_to root_url
+    if current_role.student? || current_role.ta?
+      redirect_to root_url
+    elsif current_role.instructor?
+      @assignments = @current_course.assignments
+      @grade_entry_forms = @current_course.grade_entry_forms
+      @current_assignment = @current_course.get_current_assignment
+      respond_with(@current_course)
+    end
   end
 
   # Sets current_user to nil, which clears a role switch session (see role_switch)

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -6,7 +6,7 @@ class CoursePolicy < ApplicationPolicy
   alias_rule :clear_role_switch_session?, to: :role_is_switched?
 
   def show?
-    role.instructor?
+    role.instructor? || role.student? || role.ta?
   end
 
   def index?

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -172,7 +172,7 @@ describe CoursesController do
 
     context 'updating course visibility' do
       context 'as an authorized instructor' do
-        it 'responds with success on update' do
+        it 'responds with 302 on update' do
           put_as instructor, :update,
                  params: { id: course.id, course: { name: 'CS101', display_name: 'Intro to CS', is_hidden: false } }
           expect(response).to have_http_status(302)
@@ -213,10 +213,10 @@ describe CoursesController do
 
       context 'as an unauthorized user' do
         shared_examples 'cannot update course' do
-          it 'responds with 302' do
+          it 'responds with 403' do
             put_as user, :update,
                    params: { id: course.id, course: { name: 'CS101', is_hidden: !course.is_hidden } }
-            expect(response).to have_http_status(302)
+            expect(response).to have_http_status(403)
           end
           it 'fails to update the course visibility when user unauthorized' do
             expected_course_data = {

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -182,10 +182,10 @@ describe CoursesController do
 
     context 'updating course visibility' do
       context 'as an authorized instructor' do
-        it 'responds with 403 on update' do
+        it 'responds with success on update' do
           put_as instructor, :update,
                  params: { id: course.id, course: { name: 'CS101', display_name: 'Intro to CS', is_hidden: false } }
-          expect(response).to have_http_status(403)
+          expect(response).to have_http_status(302)
         end
         it 'successfully toggles just the is_hidden attribute of a course' do
           put_as instructor, :update,

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -213,10 +213,10 @@ describe CoursesController do
 
       context 'as an unauthorized user' do
         shared_examples 'cannot update course' do
-          it 'responds with 403' do
+          it 'responds with 302' do
             put_as user, :update,
                    params: { id: course.id, course: { name: 'CS101', is_hidden: !course.is_hidden } }
-            expect(response).to have_http_status(403)
+            expect(response).to have_http_status(302)
           end
           it 'fails to update the course visibility when user unauthorized' do
             expected_course_data = {

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -1,6 +1,8 @@
 describe CoursesController do
   let(:instructor) { create :instructor }
   let(:course) { instructor.course }
+  let(:student) { create :student, course: course }
+  let(:ta) { create :ta, course: course }
 
   describe 'role switching methods' do
     let(:subject) do
@@ -161,9 +163,17 @@ describe CoursesController do
       get_as instructor, :index
       expect(response.status).to eq(200)
     end
-    it 'responds with success on show' do
+    it 'responds with success on show as an instructor' do
       get_as instructor, :show, params: { id: course }
       expect(response.status).to eq(200)
+    end
+    it 'redirects to assignments on show as a student' do
+      get_as student, :show, params: { id: course }
+      expect(response).to redirect_to(course_assignments_path(course.id))
+    end
+    it 'redirects to assignments on show as a ta' do
+      get_as ta, :show, params: { id: course }
+      expect(response).to redirect_to(course_assignments_path(course.id))
     end
     it 'responds with success on edit' do
       get_as instructor, :edit, params: { id: course }
@@ -172,10 +182,10 @@ describe CoursesController do
 
     context 'updating course visibility' do
       context 'as an authorized instructor' do
-        it 'responds with 302 on update' do
+        it 'responds with 403 on update' do
           put_as instructor, :update,
                  params: { id: course.id, course: { name: 'CS101', display_name: 'Intro to CS', is_hidden: false } }
-          expect(response).to have_http_status(302)
+          expect(response).to have_http_status(403)
         end
         it 'successfully toggles just the is_hidden attribute of a course' do
           put_as instructor, :update,

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -3,10 +3,10 @@ describe CoursePolicy do
   let(:role) { create :instructor }
   describe_rule :show? do
     succeed 'role is an instructor'
-    failed 'role is a ta' do
+    succeed 'role is a ta' do
       let(:role) { create :ta }
     end
-    failed 'role is a student' do
+    succeed 'role is a student' do
       let(:role) { create :student }
     end
   end


### PR DESCRIPTION
Added a redirect so that students and TAs do not get a 403 error upon going to <course>/courses/:id

## Motivation and Context
This solves a 403 error upon accessing courses through Quercus (I think)


## Your Changes
I added a redirect to the root_url in courses_controller. This will redirect unauthorized users to the root_url. Which for students and TA's is the assignments page and for unauthorized users should be the login page.

Also fixed tests
**Description**:


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test update (change that modifies or updates tests only) <!-- Leaving this in case tests should also be updated --> 


## Testing
I tried it as a student, instructor, and TA as well as as a user who is not logged in. It also fails 2 tests (which is good, since those tests expect a 403 error).


## Questions and Comments (if applicable)
Should I remove the tests or modify the tests which expect 403 error.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
