### PR TITLE
Add rails and rjsf groups to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
     fortawesome:
       patterns:
         - "@fortawesome*"
+    rails:
+      patterns:
+        - "@rails*"
+    rjsf:
+      patterns:
+        - "@rjsf*"
 - package-ecosystem: pip
   directory: "/"
   schedule:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As I was reviewing dependabot PRs, I noticed two more dependabot groups that we can specify to simplify the PRs.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added rails and rjsf groups to dependabot.yml.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): dependabot configuration


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
