### PR TITLE
Fix: only retain most recent test results

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 - Fix incorrect calculation of token penalties when submissions are on time (#7216)
+- Fix JSON/CSV summary of test results to always be inline with latest test run (#7214)
 
 ### 🔧 Internal changes
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -634,27 +634,29 @@ class Assignment < Assessment
 
   # Generates the summary of the most test results associated with an assignment.
   def summary_test_results
-    test_groups_query = self.test_groups
-                            .joins(test_group_results: { test_run: :grouping })
-                            .group('test_groups.id', 'groupings.id')
-                            .select('test_groups.id AS test_groups_id',
-                                    'MAX(test_group_results.created_at) AS test_group_results_created_at')
-                            .where.not('test_runs.submission_id': nil)
-                            .to_sql
+    latest_test_run_by_grouping = TestRun.group('grouping_id').select('MAX(created_at) as test_runs_created_at',
+                                                                      'grouping_id').to_sql
 
-    self.test_groups
-        .joins(test_group_results: [:test_results, { test_run: { grouping: :group } }])
-        .joins("INNER JOIN (#{test_groups_query}) sub \
-                ON test_groups.id = sub.test_groups_id
-                AND test_group_results_test_groups.created_at = sub.test_group_results_created_at")
+    latest_test_runs = TestRun.joins("INNER JOIN (#{latest_test_run_by_grouping}) latest_test_run_by_grouping \
+                  ON latest_test_run_by_grouping.grouping_id = test_runs.grouping_id \
+                  AND latest_test_run_by_grouping.test_runs_created_at = test_runs.created_at")
+                              .select('id', 'submission_id', 'grouping_id')
+                              .to_sql
+
+    self.test_groups.joins(test_group_results: :test_results)
+        .joins("INNER JOIN (#{latest_test_runs}) latest_test_runs \
+              ON test_group_results.test_run_id = latest_test_runs.id")
+        .joins('INNER JOIN groupings ON latest_test_runs.grouping_id = groupings.id')
+        .joins('INNER JOIN groups ON groups.id = groupings.group_id')
         .select('test_groups.name',
-                'test_groups_id',
+                'test_groups.id as test_groups_id',
                 'groups.group_name',
                 'test_results.name as test_result_name',
                 'test_results.status',
                 'test_results.marks_earned',
                 'test_results.marks_total',
                 :output, :extra_info, :error_type)
+        .where.not('latest_test_runs.submission_id': nil)
   end
 
   # Generate a JSON summary of the most recent test results associated with an assignment.

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -635,28 +635,29 @@ class Assignment < Assessment
   # Generates the summary of the most test results associated with an assignment.
   def summary_test_results
     latest_test_run_by_grouping = TestRun.group('grouping_id').select('MAX(created_at) as test_runs_created_at',
-                                                                      'grouping_id').to_sql
+                                                                      'grouping_id')
+                                         .where.not(submission_id: nil)
+                                         .to_sql
 
-    latest_test_runs = TestRun.joins("INNER JOIN (#{latest_test_run_by_grouping}) latest_test_run_by_grouping \
-                  ON latest_test_run_by_grouping.grouping_id = test_runs.grouping_id \
-                  AND latest_test_run_by_grouping.test_runs_created_at = test_runs.created_at")
-                              .select('id', 'submission_id', 'grouping_id')
-                              .to_sql
+    latest_test_runs = TestRun
+                       .joins(grouping: :group)
+                       .joins("INNER JOIN (#{latest_test_run_by_grouping}) latest_test_run_by_grouping \
+            ON latest_test_run_by_grouping.grouping_id = test_runs.grouping_id \
+            AND latest_test_run_by_grouping.test_runs_created_at = test_runs.created_at")
+                       .select('id', 'test_runs.grouping_id', 'groups.group_name')
+                       .to_sql
 
     self.test_groups.joins(test_group_results: :test_results)
         .joins("INNER JOIN (#{latest_test_runs}) latest_test_runs \
               ON test_group_results.test_run_id = latest_test_runs.id")
-        .joins('INNER JOIN groupings ON latest_test_runs.grouping_id = groupings.id')
-        .joins('INNER JOIN groups ON groups.id = groupings.group_id')
         .select('test_groups.name',
                 'test_groups.id as test_groups_id',
-                'groups.group_name',
+                'latest_test_runs.group_name',
                 'test_results.name as test_result_name',
                 'test_results.status',
                 'test_results.marks_earned',
                 'test_results.marks_total',
                 :output, :extra_info, :error_type)
-        .where.not('latest_test_runs.submission_id': nil)
   end
 
   # Generate a JSON summary of the most recent test results associated with an assignment.

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -183,7 +183,7 @@ describe AssignmentsController do
       test_results = CSV.parse(response.body, headers: true)
 
       expect(test_results.to_a.size).to eq 4
-      expect(test_results.headers.length).to eq 10
+      expect(test_results.headers.length).to eq 4
     end
 
     it 'returns the correct csv headers' do
@@ -219,7 +219,7 @@ describe AssignmentsController do
             count += 1
           end
         end
-        expect(count).to eq 3
+        expect(count).to eq 1
       end
     end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2058,7 +2058,7 @@ describe Assignment do
       end
     end
 
-    context 'an assignment with test results' do
+    context 'an assignment with test results across multiple test groups' do
       let(:assignment) { create(:assignment_with_criteria_and_test_results) }
 
       it 'has the correct group and test names' do
@@ -2093,6 +2093,20 @@ describe Assignment do
               expect(test_result.keys).to match_array expected_keys
             end
           end
+        end
+      end
+
+      it 'has multiple test groups' do
+        expect(assignment.test_groups.size).to be > 1
+      end
+
+      # despite having multiple test groups, assignment is set up so every test
+      # run contains results from exactly one test group; so this should also
+      # return results from only one test group
+      it 'returns results from only one test group for each group' do
+        summary_test_results = JSON.parse(assignment.summary_test_result_json)
+        summary_test_results.map do |_group_name, group|
+          expect(group.count).to eq 1
         end
       end
     end


### PR DESCRIPTION
## Proposed Changes
Fixes #7070 by making the "Download Test Results" button on the Summary page look at the latest test run to determine for which test groups the results must be downloaded, and downloads them accordingly. So, if a user deletes a test group and runs the tests again, the next summary would not contain the deleted test groups. This is in contrast to the original behaviour, where the latest results of _every_ test group would _always_ be part of the JSON/CSV summary.

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |     X     |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.
