### PR TITLE
seed: Remove references to total_mark/total_grade

### DIFF
--- a/lib/tasks/marks.rake
+++ b/lib/tasks/marks.rake
@@ -160,8 +160,6 @@ namespace :db do
       }
 
       # Generate grades for the submission
-      total_mark = 0
-
       criteria[assignment_id].each do |criterion|
         override = false
         if criterion[:type] == 'RubricCriterion'
@@ -176,7 +174,6 @@ namespace :db do
         else
           random_mark = rand(0..criterion[:max_mark])
         end
-        total_mark += random_mark
         marks << {
           result_id: result_id,
           criterion_id: criterion[:id],
@@ -188,7 +185,6 @@ namespace :db do
       end
       results << {
         id: result_id,
-        total_mark: total_mark,
         marking_state: Result::MARKING_STATES[:complete],
         released_to_students: true,
         view_token: Result.generate_unique_secure_token
@@ -210,17 +206,15 @@ namespace :db do
     # Add marks to every student
     grade_entry_form.grade_entry_students.find_each do |student|
       # For each question, assign a random mark based on its out_of value
-      total_grade = 0
       grade_entry_form.grade_entry_items.each do |grade_entry_item|
         random_grade = 1 + rand(0...Integer(grade_entry_item.out_of))
-        total_grade += random_grade
         grades << {
           grade_entry_student_id: student.id,
           grade_entry_item_id: grade_entry_item.id,
           grade: random_grade
         }
       end
-      students << { id: student.id, role_id: student.role.id, total_grade: total_grade, released_to_student: true }
+      students << { id: student.id, role_id: student.role.id, released_to_student: true }
     end
 
     Grade.insert_all grades


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes seed rake task in response to #6290.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: That PR removed the `results.total_mark` and `grade_entry_students.total_grade` columns from the database, but there were some dangling references to them in the seed file `marks.rake`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): seed data update


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran `rails db:reset`, ensured everything works properly.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
