### PR TITLE
TAs See Starter Files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Add new routes for `update`, `show`, and `index` actions of the Sections API Controller (#6955)
 - Enable the deletion of Grade Entry Forms that have no grades (#6915)
 - Fixed login_spec.rb flaky test on GitHub Actions run (#6966)
+- Gave TAs read-only access to starter file information on assignment summary page under settings menu (#6996)
 
 ## [v2.4.6]
 - Disallow students from uploading .git file and .git folder in their repository (#6963)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Add new routes for `update`, `show`, and `index` actions of the Sections API Controller (#6955)
 - Enable the deletion of Grade Entry Forms that have no grades (#6915)
 - Fixed login_spec.rb flaky test on GitHub Actions run (#6966)
-- Gave TAs read-only access to starter file information on assignment summary page under settings menu (#6996)
+- Gave TAs read-only access to starter file information under assignment settings (#6996)
 
 ## [v2.4.6]
 - Disallow students from uploading .git file and .git folder in their repository (#6963)

--- a/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
@@ -39,7 +39,6 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
       available_after_due: true,
       starterfileType: "sections",
       defaultStarterFileGroup: 1,
-      readOnly: readOnly,
     };
 
     // for the case where this is read only, we don't want to have the form as
@@ -52,7 +51,7 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
     beforeEach(() => {
       fetch.resetMocks();
       fetch.mockResponseOnce(JSON.stringify(pageInfo));
-      wrapper = mount(<StarterFileManager course_id={1} assignment_id={1} />);
+      wrapper = mount(<StarterFileManager course_id={1} assignment_id={1} read_only={readOnly} />);
     });
 
     it(`all buttons on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
@@ -90,7 +89,7 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
       wrapper.update();
       let dropdowns = wrapper.find(".starter-file-dropdown");
 
-      // one for each section, plus one for the default starter file group,
+      // one for each section, plus one for the default starter file group
       expect(dropdowns.length).toEqual(pageInfo.sections.length + 1);
 
       dropdowns.forEach(dropdown => {

--- a/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
@@ -1,5 +1,5 @@
 import {StarterFileManager} from "../starter_file_manager";
-import {render, screen, fireEvent} from "@testing-library/react";
+import {render, screen} from "@testing-library/react";
 
 import React from "react";
 
@@ -8,6 +8,12 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
     return null;
   },
 }));
+
+// workaround needed for using i18n in jest tests, see
+// https://github.com/fnando/i18n/issues/26#issuecomment-1235751777
+jest.mock("i18n-js", () => {
+  return jest.requireActual("i18n-js/dist/require/index");
+});
 
 [true, false].forEach(readOnly => {
   let container;
@@ -58,7 +64,7 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
 
     it(`all buttons on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
       const buttons = screen.getAllByRole("button", {
-        name: /sfg-action-button/i,
+        name: new RegExp(`${I18n.t("assignments.starter_file.aria_labels.action_button")}`),
       });
 
       // one delete button per starter file group, one add button on top of that
@@ -90,7 +96,7 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
 
     it(`all dropdowns on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
       const dropdowns = screen.getAllByRole("combobox", {
-        name: /starter-file-dropdown/i,
+        name: new RegExp(`${I18n.t("assignments.starter_file.aria_labels.dropdown")}`),
       });
 
       // one for each section, plus one for the default starter file group

--- a/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
@@ -1,6 +1,5 @@
 import {StarterFileManager} from "../starter_file_manager";
-
-import {mount} from "enzyme";
+import {render, screen, fireEvent} from "@testing-library/react";
 
 import React from "react";
 
@@ -11,10 +10,10 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
 }));
 
 [true, false].forEach(readOnly => {
+  let container;
   describe(`When a user ${
     readOnly ? "without" : "with"
   } assignment manage access visits the changes the StarterFileManager`, () => {
-    let wrapper;
     const pageInfo = {
       files: [
         {
@@ -51,70 +50,81 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
     beforeEach(() => {
       fetch.resetMocks();
       fetch.mockResponseOnce(JSON.stringify(pageInfo));
-      wrapper = mount(<StarterFileManager course_id={1} assignment_id={1} read_only={readOnly} />);
+
+      container = render(
+        <StarterFileManager course_id={1} assignment_id={1} read_only={readOnly} />
+      );
     });
 
     it(`all buttons on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
-      wrapper.update();
-      let buttons = wrapper.find(".button");
+      const buttons = screen.getAllByRole("button", {
+        name: /sfg-action-button/i,
+      });
 
       // one delete button per starter file group, one add button on top of that
-      expect(buttons.length).toEqual(pageInfo.files.length + 1);
+      expect(buttons).toHaveLength(pageInfo.files.length + 1);
 
       buttons.forEach(button => {
-        expect(button.props()["disabled"]).toBe(readOnly);
+        if (readOnly) {
+          expect(button).toBeDisabled();
+        } else {
+          expect(button).not.toBeDisabled();
+        }
       });
     });
 
-    it(`the internal FileManager is ${readOnly ? "in" : "not in"} readOnly mode`, () => {
-      wrapper.update();
-      let fileManager = wrapper.find("StarterFileFileManager");
-
-      expect(fileManager.props()["readOnly"]).toBe(readOnly);
-    });
-
     it(`all radio buttons are ${readOnly ? "disabled" : "enabled"}`, () => {
-      wrapper.update();
-      let radioButtons = wrapper.find({type: "radio"});
+      const radioButtons = screen.getAllByRole("radio");
 
-      // there's 4 by design
-      expect(radioButtons.length).toEqual(4);
+      // there's exactly 4 at all times
+      expect(radioButtons).toHaveLength(4);
 
       radioButtons.forEach(radioButton => {
-        expect(radioButton.props()["disabled"]).toBe(readOnly);
+        if (readOnly) {
+          expect(radioButton).toBeDisabled();
+        } else {
+          expect(radioButton).not.toBeDisabled();
+        }
       });
     });
 
     it(`all dropdowns on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
-      wrapper.update();
-      let dropdowns = wrapper.find(".starter-file-dropdown");
+      const dropdowns = screen.getAllByRole("combobox", {
+        name: /starter-file-dropdown/i,
+      });
 
       // one for each section, plus one for the default starter file group
-      expect(dropdowns.length).toEqual(pageInfo.sections.length + 1);
+      expect(dropdowns).toHaveLength(pageInfo.sections.length + 1);
 
       dropdowns.forEach(dropdown => {
-        expect(dropdown.getDOMNode().hasAttribute("disabled")).toBe(readOnly);
+        if (readOnly) {
+          expect(dropdown).toBeDisabled();
+        } else {
+          expect(dropdown).not.toBeDisabled();
+        }
       });
     });
 
     it(`the checkbox on the page is ${readOnly ? "disabled" : "enabled"}`, () => {
-      wrapper.update();
-      let checkbox = wrapper.find({type: "checkbox"});
+      // should only be one
+      const checkbox = screen.getByTestId("available_after_due_checkbox");
 
-      // only checkbox is starter files available after due
-      expect(checkbox.length).toEqual(1);
-
-      expect(checkbox.props()["disabled"]).toBe(readOnly);
+      if (readOnly) {
+        expect(checkbox).toBeDisabled();
+      } else {
+        expect(checkbox).not.toBeDisabled();
+      }
     });
 
     it(`the submit button on the page is ${readOnly ? "disabled" : "enabled"}`, () => {
-      wrapper.update();
-      let submit = wrapper.find({type: "submit"});
+      // should only be one
+      const saveButton = screen.getByTestId("save_button");
 
-      // only checkbox is starter files available after due
-      expect(submit.length).toEqual(1);
-
-      expect(submit.getDOMNode().hasAttribute("disabled")).toBe(readOnly);
+      if (readOnly) {
+        expect(saveButton).toBeDisabled();
+      } else {
+        expect(saveButton).not.toBeDisabled();
+      }
     });
   });
 });

--- a/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/starter_file_manager.test.jsx
@@ -1,0 +1,121 @@
+import {StarterFileManager} from "../starter_file_manager";
+
+import {mount} from "enzyme";
+
+import React from "react";
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => {
+    return null;
+  },
+}));
+
+[true, false].forEach(readOnly => {
+  describe(`When a user ${
+    readOnly ? "without" : "with"
+  } assignment manage access visits the changes the StarterFileManager`, () => {
+    let wrapper;
+    const pageInfo = {
+      files: [
+        {
+          id: 1,
+          name: "New Starter File Group",
+          entry_rename: "",
+          use_rename: false,
+          files: [
+            {
+              key: "a4.pdf",
+              size: 1,
+              submitted_date: "Thursday, March 14, 2024, 06:34:51 PM EDT",
+              url: "http://localhost:3000/csc108/courses/1/starter_file_groups/1/download_file?file_name=a4.pdf",
+            },
+          ],
+        },
+      ],
+      sections: [
+        {section_id: 1, section_name: "LEC0101", group_id: 1, group_name: "New Starter File Group"},
+        {section_id: 2, section_name: "LEC0201", group_id: 1, group_name: "New Starter File Group"},
+      ],
+      available_after_due: true,
+      starterfileType: "sections",
+      defaultStarterFileGroup: 1,
+      readOnly: readOnly,
+    };
+
+    // for the case where this is read only, we don't want to have the form as
+    // changed because that's impossible
+    //
+    // for the case where this is NOT read only, we want to simulate page changed
+    // so submit button is enabled (the point is to ensure this is possible)
+    pageInfo.form_changed = !readOnly;
+
+    beforeEach(() => {
+      fetch.resetMocks();
+      fetch.mockResponseOnce(JSON.stringify(pageInfo));
+      wrapper = mount(<StarterFileManager course_id={1} assignment_id={1} />);
+    });
+
+    it(`all buttons on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
+      wrapper.update();
+      let buttons = wrapper.find(".button");
+
+      // one delete button per starter file group, one add button on top of that
+      expect(buttons.length).toEqual(pageInfo.files.length + 1);
+
+      buttons.forEach(button => {
+        expect(button.props()["disabled"]).toBe(readOnly);
+      });
+    });
+
+    it(`the internal FileManager is ${readOnly ? "in" : "not in"} readOnly mode`, () => {
+      wrapper.update();
+      let fileManager = wrapper.find("StarterFileFileManager");
+
+      expect(fileManager.props()["readOnly"]).toBe(readOnly);
+    });
+
+    it(`all radio buttons are ${readOnly ? "disabled" : "enabled"}`, () => {
+      wrapper.update();
+      let radioButtons = wrapper.find({type: "radio"});
+
+      // there's 4 by design
+      expect(radioButtons.length).toEqual(4);
+
+      radioButtons.forEach(radioButton => {
+        expect(radioButton.props()["disabled"]).toBe(readOnly);
+      });
+    });
+
+    it(`all dropdowns on the page are ${readOnly ? "disabled" : "enabled"}`, () => {
+      wrapper.update();
+      let dropdowns = wrapper.find(".starter-file-dropdown");
+
+      // one for each section, plus one for the default starter file group,
+      expect(dropdowns.length).toEqual(pageInfo.sections.length + 1);
+
+      dropdowns.forEach(dropdown => {
+        expect(dropdown.getDOMNode().hasAttribute("disabled")).toBe(readOnly);
+      });
+    });
+
+    it(`the checkbox on the page is ${readOnly ? "disabled" : "enabled"}`, () => {
+      wrapper.update();
+      let checkbox = wrapper.find({type: "checkbox"});
+
+      // only checkbox is starter files available after due
+      expect(checkbox.length).toEqual(1);
+
+      expect(checkbox.props()["disabled"]).toBe(readOnly);
+    });
+
+    it(`the submit button on the page is ${readOnly ? "disabled" : "enabled"}`, () => {
+      wrapper.update();
+      let submit = wrapper.find({type: "submit"});
+
+      // only checkbox is starter files available after due
+      expect(submit.length).toEqual(1);
+
+      expect(submit.getDOMNode().hasAttribute("disabled")).toBe(readOnly);
+    });
+  });
+});

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -44,7 +44,7 @@ class StarterFileManager extends React.Component {
         this.props.course_id,
         this.props.assignment_id
       ),
-      {headers: {Accept: "aaplication/json"}}
+      {headers: {Accept: "application/json"}}
     )
       .then(reponse => {
         if (reponse.ok) {

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -353,6 +353,7 @@ class StarterFileManager extends React.Component {
                 this.toggleFormChanged(true)
               )
             }
+            className="starter-file-dropdown"
             value={this.state.defaultStarterFileGroup}
             disabled={!this.state.files.length || this.state.readOnly}
           >
@@ -386,6 +387,7 @@ class StarterFileManager extends React.Component {
                       onChange={this.updateSectionStarterFile}
                       value={selected}
                       disabled={!this.state.files.length || this.state.readOnly}
+                      className="starter-file-dropdown"
                     >
                       <option value={`${row.original.section_id}_`} />
                       {Object.entries(this.state.files).map(data => {
@@ -648,3 +650,5 @@ class StarterFileFileManager extends React.Component {
 export function makeStarterFileManager(elem, props) {
   render(<StarterFileManager {...props} />, elem);
 }
+
+export {StarterFileManager};

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -22,7 +22,6 @@ class StarterFileManager extends React.Component {
       showFileUploadModal: false,
       starterfileType: "simple",
       defaultStarterFileGroup: "",
-      readOnly: true,
       files: {},
       sections: {},
       form_changed: false,
@@ -226,7 +225,7 @@ class StarterFileManager extends React.Component {
                 groupUploadTarget={id}
                 files={files}
                 noFilesMessage={I18n.t("submissions.no_files_available")}
-                readOnly={this.state.readOnly}
+                readOnly={this.props.read_only}
                 onCreateFiles={this.handleCreateFiles}
                 onDeleteFile={this.handleDeleteFile}
                 onCreateFolder={this.handleCreateFolder}
@@ -246,7 +245,7 @@ class StarterFileManager extends React.Component {
                 key={"delete_starter_file_group_button"}
                 className={"button"}
                 onClick={() => this.deleteStarterFileGroup(id)}
-                disabled={this.state.readOnly}
+                disabled={this.props.read_only}
               >
                 <FontAwesomeIcon icon="fa-solid fa-trash" />
               </button>
@@ -285,7 +284,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"simple"}
               checked={this.state.starterfileType === "simple"}
-              disabled={!this.state.files.length || this.state.readOnly}
+              disabled={!this.state.files.length || this.props.read_only}
               onChange={() => {
                 this.setState({starterfileType: "simple"}, () => this.toggleFormChanged(true));
               }}
@@ -300,7 +299,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"sections"}
               checked={this.state.starterfileType === "sections"}
-              disabled={!this.state.files.length || this.state.readOnly}
+              disabled={!this.state.files.length || this.props.read_only}
               onChange={() => {
                 this.setState({starterfileType: "sections"}, () => this.toggleFormChanged(true));
               }}
@@ -315,7 +314,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"group"}
               checked={this.state.starterfileType === "group"}
-              disabled={!this.state.files.length || this.state.readOnly}
+              disabled={!this.state.files.length || this.props.read_only}
               onChange={() => {
                 this.setState({starterfileType: "group"}, () => this.toggleFormChanged(true));
               }}
@@ -330,7 +329,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"shuffle"}
               checked={this.state.starterfileType === "shuffle"}
-              disabled={!this.state.files.length || this.state.readOnly}
+              disabled={!this.state.files.length || this.props.read_only}
               onChange={() => {
                 this.setState({starterfileType: "shuffle"}, () => this.toggleFormChanged(true));
               }}
@@ -355,7 +354,7 @@ class StarterFileManager extends React.Component {
             }
             className="starter-file-dropdown"
             value={this.state.defaultStarterFileGroup}
-            disabled={!this.state.files.length || this.state.readOnly}
+            disabled={!this.state.files.length || this.props.read_only}
           >
             {Object.entries(this.state.files).map(data => {
               const {id, name} = data[1];
@@ -386,7 +385,7 @@ class StarterFileManager extends React.Component {
                     <select
                       onChange={this.updateSectionStarterFile}
                       value={selected}
-                      disabled={!this.state.files.length || this.state.readOnly}
+                      disabled={!this.state.files.length || this.props.read_only}
                       className="starter-file-dropdown"
                     >
                       <option value={`${row.original.section_id}_`} />
@@ -462,7 +461,7 @@ class StarterFileManager extends React.Component {
                 () => this.toggleFormChanged(true)
               );
             }}
-            disabled={this.state.readOnly}
+            disabled={this.props.read_only}
           />
           {I18n.t("assignments.starter_file.available_after_due")}
         </label>
@@ -485,7 +484,7 @@ class StarterFileManager extends React.Component {
             key={"create_starter_file_group_button"}
             className={"button"}
             onClick={this.createStarterFileGroup}
-            disabled={this.state.readOnly}
+            disabled={this.props.read_only}
           >
             <FontAwesomeIcon icon="fa-solid fa-add" />
           </button>
@@ -536,7 +535,7 @@ class StarterFileManager extends React.Component {
               type={"submit"}
               value={I18n.t("save")}
               onClick={this.saveStateChanges}
-              disabled={!this.state.form_changed || this.state.readOnly}
+              disabled={!this.state.form_changed || this.props.read_only}
             ></input>
           </p>
         </fieldset>

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -242,6 +242,7 @@ class StarterFileManager extends React.Component {
                 canFilter={false}
               />
               <button
+                aria-label="sfg-action-button"
                 key={"delete_starter_file_group_button"}
                 className={"button"}
                 onClick={() => this.deleteStarterFileGroup(id)}
@@ -353,6 +354,7 @@ class StarterFileManager extends React.Component {
               )
             }
             className="starter-file-dropdown"
+            aria-label="starter-file-dropdown"
             value={this.state.defaultStarterFileGroup}
             disabled={!this.state.files.length || this.props.read_only}
           >
@@ -387,6 +389,7 @@ class StarterFileManager extends React.Component {
                       value={selected}
                       disabled={!this.state.files.length || this.props.read_only}
                       className="starter-file-dropdown"
+                      aria-label="starter-file-dropdown"
                     >
                       <option value={`${row.original.section_id}_`} />
                       {Object.entries(this.state.files).map(data => {
@@ -455,6 +458,7 @@ class StarterFileManager extends React.Component {
           <input
             type={"checkbox"}
             checked={this.state.available_after_due}
+            data-testid="available_after_due_checkbox"
             onChange={() => {
               this.setState(
                 prev => ({available_after_due: !prev.available_after_due}),
@@ -481,6 +485,7 @@ class StarterFileManager extends React.Component {
           </legend>
           {this.renderFileManagers()}
           <button
+            aria-label="sfg-action-button"
             key={"create_starter_file_group_button"}
             className={"button"}
             onClick={this.createStarterFileGroup}
@@ -534,6 +539,7 @@ class StarterFileManager extends React.Component {
             <input
               type={"submit"}
               value={I18n.t("save")}
+              data-testid={"save_button"}
               onClick={this.saveStateChanges}
               disabled={!this.state.form_changed || this.props.read_only}
             ></input>

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -22,6 +22,7 @@ class StarterFileManager extends React.Component {
       showFileUploadModal: false,
       starterfileType: "simple",
       defaultStarterFileGroup: "",
+      readOnly: true,
       files: {},
       sections: {},
       form_changed: false,
@@ -225,7 +226,7 @@ class StarterFileManager extends React.Component {
                 groupUploadTarget={id}
                 files={files}
                 noFilesMessage={I18n.t("submissions.no_files_available")}
-                readOnly={false}
+                readOnly={this.state.readOnly}
                 onCreateFiles={this.handleCreateFiles}
                 onDeleteFile={this.handleDeleteFile}
                 onCreateFolder={this.handleCreateFolder}
@@ -245,6 +246,7 @@ class StarterFileManager extends React.Component {
                 key={"delete_starter_file_group_button"}
                 className={"button"}
                 onClick={() => this.deleteStarterFileGroup(id)}
+                disabled={this.state.readOnly}
               >
                 <FontAwesomeIcon icon="fa-solid fa-trash" />
               </button>
@@ -283,7 +285,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"simple"}
               checked={this.state.starterfileType === "simple"}
-              disabled={!this.state.files.length}
+              disabled={!this.state.files.length || this.state.readOnly}
               onChange={() => {
                 this.setState({starterfileType: "simple"}, () => this.toggleFormChanged(true));
               }}
@@ -298,7 +300,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"sections"}
               checked={this.state.starterfileType === "sections"}
-              disabled={!this.state.files.length}
+              disabled={!this.state.files.length || this.state.readOnly}
               onChange={() => {
                 this.setState({starterfileType: "sections"}, () => this.toggleFormChanged(true));
               }}
@@ -313,7 +315,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"group"}
               checked={this.state.starterfileType === "group"}
-              disabled={!this.state.files.length}
+              disabled={!this.state.files.length || this.state.readOnly}
               onChange={() => {
                 this.setState({starterfileType: "group"}, () => this.toggleFormChanged(true));
               }}
@@ -328,7 +330,7 @@ class StarterFileManager extends React.Component {
               name={"starter_file_type"}
               value={"shuffle"}
               checked={this.state.starterfileType === "shuffle"}
-              disabled={!this.state.files.length}
+              disabled={!this.state.files.length || this.state.readOnly}
               onChange={() => {
                 this.setState({starterfileType: "shuffle"}, () => this.toggleFormChanged(true));
               }}
@@ -352,7 +354,7 @@ class StarterFileManager extends React.Component {
               )
             }
             value={this.state.defaultStarterFileGroup}
-            disabled={!this.state.files.length}
+            disabled={!this.state.files.length || this.state.readOnly}
           >
             {Object.entries(this.state.files).map(data => {
               const {id, name} = data[1];
@@ -383,7 +385,7 @@ class StarterFileManager extends React.Component {
                     <select
                       onChange={this.updateSectionStarterFile}
                       value={selected}
-                      disabled={!this.state.files.length}
+                      disabled={!this.state.files.length || this.state.readOnly}
                     >
                       <option value={`${row.original.section_id}_`} />
                       {Object.entries(this.state.files).map(data => {
@@ -458,6 +460,7 @@ class StarterFileManager extends React.Component {
                 () => this.toggleFormChanged(true)
               );
             }}
+            disabled={this.state.readOnly}
           />
           {I18n.t("assignments.starter_file.available_after_due")}
         </label>
@@ -480,6 +483,7 @@ class StarterFileManager extends React.Component {
             key={"create_starter_file_group_button"}
             className={"button"}
             onClick={this.createStarterFileGroup}
+            disabled={this.state.readOnly}
           >
             <FontAwesomeIcon icon="fa-solid fa-add" />
           </button>
@@ -530,7 +534,7 @@ class StarterFileManager extends React.Component {
               type={"submit"}
               value={I18n.t("save")}
               onClick={this.saveStateChanges}
-              disabled={!this.state.form_changed}
+              disabled={!this.state.form_changed || this.state.readOnly}
             ></input>
           </p>
         </fieldset>

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -353,7 +353,6 @@ class StarterFileManager extends React.Component {
                 this.toggleFormChanged(true)
               )
             }
-            className="starter-file-dropdown"
             aria-label="starter-file-dropdown"
             value={this.state.defaultStarterFileGroup}
             disabled={!this.state.files.length || this.props.read_only}
@@ -388,7 +387,6 @@ class StarterFileManager extends React.Component {
                       onChange={this.updateSectionStarterFile}
                       value={selected}
                       disabled={!this.state.files.length || this.props.read_only}
-                      className="starter-file-dropdown"
                       aria-label="starter-file-dropdown"
                     >
                       <option value={`${row.original.section_id}_`} />

--- a/app/assets/javascripts/Components/starter_file_manager.jsx
+++ b/app/assets/javascripts/Components/starter_file_manager.jsx
@@ -242,7 +242,7 @@ class StarterFileManager extends React.Component {
                 canFilter={false}
               />
               <button
-                aria-label="sfg-action-button"
+                aria-label={I18n.t("assignments.starter_file.aria_labels.action_button")}
                 key={"delete_starter_file_group_button"}
                 className={"button"}
                 onClick={() => this.deleteStarterFileGroup(id)}
@@ -353,7 +353,7 @@ class StarterFileManager extends React.Component {
                 this.toggleFormChanged(true)
               )
             }
-            aria-label="starter-file-dropdown"
+            aria-label={I18n.t("assignments.starter_file.aria_labels.dropdown")}
             value={this.state.defaultStarterFileGroup}
             disabled={!this.state.files.length || this.props.read_only}
           >
@@ -387,7 +387,7 @@ class StarterFileManager extends React.Component {
                       onChange={this.updateSectionStarterFile}
                       value={selected}
                       disabled={!this.state.files.length || this.props.read_only}
-                      aria-label="starter-file-dropdown"
+                      aria-label={I18n.t("assignments.starter_file.aria_labels.dropdown")}
                     >
                       <option value={`${row.original.section_id}_`} />
                       {Object.entries(this.state.files).map(data => {
@@ -483,7 +483,7 @@ class StarterFileManager extends React.Component {
           </legend>
           {this.renderFileManagers()}
           <button
-            aria-label="sfg-action-button"
+            aria-label={I18n.t("assignments.starter_file.aria_labels.action_button")}
             key={"create_starter_file_group_button"}
             className={"button"}
             onClick={this.createStarterFileGroup}

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -450,7 +450,8 @@ class AssignmentsController < ApplicationController
              sections: section_data,
              available_after_due: assignment.starter_files_after_due,
              starterfileType: assignment.starter_file_type,
-             defaultStarterFileGroup: assignment.default_starter_file_group&.id || '' }
+             defaultStarterFileGroup: assignment.default_starter_file_group&.id || '',
+             readOnly: !allowed_to?(:manage?) }
     render json: data
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -450,8 +450,7 @@ class AssignmentsController < ApplicationController
              sections: section_data,
              available_after_due: assignment.starter_files_after_due,
              starterfileType: assignment.starter_file_type,
-             defaultStarterFileGroup: assignment.default_starter_file_group&.id || '',
-             readOnly: !allowed_to?(:manage?) }
+             defaultStarterFileGroup: assignment.default_starter_file_group&.id || '' }
     render json: data
   end
 

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -103,4 +103,20 @@ class AssignmentPolicy < ApplicationPolicy
         check?(:start_timed_assignment?, role.accepted_grouping_for(record.id), with: GroupingPolicy))
     )
   end
+
+  def starter_file?
+    role.instructor? || role.ta?
+  end
+
+  def download_starter_file_mappings?
+    role.instructor? || role.ta?
+  end
+
+  def download_sample_starter_files?
+    role.instructor? || role.ta?
+  end
+
+  def populate_starter_file_manager?
+    role.instructor? || role.ta?
+  end
 end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -119,4 +119,9 @@ class AssignmentPolicy < ApplicationPolicy
   def populate_starter_file_manager?
     role.instructor? || role.ta?
   end
+
+  # needed specifically for TA read-only mode
+  def see_starter_files?
+    role.instructor? || role.ta?
+  end
 end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -4,6 +4,8 @@ class AssignmentPolicy < ApplicationPolicy
   alias_rule :summary?, to: :view?
   alias_rule :stop_batch_tests?, :batch_runs?, to: :manage_tests?
   alias_rule :show?, :peer_review?, to: :student?
+  alias_rule :starter_file?, :download_starter_file_mappings?, :download_sample_starter_files?,
+             :populate_starter_file_manager?, to: :read_starter_files?
   authorize :assessment, :test_run_id, optional: true
 
   def index?
@@ -104,24 +106,7 @@ class AssignmentPolicy < ApplicationPolicy
     )
   end
 
-  def starter_file?
-    role.instructor? || role.ta?
-  end
-
-  def download_starter_file_mappings?
-    role.instructor? || role.ta?
-  end
-
-  def download_sample_starter_files?
-    role.instructor? || role.ta?
-  end
-
-  def populate_starter_file_manager?
-    role.instructor? || role.ta?
-  end
-
-  # needed specifically for TA read-only mode
-  def see_starter_files?
+  def read_starter_files?
     role.instructor? || role.ta?
   end
 end

--- a/app/policies/starter_file_group_policy.rb
+++ b/app/policies/starter_file_group_policy.rb
@@ -1,16 +1,13 @@
 # Policy for starter file groups
 class StarterFileGroupPolicy < ApplicationPolicy
   default_rule :manage?
+  alias_rule :download_file?, :download_files?, to: :read?
 
   def manage?
     check?(:manage_assessments?, role)
   end
 
-  def download_file?
-    role.instructor? || role.ta?
-  end
-
-  def download_files?
+  def read?
     role.instructor? || role.ta?
   end
 end

--- a/app/policies/starter_file_group_policy.rb
+++ b/app/policies/starter_file_group_policy.rb
@@ -5,4 +5,12 @@ class StarterFileGroupPolicy < ApplicationPolicy
   def manage?
     check?(:manage_assessments?, role)
   end
+
+  def download_file?
+    role.instructor? || role.ta?
+  end
+
+  def download_files?
+    role.instructor? || role.ta?
+  end
 end

--- a/app/views/assignments/starter_file.html.erb
+++ b/app/views/assignments/starter_file.html.erb
@@ -5,7 +5,8 @@
         document.getElementById('starter_file_manager'),
         {
           course_id: <%= @current_course.id %>,
-          assignment_id: <%= @assignment.id %>
+          assignment_id: <%= @assignment.id %>,
+          read_only: <%= !allowed_to?(:manage?) %>
         }
       );
     });

--- a/app/views/layouts/_sub_sub_menu.html.erb
+++ b/app/views/layouts/_sub_sub_menu.html.erb
@@ -44,7 +44,7 @@
                           course_assignment_criteria_path(@current_course, @assignment) %>
             </li>
           <% end %>
-          <% if allowed_to?(:manage?, with: StarterFileGroupPolicy) %>
+          <% if allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
             <li <% if controller.controller_name == 'assignments' && controller.action_name == 'starter_file' %>
                 class='active'
                 <% end %>>

--- a/app/views/layouts/_sub_sub_menu.html.erb
+++ b/app/views/layouts/_sub_sub_menu.html.erb
@@ -44,7 +44,7 @@
                           course_assignment_criteria_path(@current_course, @assignment) %>
             </li>
           <% end %>
-          <% if allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
+          <% if allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
             <li <% if controller.controller_name == 'assignments' && controller.action_name == 'starter_file' %>
                 class='active'
                 <% end %>>

--- a/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
+++ b/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
@@ -42,19 +42,27 @@
   <% elsif assessment.is_a?(Assignment) && !assessment.new_record? %>
     <% target_id = @result&.is_a_review? ? assessment.pr_assignment.id :
                                                      assessment.id %>
-    <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
-      <li <% if ['criteria',
-                 'annotation_categories',
-                 'automated_tests',
-                 'exam_templates'].include?(controller.controller_name) ||
+    <% if allowed_to?(:manage?, with: AssignmentPolicy) ||  allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
+    <li <% if ['criteria',
+               'annotation_categories',
+               'automated_tests',
+               'exam_templates'].include?(controller.controller_name) ||
         (controller.controller_name == 'assignments' &&
-          controller.action_name != 'summary' && controller.action_name != 'batch_runs') %>
-          class='active'
-          <% end %>
-      >
-        <%= link_to t('menu.settings'),
-                    edit_course_assignment_path(@current_course, target_id) %>
-      </li>
+        controller.action_name != 'summary' && controller.action_name != 'batch_runs') %>
+        class='active'
+        <% end %>
+    >
+      <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
+          <%= link_to t('menu.settings'),
+                      edit_course_assignment_path(@current_course, target_id) %>
+      <% elsif allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
+          <%= link_to t('menu.settings'),
+                      starter_file_course_assignment_path(@current_course, target_id) %>
+      <% end %>
+    </li>
+    <% end %>
+
+    <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
       <li class='<%= "active" if controller.controller_name == 'groups' %>'>
         <%= link_to Group.model_name.human.pluralize,
                     course_assignment_groups_path(@current_course, target_id) %>

--- a/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
+++ b/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
@@ -42,24 +42,24 @@
   <% elsif assessment.is_a?(Assignment) && !assessment.new_record? %>
     <% target_id = @result&.is_a_review? ? assessment.pr_assignment.id :
                                                      assessment.id %>
-    <% if allowed_to?(:manage?, with: AssignmentPolicy) ||  allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
-    <li <% if ['criteria',
-               'annotation_categories',
-               'automated_tests',
-               'exam_templates'].include?(controller.controller_name) ||
-        (controller.controller_name == 'assignments' &&
-        controller.action_name != 'summary' && controller.action_name != 'batch_runs') %>
-        class='active'
+    <% if allowed_to?(:manage?, with: AssignmentPolicy) || allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
+      <li <% if ['criteria',
+                 'annotation_categories',
+                 'automated_tests',
+                 'exam_templates'].include?(controller.controller_name) ||
+          (controller.controller_name == 'assignments' &&
+          controller.action_name != 'summary' && controller.action_name != 'batch_runs') %>
+          class='active'
+          <% end %>
+      >
+        <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
+            <%= link_to t('menu.settings'),
+                        edit_course_assignment_path(@current_course, target_id) %>
+        <% elsif allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
+            <%= link_to t('menu.settings'),
+                        starter_file_course_assignment_path(@current_course, target_id) %>
         <% end %>
-    >
-      <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
-          <%= link_to t('menu.settings'),
-                      edit_course_assignment_path(@current_course, target_id) %>
-      <% elsif allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
-          <%= link_to t('menu.settings'),
-                      starter_file_course_assignment_path(@current_course, target_id) %>
-      <% end %>
-    </li>
+      </li>
     <% end %>
 
     <% if allowed_to?(:manage?, with: AssignmentPolicy) %>

--- a/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
+++ b/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
@@ -42,7 +42,7 @@
   <% elsif assessment.is_a?(Assignment) && !assessment.new_record? %>
     <% target_id = @result&.is_a_review? ? assessment.pr_assignment.id :
                                                      assessment.id %>
-    <% if allowed_to?(:manage?, with: AssignmentPolicy) ||  allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
+    <% if allowed_to?(:manage?, with: AssignmentPolicy) ||  allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
     <li <% if ['criteria',
                'annotation_categories',
                'automated_tests',
@@ -55,7 +55,7 @@
       <% if allowed_to?(:manage?, with: AssignmentPolicy) %>
           <%= link_to t('menu.settings'),
                       edit_course_assignment_path(@current_course, target_id) %>
-      <% elsif allowed_to?(:see_starter_files?, with: AssignmentPolicy) %>
+      <% elsif allowed_to?(:read_starter_files?, with: AssignmentPolicy) %>
           <%= link_to t('menu.settings'),
                       starter_file_course_assignment_path(@current_course, target_id) %>
       <% end %>

--- a/config/locales/views/assignments/en.yml
+++ b/config/locales/views/assignments/en.yml
@@ -41,6 +41,9 @@ en:
       hidden_option: If the section-specific settings option is checked, the value for individual sections will override this value.
       visible: Visible
     starter_file:
+      aria_labels:
+        action_button: Starter file group action button
+        dropdown: Starter file dropdown
       available_after_due: Starter files are available to students after the due date has passed
       available_after_due_help: For timed assessments, this allows students who do not start the assessment to download starter files after the start window is over.
       changed_at: Starter files were last updated on %{changed_date}

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -836,8 +836,10 @@ describe AssignmentsController do
     before(:each) { get_as role, :starter_file, params: params }
     let(:assignment) { create :assignment }
     let(:params) { { course_id: assignment.course.id, id: assignment.id } }
-    context 'an instructor' do
-      let(:role) { create :instructor }
+    shared_examples 'a user with permission to view the starter file page' do
+      it 'should return a 200 status code' do
+        is_expected.to respond_with(:ok)
+      end
       context 'the assignment exists' do
         it 'should render the starter_file view' do
           expect(response).to render_template(:starter_file)
@@ -856,11 +858,13 @@ describe AssignmentsController do
         end
       end
     end
+    context 'an instructor' do
+      let(:role) { create :instructor }
+      include_examples 'a user with permission to view the starter file page'
+    end
     context 'a grader' do
       let(:role) { create :ta }
-      it 'should return a 200 status code' do
-        is_expected.to respond_with(:ok)
-      end
+      include_examples 'a user with permission to view the starter file page'
     end
     context 'a student' do
       let(:role) { create :student }
@@ -874,7 +878,7 @@ describe AssignmentsController do
     let(:assignment) { create :assignment }
     let(:params) { { course_id: assignment.course.id, id: assignment.id } }
 
-    shared_examples 'a user with permission to manage assessments' do
+    shared_examples 'a user with permission to view starter files' do
       it 'should return a 200 status code' do
         is_expected.to respond_with(:ok)
       end
@@ -924,11 +928,11 @@ describe AssignmentsController do
     end
     context 'an instructor' do
       let(:role) { create :instructor }
-      include_examples 'a user with permission to manage assessments'
+      include_examples 'a user with permission to view starter files'
     end
     context 'a grader' do
       let(:role) { create :ta }
-      include_examples 'a user with permission to manage assessments'
+      include_examples 'a user with permission to view starter files'
     end
     context 'a student' do
       let(:role) { create :student }
@@ -1069,11 +1073,14 @@ describe AssignmentsController do
     subject { get_as role, :download_starter_file_mappings, params: params }
     let(:assignment) { create :assignment }
     let(:params) { { course_id: assignment.course.id, id: assignment.id } }
-    context 'an instructor' do
-      let(:role) { create :instructor }
+    shared_examples 'a user with permission to download starter file mappings' do
       let!(:starter_file_group) { create :starter_file_group_with_entries, assignment: assignment }
       let!(:grouping) { create :grouping_with_inviter, assignment: assignment }
       let(:params) { { course_id: assignment.course.id, id: starter_file_group.assignment.id } }
+      it 'should return a 200 status code' do
+        subject
+        expect(response).to have_http_status(200)
+      end
       it 'should contain mappings' do
         expect(@controller).to receive(:send_data) do |file_content|
           mappings = file_content.split("\n")[1..-1].map { |m| m.split(',') }
@@ -1083,12 +1090,14 @@ describe AssignmentsController do
         subject
       end
     end
+
+    context 'an instructor' do
+      let(:role) { create :instructor }
+      include_examples 'a user with permission to download starter file mappings'
+    end
     context 'a grader' do
       let(:role) { create :ta }
-      it 'should return a 200 status code' do
-        subject
-        expect(response).to have_http_status(200)
-      end
+      include_examples 'a user with permission to download starter file mappings'
     end
     context 'a student' do
       let(:role) { create :student }
@@ -1382,17 +1391,8 @@ describe AssignmentsController do
       end
     end
     context 'a grader' do
-      context 'without assignment management permissions' do
-        let(:role) { create :ta }
-        it 'should respond with 200' do
-          subject
-          expect(response).to have_http_status(200)
-        end
-      end
-      context 'with assignment management permissions' do
-        let(:role) { create :ta, manage_assessments: true }
-        include_examples 'download sample starter files'
-      end
+      let(:role) { create :ta }
+      include_examples 'download sample starter files'
     end
     context 'an instructor' do
       let(:role) { create :instructor }

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -870,9 +870,21 @@ describe AssignmentsController do
     end
   end
   describe '#populate_starter_file_manager' do
-    shared_examples 'the starter file manager is populated correctly' do
+    before { get_as role, :populate_starter_file_manager, params: params }
+    let(:assignment) { create :assignment }
+    let(:params) { { course_id: assignment.course.id, id: assignment.id } }
+
+    shared_examples 'a user with permission to manage assessments' do
       it 'should return a 200 status code' do
         is_expected.to respond_with(:ok)
+      end
+      it 'should contain the right values' do
+        expected = { available_after_due: true,
+                     starterfileType: assignment.starter_file_type,
+                     defaultStarterFileGroup: '',
+                     files: [],
+                     sections: [] }
+        expect(response.parsed_body).to eq(expected.transform_keys(&:to_s))
       end
       context 'the file data' do
         let(:starter_file_group) { create :starter_file_group_with_entries, assignment: assignment }
@@ -910,59 +922,16 @@ describe AssignmentsController do
         end
       end
     end
-
-    let(:assignment) { create :assignment }
-    let(:params) { { course_id: assignment.course.id, id: assignment.id } }
     context 'an instructor' do
-      before { get_as role, :populate_starter_file_manager, params: params }
       let(:role) { create :instructor }
-      include_examples 'the starter file manager is populated correctly'
-      it 'should contain the right values' do
-        expected = { available_after_due: true,
-                     starterfileType: assignment.starter_file_type,
-                     defaultStarterFileGroup: '',
-                     files: [],
-                     sections: [],
-                     readOnly: false }
-        expect(response.parsed_body).to eq(expected.transform_keys(&:to_s))
-      end
+      include_examples 'a user with permission to manage assessments'
     end
-    context 'a grader without manage permissions' do
-      before { get_as role, :populate_starter_file_manager, params: params }
+    context 'a grader' do
       let(:role) { create :ta }
-      include_examples 'the starter file manager is populated correctly'
-      it 'should contain the right values' do
-        expected = { available_after_due: true,
-                     starterfileType: assignment.starter_file_type,
-                     defaultStarterFileGroup: '',
-                     files: [],
-                     sections: [],
-                     readOnly: true }
-        expect(response.parsed_body).to eq(expected.transform_keys(&:to_s))
-      end
-    end
-    context 'a grader with manage permissions' do
-      let(:role) { create :ta }
-      let(:grader_permission) { role.grader_permission }
-      before do
-        grader_permission.manage_assessments = true
-        grader_permission.save
-        get_as role, :populate_starter_file_manager, params: params
-      end
-      include_examples 'the starter file manager is populated correctly'
-      it 'should contain the right values' do
-        expected = { available_after_due: true,
-                     starterfileType: assignment.starter_file_type,
-                     defaultStarterFileGroup: '',
-                     files: [],
-                     sections: [],
-                     readOnly: false }
-        expect(response.parsed_body).to eq(expected.transform_keys(&:to_s))
-      end
+      include_examples 'a user with permission to manage assessments'
     end
     context 'a student' do
       let(:role) { create :student }
-      before { get_as role, :populate_starter_file_manager, params: params }
       it 'should return a 403 error' do
         is_expected.to respond_with(:forbidden)
       end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -858,8 +858,8 @@ describe AssignmentsController do
     end
     context 'a grader' do
       let(:role) { create :ta }
-      it 'should return a 403 error' do
-        is_expected.to respond_with(:forbidden)
+      it 'should return a 200 status code' do
+        is_expected.to respond_with(:ok)
       end
     end
     context 'a student' do
@@ -880,7 +880,8 @@ describe AssignmentsController do
                      starterfileType: assignment.starter_file_type,
                      defaultStarterFileGroup: '',
                      files: [],
-                     sections: [] }
+                     sections: [],
+                     readOnly: false }
         expect(response.parsed_body).to eq(expected.transform_keys(&:to_s))
       end
       context 'the file data' do
@@ -921,13 +922,14 @@ describe AssignmentsController do
     end
     context 'a grader' do
       let(:role) { create :ta }
-      it 'should return a 404 error' do
-        is_expected.to respond_with(:forbidden)
+      it 'should return a 200 status code' do
+        is_expected.to respond_with(:ok)
       end
     end
     context 'a student' do
       let(:role) { create :student }
-      it 'should return a 404 error' do
+      before { get_as role, :populate_starter_file_manager, params: params }
+      it 'should return a 403 error' do
         is_expected.to respond_with(:forbidden)
       end
     end
@@ -1080,14 +1082,14 @@ describe AssignmentsController do
     end
     context 'a grader' do
       let(:role) { create :ta }
-      it 'should return a 404 error' do
+      it 'should return a 200 status code' do
         subject
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(200)
       end
     end
     context 'a student' do
       let(:role) { create :student }
-      it 'should return a 404 error' do
+      it 'should return a 403 error' do
         subject
         expect(response).to have_http_status(403)
       end
@@ -1379,9 +1381,9 @@ describe AssignmentsController do
     context 'a grader' do
       context 'without assignment management permissions' do
         let(:role) { create :ta }
-        it 'should respond with 403' do
+        it 'should respond with 200' do
           subject
-          expect(response).to have_http_status(403)
+          expect(response).to have_http_status(200)
         end
       end
       context 'with assignment management permissions' do

--- a/spec/controllers/starter_file_groups_controller_spec.rb
+++ b/spec/controllers/starter_file_groups_controller_spec.rb
@@ -16,6 +16,22 @@ describe StarterFileGroupsController do
     end
   end
 
+  shared_examples 'student not permitted but ta permitted' do
+    before { subject }
+    context 'a grader' do
+      let(:role) { create :ta }
+      it 'should be permitted' do
+        expect(response.status).to eq 200
+      end
+    end
+    context 'a student' do
+      let(:role) { create :student }
+      it 'should not be permitted' do
+        expect(response.status).to eq 403
+      end
+    end
+  end
+
   let(:role) { create :instructor }
   let(:assignment) { create :assignment }
   let(:course) { assignment.course }
@@ -48,7 +64,7 @@ describe StarterFileGroupsController do
                                              id: starter_file_group.id,
                                              course_id: course.id }
     end
-    it_behaves_like 'student and ta not permitted'
+    it_behaves_like 'student not permitted but ta permitted'
     before { subject }
     context 'when a file exists' do
       it 'should download a file' do
@@ -80,7 +96,7 @@ describe StarterFileGroupsController do
   describe '#download_files' do
     subject { get_as role, :download_files, params: { course_id: course.id, id: starter_file_group.id } }
     let(:starter_file_group) { create :starter_file_group_with_entries, assignment: assignment, structure: {} }
-    it_behaves_like 'student and ta not permitted'
+    it_behaves_like 'student not permitted but ta permitted'
     context 'when the starter file exists' do
       let(:starter_file_group) { create :starter_file_group_with_entries, assignment: assignment }
       it 'should send a zip file containing the correct content' do


### PR DESCRIPTION
## Motivation and Context
Closes #5137. If an assignment has several starter file groups, there is a possibility that different students can have different starter files. However the grading TA cannot currently see information about starter files, so they cannot tell which files are assigned to whom. This PR aims to fix this. 

## Your Changes
* Change Rails policies to allow TAs to access starter-file-related routes.
* Add a "read-only" mode to the assignment starter file page, which TAs will see if they do not have permission to edit. This *includes* permission to download starter file mappings, which they can use to see who is assigned what starter file.

**Type of change** (select all that apply):

- [X] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
* Changed existing RSpec policy tests for routes that were changed.
* Wrote a suite of Jest tests to test the behaviour of the disabling/enabling of buttons on `readOnly` mode for the Starter File page.

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [X] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
- [X] I have made changes to the documentation and linked to that pull request below. <!-- (delete this checklist item if not applicable) -->

### Pull request to make documentation changes (if applicable)
https://github.com/MarkUsProject/Wiki/pull/207
