### PR TITLE
Fix AJAX requests missing CSRF header in Result component

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@
 - Fix rename confirmation check triggering even upon no rename input (#7124)
 - Ensured that the assignment deadline is used as a placeholder if token_end_date is not present. (#7128)
 - Fixed grader view rendering when a pre-defined annotation's content is blank (#7147)
+- Fixed AJAX requests in grader view, which were missing CSRF token headers (#7174)
 
 ### 🔧 Internal changes
 

--- a/app/assets/javascripts/Components/Result/result.jsx
+++ b/app/assets/javascripts/Components/Result/result.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import {render} from "react-dom";
 
+// TODO: This import seems to be required to automatically include the X-CSRF-TOKEN header on
+//   jQuery AJAX requests in this component, unlike all other pages. Requires further investigation.
+import "@rails/ujs";
+
 import {LeftPane} from "./left_pane";
 import {RightPane} from "./right_pane";
 import {SubmissionSelector} from "./submission_selector";


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

It appears that in #7149, changing the import of jquery [from `jquery/src/jquery` to just `jquery`](https://github.com/MarkUsProject/Markus/pull/7149/files#diff-f0a56c5756a0d0911d91b36bbf5d397c534340f153239dccbea55dd4f90fdc4bL12) caused the Rails UJS library to stop adding `X-CSRF-TOKEN` headers to ajax requests in the Result component. This caused the ajax requests to receive a Rails error "Can't verify CSRF token authenticity".

I was able to fix this by adding an explicit import of `@rails/ujs` manually to `result.jsx`, but I'm not sure why that was needed to fix the issue. I checked all other AJAX requests made in the application and no others faced the same issue.

Further investigation is required, but also Rails is encouraging the use of [request.js](https://github.com/rails/request.js) as a newer alternative to UJS.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  | X        |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
