### PR TITLE
Remove rdoc and railroady gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,13 +116,6 @@ group :development, :test, :production_test do
   gem 'faker' # required for database seeding
 end
 
-# Gems not needed at runtime should go here so that MarkUs does
-# not waste time/memory loading them during boot
-group :offline do
-  gem 'railroady'
-  gem 'rdoc'
-end
-
 # If you  plan to use unicorn servers for production
 # make sure that this group is included. You don't need this
 # group if you are using Phusion Passenger or Puma.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,8 +279,6 @@ GEM
     prawn-qrcode (0.5.2)
       prawn (>= 1)
       rqrcode (>= 1.0.0)
-    psych (5.0.1)
-      stringio
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
@@ -293,7 +291,6 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
-    railroady (1.6.0)
     rails (7.0.6)
       actioncable (= 7.0.6)
       actionmailbox (= 7.0.6)
@@ -340,8 +337,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.5.0)
-      psych (>= 4.0.0)
     redcarpet (3.6.0)
     redis (4.8.1)
     redis-namespace (1.11.0)
@@ -438,7 +433,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.0.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     terser (1.1.19)
@@ -509,13 +503,11 @@ DEPENDENCIES
   prawn-qrcode
   puma
   rack-cors
-  railroady
   rails (~> 7.0.6)
   rails-controller-testing
   rails-html-sanitizer
   rails-i18n (~> 7.0.0)
   rails_performance
-  rdoc
   redcarpet
   redis (~> 4.8.1)
   responders


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As I was reviewing the dependabot updates, I noted that we really never use rdoc or railroady. This PR removes those dependencies.

## Your Changes

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): dependency update