### PR TITLE
redis: Ensure Settings.redis.url is used for redis connections

### DIFF
--- a/app/jobs/autotest_results_job.rb
+++ b/app/jobs/autotest_results_job.rb
@@ -2,7 +2,7 @@
 # of completed tests
 class AutotestResultsJob < AutotestJob
   around_enqueue do |job, block|
-    redis = Redis::Namespace.new(Rails.root.to_s)
+    redis = Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
     block.call if redis.setnx('autotest_results', job.job_id)
     redis.expire('autotest_results', 300) # expire the key just in case
   end
@@ -45,7 +45,7 @@ class AutotestResultsJob < AutotestJob
     end
     outstanding_results
   ensure
-    redis = Redis::Namespace.new(Rails.root.to_s)
+    redis = Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
     if redis.get('autotest_results') == self.job_id
       redis.del('autotest_results')
     end

--- a/app/jobs/update_repo_permissions_job.rb
+++ b/app/jobs/update_repo_permissions_job.rb
@@ -6,7 +6,7 @@ class UpdateRepoPermissionsJob < ApplicationJob
   # If another job that will update the repo permissions file is alread enqueued, then
   # do not enqueue this one
   around_enqueue do |job, block|
-    redis = Redis::Namespace.new(Rails.root.to_s)
+    redis = Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
     block.call if redis.setnx('repo_permissions', job.job_id)
     redis.expire('repo_permissions', 300) # expire the key just in case
   end
@@ -15,12 +15,12 @@ class UpdateRepoPermissionsJob < ApplicationJob
   # delete the key in redis so that any future job will run (with updated info)
   def perform(repo_class_name)
     repo_class = repo_class_name.constantize
-    redis = Redis::Namespace.new(Rails.root.to_s)
+    redis = Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
     redis.del('repo_permissions')
     permissions = repo_class.get_all_permissions
     repo_class.update_permissions_file(permissions)
   ensure
-    redis = Redis::Namespace.new(Rails.root.to_s)
+    redis = Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
     if redis.get('repo_permissions') == self.job_id
       redis.del('repo_permissions')
     end

--- a/app/lib/repository.rb
+++ b/app/lib/repository.rb
@@ -319,7 +319,7 @@ module Repository
     # as separate resources as long as the +namespace+ value is distinct. By default the +namespace+ is the relative
     # root of the current MarkUs instance.
     def self.redis_exclusive_lock(resource_id, namespace: Rails.root.to_s, timeout: 5000, interval: 100)
-      redis = Redis::Namespace.new(namespace)
+      redis = Redis::Namespace.new(namespace, redis: Redis.new(url: Settings.redis.url))
       return yield if redis.lrange(resource_id, -1, -1).first&.to_i == Thread.current.object_id
 
       # clear any threads that are no longer alive from the queue

--- a/spec/jobs/autotest_results_job_spec.rb
+++ b/spec/jobs/autotest_results_job_spec.rb
@@ -7,23 +7,23 @@ describe AutotestResultsJob do
     let(:job_args) { [assignment.id] }
     let(:job) { described_class.perform_later(*job_args) }
     context 'if there is no job currently in progress' do
-      before { Redis::Namespace.new(Rails.root.to_s).del('autotest_results') }
+      before { redis.del('autotest_results') }
       include_examples 'background job'
       it 'sets the redis key' do
         job
-        expect(Redis::Namespace.new(Rails.root.to_s).get('autotest_results')).not_to be_nil
+        expect(redis.get('autotest_results')).not_to be_nil
       end
     end
     context 'if there is a job currently in progress' do
       before do
-        Redis::Namespace.new(Rails.root.to_s).set('autotest_results', 1)
+        redis.set('autotest_results', 1)
         clear_enqueued_jobs
         clear_performed_jobs
       end
       after do
         clear_enqueued_jobs
         clear_performed_jobs
-        Redis::Namespace.new(Rails.root.to_s).del('autotest_results')
+        redis.del('autotest_results')
       end
 
       it 'does not enqueue a job' do
@@ -33,7 +33,7 @@ describe AutotestResultsJob do
   end
   describe '#perform' do
     before do
-      Redis::Namespace.new(Rails.root.to_s).del('autotest_results')
+      redis.del('autotest_results')
       allow_any_instance_of(AutotestSetting).to(
         receive(:send_request!).and_return(OpenStruct.new(body: { api_key: 'someapikey' }.to_json))
       )

--- a/spec/jobs/update_keys_job_spec.rb
+++ b/spec/jobs/update_keys_job_spec.rb
@@ -1,7 +1,7 @@
 describe UpdateKeysJob do
   context 'when running as a background job' do
     let(:job_args) { [] }
-    before { Redis::Namespace.new(Rails.root.to_s).del('authorized_keys') }
+    before { redis.del('authorized_keys') }
     include_examples 'background job'
   end
 
@@ -22,7 +22,7 @@ describe UpdateKeysJob do
     end
     it 'should delete the redis key when finished' do
       UpdateKeysJob.perform_now
-      expect(Redis::Namespace.new(Rails.root.to_s).get('authorized_keys')).to be_nil
+      expect(redis.get('authorized_keys')).to be_nil
     end
     context 'when there are some keys' do
       let!(:keys) { create_list :key_pair, 5 }

--- a/spec/jobs/update_repo_permissions_job_spec.rb
+++ b/spec/jobs/update_repo_permissions_job_spec.rb
@@ -1,14 +1,14 @@
 describe UpdateRepoPermissionsJob do
   context 'when running as a background job' do
     let(:job_args) { [] }
-    before { Redis::Namespace.new(Rails.root.to_s).del('repo_permissions') }
+    before { redis.del('repo_permissions') }
     include_examples 'background job'
   end
 
   describe '#perform' do
     it 'should delete the redis key when finished' do
       UpdateRepoPermissionsJob.perform_now('MemoryRepository')
-      expect(Redis::Namespace.new(Rails.root.to_s).get('repo_permissions')).to be_nil
+      expect(redis.get('repo_permissions')).to be_nil
     end
 
     context 'when called with "MemoryRepository"' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -142,4 +142,8 @@ module Helpers
     end
     spec_data.deep_stringify_keys
   end
+
+  def redis
+    Redis::Namespace.new(Rails.root.to_s, redis: Redis.new(url: Settings.redis.url))
+  end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #6051 we removed `Redis.current`, a global redis connection object. We also needed to modify all existing redis connections to use `Settings.redis.url` for the connection. (By default they'll use `REDIS_URL` if specified, and otherwise `127.0.0.1`, which isn't compatible with our docker environment.)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Updated all other redis connections to use the setting.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran test suite; ensured actions in web browser that involve Redis connections work correctly (e.g., modifying repository permissions).

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

In the future, we could add `REDIS_URL` to our `docker-compose.yml` file, though the `Settings.redis.url` should still override that.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
