### PR TITLE
Add Progress Bar to File Upload Modal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - Allow inactive groups in the summary table to be toggled for display (#7029)
 - Display error message for instructor-run tests when no test groups are runnable by instructors (#7038)
 - Ensure user params are passed as keyword arguments to database queries (#7040)
+- Added a progress bar for when a student uploads a file for submission (#7078)
 
 ### 🐛 Bug fixes
 

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -153,10 +153,10 @@ class SubmissionFileUploadModal extends React.Component {
               {I18n.t("submissions.student.rename_file_to")}&nbsp;
               {this.fileRenameInputBox()}
             </label>
-            {this.props.uploadModalProgressVisible && (
+            {this.props.progressVisible && (
               <progress
                 className={"modal-progress-bar"}
-                value={this.props.uploadModalProgressPercentage}
+                value={this.props.progressPercentage}
                 max="100"
               ></progress>
             )}

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -153,6 +153,13 @@ class SubmissionFileUploadModal extends React.Component {
               {I18n.t("submissions.student.rename_file_to")}&nbsp;
               {this.fileRenameInputBox()}
             </label>
+            {this.props.progressVisible && (
+              <progress
+                className={"modal-progress-bar"}
+                value={this.props.progressPercentage}
+                max="100"
+              ></progress>
+            )}
             <div className={"modal-container"}>
               <input
                 type="submit"

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -1,3 +1,4 @@
+import I18n from "i18n-js";
 import React from "react";
 import Modal from "react-modal";
 
@@ -155,6 +156,7 @@ class SubmissionFileUploadModal extends React.Component {
             </label>
             {this.props.progressVisible && (
               <progress
+                aria-label={I18n.t("modals.submission_file_upload.progress_bar")}
                 className={"modal-progress-bar"}
                 value={this.props.progressPercentage}
                 max="100"

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -23,7 +23,7 @@ class SubmissionFileUploadModal extends React.Component {
       const originalExtension = originalFilename.split(".").pop();
       const newExtension = newFilename.split(".").pop();
 
-      if (originalExtension !== newExtension) {
+      if (newFilename !== "" && originalExtension !== newExtension) {
         const confirmChange = window.confirm(I18n.t("modals.file_upload.rename_warning"));
         if (!confirmChange) {
           // Prevent form submission if the user cancels the operation
@@ -153,10 +153,10 @@ class SubmissionFileUploadModal extends React.Component {
               {I18n.t("submissions.student.rename_file_to")}&nbsp;
               {this.fileRenameInputBox()}
             </label>
-            {this.props.progressVisible && (
+            {this.props.uploadModalProgressVisible && (
               <progress
                 className={"modal-progress-bar"}
-                value={this.props.progressPercentage}
+                value={this.props.uploadModalProgressPercentage}
                 max="100"
               ></progress>
             )}

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -1,4 +1,3 @@
-import I18n from "i18n-js";
 import React from "react";
 import Modal from "react-modal";
 

--- a/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
+++ b/app/assets/javascripts/Components/Modals/submission_file_upload_modal.jsx
@@ -23,7 +23,7 @@ class SubmissionFileUploadModal extends React.Component {
       const originalExtension = originalFilename.split(".").pop();
       const newExtension = newFilename.split(".").pop();
 
-      if (newFilename !== "" && originalExtension !== newExtension) {
+      if (originalExtension !== newExtension) {
         const confirmChange = window.confirm(I18n.t("modals.file_upload.rename_warning"));
         if (!confirmChange) {
           // Prevent form submission if the user cancels the operation

--- a/app/assets/javascripts/Components/__tests__/submission_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_file_manager.test.jsx
@@ -110,12 +110,12 @@ describe("For the SubmissionFileManager", () => {
       // Override XMLHttpRequest constructor to return our mock request instead
       jest.spyOn(window, "XMLHttpRequest").mockImplementation(() => mockXHR);
 
-      // mock ajax call to prevent request from being sent
-      $.ajax = jest.fn().mockImplementation(({xhr}) => {
+      // mock ajax post call to prevent request from being sent
+      $.post = jest.fn().mockImplementation(({xhr}) => {
         // call mock xhr send function to trigger onprogress handler
         xhr().send();
 
-        // do nothing for any chain action after ajax() itself
+        // do nothing for any chain action after $.post() itself
         return {
           then: jest.fn().mockReturnThis(),
           fail: jest.fn().mockReturnThis(),
@@ -180,7 +180,7 @@ describe("For the SubmissionFileManager", () => {
 
     it("after a file is uploaded, bar is no longer visible and its value is reset to 0.0", () => {
       // override existing mock implementation to allow always() to run
-      $.ajax = jest.fn().mockReturnValue({
+      $.post = jest.fn().mockReturnValue({
         then: jest.fn().mockReturnThis(),
         fail: jest.fn().mockReturnThis(),
         always: jest.fn().mockImplementation(func => {

--- a/app/assets/javascripts/Components/__tests__/submission_file_manager.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_file_manager.test.jsx
@@ -2,7 +2,7 @@ import {SubmissionFileManager} from "../submission_file_manager";
 
 import {mount} from "enzyme";
 
-describe("For the submissions managed by SubmissionFileManager's FileManager child component", () => {
+describe("For the SubmissionFileManager", () => {
   let wrapper, rows;
   const files_sample = {
     entries: [
@@ -53,42 +53,44 @@ describe("For the submissions managed by SubmissionFileManager's FileManager chi
     document.body.innerHTML = `<div id="content"></div>`;
   });
 
-  it("clicking on the row of each file opens up the preview for that file", () => {
-    wrapper.update();
-    rows = wrapper.find(".file");
-    expect(rows.length).toEqual(files_sample.entries.length);
-
-    rows.forEach(row => {
-      row.simulate("click");
+  describe("For the submissions managed by its FileManager child component", () => {
+    it("clicking on the row of each file opens up the preview for that file", () => {
       wrapper.update();
+      rows = wrapper.find(".file");
+      expect(rows.length).toEqual(files_sample.entries.length);
 
-      // Locate the preview block
-      const file_viewer_comp = wrapper.find("FileViewer");
-      expect(file_viewer_comp).toBeTruthy();
+      rows.forEach(row => {
+        row.simulate("click");
+        wrapper.update();
+
+        // Locate the preview block
+        const file_viewer_comp = wrapper.find("FileViewer");
+        expect(file_viewer_comp).toBeTruthy();
+      });
+    });
+
+    it("the preview opened is called with the correct props", () => {
+      wrapper.update();
+      rows = wrapper.find(".file");
+      expect(rows.length).toEqual(files_sample.entries.length);
+
+      rows.forEach(row => {
+        row.simulate("click");
+        wrapper.update();
+
+        // Locate the preview block
+        const file_viewer_comp = wrapper.find("FileViewer");
+        const file_displayed = files_sample.entries.find(
+          file => file.url === file_viewer_comp.props().selectedFileURL
+        );
+
+        expect(file_viewer_comp.props().selectedFile).toEqual(file_displayed.relativeKey);
+        expect(file_viewer_comp.props().selectedFileType).toEqual(file_displayed.type);
+      });
     });
   });
 
-  it("the preview opened is called with the correct props", () => {
-    wrapper.update();
-    rows = wrapper.find(".file");
-    expect(rows.length).toEqual(files_sample.entries.length);
-
-    rows.forEach(row => {
-      row.simulate("click");
-      wrapper.update();
-
-      // Locate the preview block
-      const file_viewer_comp = wrapper.find("FileViewer");
-      const file_displayed = files_sample.entries.find(
-        file => file.url === file_viewer_comp.props().selectedFileURL
-      );
-
-      expect(file_viewer_comp.props().selectedFile).toEqual(file_displayed.relativeKey);
-      expect(file_viewer_comp.props().selectedFileType).toEqual(file_displayed.type);
-    });
-  });
-
-  describe("For the uploadModalProgressPercentage state element", () => {
+  describe("For the upload modal's progress bar", () => {
     let file, mockXHR;
     beforeEach(() => {
       // a dummy file
@@ -122,7 +124,25 @@ describe("For the submissions managed by SubmissionFileManager's FileManager chi
       });
     });
 
-    it("when 50% of a file is uploaded, uploadModalProgressPercentage is 0.50", () => {
+    it("when 10% of file uploaded, bar is visible and has value of 10.0", () => {
+      // override our mock XMLHttpRequest's send method to send an onprogress
+      // event with 10% completion
+      mockXHR.send = jest.fn().mockImplementation(() => {
+        mockXHR.upload.onprogress({
+          lengthComputable: true,
+          loaded: 1,
+          total: 10,
+        });
+      });
+
+      // call handleCreateFiles with mock file
+      wrapper.instance().handleCreateFiles([file], "", false);
+
+      expect(wrapper.state().uploadModalProgressVisible).toBeTruthy();
+      expect(wrapper.state().uploadModalProgressPercentage).toEqual(10.0);
+    });
+
+    it("when 50% of file uploaded, bar is visible and has value of 50.0", () => {
       // override our mock XMLHttpRequest's send method to send an onprogress
       // event with 50% completion
       mockXHR.send = jest.fn().mockImplementation(() => {
@@ -133,11 +153,48 @@ describe("For the submissions managed by SubmissionFileManager's FileManager chi
         });
       });
 
-      // call handleCreateFiles with dummy file
+      // call handleCreateFiles with mock file
       wrapper.instance().handleCreateFiles([file], "", false);
 
-      // verify percentage is correct
-      expect(wrapper.state().uploadModalProgressPercentage).toEqual(50);
+      expect(wrapper.state().uploadModalProgressVisible).toBeTruthy();
+      expect(wrapper.state().uploadModalProgressPercentage).toEqual(50.0);
+    });
+
+    it("when 100% of file uploaded, bar is visible and has value of 100.0", () => {
+      // override our mock XMLHttpRequest's send method to send an onprogress
+      // event with 100% completion
+      mockXHR.send = jest.fn().mockImplementation(() => {
+        mockXHR.upload.onprogress({
+          lengthComputable: true,
+          loaded: 10,
+          total: 10,
+        });
+      });
+
+      // call handleCreateFiles with mock file
+      wrapper.instance().handleCreateFiles([file], "", false);
+
+      expect(wrapper.state().uploadModalProgressVisible).toBeTruthy();
+      expect(wrapper.state().uploadModalProgressPercentage).toEqual(100.0);
+    });
+
+    it("after a file is uploaded, bar is no longer visible and its value is reset to 0.0", () => {
+      // override existing mock implementation to allow always() to run
+      $.ajax = jest.fn().mockReturnValue({
+        then: jest.fn().mockReturnThis(),
+        fail: jest.fn().mockReturnThis(),
+        always: jest.fn().mockImplementation(func => {
+          // allow func to run
+          func();
+          return this;
+        }),
+      });
+
+      // call handleCreateFiles with mock file
+      wrapper.instance().handleCreateFiles([file], "", false);
+
+      expect(wrapper.state().uploadModalProgressVisible).toBeFalsy();
+      expect(wrapper.state().uploadModalProgressPercentage).toEqual(0.0);
     });
   });
 });

--- a/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
@@ -199,17 +199,17 @@ describe("For the SubmissionFileUploadModal", () => {
   });
 
   describe("The progress bar", () => {
-    describe("when the uploadModalProgressVisible prop is initially true and uploadModalProgressPercentage prop is 0.0", () => {
+    describe("when the progressVisible prop is initially true and progressPercentage prop is 0.0", () => {
       beforeEach(() => {
         // for testing the behaviour of progress bar after submit
         mockOnSubmit = jest.fn(() => {
-          wrapper.setProps({uploadModalProgressVisible: false});
+          wrapper.setProps({progressVisible: false});
         });
 
         wrapper = shallow(
           <SubmissionFileUploadModal
-            uploadModalProgressVisible={true}
-            uploadModalProgressPercentage={0.0}
+            progressVisible={true}
+            progressPercentage={0.0}
             requiredFiles={[]}
             onSubmit={mockOnSubmit}
           />
@@ -227,8 +227,8 @@ describe("For the SubmissionFileUploadModal", () => {
         expect(wrapper.find(".modal-progress-bar").props()["value"]).toEqual(0.0);
       });
 
-      it("the progress bar's value changes when the prop uploadModalProgressPercentage changes", () => {
-        wrapper.setProps({uploadModalProgressPercentage: 50.0});
+      it("the progress bar's value changes when the prop progressPercentage changes", () => {
+        wrapper.setProps({progressPercentage: 50.0});
         wrapper.update();
         expect(wrapper.find(".modal-progress-bar").props()["value"]).toEqual(50.0);
       });
@@ -242,12 +242,12 @@ describe("For the SubmissionFileUploadModal", () => {
       });
     });
 
-    describe("when the uploadModalProgressVisible prop is initially false", () => {
+    describe("when the progressVisible prop is initially false", () => {
       beforeEach(() => {
         wrapper = shallow(
           <SubmissionFileUploadModal
-            uploadModalProgressVisible={false}
-            uploadModalProgressPercentage={0.0}
+            progressVisible={false}
+            progressPercentage={0.0}
             requiredFiles={[]}
             onSubmit={() => {}}
           />

--- a/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
@@ -199,7 +199,7 @@ describe("For the SubmissionFileUploadModal", () => {
   });
 
   describe("The progress bar", () => {
-    describe("when the uploadModalProgressVisible prop is initially true", () => {
+    describe("when the uploadModalProgressVisible prop is initially true and uploadModalProgressPercentage prop is 0.0", () => {
       beforeEach(() => {
         // for testing the behaviour of progress bar after submit
         mockOnSubmit = jest.fn(() => {

--- a/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
+++ b/app/assets/javascripts/Components/__tests__/submission_file_upload_modal.test.jsx
@@ -197,4 +197,66 @@ describe("For the SubmissionFileUploadModal", () => {
       );
     });
   });
+
+  describe("The progress bar", () => {
+    describe("when the uploadModalProgressVisible prop is initially true", () => {
+      beforeEach(() => {
+        // for testing the behaviour of progress bar after submit
+        mockOnSubmit = jest.fn(() => {
+          wrapper.setProps({uploadModalProgressVisible: false});
+        });
+
+        wrapper = shallow(
+          <SubmissionFileUploadModal
+            uploadModalProgressVisible={true}
+            uploadModalProgressPercentage={0.0}
+            requiredFiles={[]}
+            onSubmit={mockOnSubmit}
+          />
+        );
+
+        // to ensure submit button is enabled
+        wrapper.setState({newFiles: ["q1.py", "q2.py"]});
+      });
+
+      it("the progress bar is initially visible", () => {
+        expect(wrapper.find(".modal-progress-bar").exists()).toBeTruthy();
+      });
+
+      it("the progress bar's value is initially 0.0", () => {
+        expect(wrapper.find(".modal-progress-bar").props()["value"]).toEqual(0.0);
+      });
+
+      it("the progress bar's value changes when the prop uploadModalProgressPercentage changes", () => {
+        wrapper.setProps({uploadModalProgressPercentage: 50.0});
+        wrapper.update();
+        expect(wrapper.find(".modal-progress-bar").props()["value"]).toEqual(50.0);
+      });
+
+      it("the progress bar disappears after the submit button is clicked", () => {
+        // simulate form submission
+        wrapper.instance().onSubmit({preventDefault: jest.fn()});
+        expect(mockOnSubmit).toHaveBeenCalled();
+        wrapper.update();
+        expect(wrapper.find(".modal-progress-bar").exists()).toBeFalsy();
+      });
+    });
+
+    describe("when the uploadModalProgressVisible prop is initially false", () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <SubmissionFileUploadModal
+            uploadModalProgressVisible={false}
+            uploadModalProgressPercentage={0.0}
+            requiredFiles={[]}
+            onSubmit={() => {}}
+          />
+        );
+      });
+
+      it("the progress bar is initially not visible", () => {
+        expect(wrapper.find(".modal-progress-bar").exists()).toBeFalsy();
+      });
+    });
+  });
 });

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -22,6 +22,8 @@ class SubmissionFileManager extends React.Component {
       requiredFiles: [],
       maxFileSize: 0,
       numberOfMissingFiles: 0,
+      uploadModalProgressVisible: false,
+      uploadModalProgressPercentage: 0.0,
     };
   }
 
@@ -353,6 +355,8 @@ class SubmissionFileManager extends React.Component {
           isOpen={this.state.showUploadModal}
           onRequestClose={() => this.setState({showUploadModal: false, uploadTarget: undefined})}
           onSubmit={this.handleCreateFiles}
+          uploadModalProgressVisible={this.state.uploadModalProgressVisible}
+          uploadModalProgressPercentage={this.state.uploadModalProgressPercentage}
           onlyRequiredFiles={this.state.onlyRequiredFiles}
           requiredFiles={this.state.requiredFiles}
           uploadTarget={this.state.uploadTarget}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -380,8 +380,8 @@ class SubmissionFileManager extends React.Component {
           isOpen={this.state.showUploadModal}
           onRequestClose={() => this.setState({showUploadModal: false, uploadTarget: undefined})}
           onSubmit={this.handleCreateFiles}
-          uploadModalProgressVisible={this.state.uploadModalProgressVisible}
-          uploadModalProgressPercentage={this.state.uploadModalProgressPercentage}
+          progressVisible={this.state.uploadModalProgressVisible}
+          progressPercentage={this.state.uploadModalProgressPercentage}
           onlyRequiredFiles={this.state.onlyRequiredFiles}
           requiredFiles={this.state.requiredFiles}
           uploadTarget={this.state.uploadTarget}

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -124,8 +124,8 @@ class SubmissionFileManager extends React.Component {
           this.props.assignment_id
         ),
         data: data,
-        processData: false,
-        contentType: false,
+        processData: false, // tell jQuery not to process the data
+        contentType: false, // tell jQuery not to set contentType
         xhr: () => {
           const xhr = new XMLHttpRequest();
 

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -145,14 +145,13 @@ class SubmissionFileManager extends React.Component {
       })
         .then(typeof this.props.onChange === "function" ? this.props.onChange : this.fetchData)
         .then(this.endAction)
+        .then(() => this.setState({showUploadModal: false, uploadTarget: undefined}))
         .fail(jqXHR => {
           if (jqXHR.getResponseHeader("x-message-error") == null) {
             flashMessage(I18n.t("upload_errors.generic"), "error");
           }
         })
         .always(this.resetProgressBar);
-
-      this.setState({showUploadModal: false, uploadTarget: undefined});
     }
   };
 

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -103,8 +103,9 @@ class SubmissionFileManager extends React.Component {
       !this.props.starterFileChanged ||
       confirm(I18n.t("assignments.starter_file.upload_confirmation"))
     ) {
+      this.setState({uploadModalProgressVisible: true});
+
       const prefix = path || this.state.uploadTarget || "";
-      this.setState({showUploadModal: false, uploadTarget: undefined});
       let data = new FormData();
       if (!!renameTo && files.length === 1) {
         Array.from(files).forEach(f => data.append("new_files[]", f, renameTo));
@@ -116,8 +117,6 @@ class SubmissionFileManager extends React.Component {
         data.append("grouping_id", this.props.grouping_id);
       }
       data.append("unzip", unzip);
-
-      this.setState({uploadModalProgressVisible: true});
 
       $.ajax({
         url: Routes.update_files_course_assignment_submissions_path(
@@ -152,6 +151,8 @@ class SubmissionFileManager extends React.Component {
           }
         })
         .always(this.resetProgressBar);
+
+      this.setState({showUploadModal: false, uploadTarget: undefined});
     }
   };
 

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -145,13 +145,19 @@ class SubmissionFileManager extends React.Component {
       })
         .then(typeof this.props.onChange === "function" ? this.props.onChange : this.fetchData)
         .then(this.endAction)
-        .then(() => this.setState({showUploadModal: false, uploadTarget: undefined}))
         .fail(jqXHR => {
           if (jqXHR.getResponseHeader("x-message-error") == null) {
             flashMessage(I18n.t("upload_errors.generic"), "error");
           }
         })
-        .always(this.resetProgressBar);
+        .always(() => {
+          this.setState({
+            showUploadModal: false,
+            uploadTarget: undefined,
+            uploadModalProgressVisible: false,
+            uploadModalProgressPercentage: 0.0,
+          });
+        });
     }
   };
 
@@ -340,10 +346,6 @@ class SubmissionFileManager extends React.Component {
         </div>
       </div>
     );
-  };
-
-  resetProgressBar = () => {
-    this.setState({uploadModalProgressVisible: false, uploadModalProgressPercentage: 0.0});
   };
 
   render() {

--- a/app/assets/javascripts/Components/submission_file_manager.jsx
+++ b/app/assets/javascripts/Components/submission_file_manager.jsx
@@ -118,15 +118,14 @@ class SubmissionFileManager extends React.Component {
       }
       data.append("unzip", unzip);
 
-      $.ajax({
+      $.post({
         url: Routes.update_files_course_assignment_submissions_path(
           this.props.course_id,
           this.props.assignment_id
         ),
-        type: "POST",
+        data: data,
         processData: false,
         contentType: false,
-        data: data,
         xhr: () => {
           const xhr = new XMLHttpRequest();
 

--- a/app/assets/stylesheets/common/_modals.scss
+++ b/app/assets/stylesheets/common/_modals.scss
@@ -50,3 +50,7 @@
   text-align: right;
   width: 6vw;
 }
+
+.modal-progress-bar {
+  width: 100%;
+}

--- a/config/locales/views/modals/en.yml
+++ b/config/locales/views/modals/en.yml
@@ -6,3 +6,5 @@ en:
         Changing the file extension may render the file unusable.
         Are you sure you want to proceed?
       unzip: unzip all zip files in place
+    submission_file_upload:
+      progress_bar: Submission file upload progress bar


### PR DESCRIPTION
## Proposed Changes

Closes #5401 by adding a progress bar to the file upload modal on the submissions page.

## Screenshot

The progress bar is hard to catch in action, but here is a screenshot of what it looks like moments before the modal itself closes (i.e. once the file has been completely uploaded):

![image](https://github.com/MarkUsProject/Markus/assets/56097527/f520f7b8-c74c-4576-b77d-55c19ab3ff9f)


## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |    X     |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |    X     |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.