### PR TITLE
Ensure params are passed as keyword arguments to database queries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Allow inactive groups in the submissions table to be toggled for display (#7000)
 - Display error message for student-run tests when no test groups are runnable (#7003)
 - Added a confirmation check while renaming a file with a different extension (#7024)
+- Ensure user params are passed as keyword arguments to database queries (#7040)
 
 ## [v2.4.9]
 - Peer review table bug fix to display total marks (#7034)

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -72,8 +72,10 @@ module Api
         render 'shared/http_status', locals: { code: '422', message:
           'Invalid or malformed parameter values' }, status: :unprocessable_entity
         false
+      elsif filter_params.empty?
+        collection.order('id')
       else
-        collection.order('id').where(filter_params)
+        collection.order('id').where(**filter_params)
       end
     end
 

--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -171,7 +171,8 @@ module Api
     end
 
     def filtered_roles
-      collection = Role.includes(:user).where(params.permit(:course_id)).order(:id)
+      course_id = params[:course_id]
+      collection = Role.includes(:user).where(course_id: course_id).order(:id)
       collection = collection.where.not(type: AdminRole.name) unless @real_user.admin_user?
       if params[:filter].present?
         role_filter = params[:filter].permit(*ROLE_FIELDS).to_h
@@ -183,7 +184,7 @@ module Api
                  status: :unprocessable_entity
           return false
         else
-          return collection.where(filter_params)
+          return collection.where(**filter_params)
         end
       end
       collection


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Three issues reported by GitHub's CodeQL:

- https://github.com/MarkUsProject/Markus/security/code-scanning/14
- https://github.com/MarkUsProject/Markus/security/code-scanning/15
- https://github.com/MarkUsProject/Markus/security/code-scanning/16

These are false positives in that we use `permit!` to ensure correct structure and whitelisting of the user params. However, I've modified the code to not just pass in the filtered params directly.

## Your Changes
<!--- Describe your changes here. -->
<!--- Include how your changes may affect other areas of the application, if relevant. -->
**Description**: Extract the single relevant param (`course_id`) in one case; use the double splat operator in the other two cases.


**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing through the web interface. -->

Tested manually and by running the test suite.

## Questions and Comments (if applicable)
<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the pre-commit.ci checks have passed. <!-- (check after opening pull request) -->
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the Changelog.md file. <!-- (delete this checklist item if not applicable) -->