### PR TITLE
peer review table bug fix to display total marks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Allow inactive groups in the submissions table to be toggled for display (#7000)
 - Display error message for student-run tests when no test groups are runnable (#7003)
 - Added a confirmation check while renaming a file with a different extension (#7024)
+- Peer review table bug fix to display total marks (#7034)
 
 ## [v2.4.8]
 - Validate user-provided paths (#7025)

--- a/app/controllers/peer_reviews_controller.rb
+++ b/app/controllers/peer_reviews_controller.rb
@@ -64,7 +64,7 @@ class PeerReviewsController < ApplicationController
 
     total_marks = Result.get_total_marks(peer_review_data.pluck('result_id'))
     peer_review_data.each do |data|
-      data[:final_grade] = total_marks['result_id']
+      data[:final_grade] = total_marks[data['result_id']]
       data[:marking_state] = data['results.released_to_students'] ? 'released' : data['results.marking_state']
       data[:max_mark] = assignment.peer_criteria.sum(&:max_mark)
     end

--- a/spec/controllers/peer_reviews_controller_spec.rb
+++ b/spec/controllers/peer_reviews_controller_spec.rb
@@ -318,7 +318,6 @@ describe PeerReviewsController do
                         result_id: Grouping.find(@selected_reviewee_group_ids[2]).current_result.id)
       PeerReview.create(reviewer_id: @selected_reviewer_group_ids[2],
                         result_id: Grouping.find(@selected_reviewee_group_ids[0]).current_result.id)
-      @num_peer_reviews = @assignment_with_pr.peer_reviews.count
     end
 
     it 'should list out total marks for each peer review' do

--- a/spec/controllers/peer_reviews_controller_spec.rb
+++ b/spec/controllers/peer_reviews_controller_spec.rb
@@ -340,10 +340,6 @@ describe PeerReviewsController do
       response_hash = JSON.parse(response.body)
       final_grades = response_hash.pluck('final_grade')
       expect(final_grades).to all eq(max_mark)
-
-      #       final_grades.each do |final_grade|
-      #         expect(final_grade).to eq(max_mark)
-      #       end
     end
   end
 end

--- a/spec/controllers/peer_reviews_controller_spec.rb
+++ b/spec/controllers/peer_reviews_controller_spec.rb
@@ -306,4 +306,44 @@ describe PeerReviewsController do
       it('should respond with 403') { expect(response).to have_http_status :forbidden }
     end
   end
+
+  describe 'When listing peer reviews in Peer Reviews tab' do
+    let(:instructor) { create(:instructor) }
+    let(:max_mark) { 3 }
+
+    before do
+      PeerReview.create(reviewer_id: @selected_reviewer_group_ids[0],
+                        result_id: Grouping.find(@selected_reviewee_group_ids[1]).current_result.id)
+      PeerReview.create(reviewer_id: @selected_reviewer_group_ids[1],
+                        result_id: Grouping.find(@selected_reviewee_group_ids[2]).current_result.id)
+      PeerReview.create(reviewer_id: @selected_reviewer_group_ids[2],
+                        result_id: Grouping.find(@selected_reviewee_group_ids[0]).current_result.id)
+      @num_peer_reviews = @assignment_with_pr.peer_reviews.count
+    end
+
+    it 'should list out total marks for each peer review' do
+      create_list(:flexible_criterion, 1, assignment: @assignment_with_pr.pr_assignment)
+      @assignment_with_pr.pr_assignment.criteria.first.update(peer_visible: true)
+      @assignment_with_pr.pr_assignment.criteria.first.update(max_mark: max_mark)
+
+      @assignment_with_pr.pr_assignment.groupings.each do |grouping|
+        result = grouping.peer_reviews_to_others.first.result
+        @assignment_with_pr.pr_assignment.criteria.each do |c|
+          mark = c.marks.find_or_create_by(result_id: result.id)
+          mark.update(mark: max_mark)
+        end
+        result.update(marking_state: Result::MARKING_STATES[:complete])
+      end
+
+      response = get_as instructor, :populate_table,
+                        params: { course_id: @assignment_with_pr.pr_assignment.course.id, assignment_id: @pr_id }
+      response_hash = JSON.parse(response.body)
+      final_grades = response_hash.pluck('final_grade')
+      expect(final_grades).to all eq(max_mark)
+
+      #       final_grades.each do |final_grade|
+      #         expect(final_grade).to eq(max_mark)
+      #       end
+    end
+  end
 end


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes the bug for the Peer Review page, where it displays 0 marks out of total marks (e.g. 0/4) all the time even though there are marks for the peer review. 

## Your Changes
**Description**:
Fixed the code in peer reviews controller  for the method populate_table, to refer to the correct data reference.

**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Did manual test via web interface, and created unit test.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->
