### PR TITLE
fixed download submissions link 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Replace the function `tas` of the `Assignment` model with a `tas` "has_many" association for that model (#6764)
 - Fix bug where uploading scanned exam pages with overwriting option selected did not update submission files (#6768)
 - Ensure starter files are passed to autotester in sorted order (#6771)
+- Fix bug: "Download Submissions" download link was not being rendered from partial view (#6774)
 
 ## [v2.3.2]
 - Allow MathJAX to process environments (e.g., align) (#6762)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -684,14 +684,14 @@ class SubmissionsController < ApplicationController
 
     zip_path = zipped_grouping_file_name(assignment)
 
-    download_submissions_url = download_zipped_file_course_assignment_submissions_url(course.id, assignment.id)
+    download_sub_url = download_zipped_file_course_assignment_submissions_url(course.id, assignment.id)
 
     if current_role.ta?
       groupings = groupings.joins(:ta_memberships).where('memberships.role_id': current_role.id)
     end
 
     @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id,
-                                                        download_submissions_url)
+                                                        download_sub_url)
     session[:job_id] = @current_job.job_id
 
     render 'shared/_poll_job'

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -684,11 +684,13 @@ class SubmissionsController < ApplicationController
 
     zip_path = zipped_grouping_file_name(assignment)
 
+    download_submissions_url = download_zipped_file_course_assignment_submissions_url(course.id, assignment.id)
+
     if current_role.ta?
       groupings = groupings.joins(:ta_memberships).where('memberships.role_id': current_role.id)
     end
 
-    @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id)
+    @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id, download_submissions_url)
     session[:job_id] = @current_job.job_id
 
     render 'shared/_poll_job'

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -690,7 +690,8 @@ class SubmissionsController < ApplicationController
       groupings = groupings.joins(:ta_memberships).where('memberships.role_id': current_role.id)
     end
 
-    @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id, download_submissions_url)
+    @current_job = DownloadSubmissionsJob.perform_later(groupings.ids, zip_path.to_s, assignment.id, course.id,
+                                                        download_submissions_url)
     session[:job_id] = @current_job.job_id
 
     render 'shared/_poll_job'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     type = :notice unless available_types.include?(type)
     # If a flash with that type doesn't exist, create a new array
     flash_type[type] ||= []
-    content = kwargs.empty? ? "<p>#{text.to_s.gsub("\n", ' ')}</p>" : render_to_string(**kwargs).split("\n").join
+    content = kwargs.empty? ? "<p>#{text.to_s.tr("\n", ' ')}</p>" : render_to_string(**kwargs).split("\n").join
     # If the message doesn't already exist, add it
     flash_type[type].push(content) unless flash_type[type].include?(content)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     type = :notice unless available_types.include?(type)
     # If a flash with that type doesn't exist, create a new array
     flash_type[type] ||= []
-    content = kwargs.empty? ? "<p>#{text.to_s.gsub("\n", '<br/>')}</p>" : render_to_string(**kwargs).split("\n").join
+    content = kwargs.empty? ? "<p>#{text.to_s.gsub("\n", ' ')}</p>" : render_to_string(**kwargs).split("\n").join
     # If the message doesn't already exist, add it
     flash_type[type].push(content) unless flash_type[type].include?(content)
   end

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -12,15 +12,15 @@ class DownloadSubmissionsJob < ApplicationJob
   def self.completed_message(status)
     renderer = ApplicationController.renderer.new(https: true)
     renderer.render(partial: 'submissions/download_zip_file',
-                    locals: { download_submissions_url: status[:download_submissions_url] })
+                    locals: { download_sub_url: status[:download_sub_url] })
   end
 
   before_enqueue do |job|
     self.status.update(assignment_id: job.arguments[2], course_id: job.arguments[3],
-                       download_submissions_url: job.arguments[4])
+                       download_sub_url: job.arguments[4])
   end
 
-  def perform(grouping_ids, zip_path, _assignment_id, _course_id, _download_submissions_url)
+  def perform(grouping_ids, zip_path, _assignment_id, _course_id, _download_sub_url)
     ## delete the old file if it exists
     FileUtils.rm_f(zip_path)
 

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -1,6 +1,7 @@
 # Prepares submission files from a list of groupings for download
 # by zipping them up into a single zipfile
 class DownloadSubmissionsJob < ApplicationJob
+
   def self.show_status(status)
     if status[:progress] == status[:total]
       I18n.t('poll_job.download_submissions_finalizing')
@@ -10,15 +11,15 @@ class DownloadSubmissionsJob < ApplicationJob
   end
 
   def self.completed_message(status)
-    { partial: 'submissions/download_zip_file', locals: { assignment_id: status[:assignment_id],
-                                                          course_id: status[:course_id] } }
+    renderer=ApplicationController.renderer.new(https: true)
+    renderer.render(partial: 'submissions/download_zip_file', locals: { download_submissions_url: status[:download_submissions_url] })
   end
 
   before_enqueue do |job|
-    self.status.update(assignment_id: job.arguments[2], course_id: job.arguments[3])
+    self.status.update(assignment_id: job.arguments[2], course_id: job.arguments[3], download_submissions_url: job.arguments[4])
   end
 
-  def perform(grouping_ids, zip_path, _assignment_id, _course_id)
+  def perform(grouping_ids, zip_path, _assignment_id, _course_id, download_submissions_url)
     ## delete the old file if it exists
     FileUtils.rm_f(zip_path)
 

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -1,7 +1,6 @@
 # Prepares submission files from a list of groupings for download
 # by zipping them up into a single zipfile
 class DownloadSubmissionsJob < ApplicationJob
-
   def self.show_status(status)
     if status[:progress] == status[:total]
       I18n.t('poll_job.download_submissions_finalizing')
@@ -11,15 +10,17 @@ class DownloadSubmissionsJob < ApplicationJob
   end
 
   def self.completed_message(status)
-    renderer=ApplicationController.renderer.new(https: true)
-    renderer.render(partial: 'submissions/download_zip_file', locals: { download_submissions_url: status[:download_submissions_url] })
+    renderer = ApplicationController.renderer.new(https: true)
+    renderer.render(partial: 'submissions/download_zip_file',
+                    locals: { download_submissions_url: status[:download_submissions_url] })
   end
 
   before_enqueue do |job|
-    self.status.update(assignment_id: job.arguments[2], course_id: job.arguments[3], download_submissions_url: job.arguments[4])
+    self.status.update(assignment_id: job.arguments[2], course_id: job.arguments[3],
+                       download_submissions_url: job.arguments[4])
   end
 
-  def perform(grouping_ids, zip_path, _assignment_id, _course_id, download_submissions_url)
+  def perform(grouping_ids, zip_path, _assignment_id, _course_id, _download_submissions_url)
     ## delete the old file if it exists
     FileUtils.rm_f(zip_path)
 

--- a/app/views/submissions/_download_zip_file.html.erb
+++ b/app/views/submissions/_download_zip_file.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <a id="zip_download_link" href="<%= download_submissions_url %>">
+  <a id="zip_download_link" href="<%= download_sub_url %>">
     <%= I18n.t('poll_job.download_submissions_complete') %>
   </a>
 </p>

--- a/app/views/submissions/_download_zip_file.html.erb
+++ b/app/views/submissions/_download_zip_file.html.erb
@@ -1,6 +1,5 @@
 <p>
-  <a id="zip_download_link"
-     href="<%= download_zipped_file_course_assignment_submissions_url(course_id, assignment_id) %>">
+  <a id="zip_download_link" href="<%= download_submissions_url %>">
     <%= I18n.t('poll_job.download_submissions_complete') %>
   </a>
 </p>

--- a/spec/jobs/download_submissions_job_spec.rb
+++ b/spec/jobs/download_submissions_job_spec.rb
@@ -18,7 +18,8 @@ describe DownloadSubmissionsJob do
 
   it 'should create a zip file containing all submission files for the given groupings' do
     zip_path = 'tmp/test_file.zip'
-    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id,
+                                       download_sub_url)
     Zip::File.open(zip_path) do |zip_file|
       groupings.each do |grouping|
         gid = grouping.id
@@ -31,7 +32,8 @@ describe DownloadSubmissionsJob do
 
   it 'should skip files for groupings that do not have a submission for that assignment' do
     zip_path = 'tmp/test_file.zip'
-    DownloadSubmissionsJob.perform_now(groupings_without_files.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
+    DownloadSubmissionsJob.perform_now(groupings_without_files.map(&:id), zip_path, assignment.id,
+                                       assignment.course.id, download_sub_url)
     Zip::File.open(zip_path) do |zip_file|
       groupings_without_files.each do |grouping|
         gid = grouping.id
@@ -45,7 +47,8 @@ describe DownloadSubmissionsJob do
     zip_path = 'tmp/test_file.zip'
     before_text = 'the before text'
     File.write(zip_path, before_text)
-    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id,
+                                       download_sub_url)
     expect(File.read(zip_path)).not_to eq before_text
   end
 end

--- a/spec/jobs/download_submissions_job_spec.rb
+++ b/spec/jobs/download_submissions_job_spec.rb
@@ -7,6 +7,7 @@ describe DownloadSubmissionsJob do
       grouping
     end
   end
+  let(:download_sub_url) {}
 
   context 'when running as a background job' do
     let(:job_args) { [groupings.map(&:id), 'zip_path.zip', assignment.id] }
@@ -17,7 +18,7 @@ describe DownloadSubmissionsJob do
 
   it 'should create a zip file containing all submission files for the given groupings' do
     zip_path = 'tmp/test_file.zip'
-    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id)
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
     Zip::File.open(zip_path) do |zip_file|
       groupings.each do |grouping|
         gid = grouping.id
@@ -30,7 +31,7 @@ describe DownloadSubmissionsJob do
 
   it 'should skip files for groupings that do not have a submission for that assignment' do
     zip_path = 'tmp/test_file.zip'
-    DownloadSubmissionsJob.perform_now(groupings_without_files.map(&:id), zip_path, assignment.id, assignment.course.id)
+    DownloadSubmissionsJob.perform_now(groupings_without_files.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
     Zip::File.open(zip_path) do |zip_file|
       groupings_without_files.each do |grouping|
         gid = grouping.id
@@ -44,7 +45,7 @@ describe DownloadSubmissionsJob do
     zip_path = 'tmp/test_file.zip'
     before_text = 'the before text'
     File.write(zip_path, before_text)
-    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id)
+    DownloadSubmissionsJob.perform_now(groupings.map(&:id), zip_path, assignment.id, assignment.course.id, download_sub_url)
     expect(File.read(zip_path)).not_to eq before_text
   end
 end

--- a/spec/jobs/download_submissions_job_spec.rb
+++ b/spec/jobs/download_submissions_job_spec.rb
@@ -7,7 +7,7 @@ describe DownloadSubmissionsJob do
       grouping
     end
   end
-  let(:download_sub_url) {}
+  let(:download_sub_url) { '' }
 
   context 'when running as a background job' do
     let(:job_args) { [groupings.map(&:id), 'zip_path.zip', assignment.id] }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes displaying the download link in the flash message when selecting the "Download Submissions" button under the submission tab. Somehow it stopped rendering the partial and displaying the link. 

## Your Changes
in application_helper.rb the "#{ ... }" somehow no longer renders a view:
    content = kwargs.empty? ? "<p>#{text.to_s.gsub("\n", ' ')}</p>" : render_to_string(**kwargs).split("\n").join
How this was fixed was to render the partial view before this stage and pass the output to "#{ ... }", which is done in download_submissions_job.rb

through this process discovered I have to render the url in a controller which was done in the submission_controller (download_submissions_url), otherwise we won't have the host part which is taken fro the request object.

**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
did manual test locally through the web interface

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

