### PR TITLE
Use reorder instead of order when re-ordering results

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
+
 # Changelog
 
 ## [unreleased]
+- Fix bug where in some circumstances the wrong result would be displayed to students (#6465)
 - Add option to allow Cross-Origin Resource Sharing (CORS) from JupyterHub (#6442)
 
 ## [v2.2.2]

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -107,7 +107,7 @@ class Submission < ApplicationRecord
   # then return the original result instead since that one should be visible while the remark
   # request is being processed
   def get_visible_result
-    non_pr_results.order(id: :desc).where(released_to_students: true).first || get_original_result
+    non_pr_results.reorder(id: :desc).where(released_to_students: true).first || get_original_result
   end
 
   # Sets marks when automated tests are run

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -147,5 +147,14 @@ describe Submission do
         expect(submission.get_visible_result).to eq submission.get_original_result
       end
     end
+    context 'when there are multiple results released to students' do
+      before do
+        released_result
+        released_remark_result
+      end
+      it 'should return the remark' do
+        expect(submission.get_visible_result).to eq released_remark_result
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix: if multiple results had `released_to_students: true`, `get_visible_result` would always return the oldest result due to the ordering on `non_pr_results`. Using `reorder` overrides the initial order.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
`get_visible_result` should use reorder instead of order.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)



## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested in rails console, web interface, and added a test.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
