### PR TITLE
Allow MathJax to process environments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Display error message on file upload failure (#6703)
 - Remark request grading: differentiate between old and new annotations using colour and remark flag (#6704)
 - Display detailed messages about grace period deductions for an assignment on student interface (#6706)
+- Allow MathJAX to process environments (e.g., align) (#6762)
 
 ## [v2.3.1]
 - Add filter for empty/non-empty submissions in submissions table (#6711)

--- a/app/views/layouts/_mathjax_config.html.erb
+++ b/app/views/layouts/_mathjax_config.html.erb
@@ -8,7 +8,7 @@
     tex2jax: {
       inlineMath: [['$', '$'], ['\\(', '\\)']],
       preview: 'none',
-      processEnvironments: false,
+      processEnvironments: true,
       processRefs: false,
     },
     jax: ["input/TeX", "input/MathML", "input/AsciiMath", "output/CommonHTML"],

--- a/app/views/layouts/notebook.html.erb
+++ b/app/views/layouts/notebook.html.erb
@@ -22,7 +22,7 @@
           tex2jax: {
             inlineMath: [['$', '$'], ['\\(', '\\)']],
             preview: 'none',
-            processEnvironments: false,
+            processEnvironments: true,
             processRefs: false,
           },
           jax: ["input/TeX", "input/MathML", "input/AsciiMath", "output/CommonHTML"],


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An instructor reported that `align` environments in Jupyter notebooks weren't being rendered (the raw TeX was appearing instead).

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Mathjax is used to render math in Jupyter notebooks (and throughout the rest of MarkUs). It does support environments, but was configured to ignore the environments outside of delimiters (with the `processEnvironments` option). I updated this configuration value to `true`.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Checked in the UI that environments are now being processed by MathJax.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
