### PR TITLE
Fix syntax for dependabot.yml groups key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,13 @@ updates:
     versions:
     - 5.19.0
     - 5.24.2
-  - groups:
-      babel:
-        patterns:
-          - "@babel*"
-      fortawesome:
-        patterns:
-          - "@fortawesome*"
+  groups:
+    babel:
+      patterns:
+        - "@babel*"
+    fortawesome:
+      patterns:
+        - "@fortawesome*"
 - package-ecosystem: pip
   directory: "/"
   schedule:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Building on #6770, the syntax incorrectly listed the groups under the `ignore` key. (Found this out when I asked dependabot to rebase #6732 and that ran into an error.)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the syntax.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): dependabot config update


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Will make the same change to another dependabot branch and make sure that configuration works okay there.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
