### PR TITLE
Updating nav bar layout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,6 +57,7 @@
 - Added summary statistics for criteria (#6100)
 - Pass group name and starter files to the autotester when running tests (#6104)
 - Disabled admin editing of course name and allowed instructors to edit display name (#6111)
+- Changed nav bar by moving the MarkUs logo beside the course name on the top bar (#6115)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/Changelog.md
+++ b/Changelog.md
@@ -57,7 +57,7 @@
 - Added summary statistics for criteria (#6100)
 - Pass group name and starter files to the autotester when running tests (#6104)
 - Disabled admin editing of course name and allowed instructors to edit display name (#6111)
-- Changed nav bar by moving the MarkUs logo beside the course name on the top bar (#6115)
+- Changed nav bar layout by moving the MarkUs logo beside the course name on the top bar (#6115)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -285,6 +285,7 @@ nav {
   }
 
   #course {
+    padding-top: 1.25em;
     @include breakpoint(mobile) {
       display: block;
       float: none !important;
@@ -303,6 +304,11 @@ nav {
     @include breakpoint(mobile) {
       display: block;
     }
+  }
+
+  h1 {
+    font-size: 1.1em;
+    font-weight: bold;
   }
 
   #user-info .dropdown {

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -31,6 +31,10 @@ header#header {
   #user-info {
     margin-left: auto;
   }
+
+  h1 {
+    font-size: 1.5em;
+  }
 }
 
 /* Menus */
@@ -298,10 +302,6 @@ nav {
     @include breakpoint(mobile) {
       border-bottom: 1px solid $primary-three;
     }
-  }
-
-  h1 {
-    font-size: 1.5em;
   }
 
   #user-info .dropdown {

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -6,26 +6,31 @@
 /* Header */
 
 header#header {
+  align-items: center;
   border-bottom: 1px solid $primary-three;
-  display: table;
+  display: flex;
   padding: 0.25em $dimen-horizontal-nav;
   width: 100%;
 
   @include breakpoint(mobile) {
     border-bottom: 0;
+    display: block;
   }
 
   #course,
+  #logo-img,
   #user-info {
-    display: table-cell;
-
     @include breakpoint(mobile) {
       display: block;
     }
   }
 
+  #course {
+    flex: 1;
+  }
+
   #user-info {
-    text-align: right;
+    margin-left: auto;
   }
 }
 
@@ -35,7 +40,6 @@ nav {
   .main {
     display: flex;
     flex-direction: row;
-    justify-content: flex-start;
     padding: 0 $dimen-horizontal-nav;
 
     li,
@@ -57,7 +61,7 @@ nav {
   width: 90px;
 
   @include breakpoint(mobile) {
-    display: none;
+    display: none !important;
   }
 }
 
@@ -284,7 +288,6 @@ nav {
   }
 
   #course {
-    padding-top: 1.25em;
     @include breakpoint(mobile) {
       display: block;
       float: none !important;
@@ -298,16 +301,8 @@ nav {
     }
   }
 
-  #container-for-logo-and-course {
-    display: flex;
-    @include breakpoint(mobile) {
-      display: block;
-    }
-  }
-
   h1 {
-    font-size: 1.1em;
-    font-weight: bold;
+    font-size: 1.5em;
   }
 
   #user-info .dropdown {

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -18,7 +18,6 @@ header#header {
   }
 
   #course,
-  #logo-img,
   #user-info {
     @include breakpoint(mobile) {
       display: block;
@@ -61,7 +60,7 @@ nav {
   width: 90px;
 
   @include breakpoint(mobile) {
-    display: none !important;
+    display: none;
   }
 }
 

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -35,6 +35,7 @@ nav {
   .main {
     display: flex;
     flex-direction: row;
+    justify-content: flex-start;
     padding: 0 $dimen-horizontal-nav;
 
     li,
@@ -51,6 +52,7 @@ nav {
 
 #logo-img {
   background: transparent asset-url('markus_logo.svg') no-repeat center center / 90px 30px;
+  display: block;
   margin-right: $dimen-horizontal-nav;
   min-height: 38px;
   width: 90px;
@@ -293,6 +295,13 @@ nav {
   #course {
     @include breakpoint(mobile) {
       border-bottom: 1px solid $primary-three;
+    }
+  }
+
+  #container-for-logo-and-course {
+    display: flex;
+    @include breakpoint(mobile) {
+      display: block;
     }
   }
 

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -52,7 +52,6 @@ nav {
 
 #logo-img {
   background: transparent asset-url('markus_logo.svg') no-repeat center center / 90px 30px;
-  display: block;
   margin-right: $dimen-horizontal-nav;
   min-height: 38px;
   width: 90px;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,16 @@
 <% is_not_admin_route = controller.class.module_parent.to_s != 'Admin' %>
 <header id='header'>
-  <div id='course'>
-    <% if is_not_admin_route && @current_course %>
-      <strong><%= @current_course.display_name %></strong>
+  <div id = "container-for-logo-and-course">
+    <% if allowed_to?(:role_is_switched?) %>
+      <span id='logo-img'></span>
+    <% else %>
+      <a href='<%= root_path %>' id='logo-img' aria-label='<%= t('menu.home') %>'></a>
     <% end %>
+    <div id='course'>
+      <% if is_not_admin_route && @current_course %>
+        <h1><%= @current_course.display_name %></h1>
+      <% end %>
+    </div>
   </div>
   <div id='user-info'>
     <ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,16 +1,14 @@
 <% is_not_admin_route = controller.class.module_parent.to_s != 'Admin' %>
 <header id='header'>
-  <div id = "container-for-logo-and-course">
-    <% if allowed_to?(:role_is_switched?) %>
-      <span id='logo-img'></span>
-    <% else %>
-      <a href='<%= root_path %>' id='logo-img' aria-label='<%= t('menu.home') %>'></a>
+  <% if allowed_to?(:role_is_switched?) %>
+    <span id='logo-img'></span>
+  <% else %>
+    <a href='<%= root_path %>' id='logo-img' aria-label='<%= t('menu.home') %>'></a>
+  <% end %>
+  <div id='course'>
+    <% if is_not_admin_route && @current_course %>
+      <h1><%= @current_course.display_name %></h1>
     <% end %>
-    <div id='course'>
-      <% if is_not_admin_route && @current_course %>
-        <h1><%= @current_course.display_name %></h1>
-      <% end %>
-    </div>
   </div>
   <div id='user-info'>
     <ul>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,9 +1,4 @@
 <div class='main'>
-  <% if allowed_to?(:role_is_switched?) %>
-    <span id='logo-img'></span>
-  <% else %>
-    <a href='<%= root_path %>' id='logo-img' aria-label='<%= t('menu.home') %>'></a>
-  <% end %>
 <ul>
   <% is_admin_route = controller.class.module_parent.to_s == 'Admin' %>
   <% if !is_admin_route && @current_course %>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
On higher resolution devices such as laptops and desktops, the MarkUs logo is moved in the top row of the nav bar beside the course name.

The nav bar is unchanged for mobile.

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Aesthetic Improvement

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
`_navigation.scss`: Adding new styles
`_header.html.erb`: Adding the html for the logo and wrapping the logo and course in a specific div so that appropriate styles can be applied.
`_menu.html.erb`: Removing the html for the logo


Here is a screenshot for reference:
![new header](https://i.ibb.co/X5Nsh0r/header.png)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
No new testing was performed, the current rspec and jest suites were ran just in case.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
