### PR TITLE
Autotest fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Fix autotest settings criterion JSON schema validation (#6907)
+
 ## [v2.4.2]
 - Fix feedback file API not returning feedback file IDs correctly (#6875)
 - Allow inactive groups in the graders table to be toggled for display (#6778)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - Fix autotest settings criterion JSON schema validation (#6907)
+- Ensure autotested criteria do not have marks set if tests time out (#6907)
 
 ## [v2.4.2]
 - Fix feedback file API not returning feedback file IDs correctly (#6875)

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -36,11 +36,6 @@ class AutotestManager extends React.Component {
                 category: {
                   "ui:title": I18n.t("automated_tests.category"),
                 },
-                extra_info: {
-                  criterion: {
-                    "ui:enumDisabled": [""],
-                  },
-                },
                 feedback_file_names: {
                   "ui:classNames": "feedback-file-names",
                   "ui:options": {orderable: false},

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -2,7 +2,8 @@ require 'net/http'
 
 module AutomatedTestsHelper
   def extra_test_group_schema(assignment)
-    criterion_names = assignment.ta_criteria.order(:name).pluck(:name)
+    criterion_names = [{ const: nil, title: I18n.t('not_applicable') }]
+    criterion_names += assignment.ta_criteria.order(:name).pluck(:name).map { |c| { const: c, title: c } }
     { type: :object,
       properties: {
         name: {
@@ -19,9 +20,10 @@ module AutomatedTestsHelper
           title: I18n.t('automated_tests.display_output_title')
         },
         criterion: {
-          type: :string,
-          enum: criterion_names.presence || [''],
-          title: Criterion.model_name.human
+          type: %w[string null],
+          title: Criterion.model_name.human,
+          oneOf: criterion_names,
+          default: nil
         }
       },
       required: %w[display_output] }

--- a/spec/factories/test_group_results.rb
+++ b/spec/factories/test_group_results.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     marks_earned { 1 }
     marks_total { 1 }
     time { Faker::Number.number(digits: 4) }
+    error_type { nil }
   end
 end

--- a/spec/factories/test_groups.rb
+++ b/spec/factories/test_groups.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :assignment
     sequence(:name) { |n| "Test Group #{n}" }
     sequence(:position) { |n| n }
+    criterion { nil }
 
     after :create do |test_group|
       test_group.update!(autotest_settings: { 'extra_info' => { 'test_group_id' => test_group.id } })


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There were two bugs related to autotesting that instructors (and I) encountered.

1. The autotest settings client-side validation was (sometimes) reporting an error when a criterion was not selected for a test group.
2. Test groups that were timing out were still causing marks to be set for their associated criteria. (I encountered this as a consequence of testing https://github.com/MarkUsProject/markus-autotesting/pull/471.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

1. Ensured that a criterion value of `null` is permitted in the form. This replaces the old `''` default value; this is consistent with the data pulled from the database, which has each test group object's `criterion_id` set to `nil` (not `''`). I think this was the cause of the flakiness of this error.
    - Also, modified the criterion label to 'N/A' to better communicate what a blank value means.
2. Improve the check for timed-out test group results. Note that the previous code used `.slice` to check for specific error type values; I've modified this to look for any specified error type.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually. Added test cases for the second change.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
