### PR TITLE
Complete test coverage for CheckboxCriterion.create_or_update_from_csv_row

### DIFF
--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -33,15 +33,15 @@ class CheckboxCriterion < Criterion
     # create a new one.
     criterion = assignment.criteria.find_or_create_by(name: name, type: 'CheckboxCriterion')
 
-    # Check that max is not a string.
+    # Check that the maximum mark is a valid number.
     begin
       criterion.max_mark = Float(working_row.shift)
     rescue ArgumentError, TypeError
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
 
-    # Check that the maximum mark given is a valid number.
-    if criterion.max_mark.nil? || criterion.max_mark.zero?
+    # Check that the maximum mark given is greater than 0.
+    if criterion.max_mark.zero?
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
 

--- a/app/models/checkbox_criterion.rb
+++ b/app/models/checkbox_criterion.rb
@@ -36,7 +36,7 @@ class CheckboxCriterion < Criterion
     # Check that max is not a string.
     begin
       criterion.max_mark = Float(working_row.shift)
-    rescue ArgumentError
+    rescue ArgumentError, TypeError
       raise CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format')
     end
 

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -72,6 +72,11 @@ describe CheckboxCriterion do
         .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
 
+    it 'raises an error message on a max mark that is nil' do
+      expect { CheckboxCriterion.create_or_update_from_csv_row(['name', nil], @assignment) }
+        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+    end
+
     it 'raises an error message if the checkbox criterion fails to save' do
       allow_any_instance_of(CheckboxCriterion).to receive(:save).and_return(false)
 

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -47,7 +47,7 @@ describe CheckboxCriterion do
     end
   end
 
-  context 'With non-existent criteria' do
+  context 'With bad CSV line input' do
     before :each do
       @assignment = create(:assignment)
     end

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -66,6 +66,11 @@ describe CheckboxCriterion do
       expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name max_value], @assignment) }
         .to raise_error(CsvInvalidLineError)
     end
+
+    it 'raises an error message on a max mark that is zero' do
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name 0], @assignment) }
+        .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
+    end
   end
 
   context 'for an assignment' do

--- a/spec/models/checkbox_criterion_spec.rb
+++ b/spec/models/checkbox_criterion_spec.rb
@@ -71,6 +71,13 @@ describe CheckboxCriterion do
       expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name 0], @assignment) }
         .to raise_error(CsvInvalidLineError, I18n.t('upload_errors.invalid_csv_row_format'))
     end
+
+    it 'raises an error message if the checkbox criterion fails to save' do
+      allow_any_instance_of(CheckboxCriterion).to receive(:save).and_return(false)
+
+      expect { CheckboxCriterion.create_or_update_from_csv_row(%w[name 2], @assignment) }
+        .to raise_error(CsvInvalidLineError)
+    end
   end
 
   context 'for an assignment' do


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

This PR completes test coverage for the method static `CheckboxCriterion.create_or_update_from_csv_row` by testing the following cases:

* when max mark in `row` is 0
* when max mark in `row` is `nil` (see comment below)
* when a checkbox criterion fails to save

Since a max mark of `nil` triggered an unhandled `TypeError`, `CheckboxCriterion.create_or_update_from_csv_row` has also been slightly modified to account for this case by rescuing that error and preventing unexpected behaviour. Also, a redundant check for max mark being 0 has been removed.

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR (parallel to #6953) was required to complete test coverage on `CheckboxCriterion.create_or_update_from_csv_row`, as well as deal with unexpected behaviour caused by a potential unhandled exception.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: 
* Add tests for `CheckboxCriterion.create_or_update_from_csv_row` for the cases described in the summary
* Added error handling for `TypeError`
* Removed redundant max mark check
* Renamed a test context to make more sense

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Test update (change that modifies or updates tests only)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

The tests themselves were the pull request. The minor change in `CheckboxCriterion.create_or_update_from_csv_row` was also covered in these tests. See the summary at the top of this pull request for more information. 

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->