### PR TITLE
spec: Fix flaky test for AutotestRunJob

### DIFF
--- a/spec/jobs/autotest_run_job_spec.rb
+++ b/spec/jobs/autotest_run_job_spec.rb
@@ -67,11 +67,11 @@ describe AutotestRunJob do
           subject
           expect(TestRun.where(status: :in_progress).count).to eq n_groups
         end
-        it 'should create test runs associated to the correct grouping and with the correct autotest_run_ids' do
+        it 'should create test runs associated to the correct autotest_run_ids' do
           subject
-          test_run_data = TestRun.joins(grouping: :group).pluck('groups.id', 'test_runs.autotest_test_id')
-          expected = groups.map(&:id).zip(JSON.parse(dummy_return.body)['test_ids'])
-          expect(test_run_data).to contain_exactly(*expected)
+          autotest_test_ids = TestRun.joins(grouping: :group).pluck('test_runs.autotest_test_id')
+          expected = JSON.parse(dummy_return.body)['test_ids']
+          expect(autotest_test_ids).to contain_exactly(*expected)
         end
       end
       it 'should enqueue an AutotestResultsJob job' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a flaky test for `AutotestRunJob`. The problem was we couldn't assume a specific order of group ids when autotest jobs are requested

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Modified the test to just check the ids returned by the autotesting server. There was a separate test to ensure the group ids are stored correctly


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Test update (change that modifies or updates tests only)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Ran test suite.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
