### PR TITLE
Grader data performance improvements

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1030,10 +1030,7 @@ class Assignment < Assessment
       groups[[group_id, group_name, count]]
       groups[[group_id, group_name, count]] << { grader: ta, hidden: hidden } unless ta.nil?
     end
-    group_sections = {}
-    self.groupings.includes(:section).find_each do |g|
-      group_sections[g.id] = g.section&.id
-    end
+    group_sections = self.groupings.left_outer_joins(:section).pluck('groupings.id', 'sections.id').to_h
     groups = groups.map do |k, v|
       {
         _id: k[0],

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -89,12 +89,12 @@ class Result < ApplicationRecord
     Result.get_subtotals([self.id], user_visibility: user_visibility)[self.id]
   end
 
-  def self.get_subtotals(result_ids, user_visibility: :ta_visible)
-    marks = Mark.joins(:criterion)
-                .where(result_id: result_ids)
-                .where("criteria.#{user_visibility}": true)
-                .group(:result_id)
-                .sum(:mark)
+  def self.get_subtotals(result_ids, user_visibility: :ta_visible, criterion_ids: nil)
+    all_marks = Mark.joins(:criterion)
+                    .where(result_id: result_ids, "criteria.#{user_visibility}": true)
+    all_marks = all_marks.where('criteria.id': criterion_ids) if criterion_ids.present?
+
+    marks = all_marks.group(:result_id).sum(:mark)
     result_ids.index_with { |r_id| marks[r_id] || 0 }
   end
 

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -18,19 +18,6 @@ class Ta < Role
              .includes(:students, :tas, :group, :assignment)
   end
 
-  # Determine the total mark for a particular student, as a percentage
-  def calculate_total_percent(result, out_of)
-    total = result.get_total_mark
-
-    percent = BLANK_MARK
-
-    # Check for NA mark or division by 0
-    unless total.nil? || out_of == 0
-      percent = (total / out_of) * 100
-    end
-    percent
-  end
-
   # An array of all the grades for an assignment for this TA.
   # If TAs are assigned to grade criteria, returns just the subtotal
   # for the criteria the TA was assigned.

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -31,49 +31,29 @@ class Ta < Role
     percent
   end
 
-  # An array of all the grades for an assignment
+  # An array of all the grades for an assignment for this TA.
+  # If TAs are assigned to grade criteria, returns just the subtotal
+  # for the criteria the TA was assigned.
   def percentage_grades_array(assignment)
-    groupings = assignment.groupings
-                          .joins(:tas)
-                          .where(memberships: { role_id: id })
-    grades = []
+    result_ids = assignment.current_results
+                           .joins(grouping: :tas)
+                           .where(marking_state: Result::MARKING_STATES[:complete], 'roles.id': self.id)
+                           .ids
 
     if assignment.assign_graders_to_criteria
-      criteria_ids = self.criterion_ta_associations.where(assessment_id: assignment.id).pluck(:criterion_id)
-      out_of = criteria_ids.sum do |criterion_id|
-        Criterion.find(criterion_id).max_mark
-      end
+      criterion_ids = self.criterion_ta_associations.where(assessment_id: assignment.id).pluck(:criterion_id)
+      out_of = assignment.ta_criteria.where(id: criterion_ids).sum(:max_mark)
       return [] if out_of.zero?
 
-      mark_data = groupings.joins(current_result: :marks)
-                           .where('marks.criterion_id': criteria_ids)
-                           .where.not('marks.mark': nil)
-                           .pluck('results.id', 'marks.mark')
-                           .group_by { |x| x[0] }
-      mark_data.each_value do |marks|
-        next if marks.empty?
-
-        subtotal = 0
-        has_mark = false
-        marks.each do |_, mark|
-          subtotal += mark
-          has_mark = true
-        end
-        grades << subtotal / out_of * 100 if has_mark
-      end
+      raw_marks = Result.get_subtotals(result_ids, criterion_ids: criterion_ids).values
     else
       out_of = assignment.max_mark
-      groupings.includes(:current_result).find_each do |grouping|
-        result = grouping.current_result
-        unless result.nil? || result.get_total_mark.nil? || result.marking_state != Result::MARKING_STATES[:complete]
-          percent = calculate_total_percent(result, out_of)
-          unless percent == BLANK_MARK
-            grades << percent
-          end
-        end
-      end
+      return [] if out_of.zero?
+
+      raw_marks = Result.get_total_marks(result_ids).values
     end
-    grades
+
+    raw_marks.map { |mark| mark * 100 / out_of }
   end
 
   # Returns grade distribution for a grade entry item for each student

--- a/spec/models/ta_spec.rb
+++ b/spec/models/ta_spec.rb
@@ -21,12 +21,11 @@ describe Ta do
       context 'when TAs are not assigned criteria' do
         it 'returns the grades for their assigned groupings based on total marks' do
           expected = ta.groupings.where(assessment_id: assignment.id).map do |g|
-            g.current_result.get_total_mark / assignment.max_mark * 100
+            be_within(1e-4).of(g.current_result.get_total_mark / assignment.max_mark * 100)
           end
 
           actual = ta.percentage_grades_array(assignment)
-          expect(actual.length).to eq 2
-          expect(actual.sort).to eq expected.sort
+          expect(actual).to match_array(expected)
         end
       end
 
@@ -48,12 +47,11 @@ describe Ta do
               result.marks.find_by(criterion: criterion1).mark +
               result.marks.find_by(criterion: criterion2).mark
             )
-            subtotal / out_of * 100
+            be_within(1e-4).of(subtotal / out_of * 100)
           end
 
           actual = ta.percentage_grades_array(assignment)
-          expect(actual.length).to eq 2
-          expect(actual.sort).to eq expected.sort
+          expect(actual).to match_array expected
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed a few slow-loading actions related to TA management: loading an assignment grade summary (and specifically the TA grade distribution graphs); and updating the graders table.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Improved the performance of the relevant methods. Notably, I consolidated the grader mark calculations into `Result` to align with other places where the calculate marks.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI; ran test suite.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
