### PR TITLE
fix regex for flaky lti tests

### DIFF
--- a/spec/controllers/lti_deployments_controller_spec.rb
+++ b/spec/controllers/lti_deployments_controller_spec.rb
@@ -156,7 +156,7 @@ describe LtiDeploymentsController do
       stub_request(:post, "#{lti_service_lineitem.url}/1/scores").with(headers:
                                                                              { Authorization: 'Bearer access_token' },
                                                                        body: hash_including({
-                                                                         scoreGiven: /\d+\.?\d+/,
+                                                                         scoreGiven: /\d+(\.\d+)?/,
                                                                          scoreMaximum: assignment.max_mark.to_s,
                                                                          activityProgress: 'Completed',
                                                                          gradingProgress: 'FullyGraded'

--- a/spec/models/lti_deployment_spec.rb
+++ b/spec/models/lti_deployment_spec.rb
@@ -246,7 +246,7 @@ describe LtiDeployment do
       stub_request(:post, "#{lti_line_item.lti_line_item_id}/scores").with(headers:
                                                                             { Authorization: 'Bearer access_token' },
                                                                            body: hash_including({
-                                                                             scoreGiven: /\d+\.?\d+/,
+                                                                             scoreGiven: /\d+(\.\d+)?/,
                                                                              scoreMaximum: assessment.max_mark.to_s,
                                                                              activityProgress: 'Completed',
                                                                              gradingProgress: 'FullyGraded'


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The regex for a mocked request to the lti `scores` endpoint incorrectly was not matching single digit scores, which leads to failure with scores of e.g.`0`. This PR updates that regex to correctly match single digit numbers.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Updated mocked request regex.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested the regex by stubbing assignment marks to return both ints and floats of varying sizes


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

