### PR TITLE
keep pending memberships when adding due date extensions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Do not destroy pending group memberships if the group is given an extension (#)
 - Add OCR for parsing scanned exam uploads (#6433)
 - Move submission-specific results/ routes to be under submissions/ (#6434)
 - Add option to allow Cross-Origin Resource Sharing (CORS) from JupyterHub (#6442)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [unreleased]
-- Do not destroy pending group memberships if the group is given an extension (#)
+- Do not destroy pending group memberships if the group is given an extension (#6582)
 - Add OCR for parsing scanned exam uploads (#6433)
 - Move submission-specific results/ routes to be under submissions/ (#6434)
 - Add option to allow Cross-Origin Resource Sharing (CORS) from JupyterHub (#6442)

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -7,7 +7,7 @@ class Extension < ApplicationRecord
 
   validates :time_delta, numericality: { greater_than: 0 }
 
-  after_create :remove_pending_memberships
+  after_create :validate_grouping
 
   PARTS = [:weeks, :days, :hours, :minutes].freeze
 
@@ -26,8 +26,7 @@ class Extension < ApplicationRecord
 
   private
 
-  def remove_pending_memberships
-    grouping.pending_student_memberships.destroy_all
+  def validate_grouping
     grouping.validate_grouping
   end
 end

--- a/spec/models/extension_spec.rb
+++ b/spec/models/extension_spec.rb
@@ -14,9 +14,9 @@ describe Extension do
     end
   end
   describe 'check callbacks' do
-    it 'should remove pending memberships on creation' do
+    it 'should mark the group as instructor approved on creation' do
       create :student_membership, grouping: grouping
-      expect { extension }.to change { Membership.count }.by(-1)
+      expect { extension }.to change { grouping.instructor_approved }.to(true)
     end
   end
   describe '#to_parts' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pull request allows pending student memberships to stay even if a group is granted an extension. Resolves #6555 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Change extension behavior to not destroy pending memberships after a due date extensions is provided for a group. However, the group is still marked as instructor approved, to allow the group to remain valid if the pending member rejects the invitation.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested adding extensions to groups with pending members, rejecting pending invites from groups with extensions via the web interface.


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
