### PR TITLE
Fix bug where graders table failed to load when a group had no members

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - Fix websocket connection when logged in with remote auth (#6912)
+- Fix bug where graders table failed to load when a group had no members (#6916)
 
 ## [v2.4.3]
 - Fix autotest settings criterion JSON schema validation (#6907)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1098,7 +1098,9 @@ class Assignment < Assessment
     grouped_data = members_data.group_by { |x| x[0] }
     grouped_data.each_value { |a| a.each { |b| b.delete_at(0) } }
 
-    result[:groups].each { |group| group[:members] = grouped_data[group[:_id]] }
+    result[:groups].each do |group|
+      group[:members] = grouped_data[group[:_id]] || []
+    end
 
     result
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2546,6 +2546,7 @@ describe Assignment do
         actual_grouping = assignment.current_grader_data[:groups][0]
         expect(actual_grouping[:_id]).to eq(grouping.id)
         expect(actual_grouping[:section]).to be_nil
+        expect(actual_grouping[:members]).to eq []
       end
     end
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #6913.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: The server was sending a `null` JSON value rather than an empty list in the grader data when there were no members. This PR fixes that.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI and added a test assertion to check for this explicitly.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->