### PR TITLE
Find correct test run when autotest_test_ids can be duplicated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Hide manual submission collection button from users who don't have permission (#6282)
 - Fix bug where gzipped binary feedback files were not unzipped correctly (#6283)
 - Fix bug where remark request summary table wasn't being rendered correctly (#6284)
+- Fix bug where test results were being associated with the wrong test runs (#6287)
 
 ## [v2.1.4]
 - Fix bug where git hooks are not run server side when symlinked (#6276/#6277)

--- a/app/jobs/autotest_results_job.rb
+++ b/app/jobs/autotest_results_job.rb
@@ -34,7 +34,7 @@ class AutotestResultsJob < AutotestJob
         if %(started queued deferred).include? status
           outstanding_results = true
         else
-          test_run = TestRun.find_by(autotest_test_id: autotest_test_id)
+          test_run = test_runs.find_by(autotest_test_id: autotest_test_id)
           if %(finished failed).include? status
             results(test_run.grouping.assignment, test_run) unless test_run.nil?
           else

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -147,11 +147,11 @@ class TestRun < ApplicationRecord
   def autotest_test_id_uniqueness
     return unless self.autotest_test_id
 
-    other_test_runs = TestRun.joins(role: [course: :autotest_setting])
+    other_test_runs = TestRun.joins(role: :course)
                              .where('courses.autotest_setting_id': self.course.autotest_setting_id,
                                     autotest_test_id: self.autotest_test_id)
                              .where.not(id: self.id)
-                             .count
-    errors.add(:base, 'autotest_test_id must be unique scoped to autotest settings') unless other_test_runs.zero?
+                             .exists?
+    errors.add(:base, 'autotest_test_id must be unique scoped to autotest settings') if other_test_runs
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`autotest_test_id`s are only unique for autotester servers. If there are multiple servers that the autotester is associated with, then we need to find the test run associated with the correct autotest server and the correct autotest_test_id

This PR ensures that the uniqueness validation is scoped correctly (to the autotest_settings) and that the correct test run is selected when associating test results to that test run.

NOTE: when creating a minor release that includes this PR, only add changes for the job since the validation on the model is not yet in production (as of v2.1.4)

Resolves #6286

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->


### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
