### PR TITLE
Add setting to enable filtering of new course creation from LTI launch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 - Added validations to the `TextAnnotation` model to ensure `line_start` and `line_end` are >= 1, and `column_start` and `column_end` are >= 0. (#7081)
 - Calculate and display the exact future time for the next token generation to help students plan their test runs more effectively. (#7127)
 - Set the default date for "Tokens available on" to the current time (#7173).
+- Add setting to enable filtering of new course creation from LTI launch (#7151)
 
 ### 🐛 Bug fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,7 @@
 - Fixed flaky test #creates groups for individual students in groups_controller_spec (#7145)
 - Switch from SyntaxHighlighter to Prism for syntax highlighting (#7122)
 - Move jquery-ui and ui-contextmenu dependencies to package.json and upgrade jquery-ui to v1.13.3 (#7149)
+- Do not enforce secure cookies in development for LTI deployments (#7151)
 - Remove CI chromedriver version and Chrome dependency (#7170)
 - Update Jupyter notebook Javascript dependencies (require.js to v2.3.7, plotly.js to v2.34.0) (#7175)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@
 - Fixed grader view rendering when a pre-defined annotation's content is blank (#7147)
 - Fixed AJAX requests in grader view, which were missing CSRF token headers (#7174)
 - Use jQuery `.find` method in `ModalMarkus` to guard against potential XSS attack (#7176)
+- Sanitize LTI deployment course names when creating new courses (#7151)
 
 ### 🔧 Internal changes
 

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -191,7 +191,8 @@ class LtiDeploymentsController < ApplicationController
       return
     end
 
-    new_course = Course.find_or_initialize_by(name: params['name'])
+    name = params['name'].gsub(/[^a-zA-Z0-9\-_]/, '-')  # Sanitize name to comply with Course name validation
+    new_course = Course.find_or_initialize_by(name: name)
     unless new_course.new_record?
       flash_message(:error, I18n.t('lti.course_exists'))
       redirect_to choose_course_lti_deployment_path

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -7,6 +7,8 @@ class LtiDeploymentsController < ApplicationController
   before_action(except: [:get_config, :launch, :public_jwk, :redirect_login]) { authorize! }
   before_action :check_host, only: [:launch, :redirect_login]
 
+  USE_SECURE_COOKIES = !Rails.env.local?
+
   def launch
     if params[:client_id].blank? || params[:login_hint].blank? ||
       params[:target_link_uri].blank? || params[:lti_message_hint].blank?
@@ -21,7 +23,7 @@ class LtiDeploymentsController < ApplicationController
     lti_launch_data[:nonce] = nonce
     lti_launch_data[:state] = session_nonce
     cookies.permanent.encrypted[:lti_launch_data] =
-      { value: JSON.generate(lti_launch_data), expires: 1.hour.from_now, same_site: :none, secure: true }
+      { value: JSON.generate(lti_launch_data), expires: 1.hour.from_now, same_site: :none, secure: USE_SECURE_COOKIES }
     auth_params = {
       scope: 'openid',
       response_type: 'id_token',
@@ -104,7 +106,7 @@ class LtiDeploymentsController < ApplicationController
       unless logged_in?
         lti_data[:lti_redirect] = request.url
         cookies.encrypted.permanent[:lti_data] =
-          { value: JSON.generate(lti_data), expires: 1.hour.from_now, same_site: :none, secure: true }
+          { value: JSON.generate(lti_data), expires: 1.hour.from_now, same_site: :none, secure: USE_SECURE_COOKIES }
         redirect_to root_path
         return
       end

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -180,6 +180,15 @@ class LtiDeploymentsController < ApplicationController
   end
 
   def create_course
+    if LtiConfig.respond_to?(:allowed_to_create_course?) && !LtiConfig.allowed_to_create_course?(record)
+      render 'shared/http_status',
+             locals: { code: '422',
+                       message: format(Settings.lti.unpermitted_new_course_message,
+                                       course_name: record.lms_course_name) },
+             status: :unprocessable_entity, layout: false
+      return
+    end
+
     new_course = Course.find_or_initialize_by(name: params['name'])
     unless new_course.new_record?
       flash_message(:error, I18n.t('lti.course_exists'))

--- a/app/lib/lti_config.rb
+++ b/app/lib/lti_config.rb
@@ -1,0 +1,2 @@
+module LtiConfig
+end

--- a/app/views/shared/http_status.html.erb
+++ b/app/views/shared/http_status.html.erb
@@ -13,7 +13,7 @@
   <div id='wrapper'>
     <section id='content'>
       <h1><%= code + ' ' + HttpStatusHelper::ERROR_CODE[code] %></h1>
-      <p>Uh oh! <%= message %></p>
+      <p><%= message %></p>
     </section>
   </div>
 </body>

--- a/config/dummy_lti_config.rb
+++ b/config/dummy_lti_config.rb
@@ -1,0 +1,7 @@
+module LtiConfig
+  # Implement LtiConfig.allowed_to_create_course? to set a filter for LTI deployments that are
+  # permitted to trigger course creation for MarkUs.
+  def self.allowed_to_create_course?(lti_deployment)
+    lti_deployment.lms_course_name.start_with? 'csc'
+  end
+end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -190,7 +190,7 @@ Config.setup do |config|
       end
       optional(:lti).hash do
         optional(:course_filter_file).filled(:string)
-        optional(:domains).array(:str?)
+        required(:domains).array(:str?)
         required(:token_endpoint).filled(:string)
         optional(:unpermitted_new_course_message).filled(:string)
       end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -188,6 +188,12 @@ Config.setup do |config|
         optional(:lti).filled(:string)
         optional(:repos).filled(:string)
       end
+      optional(:lti).hash do
+        optional(:course_filter_file).filled(:string)
+        optional(:domains).array(:str?)
+        required(:token_endpoint).filled(:string)
+        optional(:unpermitted_new_course_message).filled(:string)
+      end
     end
   end
 end

--- a/config/initializers/lti_config.rb
+++ b/config/initializers/lti_config.rb
@@ -1,0 +1,7 @@
+if Settings.lti.course_filter_file.present?
+  # config.to_prepare is used so that the block is executed on reloads.
+  # See https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload
+  Rails.application.config.to_prepare do
+    load Settings.lti.course_filter_file
+  end
+end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -38,10 +38,8 @@ logging:
 autotest:
   max_batch_size: 10
 
-# The settings below are for an experimental feature that is not available
-# in production yet. Please disregard for now.
 lti:
   course_filter_file: <%= "#{::Rails.root}/config/dummy_lti_config.rb" %>
-  domains: <%= %w[host.docker.internal localhost] %>
-  token_endpoint: "http://host.docker.internal:80/login/oauth2/token"
+  domains: <%= %w[host.docker.internal] %>
+  token_endpoint: "http://host.docker.internal:3100/login/oauth2/token"
   unpermitted_new_course_message: 'You are not permitted to create a new MarkUs course for %{course_name}. Please contact your system administrator.'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -41,5 +41,7 @@ autotest:
 # The settings below are for an experimental feature that is not available
 # in production yet. Please disregard for now.
 lti:
-  domains: <%= %w[host.docker.internal] %>
-  token_endpoint: "http://host.docker.internal:3100/login/oauth2/token"
+  course_filter_file: <%= "#{::Rails.root}/config/dummy_lti_config.rb" %>
+  domains: <%= %w[host.docker.internal localhost] %>
+  token_endpoint: "http://host.docker.internal:80/login/oauth2/token"
+  unpermitted_new_course_message: 'You are not permitted to create a new MarkUs course for %{course_name}. Please contact your system administrator.'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -31,8 +31,8 @@ logging:
 autotest:
   max_batch_size: 10
 
-# The settings below are for an experimental feature that is not available
-# in production yet. Please disregard for now.
 lti:
+  course_filter_file: <%= "#{::Rails.root}/config/dummy_lti_config.rb" %>
   domains: <%= %w[test.host] %>
   token_endpoint: "http://test.host.com/login/oauth2/token"
+  unpermitted_new_course_message: 'You are not permitted to create a new MarkUs course for %{course_name}. Please contact your system administrator.'


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

This pull request introduces a new configuration setting, `lti.course_filter_file`, to allow administrators to filter which LTI course deployments are permitted to create new course instances. LTI deployments that are not permitted to trigger new course creation can still be linked to existing MarkUs courses. 

The development default configuration, found in `config/dummy_lti_config.rb`, permits course names starting with `'csc'`. 

In testing this work, I realized that if the Canvas course has a name containing spaces or other characters not allowed in the MarkUs `Course` `:name` field, there will be an error. I introduced a change to sanitize the LTI course name field before creating the corresponding MarkUs course.

I also added a quality of life improvement for local development: `LtiDeploymentsController::USE_SECURE_COOKIES`, which is `true` in production but `false` in development, to specify whether the controller methods require setting secure cookies.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

https://github.com/MarkUsProject/Wiki/pull/215

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          | X        |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         | X        |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [X] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*

Seems like the code added to `config/initializers/config.rb` wasn't detected as covered, which is consistent with most of that file. Requires further investigation, and possibly related to https://github.com/rubyconfig/config/issues/352.
