### PR TITLE
Allow websocket connections with external auth

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Fix websocket connection when logged in with remote auth (#6912)
 
 ## [v2.4.3]
 - Fix autotest settings criterion JSON schema validation (#6907)

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -2,6 +2,9 @@ module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
     def connect
+      if request.session[:auth_type] == 'remote'
+        self.current_user = User.find_by user_name: request.env['HTTP_X_FORWARDED_USER']
+      end
       unless request.session[:user_name].nil?
         self.current_user = User.find_by user_name: request.session[:user_name]
       end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -21,11 +21,28 @@ describe ApplicationCable::Connection, type: :channel do
     end
   end
   context 'when connecting with external auth' do
-    let(:student) { create :student }
-    let(:user_name) { student.user_name }
-    it 'should connect' do
-      connect '/cable', session: { auth_type: 'remote' }, headers: { HTTP_X_FORWARDED_USER: user_name }
-      expect(connection.current_user.user_name).to eq(user_name)
+    context 'as an instructor' do
+      let(:instructor) { create :instructor }
+      it 'should connect' do
+        connect '/cable', session: { auth_type: 'remote' }, headers: { HTTP_X_FORWARDED_USER: instructor.user_name }
+        expect(connection.current_user.user_name).to eq(instructor.user_name)
+      end
+      context 'when role switched' do
+        let(:ta) { create :ta }
+        it 'should connect as the TA' do
+          connect '/cable', session: { auth_type: 'remote', user_name: ta.user_name },
+                            headers: { HTTP_X_FORWARDED_USER: instructor.user_name }
+          expect(connection.current_user.user_name).to eq(ta.user_name)
+        end
+      end
+    end
+    context 'as a student' do
+      let(:student) { create :student }
+      let(:user_name) { student.user_name }
+      it 'should connect' do
+        connect '/cable', session: { auth_type: 'remote' }, headers: { HTTP_X_FORWARDED_USER: user_name }
+        expect(connection.current_user.user_name).to eq(user_name)
+      end
     end
   end
 end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -20,4 +20,12 @@ describe ApplicationCable::Connection, type: :channel do
       end
     end
   end
+  context 'when connecting with external auth' do
+    let(:student) { create :student }
+    let(:user_name) { student.user_name }
+    it 'should connect' do
+      connect '/cable', session: { auth_type: 'remote' }, headers: { HTTP_X_FORWARDED_USER: user_name }
+      expect(connection.current_user.user_name).to eq(user_name)
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, websocket connections fail when users are logged in via external auth (i.e. UTORAuth). This is because `current_user` is not added to user sessions when logged in via external auth.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:
Added a check for remote authorization when attempting to create a websocket connection.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
Tested that when logged in via external auth websocket connections work in the web interface. Added a test for the case that a user is logged in via external auth.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
I think the order of the checks is right - as it stands, we check for the remote auth first, then override with current user if it exists (which should catch role-switched users), then falling back to `real_user_name` if `current_user` is not set by either previous check. But I'd appreciate a second opinion.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
<!--- Add a link to a pull request on the MarkUsProject/Wiki repo -->
