### PR TITLE
Remove extra newlines generated from running db:prepare

### DIFF
--- a/.dockerfiles/entrypoint-dev-rails.sh
+++ b/.dockerfiles/entrypoint-dev-rails.sh
@@ -21,6 +21,9 @@ done
 cp .dockerfiles/database.yml.postgresql config/database.yml
 bundle exec rails db:prepare
 
+# strip newlines from end of structure.sql (revert when/if https://github.com/rails/rails/pull/46454 is implemented)
+sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' /app/db/structure.sql
+
 rm -f ./tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile or docker-compose.yml).


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Running db:prepare in the entrypoint file writes additional newlines to the end of the db/structure.sql file. This creates unnecessary changes to that file that cannot be committed (pre-commit complains).

This PR removes the additional newlines from the end of the file as a temporary measure (see the PR link in the comment for  more information)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): docker entrypoint update


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->


### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
