### PR TITLE
Fix bug where csv summary download fails if criteria are created after marking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Allow admin users to manage the maximum file size setting through the UI (#6195)
 - Disable python features if python dependencies are not installed (#6232)
 - Allow results to be made available only through unique tokens (#6244)
+- Fix bug where csv summary download fails if criteria are created after marking (#6302)
 
 ## [v2.1.5]
 - Add admin users to the .access file so that they can be authenticated as having access to the git repos (#6237)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -711,7 +711,7 @@ class Assignment < Assessment
             row += Array.new(2 + self.ta_criteria.count, nil)
           else
             row << result.total_mark
-            row += self.ta_criteria.map { |crit| marks[crit.id][:mark] }
+            row += self.ta_criteria.map { |crit| marks[crit.id]&.[](:mark) }
             row << extra_marks_hash[result&.id]
           end
           csv << row

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2177,18 +2177,15 @@ describe Assignment do
 
     context 'an Instructor user' do
       let(:instructor) { create :instructor }
+      let(:assignment) { create :assignment_with_criteria_and_results }
+      let(:summary) { CSV.parse assignment.summary_csv(instructor) }
 
-      before :each do
-        @assignment = create(:assignment_with_criteria_and_results)
-      end
+      shared_examples 'check csv content' do
+        it 'contains data' do
+          expect(summary).not_to be_empty
+        end
 
-      context 'with assigned students' do
-        it 'has student data' do
-          summary_string = @assignment.summary_csv(instructor)
-          summary = CSV.parse(summary_string)
-
-          expect(summary).to_not be_empty
-          expect(summary[0]).to_not be_empty
+        it 'contains header information' do
           expect(summary[0]).to include(User.human_attribute_name(:group_name),
                                         User.human_attribute_name(:user_name),
                                         User.human_attribute_name(:last_name),
@@ -2197,6 +2194,13 @@ describe Assignment do
                                         User.human_attribute_name(:id_number),
                                         User.human_attribute_name(:email))
         end
+      end
+      context 'when all criteria are pre-created' do
+        include_examples 'check csv content'
+      end
+      context 'when criteria are created after marking' do
+        before { create :flexible_criterion, assignment: assignment }
+        include_examples 'check csv content'
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Newly created criteria don't automatically create marks for every grouping (and they shouldn't because that would be a huge amount of overhead and a potential point of failure).  But this means that the summary_csv function needs to handle the case where the hash of marks does not contain a key for every criteria.

If a criteria is created after the initial marks are created, the summary csv should contain an empty (nil) value for that mark, until an actual mark is assigned. 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
