### PR TITLE
RT 11116 - Downloading Submissions Issue AB#26

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Replace the function `tas` of the `Assignment` model with a `tas` "has_many" association for that model (#6764)
 - Fix bug where uploading scanned exam pages with overwriting option selected did not update submission files (#6768)
 - Ensure starter files are passed to autotester in sorted order (#6771)
+- Fix bug: "Download Submissions" download link was not being rendered from partial view (#6774)
 
 ## [v2.3.2]
 - Allow MathJAX to process environments (e.g., align) (#6762)

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@
 - Replace the function `tas` of the `Assignment` model with a `tas` "has_many" association for that model (#6764)
 - Fix bug where uploading scanned exam pages with overwriting option selected did not update submission files (#6768)
 - Ensure starter files are passed to autotester in sorted order (#6771)
-- Fix bug: "Download Submissions" download link was not being rendered from partial view (#6774)
+- Fix bug: "Download Submissions" download link was not being rendered from partial view (#6779)
 
 ## [v2.3.2]
 - Allow MathJAX to process environments (e.g., align) (#6762)

--- a/app/controllers/job_messages_controller.rb
+++ b/app/controllers/job_messages_controller.rb
@@ -8,7 +8,12 @@ class JobMessagesController < ApplicationController
       session[:job_id] = nil
     elsif status.completed?
       status[:progress] = status[:total]
-      flash_message(:success, status[:job_class].completed_message(status))
+      completed_message = status[:job_class].completed_message(status)
+      if completed_message.is_a?(Hash)
+        flash_message(:success, **completed_message)
+      else
+        flash_message(:success, completed_message)
+      end
       session[:job_id] = nil
     elsif status.read.empty?
       flash_message(:error, t('poll_job.failed'))

--- a/app/jobs/download_submissions_job.rb
+++ b/app/jobs/download_submissions_job.rb
@@ -10,8 +10,8 @@ class DownloadSubmissionsJob < ApplicationJob
   end
 
   def self.completed_message(status)
-    { partial: 'submissions/download_zip_file', locals: { assignment_id: status[:assignment_id],
-                                                          course_id: status[:course_id] } }
+    { partial: 'submissions/download_zip_file', formats: [:html], locals: { assignment_id: status[:assignment_id],
+                                                                            course_id: status[:course_id] } }
   end
 
   before_enqueue do |job|


### PR DESCRIPTION
## Motivation and Context
This fixes displaying the download link in the flash message when selecting the "Download Submissions" button under the submission tab. In Ruby 3, it changed how keyword arguments are passed to functions. Because of this, this partial view was passed as a positional argument, thus becoming the text var in the flash_message function rather than the original variable keyword argument `**kwargs`.

## Your Changes
Modified code to pass complete message output as a variable deconstructed keyword argument, `**completed_message`, to the flash message function if it is a Hash. 


**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
did manual test locally through the web interface

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
