### PR TITLE
remove redis deprecation warnings, use local variable instead of Redis.current

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,4 @@
-Redis.current = Redis.new(url: Settings.redis.url)
-Resque.redis = Redis.current
-RailsPerformance.redis = Redis::Namespace.new("#{Rails.env}-rails-performance", redis: Redis.current)
+Redis.silence_deprecations = true
+redis = Redis.new(url: Settings.redis.url)
+Resque.redis = redis
+RailsPerformance.redis = Redis::Namespace.new("#{Rails.env}-rails-performance", redis: redis)


### PR DESCRIPTION
## Motivation and Context
Remove the repeating Redis.current deprecation warnings when running rspec tests. 

## Your Changes
- Silence Redis deprecation warnings
- Use local variable in place of redis.current


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Ran the rspec suite. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
