### PR TITLE
Explicit inactive description for inactive students/groups

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -56,7 +56,7 @@
 - Sorted courses on the dashboard. (#6099)
 - Added summary statistics for criteria (#6100)
 - Pass group name and starter files to the autotester when running tests (#6104)
-- Added explicit status and filtering for inactive students and groups in grouping page. (#6112)
+- Added explicit status and filtering for inactive students and groups in assignment groups page. (#6112)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - Remove unmaintained locales (#5727)
+- Introduce standalone ruby script as an alternative method to checking for repository access (#5736)
 - Added the ability to submit URLs (#5822)
 - Switch Javascript bundling to jsbundling-rails gem, and update to webpack v5 (#5833)
 - Remove group name displayed attribute from assignment properties table (#5834)
@@ -53,7 +54,7 @@
 - Changed flash message that is displayed when students upload a file with an incorrect name. (#6062)
 - Added emoji annotations for graders and removed `control+click` quick annotations. (#6093)
 - Sorted courses on the dashboard. (#6099)
-- Introduce standalone ruby script as an alternative method to checking for repository access (#5736)
+- Added explicit status and filtering for inactive students and groups in grouping page. (#6112)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -243,8 +243,8 @@ class GroupsManager extends React.Component {
           createAllGroups={this.createAllGroups}
           createGroup={this.createGroup}
           deleteGroups={this.deleteGroups}
-          hiddenStudentsCount={this.state.loading ? "" : this.state.hidden_students_count}
-          hiddenGroupsCount={this.state.loading ? "" : this.state.inactive_groups_count}
+          hiddenStudentsCount={this.state.loading ? null : this.state.hidden_students_count}
+          hiddenGroupsCount={this.state.loading ? null : this.state.inactive_groups_count}
           showHidden={this.state.show_hidden}
           updateShowHidden={this.updateShowHidden}
         />
@@ -376,11 +376,7 @@ class RawGroupsTable extends React.Component {
       },
       filterMethod: (filter, row) => {
         if (filter.value) {
-          return row._original.members.some(member =>
-            `${member[1]}${
-              member[2] ? `, ${I18n.t("activerecord.attributes.user.hidden")}` : ""
-            }`.includes(filter.value)
-          );
+          return row._original.members.some(member => member.display_label.includes(filter.value));
         } else {
           return true;
         }
@@ -639,8 +635,8 @@ const StudentsTable = withSelection(RawStudentsTable);
 
 class GroupsActionBox extends React.Component {
   render = () => {
-    var showHiddenTooltip = "";
-    if (this.props.hiddenStudentsCount && this.props.hiddenGroupsCount) {
+    var showHiddenTooltip = null;
+    if (this.props.hiddenStudentsCount !== null && this.props.hiddenGroupsCount !== null) {
       showHiddenTooltip = `${I18n.t("activerecord.attributes.grouping.inactive_students", {
         count: this.props.hiddenStudentsCount,
       })}, ${I18n.t("activerecord.attributes.grouping.inactive_groups", {

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -638,7 +638,7 @@ class GroupsActionBox extends React.Component {
     const showHiddenTooltip =
       this.props.hiddenStudentsCount && this.props.hiddenGroupsCount
         ? `${this.props.hiddenStudentsCount} ${I18n.t(
-            "activerecord.attributes.user.inactive_students"
+            "activerecord.attributes.grouping.inactive_students"
           )}, ${this.props.hiddenGroupsCount} ${I18n.t(
             "activerecord.attributes.grouping.inactive_groups"
           )}`

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -44,16 +44,26 @@ class GroupsManager extends React.Component {
     }).then(res => {
       this.studentsTable.resetSelection();
       this.groupsTable.resetSelection();
+      var inactive_groups_count = 0;
+      res.groups.forEach(group => {
+        if (group.members.every(member => member[2])) {
+          group.inactive = true;
+          inactive_groups_count += 1;
+        } else {
+          group.inactive = false;
+        }
+        group.members.forEach(member => {
+          member.display_label = `(${member[1]}${
+            member[2] ? `, ${I18n.t("activerecord.attributes.user.hidden")}` : ""
+          })`;
+        });
+      });
       this.setState({
-        groups: res.groups.map(group => ({
-          ...group,
-          inactive: group.members.every(member => member[2]),
-        })),
+        groups: res.groups,
         students: res.students || [],
         loading: false,
         hidden_students_count: res.students.filter(student => student.hidden).length,
-        inactive_groups_count: res.groups.filter(group => group.members.every(member => member[2]))
-          .length,
+        inactive_groups_count: inactive_groups_count,
       });
     });
   };
@@ -340,9 +350,7 @@ class RawGroupsTable extends React.Component {
             if (member[1] === "pending") {
               status = <strong>({member[1]})</strong>;
             } else {
-              status = `(${member[1]}${
-                member[2] ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
-              })`;
+              status = member.display_label;
             }
             return (
               <div key={`${row.original._id}-${member[0]}`}>
@@ -370,7 +378,7 @@ class RawGroupsTable extends React.Component {
         if (filter.value) {
           return row._original.members.some(member =>
             `${member[1]}${
-              member[2] ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
+              member[2] ? `, ${I18n.t("activerecord.attributes.user.hidden")}` : ""
             }`.includes(filter.value)
           );
         } else {
@@ -478,12 +486,8 @@ class RawGroupsTable extends React.Component {
   ];
 
   static getDerivedStateFromProps(props, state) {
-    let filtered = [];
-    for (let i = 0; i < state.filtered.length; i++) {
-      if (state.filtered[i].id !== "inactive") {
-        filtered.push(state.filtered[i]);
-      }
-    }
+    let filtered = state.filtered.filter(group => group.id !== "inactive");
+
     if (!props.showInactive) {
       filtered.push({id: "inactive", value: false});
     }
@@ -544,18 +548,18 @@ class RawStudentsTable extends React.Component {
         id: "user_name",
         Cell: props =>
           props.original.hidden
-            ? `${props.value} (${I18n.t("activerecord.attributes.user.inactive")})`
+            ? `${props.value} (${I18n.t("activerecord.attributes.user.hidden")})`
             : props.value,
         filterMethod: (filter, row) => {
           if (filter.value) {
             return `${row._original.user_name}${
-              row._original.hidden ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
+              row._original.hidden ? `, ${I18n.t("activerecord.attributes.user.hidden")}` : ""
             }`.includes(filter.value);
           } else {
             return true;
           }
         },
-        sortable: false,
+        sortable: true,
         minWidth: 90,
       },
       {
@@ -635,14 +639,14 @@ const StudentsTable = withSelection(RawStudentsTable);
 
 class GroupsActionBox extends React.Component {
   render = () => {
-    const showHiddenTooltip =
-      this.props.hiddenStudentsCount && this.props.hiddenGroupsCount
-        ? `${this.props.hiddenStudentsCount} ${I18n.t(
-            "activerecord.attributes.grouping.inactive_students"
-          )}, ${this.props.hiddenGroupsCount} ${I18n.t(
-            "activerecord.attributes.grouping.inactive_groups"
-          )}`
-        : "";
+    var showHiddenTooltip = "";
+    if (this.props.hiddenStudentsCount && this.props.hiddenGroupsCount) {
+      showHiddenTooltip = `${I18n.t("activerecord.attributes.grouping.inactive_students", {
+        count: this.props.hiddenStudentsCount,
+      })}, ${I18n.t("activerecord.attributes.grouping.inactive_groups", {
+        count: this.props.hiddenGroupsCount,
+      })}`;
+    }
     // TODO: 'icons/bin_closed.png' for Group deletion icon
     return (
       <div className="rt-action-box">

--- a/app/assets/javascripts/Components/groups_manager.jsx
+++ b/app/assets/javascripts/Components/groups_manager.jsx
@@ -340,7 +340,9 @@ class RawGroupsTable extends React.Component {
             if (member[1] === "pending") {
               status = <strong>({member[1]})</strong>;
             } else {
-              status = `(${member[1]}${member[2] ? ", inactive" : ""})`;
+              status = `(${member[1]}${
+                member[2] ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
+              })`;
             }
             return (
               <div key={`${row.original._id}-${member[0]}`}>
@@ -367,7 +369,9 @@ class RawGroupsTable extends React.Component {
       filterMethod: (filter, row) => {
         if (filter.value) {
           return row._original.members.some(member =>
-            `${member[1]}${member[2] ? ", inactive" : ""}`.includes(filter.value)
+            `${member[1]}${
+              member[2] ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
+            }`.includes(filter.value)
           );
         } else {
           return true;
@@ -538,12 +542,15 @@ class RawStudentsTable extends React.Component {
         Header: I18n.t("activerecord.attributes.user.user_name"),
         accessor: "user_name",
         id: "user_name",
-        Cell: props => (props.original.hidden ? props.value + " (inactive)" : props.value),
+        Cell: props =>
+          props.original.hidden
+            ? `${props.value} (${I18n.t("activerecord.attributes.user.inactive")})`
+            : props.value,
         filterMethod: (filter, row) => {
           if (filter.value) {
-            return `${row._original.user_name}${row._original.hidden ? ", inactive" : ""}`.includes(
-              filter.value
-            );
+            return `${row._original.user_name}${
+              row._original.hidden ? `, ${I18n.t("activerecord.attributes.user.inactive")}` : ""
+            }`.includes(filter.value);
           } else {
             return true;
           }
@@ -630,7 +637,11 @@ class GroupsActionBox extends React.Component {
   render = () => {
     const showHiddenTooltip =
       this.props.hiddenStudentsCount && this.props.hiddenGroupsCount
-        ? `${this.props.hiddenStudentsCount} hidden student(s), ${this.props.hiddenGroupsCount} inactive group(s)`
+        ? `${this.props.hiddenStudentsCount} ${I18n.t(
+            "activerecord.attributes.user.inactive_students"
+          )}, ${this.props.hiddenGroupsCount} ${I18n.t(
+            "activerecord.attributes.grouping.inactive_groups"
+          )}`
         : "";
     // TODO: 'icons/bin_closed.png' for Group deletion icon
     return (

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -298,7 +298,7 @@ class Assignment < Assessment
   def all_grouping_data
     student_data = self.course
                        .students
-                       .joins(user: :roles)
+                       .joins(:user)
                        .pluck_to_hash(:id, :user_name, :first_name, :last_name, :hidden)
     students = student_data.map do |s|
       [s[:user_name], s.merge(_id: s[:id], assigned: false)]

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -298,7 +298,7 @@ class Assignment < Assessment
   def all_grouping_data
     student_data = self.course
                        .students
-                       .joins(:user)
+                       .joins(user: :roles)
                        .pluck_to_hash(:id, :user_name, :first_name, :last_name, :hidden)
     students = student_data.map do |s|
       [s[:user_name], s.merge(_id: s[:id], assigned: false)]
@@ -313,6 +313,7 @@ class Assignment < Assessment
                                    'groupings.instructor_approved',
                                    'groups.group_name',
                                    'users.user_name',
+                                   'roles.hidden',
                                    'memberships.membership_status',
                                    'sections.name',
                                    'extensions.id',
@@ -323,7 +324,8 @@ class Assignment < Assessment
     members = Hash.new { |h, k| h[k] = [] }
     grouping_data.each do |data|
       if data['users.user_name']
-        members[data['groupings.id']] << [data['users.user_name'], data['memberships.membership_status']]
+        members[data['groupings.id']] << [data['users.user_name'], data['memberships.membership_status'],
+                                          data['roles.hidden']]
         students[data['users.user_name']][:assigned] = true
       end
     end

--- a/config/locales/models/groupings/en.yml
+++ b/config/locales/models/groupings/en.yml
@@ -6,9 +6,9 @@ en:
         inactive_groups:
           one: 1 inactive group
           other: "%{count} inactive groups"
-          zero: 0 inactive group
+          zero: 0 inactive groups
         inactive_students:
           one: 1 inactive student
           other: "%{count} inactive students"
-          zero: 0 inactive student
+          zero: 0 inactive students
         test_tokens: Tokens available

--- a/config/locales/models/groupings/en.yml
+++ b/config/locales/models/groupings/en.yml
@@ -3,6 +3,12 @@ en:
   activerecord:
     attributes:
       grouping:
-        inactive_groups: inactive group(s)
-        inactive_students: inactive student(s)
+        inactive_groups:
+          one: 1 inactive group
+          other: "%{count} inactive groups"
+          zero: 0 inactive group
+        inactive_students:
+          one: 1 inactive student
+          other: "%{count} inactive students"
+          zero: 0 inactive student
         test_tokens: Tokens available

--- a/config/locales/models/groupings/en.yml
+++ b/config/locales/models/groupings/en.yml
@@ -3,4 +3,6 @@ en:
   activerecord:
     attributes:
       grouping:
+        inactive_groups: inactive group(s)
+        inactive_students: inactive student(s)
         test_tokens: Tokens available

--- a/config/locales/models/users/en.yml
+++ b/config/locales/models/users/en.yml
@@ -12,8 +12,8 @@ en:
         first_name: First Name
         full_name: Name
         grace_credits: Grace Credits
+        hidden: inactive
         id_number: ID number
-        inactive: inactive
         last_name: Last Name
         locale: Language
         section_name: Section

--- a/config/locales/models/users/en.yml
+++ b/config/locales/models/users/en.yml
@@ -13,6 +13,7 @@ en:
         full_name: Name
         grace_credits: Grace Credits
         id_number: ID number
+        inactive: inactive
         last_name: Last Name
         locale: Language
         section_name: Section


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves user exprience on the viewing/filtering of inactive students and groups

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

#### When option deselected, inactive students/groups are not shown
![loading](https://user-images.githubusercontent.com/67441706/179866158-4ec9b3b6-7ab0-4fee-9d89-e3a01b32bb19.PNG)

#### When option selected, inactive students/groups are shown
![shown](https://user-images.githubusercontent.com/67441706/179866291-eaaacbee-afd2-46ac-8386-f9e2ee129f61.PNG)

#### Modified the search function to be able to filter inactive students
![search](https://user-images.githubusercontent.com/67441706/179866073-b19fb230-fc26-4ca8-be08-13d5b4dffe94.PNG)

#### Tooltip to show number of inactive student(s)/group(s)
![tooltip](https://user-images.githubusercontent.com/67441706/179868061-b31cd5d8-5eb8-4521-8b53-6e3edcc2d576.jpg)

**Type of change** (select all that apply):
- [x] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
- Mannual testing on chrome and firefox. 
- Mannual inspection of browser console to make sure no errors were present. 

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
The horizontal space might run out. I tried enabling scrolling which is the usual solution, but for some reason the ellipsis text-overflow (i.e. 3 dots at the end of long text) for the students table, carried over to the scrolling: 
![size](https://user-images.githubusercontent.com/67441706/179868013-675cf4cc-3d49-4084-993a-bd46a724a19e.PNG)
This change is not up yet, planning to delay until we figure out the solution.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [x] I have made changes to the documentation and linked to that pull request below. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
https://github.com/MarkUsProject/Wiki/pull/133