### PR TITLE
Improve add button label on autotest settings page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - Add workaround for CSP in Safari < 16 (#6947)
+- Improve add button labels on autotest settings page (#6948)
 
 ## [v2.4.4]
 - Fix websocket connection when logged in with remote auth (#6912)

--- a/app/assets/javascripts/Components/autotest_manager.jsx
+++ b/app/assets/javascripts/Components/autotest_manager.jsx
@@ -24,6 +24,8 @@ class AutotestManager extends React.Component {
         testers: {
           items: {
             "ui:classNames": "tester-item",
+            "ui:placeholder": I18n.t("automated_tests.tester", {count: 1}),
+            "ui:title": I18n.t("automated_tests.tester", {count: 1}),
             env_data: {
               pip_requirements: {
                 "ui:widget": "textarea",
@@ -31,6 +33,8 @@ class AutotestManager extends React.Component {
             },
             test_data: {
               items: {
+                "ui:placeholder": I18n.t("automated_tests.test_group", {count: 1}),
+                "ui:title": I18n.t("automated_tests.test_group", {count: 1}),
                 "ui:order": ["extra_info", "*"],
                 "ui:options": {label: false},
                 category: {
@@ -435,7 +439,7 @@ class AutotestManager extends React.Component {
         </fieldset>
         <fieldset>
           <legend>
-            <span>{"Testers"}</span>
+            <span>{I18n.t("automated_tests.tester", {count: 2})}</span>
           </legend>
           <div className={"rt-action-box upload-download"}>
             <a href={this.specsDownloadURL()} className={"button"}>
@@ -515,6 +519,11 @@ function AddButton(props) {
     registry: {translateString},
     ...btnProps
   } = props;
+  let label = (uiSchema.items && uiSchema.items["ui:title"]) || "";
+  if (label) {
+    label = `${I18n.t("add")} ${label}`;
+  }
+  console.log(props);
   return (
     <div className="row">
       <p className={`col-xs-3 col-xs-offset-9 text-right`}>
@@ -524,7 +533,7 @@ function AddButton(props) {
           title={translateString(TranslatableString.AddButton)}
           {...btnProps}
         >
-          <FontAwesomeIcon icon="fa-solid fa-add" />
+          {label || <FontAwesomeIcon icon="fa-solid fa-add" />}
         </button>
       </p>
     </div>

--- a/config/locales/views/automated_tests/en.yml
+++ b/config/locales/views/automated_tests/en.yml
@@ -50,12 +50,18 @@ en:
     stop_batch: Stop batch
     stop_test: Stop test
     student_tests: Student-Run Tests
+    test_group:
+      one: Test Group
+      other: Test Groups
     test_runs_status: Test Runs Status
     test_runs_statuses:
       cancelled: cancelled
       complete: complete
       failed: error
       in_progress: in progress
+    tester:
+      one: Tester
+      other: Testers
     testing_disabled: Automated testing is not enabled for this assignment.
     tests_run: Tests have been run for this assignment. Please re-run tests once the settings have been updated.
     timeout: Timeout (s)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An instructor notes that on the autotest settings page, the "+" buttons for test groups and testers were close together and a bit confusing. This PR adds explicit labels for the "+" buttons on the autotest settings form.

Fixes #6901 

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Added button labels. Example:

![image](https://github.com/MarkUsProject/Markus/assets/3333115/126e3a88-2419-4723-9b9f-d42845c7f1fe)

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Other (please specify): UI update


## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested in the UI.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->