### PR TITLE
Issue 6192 - Disables emoji annotation options if no text/region is selected

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 - Fix bug where rubric grades could not be selected with the return key (#6354)
 - Allow admins to set the number of puma workers and threads from the settings files (#6348)
 - Fix bug where a user who has switched roles could not view the about modal or log out (#6247)
+- Fix bug where emoji annotation options were available even if no text/region was selected (#6192)
 
 ## [v2.1.7]
 - Switch from jquery-ui-timepicker-addon to flatpickr for datetime inputs (#6158)

--- a/app/assets/javascripts/Results/context_menu.js
+++ b/app/assets/javascripts/Results/context_menu.js
@@ -136,6 +136,10 @@ var annotation_context_menu = {
       beforeOpen: function (event, ui) {
         // Enable annotation menu items only if a selection has been made
         var selection_exists = !!window.annotation_manager.getSelection(false);
+        $(document).contextmenu("enableEntry", "check_mark_annotation", selection_exists);
+        $(document).contextmenu("enableEntry", "thumbs_up_annotation", selection_exists);
+        $(document).contextmenu("enableEntry", "heart_annotation", selection_exists);
+        $(document).contextmenu("enableEntry", "smile_annotation", selection_exists);
         $(document).contextmenu("enableEntry", "new_annotation", selection_exists);
         $(document).contextmenu("enableEntry", "common_annotations", selection_exists);
         $(document).contextmenu("enableEntry", "copy", selection_exists);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #6192 


## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
- Emoji annotation options are now disabled when annotation context menu is opened but no text/region has been selected.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
I tested that after my change, opening the annotation context box without having selected text results in emojis being disabled and opening it with having selected text results in emojis being enabled. 

**Before (opening annotation context menu arbitrarily):**
<img width="200" alt="Before" src="https://user-images.githubusercontent.com/58835213/205992759-3616ab18-7d1c-450b-b79c-5c6ff1d2a342.png">

**After (opening annotation context menu when...):**

1. (text/region has been selected)
<img width="450" alt="After-Selected" src="https://user-images.githubusercontent.com/58835213/205993012-7db2047f-ca7d-48d1-9f51-dd961dabddd2.png">
2. (text/region has not been selected)
<img width="450" alt="After-Not_Selected" src="https://user-images.githubusercontent.com/58835213/205993825-74bfe84f-07f5-4288-b530-e968e76e4a3b.png">



## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
