### PR TITLE
text viewer: Ensure syntax highlighter only applies to local component

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -63,6 +63,7 @@
 - Added explicit status and filtering for inactive students and groups in assignment groups page. (#6112)
 - Fixed flaky automated test file tests by rearranging order of test file cleanup (#6114)
 - Changed nav bar layout by moving the MarkUs logo beside the course name on the top bar (#6115)
+- Ensure each file viewer has independent syntax highlighting (#6139)
 
 ## [v2.0.10]
 - Fix bug when sorting batch test runs where sorting by date was not working (#5906)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current syntax highlighting implementation (in `app/assets/javascripts/Components/Result/text_viewer.jsx`) assumes that only one text viewer component is rendered. We can see this in two ways:

1. `dp.SyntaxHighlighter.HighlightAll` performs syntax highlighting for all `pre` tags with `name="code"` in the entire document. (This function doesn't have a way to limit its search to a subtree of the DOM.)
2. The `this.highlight_root` attribute was being assigned to `document.getElementsByClassName("dp-highlighter")[0]`.

Because of this, when there were both plaintext submission files and feedback files in the grading view, the plaintext was being "syntax highlighted" multiple times, resulting in duplicated code appearing. (In the dev environment this is noticeable for the short submission files like `hello.py`.)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Modified the `TextViewer` component to ensure syntax highlighting is only applied to the content of that component.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI. Verified that various grading actions (e.g. switching between submission files and feedback files, adding annotations) doesn't result in multiple syntax highlighted text appearing.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

It would be good in the future to switch to a React library for syntax highlighting like https://github.com/react-syntax-highlighter. That would free us from manually controlling the syntax highlighting (which is particularly awkward from within React because the SyntaxHighlighter library manipulates the DOM directly). I'll make an issue for this.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
