### PR TITLE
Improve result switching UI

### DIFF
--- a/app/assets/javascripts/Components/Result/marks_panel.jsx
+++ b/app/assets/javascripts/Components/Result/marks_panel.jsx
@@ -33,7 +33,7 @@ export class MarksPanel extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.marks.length !== this.props.marks.length) {
+    if (prevProps.marks !== this.props.marks) {
       // Expand by default if a mark has not yet been given, and the current user can give the mark.
       let expanded = new Set();
       this.props.marks.forEach(data => {

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -47,6 +47,9 @@ class Result extends React.Component {
     document.addEventListener("fullscreenchange", () => {
       this.setState({fullscreen: !!document.fullscreenElement}, fix_panes);
     });
+
+    // Clear text selection to enable shift + arrow keyboard shortcuts
+    document.getSelection().removeAllRanges();
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Small UI improvements when switching between results.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

1. Show unmarked criteria by default when switching results (previously, MarkUs only did this when the page first loaded). Fixes #6482.
2. Ensure no text is selected after switching results. This allows the Shift + Left/Right arrow keys to be used more easily in sequence, without having to clear the current text selection.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): UI improvement


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the web interface.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
