### PR TITLE
Use websockets to display autotest run errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Allow inactive groups in the graders table to be toggled for display (#6778)
 - Enable plotly rendering for jupyter notebooks (#6871)
 - Added new API routes for the `create` and `destroy` actions of SectionsController (#6873)
+- Display error message in real-time when running automated tests, rather than waiting for page refresh (#6878)
 
 ## [v2.4.1]
 - Internal changes only

--- a/app/assets/javascripts/flash.js
+++ b/app/assets/javascripts/flash.js
@@ -5,18 +5,18 @@ const generateFlashMessageContentsUsingStatus = status_data => {
   switch (status_data["status"]) {
     case "failed":
       if (!status_data["exception"] || !status_data["exception"]["message"]) {
-        message_data["error"] = I18n.t("submissions.collect.status.failed.no_message");
+        message_data["error"] = I18n.t("job.status.failed.no_message");
       } else {
-        message_data["error"] = I18n.t("submissions.collect.status.failed.message", {
+        message_data["error"] = I18n.t("job.status.failed.message", {
           error: status_data["exception"]["message"],
         });
       }
       break;
     case "completed":
-      message_data["success"] = I18n.t("submissions.collect.status.completed");
+      message_data["success"] = I18n.t("job.status.completed");
       break;
     case "queued":
-      message_data["notice"] = I18n.t("submissions.collect.status.queued");
+      message_data["notice"] = I18n.t("job.status.queued");
       break;
     default:
       let progress = status_data["progress"];

--- a/app/controllers/automated_tests_controller.rb
+++ b/app/controllers/automated_tests_controller.rb
@@ -55,13 +55,13 @@ class AutomatedTestsController < ApplicationController
                                                    context: { assignment: assignment, grouping: grouping })).value
     if allowed
       grouping.decrease_test_tokens
-      @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
-                                                  current_role.id,
-                                                  assignment.id,
-                                                  [grouping.group_id],
-                                                  collected: false)
-      session[:job_id] = @current_job.job_id
-      flash_message(:success, I18n.t('automated_tests.test_run_table.tests_running'))
+      flash_message(:notice, I18n.t('automated_tests.autotest_run_job.status.in_progress'))
+      AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                   current_role.id,
+                                   assignment.id,
+                                   [grouping.group_id],
+                                   user: current_user,
+                                   collected: false)
     end
   rescue StandardError => e
     flash_message(:error, e.message)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -281,12 +281,12 @@ class ResultsController < ApplicationController
 
   def run_tests
     submission = record.submission
-    @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
-                                                current_role.id,
-                                                submission.assignment.id,
-                                                [submission.grouping.group_id])
-    session[:job_id] = @current_job.job_id
-    flash_message(:success, I18n.t('automated_tests.test_run_table.tests_running'))
+    flash_message(:notice, I18n.t('automated_tests.autotest_run_job.status.in_progress'))
+    AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                 current_role.id,
+                                 submission.assignment.id,
+                                 [submission.grouping.group_id],
+                                 user: current_user)
   end
 
   ##  Tag Methods  ##

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -252,12 +252,12 @@ class SubmissionsController < ApplicationController
     begin
       if !group_ids.empty?
         if flash_allowance(:error, allowance_to(:run_tests?, current_role, context: { assignment: assignment })).value
-          @current_job = AutotestRunJob.perform_later(request.protocol + request.host_with_port,
-                                                      current_role.id,
-                                                      assignment.id,
-                                                      group_ids)
-          session[:job_id] = @current_job.job_id
-          success = I18n.t('automated_tests.tests_running', assignment_identifier: assignment.short_identifier)
+          AutotestRunJob.perform_later(request.protocol + request.host_with_port,
+                                       current_role.id,
+                                       assignment.id,
+                                       group_ids,
+                                       user: current_user)
+          success = I18n.t('automated_tests.autotest_run_job.status.in_progress')
         end
       else
         error = I18n.t('automated_tests.need_submission')

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -222,9 +222,6 @@ module AutomatedTestsHelper
           autotest_test_id: test_id_hash[grouping.group.id],
           status: :in_progress
         )
-        if batch.nil?
-          TestRunsChannel.broadcast_to(role.user, body: 'sent')
-        end
       end
     end
 

--- a/app/jobs/autotest_results_job.rb
+++ b/app/jobs/autotest_results_job.rb
@@ -25,26 +25,46 @@ class AutotestResultsJob < AutotestJob
                     .pluck('assessments.id', 'test_runs.id')
                     .group_by(&:first)
                     .transform_values { |v| v.map(&:second) }
+
+    # Map users to the ids of assignments with updated results from their test runs
+    updated_assignment_batch_runs = Hash.new { |h, k| h[k] = [] }
+
     ids.each do |assignment_id, test_run_ids|
       assignment = Assignment.find(assignment_id)
       test_runs = TestRun.where(id: test_run_ids)
-      statuses(assignment, test_runs).each do |autotest_test_id, status|
+      updated_users = []
+      statuses(assignment, test_runs).each do |autotest_test_id, test_run_status|
         # statuses from rq: https://python-rq.org/docs/jobs/#retrieving-a-job-from-redis
-        status = 'not_found' if status.nil?
-        if %(started queued deferred).include? status
+        test_run_status = 'not_found' if test_run_status.nil?
+        if %(started queued deferred).include? test_run_status
           outstanding_results = true
         else
           test_run = test_runs.find_by(autotest_test_id: autotest_test_id)
-          if %(finished failed).include? status
+          if %(finished failed).include? test_run_status
             results(test_run.grouping.assignment, test_run) unless test_run.nil?
           else
-            test_run&.failure(status)
+            test_run&.failure(test_run_status)
           end
-          if !test_run.nil? && test_run.test_batch_id.nil?
-            TestRunsChannel.broadcast_to(test_run.role.user, body: 'sent')
+          unless test_run.nil?
+            if test_run.test_batch_id.nil?
+              TestRunsChannel.broadcast_to(test_run.role.user, { status: 'completed', job_class: 'AutotestResultsJob' })
+            else
+              updated_users << test_run.role.user
+            end
           end
         end
       end
+      updated_users.each do |user|
+        updated_assignment_batch_runs[user] << assignment_id
+      end
+    end
+
+    updated_assignment_batch_runs.each do |user, assignment_ids|
+      TestRunsChannel.broadcast_to(user,
+                                   { status: 'completed',
+                                     job_class: 'AutotestResultsJob',
+                                     assignment_ids: assignment_ids,
+                                     update_table: true })
     end
     outstanding_results
   ensure

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -4,7 +4,7 @@ class AutotestRunJob < AutotestJob
     I18n.t('poll_job.autotest_run_job_enqueuing')
   end
 
-  def perform(host_with_port, role_id, assignment_id, group_ids, collected: true)
+  def perform(host_with_port, role_id, assignment_id, group_ids, user: nil, collected: true)
     # create and enqueue test runs
     role = Role.find(role_id)
     test_batch = group_ids.size > 1 ? TestBatch.create(course: role.course) : nil # create 1 batch object if needed
@@ -14,5 +14,14 @@ class AutotestRunJob < AutotestJob
       run_tests(assignment, host_with_port, group_id_slice, role, collected: collected, batch: test_batch)
     end
     AutotestResultsJob.perform_later
+    unless user.nil?
+      TestRunsChannel.broadcast_to(user, { status: 'completed', job_class: 'AutotestRunJob' })
+    end
+  rescue StandardError => e
+    status.catch_exception(e)
+    unless user.nil?
+      TestRunsChannel.broadcast_to(user, { **status.to_h, job_class: 'AutotestRunJob' })
+    end
+    raise e
   end
 end

--- a/config/locales/defaults/job/en.yml
+++ b/config/locales/defaults/job/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  job:
+    status:
+      completed: This job is now complete.
+      failed:
+        message: 'This job failed due to the following error: {{error}}'
+        no_message: This job failed due to an unexpected error.
+      in_progress: This job is in progress.
+      queued: This job is waiting to be run.

--- a/config/locales/views/automated_tests/en.yml
+++ b/config/locales/views/automated_tests/en.yml
@@ -1,6 +1,13 @@
 ---
 en:
   automated_tests:
+    autotest_results_job:
+      status:
+        completed: Tests have been run and results are available.
+    autotest_run_job:
+      status:
+        completed: Running tests.
+        in_progress: Setting up tests.
     cancel_tests: Cancel tests
     category: Run by
     display_output:
@@ -43,8 +50,6 @@ en:
     stop_batch: Stop batch
     stop_test: Stop test
     student_tests: Student-Run Tests
-    test_run_table:
-      tests_running: Running tests.
     test_runs_status: Test Runs Status
     test_runs_statuses:
       cancelled: cancelled
@@ -53,6 +58,5 @@ en:
       in_progress: in progress
     testing_disabled: Automated testing is not enabled for this assignment.
     tests_run: Tests have been run for this assignment. Please re-run tests once the settings have been updated.
-    tests_running: Running tests. Please refresh this page in a bit to view the results.
     timeout: Timeout (s)
     title: Automated Testing

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -22,12 +22,7 @@ en:
       results_loss_warning: This action identifies the version of files to grade for each selected group. Instructors and TAs can begin grading after files are collected.
       scanned_exam_latest_warning: For scanned exams, the latest submitted file version for each selected group is used regardless of the due date.
       status:
-        completed: This job is now complete.
-        failed:
-          message: 'This job failed due to the following error: {{error}}'
-          no_message: This job failed due to an unexpected error.
         in_progress: "{{progress}}/{{total}} submissions collected."
-        queued: This job is waiting to be run.
       submit: Collect Submissions
       this_revision: Collect and Grade This Revision
       undo_results_loss_warning: 'This operation will undo the previous Collect All Submissions operation. This should only be done if the previous Collect All Submissions operation was done in error. WARNING: All grading work done since the previous Collect All Submissions operation will be lost.'

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1921,6 +1921,21 @@ describe ResultsController do
         end
       end
     end
+
+    describe '#run_tests' do
+      before do
+        assignment.update!(enable_test: true,
+                           enable_student_tests: true,
+                           unlimited_tokens: true,
+                           token_start_date: 1.day.ago,
+                           remote_autotest_settings_id: 1)
+      end
+
+      it 'enqueues an AutotestRunJob' do
+        params = { course_id: course.id, id: incomplete_result.id }
+        expect { post :run_tests, params: params }.to have_enqueued_job(AutotestRunJob)
+      end
+    end
   end
 
   context 'A TA' do

--- a/spec/jobs/autotest_results_job_spec.rb
+++ b/spec/jobs/autotest_results_job_spec.rb
@@ -149,7 +149,8 @@ describe AutotestResultsJob do
           context 'when getting results for a completed test' do
             it 'broadcasts a message to the user' do
               expect { described_class.perform_now }
-                .to have_broadcasted_to(student).from_channel(TestRunsChannel).with(body: 'sent')
+                .to have_broadcasted_to(student).from_channel(TestRunsChannel)
+                                                .with(status: 'completed', job_class: 'AutotestResultsJob')
             end
             it 'broadcasts exactly one message' do
               expect { described_class.perform_now }
@@ -161,10 +162,14 @@ describe AutotestResultsJob do
             end
           end
           context 'when a the test was batch run' do
-            let(:test_run2) { create :batch_test_run, grouping: grouping, status: :in_progress }
-            it "doesn't broadcast a message" do
+            let(:test_run2) { create :batch_test_run, grouping: grouping, role: grouping.inviter, status: :in_progress }
+            it 'broadcasts a message to the user' do
               expect { described_class.perform_now }
-                .to have_broadcasted_to(test_run2.role.user).from_channel(TestRunsChannel).exactly 0
+                .to have_broadcasted_to(student).from_channel(TestRunsChannel)
+                                                .with(status: 'completed',
+                                                      job_class: 'AutotestResultsJob',
+                                                      assignment_ids: [grouping.assessment_id],
+                                                      update_table: true)
             end
           end
         end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently if there is an autotest setup error (e.g., an error in package installation), the autotests fail to run, but no error message is displayed until the page is refreshed.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Modified the `AutotestRunJob` so that it reports errors using websockets. This ensures the error messages are displayed in real-time.

Because I removed the old error flash message, I also modified the submissions table to use websockets to track autotesting status. This required updating the `AutotestRunJob` and `AutotestResultsJob` to broadcast messages for both individual and batch test runs.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually in the UI for both instructor-run (individual and batch) and student-run tests.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
