### PR TITLE
Hide Inactive Groups in Assignments Summary Table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Allow inactive groups in the submissions table to be toggled for display (#7000)
 - Display error message for student-run tests when no test groups are runnable (#7003)
 - Added a confirmation check while renaming a file with a different extension (#7024)
+- Allow inactive groups in the summary table to be toggled for display (#7029)
 
 ## [v2.4.9]
 - Peer review table bug fix to display total marks (#7034)

--- a/app/assets/javascripts/Components/__tests__/assignment_summary.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/assignment_summary.test.jsx
@@ -1,0 +1,100 @@
+/***
+ * Tests for AssignmentSummaryTable Component
+ */
+
+import {AssignmentSummaryTable} from "../assignment_summary_table";
+import {render, screen, fireEvent, cleanup, waitFor} from "@testing-library/react";
+
+describe("For the AssignmentSummaryTable's display of inactive groups", () => {
+  let groups_sample;
+  beforeEach(async () => {
+    groups_sample = [
+      {
+        group_name: "group_0001",
+        section: null,
+        members: [
+          ["c9nielse", "Nielsen", "Carl", true],
+          ["c8szyman", "Szymanowski", "Karol", true],
+        ],
+        tags: [],
+        graders: [["c9varoqu", "Nelle", "Varoquaux"]],
+        marking_state: "released",
+        final_grade: 9.0,
+        criteria: {1: 0.0},
+        max_mark: "21.0",
+        result_id: 15,
+        submission_id: 15,
+        total_extra_marks: null,
+      },
+      {
+        group_name: "group_0002",
+        section: "LEC0101",
+        members: [
+          ["c8debuss", "Debussy", "Claude", false],
+          ["c8holstg", "Holst", "Gustav", false],
+        ],
+        tags: [],
+        graders: [["c9varoqu", "Nelle", "Varoquaux"]],
+        marking_state: "released",
+        final_grade: 6.0,
+        criteria: {1: 2.0},
+        max_mark: "21.0",
+        result_id: 5,
+        submission_id: 5,
+        total_extra_marks: null,
+      },
+    ];
+    fetch.mockReset();
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce({
+        data: groups_sample,
+        criteriaColumns: [
+          {
+            Header: "dolores",
+            accessor: "criteria.1",
+            className: "number",
+            headerClassName: "",
+          },
+        ],
+        numAssigned: 2,
+        numMarked: 2,
+        ltiDeployments: [],
+      }),
+    });
+
+    render(
+      <AssignmentSummaryTable
+        assignment_id={1}
+        course_id={1}
+        is_instructor={false}
+        lti_deployments={[]}
+      />
+    );
+  });
+
+  it("contains the correct amount of inactive groups in the hidden tooltip", () => {
+    expect(screen.getByTestId("show_inactive_groups_tooltip").getAttribute("title")).toEqual(
+      "1 inactive group"
+    );
+  });
+
+  it("initially contains the active group", () => {
+    expect(screen.queryByText(/group_0002/)).toBeInTheDocument();
+  });
+
+  it("initially does not contain the inactive group", () => {
+    expect(screen.queryByText(/group_0001/)).not.toBeInTheDocument();
+  });
+
+  it("contains the inactive group after a single toggle", () => {
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    expect(screen.queryByText(/group_0001/)).toBeInTheDocument();
+  });
+
+  it("doesn't contain the inactive group after two toggles", () => {
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    fireEvent.click(screen.getByTestId("show_inactive_groups"));
+    expect(screen.queryByText(/group_0001/)).not.toBeInTheDocument();
+  });
+});

--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -20,12 +20,26 @@ export class AssignmentSummaryTable extends React.Component {
       showDownloadTestsModal: false,
       showLtiGradeModal: false,
       lti_deployments: [],
+      filtered: [],
+      inactiveGroupsCount: 0,
     };
   }
 
   componentDidMount() {
     this.fetchData();
   }
+
+  toggleShowInactiveGroups = showInactiveGroups => {
+    let filtered = this.state.filtered.filter(group => {
+      group.id !== "inactive";
+    });
+
+    if (!showInactiveGroups) {
+      filtered.push({id: "inactive", value: false});
+    }
+
+    this.setState({filtered});
+  };
 
   memberDisplay = (group_name, members) => {
     if (members.length !== 0 && !(members.length === 1 && members[0][0] === group_name)) {
@@ -57,6 +71,19 @@ export class AssignmentSummaryTable extends React.Component {
           col["filterable"] = false;
           col["defaultSortDesc"] = true;
         });
+
+        let inactive_groups_count = 0;
+        res.data.forEach(group => {
+          if (group.members.length && group.members.every(member => member[3])) {
+            group.inactive = true;
+            inactive_groups_count++;
+          } else {
+            group.inactive = false;
+          }
+        });
+
+        this.toggleShowInactiveGroups(false);
+
         const markingStates = getMarkingStates(res.data);
         this.setState({
           data: res.data,
@@ -66,6 +93,7 @@ export class AssignmentSummaryTable extends React.Component {
           loading: false,
           marking_states: markingStates,
           lti_deployments: res.ltiDeployments,
+          inactiveGroupsCount: inactive_groups_count,
         });
       });
   };
@@ -79,10 +107,17 @@ export class AssignmentSummaryTable extends React.Component {
       const markingStateFilter = filtered.find(filter => filter.id == "marking_state").value;
       this.setState({markingStateFilter: markingStateFilter});
     }
+
+    this.setState({filtered});
   };
 
   fixedColumns = () => {
     return [
+      {
+        show: false,
+        accessor: "inactive",
+        id: "inactive",
+      },
       {
         Header: I18n.t("activerecord.models.group.one"),
         id: "group_name",
@@ -200,6 +235,15 @@ export class AssignmentSummaryTable extends React.Component {
         </button>
       );
     }
+
+    let displayInactiveGroupsTooltip = "";
+
+    if (this.state.inactiveGroupsCount !== null) {
+      displayInactiveGroupsTooltip = `${I18n.t("activerecord.attributes.grouping.inactive_groups", {
+        count: this.state.inactiveGroupsCount,
+      })}`;
+    }
+
     return (
       <div>
         <div style={{display: "inline-block"}}>
@@ -220,6 +264,21 @@ export class AssignmentSummaryTable extends React.Component {
         </div>
         {this.props.is_instructor && (
           <div className="rt-action-box">
+            <input
+              id="show_inactive_groups"
+              name="show_inactive_groups"
+              type="checkbox"
+              onChange={e => this.toggleShowInactiveGroups(e.target.checked)}
+              className={"hide-user-checkbox"}
+              data-testid={"show_inactive_groups"}
+            />
+            <label
+              title={displayInactiveGroupsTooltip}
+              htmlFor="show_inactive_groups"
+              data-testid={"show_inactive_groups_tooltip"}
+            >
+              {I18n.t("submissions.groups.display_inactive")}
+            </label>
             <form
               action={Routes.summary_course_assignment_path({
                 course_id: this.props.course_id,
@@ -245,6 +304,7 @@ export class AssignmentSummaryTable extends React.Component {
           data={data}
           columns={this.fixedColumns().concat(criteriaColumns, [this.bonusColumn])}
           filterable
+          filtered={this.state.filtered}
           onFilteredChange={this.onFilteredChange}
           defaultSorted={[{id: "group_name"}]}
           ref={r => (this.wrappedInstance = r)}

--- a/app/assets/javascripts/Components/assignment_summary_table.jsx
+++ b/app/assets/javascripts/Components/assignment_summary_table.jsx
@@ -107,8 +107,6 @@ export class AssignmentSummaryTable extends React.Component {
       const markingStateFilter = filtered.find(filter => filter.id == "marking_state").value;
       this.setState({markingStateFilter: markingStateFilter});
     }
-
-    this.setState({filtered});
   };
 
   fixedColumns = () => {
@@ -262,44 +260,46 @@ export class AssignmentSummaryTable extends React.Component {
             {I18n.t("submissions.state.complete")}
           </div>
         </div>
-        {this.props.is_instructor && (
-          <div className="rt-action-box">
-            <input
-              id="show_inactive_groups"
-              name="show_inactive_groups"
-              type="checkbox"
-              onChange={e => this.toggleShowInactiveGroups(e.target.checked)}
-              className={"hide-user-checkbox"}
-              data-testid={"show_inactive_groups"}
-            />
-            <label
-              title={displayInactiveGroupsTooltip}
-              htmlFor="show_inactive_groups"
-              data-testid={"show_inactive_groups_tooltip"}
-            >
-              {I18n.t("submissions.groups.display_inactive")}
-            </label>
-            <form
-              action={Routes.summary_course_assignment_path({
-                course_id: this.props.course_id,
-                id: this.props.assignment_id,
-                format: "csv",
-                _options: true,
-              })}
-              method="get"
-            >
-              <button type="submit" name="download">
-                {I18n.t("download")}
+        <div className="rt-action-box">
+          <input
+            id="show_inactive_groups"
+            name="show_inactive_groups"
+            type="checkbox"
+            onChange={e => this.toggleShowInactiveGroups(e.target.checked)}
+            className={"hide-user-checkbox"}
+            data-testid={"show_inactive_groups"}
+          />
+          <label
+            title={displayInactiveGroupsTooltip}
+            htmlFor="show_inactive_groups"
+            data-testid={"show_inactive_groups_tooltip"}
+          >
+            {I18n.t("submissions.groups.display_inactive")}
+          </label>
+          {this.props.is_instructor && (
+            <>
+              <form
+                action={Routes.summary_course_assignment_path({
+                  course_id: this.props.course_id,
+                  id: this.props.assignment_id,
+                  format: "csv",
+                  _options: true,
+                })}
+                method="get"
+              >
+                <button type="submit" name="download">
+                  {I18n.t("download")}
+                </button>
+              </form>
+              <button type="submit" name="download_tests" onClick={this.onDownloadTestsModal}>
+                {I18n.t("download_the", {
+                  item: I18n.t("activerecord.models.test_result.other"),
+                })}
               </button>
-            </form>
-            <button type="submit" name="download_tests" onClick={this.onDownloadTestsModal}>
-              {I18n.t("download_the", {
-                item: I18n.t("activerecord.models.test_result.other"),
-              })}
-            </button>
-            {ltiButton}
-          </div>
-        )}
+              {ltiButton}
+            </>
+          )}
+        </div>
         <ReactTable
           data={data}
           columns={this.fixedColumns().concat(criteriaColumns, [this.bonusColumn])}

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -550,7 +550,7 @@ class Assignment < Assessment
                              .group_by { |x| x[:id] }
     members = Grouping.joins(accepted_students: :user)
                       .where(id: groupings)
-                      .pluck_to_hash(:id, 'users.user_name', 'users.first_name', 'users.last_name')
+                      .pluck_to_hash(:id, 'users.user_name', 'users.first_name', 'users.last_name', 'roles.hidden')
                       .group_by { |x| x[:id] }
     tag_data = groupings
                .joins(:tags)
@@ -595,7 +595,9 @@ class Assignment < Assessment
         group_name = grouping_data[g.id][0]['groups.group_name']
         section = grouping_data[g.id][0]['sections.name']
         group_members = members.fetch(g.id, [])
-                               .map { |s| [s['users.user_name'], s['users.first_name'], s['users.last_name']] }
+                               .map do |s|
+          [s['users.user_name'], s['users.first_name'], s['users.last_name'], s['roles.hidden']]
+        end
       end
 
       tag_info = tag_data.fetch(g.id, [])


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR mirrors #7000 for the summary table on the assignments page.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**:

* Made Assignment Summary table hide inactive groups by default
* Added a toggle to allow Instructors and TAs to see inactive groups if they wish

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)

## Testing
* Manual testing
* Added new RSpec tests to test data being sent back from server (didn't exist before, so had to add new ones instead of amending existing tests).
* Wrote a Jest test suite for the new front-end check box functionality

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->