### PR TITLE
Hide Inactive Groups in Submission Table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Add new routes for `update`, `show`, and `index` actions of the Sections API Controller (#6955)
 - Enable the deletion of Grade Entry Forms that have no grades (#6915)
 - Fixed login_spec.rb flaky test on GitHub Actions run (#6966)
+- Allow inactive groups in the submissions table to be toggled for display (#7000)
 
 ## [v2.4.6]
 - Disallow students from uploading .git file and .git folder in their repository (#6963)

--- a/app/assets/javascripts/Components/__tests__/submission_table.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_table.test.jsx
@@ -1,0 +1,118 @@
+/***
+ * Tests for SubmissionTable Component
+ */
+
+import {SubmissionTable} from "../submission_table";
+import {screen, fireEvent} from "@testing-library/react";
+import {mount} from "enzyme";
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => {
+    return null;
+  },
+}));
+
+describe("For the SubmissionTable's display of inactive groups", () => {
+  let groups_sample, wrapper;
+  beforeEach(() => {
+    groups_sample = [
+      {
+        _id: 1,
+        max_mark: 21.0,
+        group_name: "group_0001",
+        tags: [],
+        marking_state: "released",
+        submission_time: "Monday, March 25, 2024, 01:49:14 PM EDT",
+        result_id: 1,
+        final_grade: 12.0,
+        members: [
+          ["c6scriab", true],
+          ["g5dalber", true],
+        ],
+        grace_credits_used: 1,
+      },
+      {
+        _id: 2,
+        max_mark: 21.0,
+        group_name: "group_0002",
+        tags: [],
+        marking_state: "released",
+        submission_time: "Monday, March 25, 2024, 01:49:14 PM EDT",
+        result_id: 2,
+        final_grade: 7.0,
+        members: [
+          ["g8butter", false],
+          ["g6duparc", false],
+        ],
+        section: "LEC0101",
+        grace_credits_used: 1,
+      },
+    ];
+    fetch.mockReset();
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce({
+        groupings: groups_sample,
+        sections: {},
+      }),
+    });
+
+    wrapper = mount(
+      <SubmissionTable
+        assignment_id={1}
+        course_id={1}
+        show_grace_tokens={true}
+        show_sections={true}
+        is_timed={false}
+        is_scanned_exam={false}
+        release_with_urls={false}
+        can_collect={true}
+        can_run_tests={false}
+        defaultFiltered={[{id: "", value: ""}]}
+      />
+    );
+  });
+
+  it("contains the correct amount of inactive groups in the hidden tooltip", () => {
+    wrapper.update();
+
+    expect(wrapper.find({"data-testid": "show_inactive_groups_tooltip"}).prop("title")).toEqual(
+      "1 inactive group"
+    );
+  });
+
+  it("initially contains the active group", () => {
+    wrapper.update();
+
+    expect(wrapper.text().includes("group_0002")).toBe(true);
+  });
+
+  it("initially does not contain the inactive group", () => {
+    wrapper.update();
+
+    expect(wrapper.text().includes("group_0001")).toBe(false);
+  });
+
+  it("contains the inactive group after a single toggle", () => {
+    wrapper.update();
+
+    wrapper
+      .find({"data-testid": "show_inactive_groups"})
+      .simulate("change", {target: {checked: true}});
+
+    expect(wrapper.text().includes("group_0001")).toBe(true);
+  });
+
+  it("doesn't contain the inactive group after two toggles", () => {
+    wrapper.update();
+
+    wrapper
+      .find({"data-testid": "show_inactive_groups"})
+      .simulate("change", {target: {checked: true}});
+    wrapper
+      .find({"data-testid": "show_inactive_groups"})
+      .simulate("change", {target: {checked: false}});
+
+    expect(wrapper.text().includes("group_0001")).toBe(false);
+  });
+});

--- a/app/assets/javascripts/Components/__tests__/submission_table.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_table.test.jsx
@@ -3,8 +3,7 @@
  */
 
 import {SubmissionTable} from "../submission_table";
-import {screen, fireEvent} from "@testing-library/react";
-import {mount} from "enzyme";
+import {render, screen, fireEvent} from "@testing-library/react";
 
 jest.mock("@fortawesome/react-fontawesome", () => ({
   FontAwesomeIcon: () => {
@@ -13,7 +12,7 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
 }));
 
 describe("For the SubmissionTable's display of inactive groups", () => {
-  let groups_sample, wrapper;
+  let groups_sample;
   beforeEach(() => {
     groups_sample = [
       {
@@ -57,7 +56,7 @@ describe("For the SubmissionTable's display of inactive groups", () => {
       }),
     });
 
-    wrapper = mount(
+    render(
       <SubmissionTable
         assignment_id={1}
         course_id={1}
@@ -74,45 +73,27 @@ describe("For the SubmissionTable's display of inactive groups", () => {
   });
 
   it("contains the correct amount of inactive groups in the hidden tooltip", () => {
-    wrapper.update();
-
-    expect(wrapper.find({"data-testid": "show_inactive_groups_tooltip"}).prop("title")).toEqual(
+    expect(screen.getByTestId("show_inactive_groups_tooltip").getAttribute("title")).toEqual(
       "1 inactive group"
     );
   });
 
   it("initially contains the active group", () => {
-    wrapper.update();
-
-    expect(wrapper.text().includes("group_0002")).toBe(true);
+    expect(screen.queryByText("group_0002")).toBeInTheDocument();
   });
 
   it("initially does not contain the inactive group", () => {
-    wrapper.update();
-
-    expect(wrapper.text().includes("group_0001")).toBe(false);
+    expect(screen.queryByText("group_0001")).not.toBeInTheDocument();
   });
 
   it("contains the inactive group after a single toggle", () => {
-    wrapper.update();
-
-    wrapper
-      .find({"data-testid": "show_inactive_groups"})
-      .simulate("change", {target: {checked: true}});
-
-    expect(wrapper.text().includes("group_0001")).toBe(true);
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    expect(screen.queryByText("group_0001")).toBeInTheDocument();
   });
 
   it("doesn't contain the inactive group after two toggles", () => {
-    wrapper.update();
-
-    wrapper
-      .find({"data-testid": "show_inactive_groups"})
-      .simulate("change", {target: {checked: true}});
-    wrapper
-      .find({"data-testid": "show_inactive_groups"})
-      .simulate("change", {target: {checked: false}});
-
-    expect(wrapper.text().includes("group_0001")).toBe(false);
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    expect(screen.queryByText("group_0001")).not.toBeInTheDocument();
   });
 });

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -63,7 +63,7 @@ class RawSubmissionTable extends React.Component {
           }
         });
 
-        this.toggleShowInactiveGroups(null, true);
+        this.toggleShowInactiveGroups(false);
 
         const markingStates = getMarkingStates(res.groupings);
 
@@ -437,17 +437,7 @@ class RawSubmissionTable extends React.Component {
     );
   };
 
-  toggleShowInactiveGroups = (event, init) => {
-    let showInactiveGroups;
-
-    // if this is during page initialization
-    if (init) {
-      // never show inactive groups by default
-      showInactiveGroups = false;
-    } else {
-      showInactiveGroups = event.target.checked;
-    }
-
+  toggleShowInactiveGroups = showInactiveGroups => {
     let filtered = this.state.filtered.filter(group => {
       group.id !== "inactive";
     });
@@ -571,7 +561,7 @@ class SubmissionsActionBox extends React.Component {
           name="show_inactive_groups"
           type="checkbox"
           checked={this.props.showInactiveGroups}
-          onChange={e => this.props.updateShowInactiveGroups(e, false)}
+          onChange={e => this.props.updateShowInactiveGroups(e.target.checked)}
           className={"hide-user-checkbox"}
           data-testid={"show_inactive_groups"}
         />

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -11,7 +11,7 @@ import {
 } from "./Helpers/table_helpers";
 import CollectSubmissionsModal from "./Modals/collect_submissions_modal";
 import ReleaseUrlsModal from "./Modals/release_urls_modal";
-import consumer from "/app/javascript/channels/consumer";
+import consumer from "../../../../app/javascript/channels/consumer";
 import {renderFlashMessages} from "../flash";
 
 class RawSubmissionTable extends React.Component {
@@ -266,6 +266,7 @@ class RawSubmissionTable extends React.Component {
   // Custom getTrProps function to highlight submissions that have been collected.
   getTrProps = (state, ri, ci, instance) => {
     if (
+      ri === undefined ||
       ri.original.marking_state === undefined ||
       ri.original.marking_state === "not_collected" ||
       ri.original.marking_state === "before_due_date"
@@ -559,14 +560,19 @@ class SubmissionsActionBox extends React.Component {
     displayInactiveGroupsCheckbox = (
       <>
         <input
-          id="show_hidden"
-          name="show_hidden"
+          id="show_inactive_groups"
+          name="show_inactive_groups"
           type="checkbox"
           checked={this.props.showInactiveGroups}
           onChange={this.props.updateShowInactiveGroups}
           className={"hide-user-checkbox"}
+          data-testid={"show_inactive_groups"}
         />
-        <label title={displayInactiveGroupsTooltip} htmlFor="show_hidden">
+        <label
+          title={displayInactiveGroupsTooltip}
+          htmlFor="show_inactive_groups"
+          data-testid={"show_inactive_groups_tooltip"}
+        >
           {I18n.t("submissions.groups.display_inactive")}
         </label>
       </>
@@ -731,3 +737,5 @@ function generateMessage(status_data) {
   }
   return message_data;
 }
+
+export {SubmissionTable};

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -79,12 +79,12 @@ class RawSubmissionTable extends React.Component {
 
   onFilteredChange = (filtered, column) => {
     const summaryTable = this.checkboxTable.getWrappedInstance();
-    if (column.id == "marking_state") {
-      const markingStateFilter = filtered.find(filter => filter.id == "marking_state").value;
-      this.setState({markingStateFilter: markingStateFilter});
-    } else {
+    if (column.id != "marking_state") {
       const markingStates = getMarkingStates(summaryTable.state.sortedData);
       this.setState({marking_states: markingStates});
+    } else {
+      const markingStateFilter = filtered.find(filter => filter.id == "marking_state").value;
+      this.setState({markingStateFilter: markingStateFilter});
     }
 
     this.setState({filtered});

--- a/app/assets/javascripts/Components/submission_table.jsx
+++ b/app/assets/javascripts/Components/submission_table.jsx
@@ -63,7 +63,7 @@ class RawSubmissionTable extends React.Component {
           }
         });
 
-        this.toggleShowInactiveGroups(null);
+        this.toggleShowInactiveGroups(null, true);
 
         const markingStates = getMarkingStates(res.groupings);
 
@@ -437,9 +437,16 @@ class RawSubmissionTable extends React.Component {
     );
   };
 
-  toggleShowInactiveGroups = event => {
-    // depends if the function is called organically or not
-    let showInactiveGroups = event ? event.target.checked : false;
+  toggleShowInactiveGroups = (event, init) => {
+    let showInactiveGroups;
+
+    // if this is during page initialization
+    if (init) {
+      // never show inactive groups by default
+      showInactiveGroups = false;
+    } else {
+      showInactiveGroups = event.target.checked;
+    }
 
     let filtered = this.state.filtered.filter(group => {
       group.id !== "inactive";
@@ -564,7 +571,7 @@ class SubmissionsActionBox extends React.Component {
           name="show_inactive_groups"
           type="checkbox"
           checked={this.props.showInactiveGroups}
-          onChange={this.props.updateShowInactiveGroups}
+          onChange={e => this.props.updateShowInactiveGroups(e, false)}
           className={"hide-user-checkbox"}
           data-testid={"show_inactive_groups"}
         />

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1157,7 +1157,7 @@ class Assignment < Assessment
       section_data = {}
     else
       member_data = groupings.joins(accepted_students: :user)
-                             .pluck_to_hash('groupings.id', 'users.user_name')
+                             .pluck_to_hash('groupings.id', 'users.user_name', 'roles.hidden')
                              .group_by { |h| h['groupings.id'] }
 
       section_data = groupings.joins(inviter: :section)
@@ -1228,7 +1228,7 @@ class Assignment < Assessment
         end
       end
 
-      base[:members] = member_info.pluck('users.user_name') unless member_info.nil?
+      base[:members] = member_info.pluck('users.user_name', 'roles.hidden') unless member_info.nil?
       base[:section] = section_info unless section_info.nil?
       base[:grace_credits_used] = deductions[grouping_id] if self.submission_rule.is_a? GracePeriodSubmissionRule
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1235,7 +1235,7 @@ class Assignment < Assessment
         end
       end
 
-      base[:members] = member_info.pluck('users.user_name', 'roles.hidden') unless member_info.nil?
+      base[:members] = member_info.nil? ? [] : member_info.pluck('users.user_name', 'roles.hidden')
       base[:section] = section_info unless section_info.nil?
       base[:grace_credits_used] = deductions[grouping_id] if self.submission_rule.is_a? GracePeriodSubmissionRule
 

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -43,6 +43,8 @@ en:
     grading_can_begin_after: Grading can begin after %{time}
     grading_can_begin_after_for_sections: 'Grading can begin after %{time} for sections: %{sections}'
     grading_can_begin_for_sections: 'Grading can begin for sections: %{sections}'
+    groups:
+      display_inactive: Display inactive groups
     help:
       browse:
         instructors: 'Check the status of the student submissions. Before grading can begin, the student assignments must be collected. This associates each group with the version of their files that should be graded. This means that when the grader adds annotations and marks, they belong to this particular submission. There are three different ways of collecting submissions: Collect All Submissions, which automatically collects all submissions, based on the due date and late penalties; clicking on an individual group name triggers automatic collection for that group; clicking on the Repository name takes you the Repository view, where you can manually choose a revision to collect.<br>Rows in green have been collected and are ready to begin marking. Clicking on the group name takes you to the Grader view. When a grader sets the Marking State to Complete and you are ready to allow students to view the results, select the students and press "Release Marks".<br>CSV Report and Detailed CSV Report are two different ways of downloading the marks in csv format. Repository List downloads a text file that maps group name to repository path. Repository Checkout File downloads a text file where each line is a repository checkout command for the collected version of each student submission. Download all submissions downloads a zip file containing repositories for all of the students.'

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1924,12 +1924,12 @@ describe Assignment do
 
         it 'should not include member information for groups without members' do
           expect(data.count).to eq 5
-          expect(data.count { |h| h.key? :members }).to eq 3
+          expect(data.count { |h| h[:members].present? }).to eq 3
         end
 
         it 'should include member information for groups with members' do
           members = groupings.map { |g| g.accepted_students.joins(:user).pluck('users.user_name', 'roles.hidden') }
-          expect(data.pluck(:members).compact).to contain_exactly(*members)
+          expect(data.pluck(:members).compact_blank).to contain_exactly(*members)
         end
       end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1928,7 +1928,7 @@ describe Assignment do
         end
 
         it 'should include member information for groups with members' do
-          members = groupings.map { |g| g.accepted_students.joins(:user).pluck('users.user_name') }
+          members = groupings.map { |g| g.accepted_students.joins(:user).pluck('users.user_name', 'roles.hidden') }
           expect(data.pluck(:members).compact).to contain_exactly(*members)
         end
       end


### PR DESCRIPTION
## Motivation and Context
Similar to #6778, this PR hides inactive groups in the Submissions table by default and adds a toggle to show inactive groups if needed.

## Your Changes
* Made Submissions table hide inactive groups by default
* Added a toggle to allow Instructors and TAs to see inactive groups if they wish
* Minor bug fixes in relevant components, as revealed by attempting to write unit tests for them

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->
* Amended existing RSpec to account for minor change in the information sent by the server on a specific request.
* Wrote a Jest test suite for the new front-end check box functionality

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->