### PR TITLE
autocomplete with active students only for 'assign scans' matching process

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Ensure bonus marks are not included in assignment "out of" in submissions table (#6836)
 - Ensure assignment "out of" in submissions table is rounded to two decimal places (#6836)
 - Added POST API for Group Creation (#6834)
+- Autocomplete with active students only for matching process in 'assign scans' (#6844)
 
 ## [v2.3.3]
 - Fix bug where uploading scanned exam pages with overwriting option selected did not update submission files (#6768)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -168,7 +168,7 @@ class GroupsController < ApplicationController
                           .where('(lower(first_name) like ? OR
                                    lower(last_name) like ? OR
                                    lower(user_name) like ? OR
-                                   id_number like ?) AND roles.id NOT IN (?)',
+                                   id_number like ?) AND roles.hidden = false AND roles.id NOT IN (?)',
                                  "#{ApplicationRecord.sanitize_sql_like(params[:term].downcase)}%",
                                  "#{ApplicationRecord.sanitize_sql_like(params[:term].downcase)}%",
                                  "#{ApplicationRecord.sanitize_sql_like(params[:term].downcase)}%",

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -693,16 +693,6 @@ describe GroupsController do
            'user_name' => student1.user_name,
            'value' => "#{student1.first_name} #{student1.last_name}" }]
       end
-      it 'does not return matches for inactive user_name' do
-        puts(role.inspect)
-        post_as instructor, :get_names, params: { course_id: course.id,
-                                                  assignment_id: assignment.id,
-                                                  assignment: assignment.id,
-                                                  term: 'c9',
-                                                  format: :json }
-
-        expect(response.parsed_body).to eq student1
-      end
       it 'returns matches for user_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -711,15 +701,6 @@ describe GroupsController do
                                                   format: :json }
 
         expect(response.parsed_body).to eq expected
-      end
-      it 'returns matches for active students only' do
-        post_as instructor, :get_names, params: { course_id: course.id,
-                                                  assignment_id: assignment.id,
-                                                  assignment: assignment.id,
-                                                  term: 'f',
-                                                  format: :json }
-
-        expect(response.parsed_body).to match_array expected
       end
       it 'returns matches for first_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
@@ -748,7 +729,15 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+      it 'returns matches for active students only' do
+        post_as instructor, :get_names, params: { course_id: course.id,
+                                                  assignment_id: assignment.id,
+                                                  assignment: assignment.id,
+                                                  term: 'f',
+                                                  format: :json }
 
+        expect(response.parsed_body).to match_array expected
+      end
       describe 'when users are already in groups' do
         let!(:grouping) { create :grouping_with_inviter, assignment: assignment, inviter: student1 }
         let(:assignment2) { create :assignment }

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -672,6 +672,7 @@ describe GroupsController do
                user: create(:end_user, user_name: 'c9test1', first_name: 'first', last_name: 'last',
                                        id_number: '12345'))
       end
+
       let!(:student2) do
         create(:student,
                user: create(:end_user, user_name: 'zzz', first_name: 'zzz', last_name: 'zzz', id_number: '789'))
@@ -681,13 +682,27 @@ describe GroupsController do
                user: create(:end_user, user_name: 'zz396', first_name: 'zzfirst', last_name: 'zzlast',
                                        id_number: '781034'))
       end
+      let!(:student4) do
+        create(:student,
+               user: create(:end_user, user_name: 'c123hello', first_name: 'fhello', last_name: 'lhello',
+                                       id_number: '1284923'), hidden: true)
+      end
       let(:expected) do
         [{ 'id' => student1.id,
            'id_number' => student1.id_number,
            'user_name' => student1.user_name,
            'value' => "#{student1.first_name} #{student1.last_name}" }]
       end
+      it 'does not return matches for inactive user_name' do
+        puts(role.inspect)
+        post_as instructor, :get_names, params: { course_id: course.id,
+                                                  assignment_id: assignment.id,
+                                                  assignment: assignment.id,
+                                                  term: 'c9',
+                                                  format: :json }
 
+        expect(response.parsed_body).to eq student1
+      end
       it 'returns matches for user_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -697,7 +712,15 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+      it 'returns matches for active students only' do
+        post_as instructor, :get_names, params: { course_id: course.id,
+                                                  assignment_id: assignment.id,
+                                                  assignment: assignment.id,
+                                                  term: 'f',
+                                                  format: :json }
 
+        expect(response.parsed_body).to match_array expected
+      end
       it 'returns matches for first_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -707,7 +730,6 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
-
       it 'returns matches for last_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -717,7 +739,6 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
-
       it 'returns matches for id_number' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -672,7 +672,6 @@ describe GroupsController do
                user: create(:end_user, user_name: 'c9test1', first_name: 'first', last_name: 'last',
                                        id_number: '12345'))
       end
-
       let!(:student2) do
         create(:student,
                user: create(:end_user, user_name: 'zzz', first_name: 'zzz', last_name: 'zzz', id_number: '789'))
@@ -693,6 +692,7 @@ describe GroupsController do
            'user_name' => student1.user_name,
            'value' => "#{student1.first_name} #{student1.last_name}" }]
       end
+
       it 'returns matches for user_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -702,6 +702,7 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+
       it 'returns matches for first_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -711,6 +712,7 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+
       it 'returns matches for last_name' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -720,6 +722,7 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+
       it 'returns matches for id_number' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,
@@ -729,6 +732,7 @@ describe GroupsController do
 
         expect(response.parsed_body).to eq expected
       end
+
       it 'returns matches for active students only' do
         post_as instructor, :get_names, params: { course_id: course.id,
                                                   assignment_id: assignment.id,


### PR DESCRIPTION
## Motivation and Context
For the MarkUs "assign scans" matching process, the student autocomplete dropdown is to only contain active students, and not suggest inactive students.


## Your Changes
<!--- Describe your changes here. -->
Update the current SQL query to only include students who are active (role.hidden = false)

**Type of change** (select all that apply):
- [x] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Manually tested through UI. Changed the role.hidden value in the database for a student to see its effects on UI side.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

