### PR TITLE
Fix loading results page when group is created after the due date

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Ensure bonus marks are not included in assignment "out of" in submissions table (#6836)
 - Ensure assignment "out of" in submissions table is rounded to two decimal places (#6836)
 - Added POST API for Group Creation (#6834)
+- Fix loading results page when group is created after the due date (#6863)
 
 ## [v2.3.3]
 - Fix bug where uploading scanned exam pages with overwriting option selected did not update submission files (#6768)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -49,7 +49,7 @@ class ResultsController < ApplicationController
           parent_assignment_id: pr_assignment&.id,
           student_view: current_role.student? && !is_reviewer,
           due_date: I18n.l(grouping.due_date.in_time_zone),
-          submission_time: I18n.l(submission.revision_timestamp.in_time_zone)
+          submission_time: submission.revision_timestamp && I18n.l(submission.revision_timestamp.in_time_zone)
         }
         if original_result.nil?
           data[:overall_comment] = result.overall_comment

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1228,13 +1228,15 @@ describe ResultsController do
           instructor_run: data['instructor_run'],
           is_reviewer: data['is_reviewer'],
           student_view: data['student_view'],
-          can_run_tests: data['can_run_tests']
+          can_run_tests: data['can_run_tests'],
+          submission_time: data['submission_time']
         }
         expected_data = {
           instructor_run: true,
           is_reviewer: false,
           student_view: is_student,
-          can_run_tests: false
+          can_run_tests: false,
+          submission_time: I18n.l(submission.revision_timestamp.in_time_zone)
         }
         expect(received_data).to eq(expected_data)
       end
@@ -1287,6 +1289,22 @@ describe ResultsController do
             }.stringify_keys
           end
           expect(data['grace_token_deductions']).to eq(expected_deduction_data)
+        end
+      end
+
+      context 'when there is no submission' do
+        before do
+          submission.update!(
+            revision_identifier: nil,
+            revision_timestamp: nil
+          )
+        end
+
+        it 'sends a submission_time of null' do
+          subject
+          data = response.parsed_body
+
+          expect(data['submission_time']).to be_nil
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was a server error when loading the results (grading) view when a submission did not have an associated revision. (This could occur when the group was created after the due date, and then a submission was collected.)

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Fixed the error that was assuming a non-nil value (`submission.revision_timestamp`).


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI and added a test case.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
