### PR TITLE
UI improvements to autotest settings page

### DIFF
--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -21,14 +21,40 @@ class AutotestManager extends React.Component {
         testers: {
           items: {
             "ui:classNames": "tester-item",
+            env_data: {
+              pip_requirements: {
+                "ui:widget": "textarea",
+              },
+            },
             test_data: {
               items: {
                 "ui:order": ["extra_info", "*"],
                 "ui:options": {label: false},
+                category: {
+                  "ui:title": I18n.t("automated_tests.category"),
+                },
                 feedback_file_names: {
+                  "ui:classNames": "feedback-file-names",
+                  "ui:options": {orderable: false},
+                  items: {
+                    "ui:placeholder": I18n.t("attributes.filename"),
+                    "ui:options": {label: false},
+                    "ui:title": I18n.t("attributes.filename"),
+                  },
+                },
+                script_files: {
                   items: {
                     "ui:options": {label: false},
                   },
+                },
+                student_files: {
+                  items: {
+                    "ui:options": {label: false},
+                  },
+                },
+                timeout: {
+                  "ui:title": I18n.t("automated_tests.timeout"),
+                  "ui:widget": "updown",
                 },
               },
             },
@@ -371,12 +397,14 @@ class AutotestManager extends React.Component {
     return (
       <div>
         <div className="inline-labels">
-          <input
-            type="checkbox"
-            checked={this.state.enable_test}
-            onChange={this.toggleEnableTest}
-          />
-          <label>{I18n.t("activerecord.attributes.assignment.enable_test")}</label>
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.enable_test}
+              onChange={this.toggleEnableTest}
+            />
+            {I18n.t("activerecord.attributes.assignment.enable_test")}
+          </label>
         </div>
         <fieldset>
           <legend>
@@ -401,8 +429,9 @@ class AutotestManager extends React.Component {
             <span>{"Testers"}</span>
           </legend>
           <div className={"rt-action-box upload-download"}>
-            <a href={this.specsDownloadURL()} className={"button download-button"}>
-              {I18n.t("download")}
+            <a href={this.specsDownloadURL()} className={"button"}>
+              <i className="fa fa-download-file-o" aria-hidden="true" />
+              &nbsp;{I18n.t("download")}
             </a>
             <a onClick={this.onSpecUploadModal} className={"button upload-button"}>
               {I18n.t("upload")}
@@ -452,7 +481,7 @@ class AutotestManager extends React.Component {
 
 class AutotestErrorList extends React.Component {
   render() {
-    return <p>{I18n.t("automated_tests.errors.settings_invalid")}</p>;
+    return <p className={"error"}>{I18n.t("automated_tests.errors.settings_invalid")}</p>;
   }
 }
 

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -238,6 +238,10 @@ select {
   padding-left: 5px;
 }
 
+select[multiple] {
+  padding-left: 0;
+}
+
 /** Buttons */
 
 input[type='button'],

--- a/app/assets/stylesheets/common/_react_json_schema_form.scss
+++ b/app/assets/stylesheets/common/_react_json_schema_form.scss
@@ -78,9 +78,15 @@
     font-size: 1.4em;
   }
 
+  select[multiple] > option:checked {
+    background-color: $primary-two;
+    color: $sharp-line;
+  }
+
   input,
   textarea {
     margin: 5px;
+    padding: 0.25em;
   }
 
   input[type='checkbox'] {
@@ -94,9 +100,27 @@
   .form-control {
     min-width: 75pt;
 
+    &[type='text'] {
+      min-width: 150pt;
+    }
+
     &[multiple=''] {
       vertical-align: middle;
     }
+  }
+
+  select.form-control {
+    min-width: 150pt;
+  }
+
+  textarea.form-control {
+    height: 5em;
+    min-width: 400pt;
+  }
+
+  .control-label {
+    padding-top: 5px;
+    vertical-align: top;
   }
 
   /* stylelint-disable property-no-vendor-prefix */
@@ -115,5 +139,33 @@
   fieldset > legend[id$='extra_info__title'],
   #root_testers__title {
     display: none;
+  }
+
+  .feedback-file-names {
+    fieldset {
+      border: 1px solid $primary-two;
+      border-radius: $radius;
+      margin: 10px 0;
+      padding: 10px;
+    }
+
+    legend {
+      width: initial;
+    }
+
+    .array-item {
+      border: 0;
+    }
+  }
+
+  // Error messages
+  .error-detail {
+    background: $light-error asset-url('icons/exclamation.png') no-repeat 5px center;
+    border: 1px solid $severe-error;
+    border-radius: $radius;
+    list-style: none;
+    margin-bottom: 1em;
+    margin-left: 170px;
+    padding: 0.25em 0.5em 0.25em 2em;
   }
 }

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -91,6 +91,7 @@ class AutomatedTestsController < ApplicationController
           url: download_file_course_assignment_automated_tests_url(assignment.course, assignment, file_name: file) }
       end
     end
+    file_keys.sort!
 
     schema_data = JSON.parse(assignment.course.autotest_setting.schema)
     fill_in_schema_data!(schema_data, file_keys, assignment)

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -28,7 +28,11 @@ module AutomatedTestsHelper
   end
 
   def fill_in_schema_data!(schema_data, files, assignment)
-    schema_data['definitions']['files_list']['enum'] = files
+    if files.present?
+      schema_data['definitions']['files_list']['enum'] = files
+    else
+      schema_data['definitions']['files_list']['enum'] = ['']
+    end
     schema_data['definitions']['test_data_categories']['enum'] = TestRun.all_test_categories
     schema_data['definitions']['extra_group_data'] = extra_test_group_schema(assignment)
 

--- a/config/locales/views/automated_tests/en.yml
+++ b/config/locales/views/automated_tests/en.yml
@@ -2,6 +2,7 @@
 en:
   automated_tests:
     cancel_tests: Cancel tests
+    category: Run by
     display_output:
       instructors: Never display test output to students
       instructors_and_student_tests: Only display test output to students for student-run tests
@@ -53,4 +54,5 @@ en:
     testing_disabled: Automated testing is not enabled for this assignment.
     tests_run: Tests have been run for this assignment. Please re-run tests once the settings have been updated.
     tests_running: Running tests. Please refresh this page in a bit to view the results.
+    timeout: Timeout (s)
     title: Automated Testing


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Based on some user feedback, I reviewed and made some minor improvements to the UI for the automated tests settings ("manage") page.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

- In multi-select, made the selected options more visible when not in focus.
- Made `pip_requirements` input a `textarea` to expand the visible area.
- Renamed "Category" to "Run by" and "Timeout" to "Timeout (s)". *Note* this change only affects the labels, not the underlying test schema.
- Improved the layout for feedback files.
- Removed the auto-generated labels for feedback files, script files and student files (PyTA tester).
- Associated the "Enable tests for this assignment" label with its input.
- Modified the "Download" test spec button icon to align with other download icons.
- Applied "error div" styling to validation error messages.
- Ensured test filenames are sorted when merged with test schema.
- Made a few minor padding/alignment changes.

Additionally, fixed bug in PyTA tester when there are no test files.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
  - With the PyTA tester
- [x] Other (please specify): UI updates


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually in the UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

I didn't modify the R requirements input box because those requirements currently have to be comma separated, so we don't want them to be entered on separate lines. If we modify the R tester to allow for line-separated requirements, we can then make the R requirements input a `textarea` as well.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
