### PR TITLE
assignment: Fix query for non-peer review results

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -499,7 +499,7 @@ class SubmissionsController < ApplicationController
       end
     rescue StandardError => e
       flash_message(:error, e.message)
-      redirect_to edit_course_result_path(current_course, record.current_result)
+      head :internal_server_error
       return
     end
     filename = file.filename

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -1697,7 +1697,7 @@ describe SubmissionsController do
                                         from_codeviewer: from_codeviewer,
                                         id: submission.id, assignment_id: assignment.id }
         end
-        it { expect(response).to have_http_status(:redirect) }
+        it { expect(response).to have_http_status(:internal_server_error) }
         it 'should display a flash error' do
           expect(extract_text(flash[:error][0])).to eq SAMPLE_ERROR_MESSAGE
         end

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -149,7 +149,6 @@ FactoryBot.define do
 
         create(:version_used_submission, grouping: groupings[i])
         groupings[i].reload
-        # create(:result, submission: submission, marking_state: Result::MARKING_STATES[:complete])
       end
     end
   end

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -147,8 +147,9 @@ FactoryBot.define do
         create(:accepted_student_membership, role: students[i], grouping: groupings[i])
         create(:accepted_student_membership, role: students[i + 3], grouping: pr_groupings[i])
 
-        submission = create(:version_used_submission, grouping: groupings[i])
-        create(:result, submission: submission, marking_state: Result::MARKING_STATES[:complete])
+        create(:version_used_submission, grouping: groupings[i])
+        groupings[i].reload
+        # create(:result, submission: submission, marking_state: Result::MARKING_STATES[:complete])
       end
     end
   end

--- a/spec/factories/peer_review.rb
+++ b/spec/factories/peer_review.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :peer_review do
-    result { association :result, marking_state: 'incomplete', grouping: result_grouping }
+    result { association :result, marking_state: 'incomplete', submission: result_grouping.current_submission_used }
     reviewer { create :grouping, assignment: assignment.pr_assignment }
 
     transient do
       assignment { create(:assignment_with_peer_review) }
-      result_grouping { create(:grouping, assignment: assignment) }
+      result_grouping { create(:grouping_with_inviter_and_submission, assignment: assignment) }
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently on master peer review results are being loaded alongside non-peer review results for an assignment. This is visible using the seed data by going to the "A1" submissions table.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the query in `Assignment` to retrieve only non-peer review results.

Note that the previous approach, `self.groupings.joins(:current_result)`, doesn't actually correct fetch one result per grouping, even though `Grouping` has a `has_one :current_result` association. This is a limitation of Rails' associations, I suppose.

I fixed a similar bug in the assignment grade summary display with the number of graded submissions (`Assignment#ungraded_submission_results`).

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI to ensure the data was displayed correctly.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
