### PR TITLE
Fix undefined prop type warnings when loading assessment charts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Moved markdown text preview to new tab in the modify/create annotation modal (#6138)
 - Enable bulk removal of students from section in student table (#6145)
 - Enable updating student active/inactive status in student edit form (#6145)
+- Fix undefined prop type warnings when loading assessment charts (#6172)
 
 ## [v2.1.0]
 - Remove unmaintained locales (#5727)

--- a/app/assets/javascripts/Components/Assessment_Chart/grade_breakdown_chart.jsx
+++ b/app/assets/javascripts/Components/Assessment_Chart/grade_breakdown_chart.jsx
@@ -41,7 +41,7 @@ export class GradeBreakdownChart extends React.Component {
                     average={row.original.average}
                     median={row.original.median}
                     standard_deviation={row.original.standard_deviation}
-                    max_mark={row.original.max_mark}
+                    max_mark={Number(row.original.max_mark)}
                     num_zeros={row.original.num_zeros}
                     num_groupings={this.props.num_groupings}
                   />

--- a/app/assets/javascripts/Components/Assessment_Chart/grade_breakdown_chart.jsx
+++ b/app/assets/javascripts/Components/Assessment_Chart/grade_breakdown_chart.jsx
@@ -41,7 +41,7 @@ export class GradeBreakdownChart extends React.Component {
                     average={row.original.average}
                     median={row.original.median}
                     standard_deviation={row.original.standard_deviation}
-                    max_mark={Number(row.original.max_mark)}
+                    max_mark={row.original.max_mark}
                     num_zeros={row.original.num_zeros}
                     num_groupings={this.props.num_groupings}
                   />

--- a/app/assets/javascripts/Components/assignment_chart.jsx
+++ b/app/assets/javascripts/Components/assignment_chart.jsx
@@ -186,6 +186,7 @@ export class AssignmentChart extends React.Component {
           </div>
         );
       }
+
       return (
         <React.Fragment>
           <h2>

--- a/app/assets/javascripts/Components/assignment_chart.jsx
+++ b/app/assets/javascripts/Components/assignment_chart.jsx
@@ -92,101 +92,100 @@ export class AssignmentChart extends React.Component {
   }
 
   render() {
-    let outstanding_remark_request_link = "";
-    if (this.state.summary.remark_requests_enabled) {
-      const remark_submissions_list_link = Routes.browse_course_assignment_submissions_path(
-        this.props.course_id,
-        this.props.assessment_id,
-        {
-          filter_by: "marking_state",
-          filter_value: "remark",
-        }
-      );
-      outstanding_remark_request_link = (
-        <React.Fragment>
-          <a className="summary-stats-label" href={remark_submissions_list_link}>
-            {I18n.t("remark_requests_completed")}
-          </a>
-          <a href={remark_submissions_list_link}>
-            <FractionStat
-              numerator={this.state.summary.num_remark_requests_completed}
-              denominator={this.state.summary.num_remark_requests}
-            />
-          </a>
-        </React.Fragment>
-      );
-    }
+    if (this.state.loading) {
+      return "";
+    } else {
+      let outstanding_remark_request_link = null;
+      if (this.state.summary.remark_requests_enabled) {
+        const remark_submissions_list_link = Routes.browse_course_assignment_submissions_path(
+          this.props.course_id,
+          this.props.assessment_id,
+          {
+            filter_by: "marking_state",
+            filter_value: "remark",
+          }
+        );
+        outstanding_remark_request_link = (
+          <React.Fragment>
+            <a className="summary-stats-label" href={remark_submissions_list_link}>
+              {I18n.t("remark_requests_completed")}
+            </a>
+            <a href={remark_submissions_list_link}>
+              <FractionStat
+                numerator={this.state.summary.num_remark_requests_completed}
+                denominator={this.state.summary.num_remark_requests}
+              />
+            </a>
+          </React.Fragment>
+        );
+      }
 
-    let criteria_graph = "";
-    if (this.props.show_criteria_stats) {
-      criteria_graph = (
-        <GradeBreakdownChart
-          show_stats={true}
-          summary={this.state.criteria_summary}
-          num_groupings={this.state.summary.groupings_size}
-          chart_title={I18n.t("criteria_grade_distribution")}
-          distribution_data={this.state.criteria_grade_distribution.data}
-          item_name={I18n.t("activerecord.models.criterion.one")}
-          create_link={Routes.course_assignment_criteria_path(
-            this.props.course_id,
-            this.props.assessment_id
-          )}
-        />
-      );
-    }
-
-    let ta_grade_distribution_chart = (
-      <div className="distribution-graph">
-        <h3>{I18n.t("grader_distribution")}</h3>
-        <h4>
-          (
-          <a
-            href={Routes.course_assignment_graders_path(
+      let criteria_graph = "";
+      if (this.props.show_criteria_stats) {
+        criteria_graph = (
+          <GradeBreakdownChart
+            show_stats={true}
+            summary={this.state.criteria_summary}
+            num_groupings={this.state.summary.groupings_size}
+            chart_title={I18n.t("criteria_grade_distribution")}
+            distribution_data={this.state.criteria_grade_distribution.data}
+            item_name={I18n.t("activerecord.models.criterion.one")}
+            create_link={Routes.course_assignment_criteria_path(
               this.props.course_id,
               this.props.assessment_id
             )}
-          >
-            {I18n.t("graders.actions.assign_grader")}
-          </a>
-          )
-        </h4>
-      </div>
-    );
-    if (this.state.ta_grade_distribution.data.datasets.length !== 0) {
-      const ta_grade_chart_options = {
-        plugins: {
-          legend: {
-            display: true,
-          },
-        },
-        scales: chartScales(),
-      };
-      ta_grade_distribution_chart = (
+          />
+        );
+      }
+
+      let ta_grade_distribution_chart = (
         <div className="distribution-graph">
           <h3>{I18n.t("grader_distribution")}</h3>
-          <Bar
-            data={this.state.ta_grade_distribution.data}
-            options={ta_grade_chart_options}
-            width="400"
-            height="350"
-          />
-          <p>
+          <h4>
+            (
             <a
-              href={Routes.grader_summary_course_assignment_graders_path(
+              href={Routes.course_assignment_graders_path(
                 this.props.course_id,
                 this.props.assessment_id
               )}
             >
-              {I18n.t("activerecord.models.ta.other")}
+              {I18n.t("graders.actions.assign_grader")}
             </a>
-          </p>
+            )
+          </h4>
         </div>
       );
-    }
-
-    if (this.state.loading) {
-      return "";
-    } else {
+      if (this.state.ta_grade_distribution.data.datasets.length !== 0) {
+        const ta_grade_chart_options = {
+          plugins: {
+            legend: {
+              display: true,
+            },
+          },
+          scales: chartScales(),
+        };
+        ta_grade_distribution_chart = (
+          <div className="distribution-graph">
+            <h3>{I18n.t("grader_distribution")}</h3>
+            <Bar
+              data={this.state.ta_grade_distribution.data}
+              options={ta_grade_chart_options}
+              width="400"
+              height="350"
+            />
+            <p>
+              <a
+                href={Routes.grader_summary_course_assignment_graders_path(
+                  this.props.course_id,
+                  this.props.assessment_id
+                )}
+              >
+                {I18n.t("activerecord.models.ta.other")}
+              </a>
+            </p>
+          </div>
+        );
+      }
       return (
         <React.Fragment>
           <h2>

--- a/app/assets/javascripts/Components/assignment_chart.jsx
+++ b/app/assets/javascripts/Components/assignment_chart.jsx
@@ -37,6 +37,7 @@ export class AssignmentChart extends React.Component {
           datasets: [],
         },
       },
+      loading: true,
     };
   }
 
@@ -67,6 +68,7 @@ export class AssignmentChart extends React.Component {
           ta_grade_distribution: {
             data: res.ta_data,
           },
+          loading: false,
         });
 
         if (this.props.show_criteria_stats) {
@@ -182,47 +184,51 @@ export class AssignmentChart extends React.Component {
       );
     }
 
-    return (
-      <React.Fragment>
-        <h2>
-          <a
-            href={Routes.browse_course_assignment_submissions_path(
-              this.props.course_id,
-              this.props.assessment_id
-            )}
-          >
-            {this.props.show_chart_header ? this.state.summary.name : ""}
-          </a>
-        </h2>
-        <AssessmentChart
-          summary={this.state.summary}
-          assessment_data={this.state.assignment_grade_distribution.data}
-          additional_assessment_stats={
-            <React.Fragment>
-              <span className="summary-stats-label">{I18n.t("num_groups")}</span>
-              <span>{this.state.summary.groupings_size}</span>
-              <span className="summary-stats-label">{I18n.t("num_students_in_group")}</span>
-              <FractionStat
-                numerator={this.state.summary.num_students_in_group}
-                denominator={this.state.summary.num_active_students}
-              />
-              <span className="summary-stats-label">{I18n.t("assignments_submitted")}</span>
-              <FractionStat
-                numerator={this.state.summary.num_submissions_collected}
-                denominator={this.state.summary.groupings_size}
-              />
-              <span className="summary-stats-label">{I18n.t("assignments_graded")}</span>
-              <FractionStat
-                numerator={this.state.summary.num_submissions_graded}
-                denominator={this.state.summary.groupings_size}
-              />
-            </React.Fragment>
-          }
-          outstanding_remark_request_link={outstanding_remark_request_link}
-        />
-        {criteria_graph}
-        {ta_grade_distribution_chart}
-      </React.Fragment>
-    );
+    if (this.state.loading) {
+      return "";
+    } else {
+      return (
+        <React.Fragment>
+          <h2>
+            <a
+              href={Routes.browse_course_assignment_submissions_path(
+                this.props.course_id,
+                this.props.assessment_id
+              )}
+            >
+              {this.props.show_chart_header ? this.state.summary.name : ""}
+            </a>
+          </h2>
+          <AssessmentChart
+            summary={this.state.summary}
+            assessment_data={this.state.assignment_grade_distribution.data}
+            additional_assessment_stats={
+              <React.Fragment>
+                <span className="summary-stats-label">{I18n.t("num_groups")}</span>
+                <span>{this.state.summary.groupings_size}</span>
+                <span className="summary-stats-label">{I18n.t("num_students_in_group")}</span>
+                <FractionStat
+                  numerator={this.state.summary.num_students_in_group}
+                  denominator={this.state.summary.num_active_students}
+                />
+                <span className="summary-stats-label">{I18n.t("assignments_submitted")}</span>
+                <FractionStat
+                  numerator={this.state.summary.num_submissions_collected}
+                  denominator={this.state.summary.groupings_size}
+                />
+                <span className="summary-stats-label">{I18n.t("assignments_graded")}</span>
+                <FractionStat
+                  numerator={this.state.summary.num_submissions_graded}
+                  denominator={this.state.summary.groupings_size}
+                />
+              </React.Fragment>
+            }
+            outstanding_remark_request_link={outstanding_remark_request_link}
+          />
+          {criteria_graph}
+          {ta_grade_distribution_chart}
+        </React.Fragment>
+      );
+    }
   }
 }

--- a/app/assets/javascripts/Components/dashboard.jsx
+++ b/app/assets/javascripts/Components/dashboard.jsx
@@ -31,6 +31,7 @@ class Dashboard extends React.Component {
           course_id={this.props.course_id}
           assessment_id={this.state.assessment_id}
           show_chart_header={true}
+          show_column_stats={false}
         />
       );
     } else {

--- a/app/assets/javascripts/Components/grade_entry_form_chart.jsx
+++ b/app/assets/javascripts/Components/grade_entry_form_chart.jsx
@@ -29,6 +29,7 @@ export class GradeEntryFormChart extends React.Component {
           datasets: [],
         },
       },
+      loading: true,
     };
   }
 
@@ -57,6 +58,7 @@ export class GradeEntryFormChart extends React.Component {
           column_grade_distribution: {
             data: res.column_distributions,
           },
+          loading: false,
         });
       });
   };
@@ -68,46 +70,50 @@ export class GradeEntryFormChart extends React.Component {
   }
 
   render() {
-    return (
-      <React.Fragment>
-        <h2>
-          <a
-            href={Routes.edit_course_grade_entry_form_path(
+    if (this.state.loading) {
+      return "";
+    } else {
+      return (
+        <React.Fragment>
+          <h2>
+            <a
+              href={Routes.edit_course_grade_entry_form_path(
+                this.props.course_id,
+                this.props.assessment_id
+              )}
+            >
+              {this.props.show_chart_header ? this.state.summary.name : ""}
+            </a>
+          </h2>
+          <AssessmentChart
+            summary={this.state.summary}
+            assessment_data={this.state.grade_entry_form_distribution.data}
+            additional_assessment_stats={
+              <React.Fragment>
+                <span className="summary-stats-label">{I18n.t("num_students")}</span>
+                <span>{this.state.summary.groupings_size}</span>
+                <span className="summary-stats-label">{I18n.t("num_students_graded")}</span>
+                <FractionStat
+                  numerator={this.state.summary.num_entries}
+                  denominator={this.state.summary.groupings_size}
+                />
+              </React.Fragment>
+            }
+          />
+          <GradeBreakdownChart
+            show_stats={this.props.show_column_stats}
+            summary={this.state.column_summary}
+            num_groupings={this.state.summary.groupings_size}
+            chart_title={I18n.t("grade_entry_forms.grade_entry_item_distribution")}
+            distribution_data={this.state.column_grade_distribution.data}
+            item_name={I18n.t("activerecord.models.grade_entry_item.one")}
+            create_link={Routes.edit_course_grade_entry_form_path(
               this.props.course_id,
               this.props.assessment_id
             )}
-          >
-            {this.props.show_chart_header ? this.state.summary.name : ""}
-          </a>
-        </h2>
-        <AssessmentChart
-          summary={this.state.summary}
-          assessment_data={this.state.grade_entry_form_distribution.data}
-          additional_assessment_stats={
-            <React.Fragment>
-              <span className="summary-stats-label">{I18n.t("num_students")}</span>
-              <span>{this.state.summary.groupings_size}</span>
-              <span className="summary-stats-label">{I18n.t("num_students_graded")}</span>
-              <FractionStat
-                numerator={this.state.summary.num_entries}
-                denominator={this.state.summary.groupings_size}
-              />
-            </React.Fragment>
-          }
-        />
-        <GradeBreakdownChart
-          show_stats={this.props.show_column_stats}
-          summary={this.state.column_summary}
-          num_groupings={this.state.summary.groupings_size}
-          chart_title={I18n.t("grade_entry_forms.grade_entry_item_distribution")}
-          distribution_data={this.state.column_grade_distribution.data}
-          item_name={I18n.t("activerecord.models.grade_entry_item.one")}
-          create_link={Routes.edit_course_grade_entry_form_path(
-            this.props.course_id,
-            this.props.assessment_id
-          )}
-        />
-      </React.Fragment>
-    );
+          />
+        </React.Fragment>
+      );
+    }
   }
 }

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -397,7 +397,7 @@ class AssignmentsController < ApplicationController
           name: criterion.name,
           average: criterion.average || 0,
           median: criterion.median || 0,
-          max_mark: criterion.max_mark || 0,
+          max_mark: criterion.max_mark.to_f || 0,
           standard_deviation: criterion.standard_deviation || 0,
           position: criterion.position,
           num_zeros: criterion_grades.count(&:zero?)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1096,7 +1096,7 @@ describe AssignmentsController do
         expected = { name: "#{assignment.short_identifier}: #{assignment.description}",
                      average: assignment.results_average(points: true) || 0,
                      median: assignment.results_median(points: true) || 0,
-                     max_mark: assignment.max_mark.to_f || 0,
+                     max_mark: assignment.max_mark || 0,
                      standard_deviation: assignment.results_standard_deviation || 0,
                      num_submissions_collected: assignment.current_submissions_used.size,
                      num_submissions_graded: assignment.current_submissions_used.size -
@@ -1165,7 +1165,7 @@ describe AssignmentsController do
         expected = { name: criterion.name,
                      average: criterion.average,
                      median: criterion.median || 0,
-                     max_mark: criterion.max_mark || 0,
+                     max_mark: criterion.max_mark.to_f || 0,
                      standard_deviation: criterion.standard_deviation || 0,
                      position: criterion.position,
                      num_zeros: criterion.grades_array.count(&:zero?) }

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1096,7 +1096,7 @@ describe AssignmentsController do
         expected = { name: "#{assignment.short_identifier}: #{assignment.description}",
                      average: assignment.results_average(points: true) || 0,
                      median: assignment.results_median(points: true) || 0,
-                     max_mark: assignment.max_mark || 0,
+                     max_mark: assignment.max_mark.to_f || 0,
                      standard_deviation: assignment.results_standard_deviation || 0,
                      num_submissions_collected: assignment.current_submissions_used.size,
                      num_submissions_graded: assignment.current_submissions_used.size -


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From pull request #6118, a minor bug occurs where data that was not yet fetched would be loaded to a helper chart component that required that data. This causes warnings when loading the assessment chart. This pull request aims to fix this minor bug by not loading the assessment chart until all the required data is fetched. This also fixes other prop type errors when loading assessment charts.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Refactored assignment and grade entry chart to load nothing until data is fetched (through use of a `loading` state)
- Fixed undefined `show_column_stats` prop when loading grade entry chart in dashboard
- Fixed `max_mark` is a string error when loading GradeBreakdownChart

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Manual testing was done via the UI to ensure the prop type warnings no longer appeared when loading the assignment and grade entry charts

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
