### PR TITLE
Quick Fix - PR 6597 - Use "status" provided by activejob-status in place of looking up job status

### DIFF
--- a/app/jobs/submissions_job.rb
+++ b/app/jobs/submissions_job.rb
@@ -40,7 +40,7 @@ class SubmissionsJob < ApplicationJob
       add_warning_messages(grouping.errors.full_messages) if grouping.errors.present?
       progress.increment
       unless options[:notify_socket].nil? || options[:enqueuing_user].nil?
-        CollectSubmissionsChannel.broadcast_to(options[:enqueuing_user], ActiveJob::Status.get(job_id).to_h)
+        CollectSubmissionsChannel.broadcast_to(options[:enqueuing_user], status.to_h)
       end
     end
   rescue StandardError => e
@@ -56,7 +56,7 @@ class SubmissionsJob < ApplicationJob
             status[:warning_message] }
         end
       else
-        message = ActiveJob::Status.get(job_id).to_h
+        message = status.to_h
       end
       CollectSubmissionsChannel.broadcast_to(options[:enqueuing_user], message.merge({ update_table: true }))
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
No need to call `ActiveJob::Status.get(job_id)` since referencing `status` gives the same result within a job

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Replaced occurrences of `ActiveJob::Status.get(job_id)` with `status` in the `SubmissionsJob`


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
- Re-ran tests in place to make sure correct status updates were being broadcasted throughout the `SubmissionsJob` lifecycle
- Tried collecting submissions on the web interface to assure the change had no impact


## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
