### PR TITLE
Ensure correct LTI version of lti_user_id is used on launch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Fixed bug in grading context menu for editing/deleting annotations (#7309)
 - Fixed bug in grading annotations table when deleting annotations (#7309)
 - Ensures row selection for peer reviewer unassigning has the same validation checks as individual selections (#7274)
+- Ensure correct LTI version of lti_user_id is used on launch (#7335)
 
 ### 🔧 Internal changes
 

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -102,7 +102,7 @@ class LtiDeploymentsController < ApplicationController
           lti_data[:line_items] = grades_endpoints['lineitems']
         end
       end
-      lti_data[:lti_user_id] = lti_params[LtiDeployment::LTI_CLAIMS[:user_launch_data]]['user_id']
+      lti_data[:lti_user_id] = lti_params[LtiDeployment::LTI_CLAIMS[:user_id]]
       unless logged_in?
         lti_data[:lti_redirect] = request.url
         cookies.encrypted.permanent[:lti_data] =

--- a/app/models/lti_deployment.rb
+++ b/app/models/lti_deployment.rb
@@ -15,7 +15,7 @@ class LtiDeployment < ApplicationRecord
                  names_role: 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice',
                  ags_lineitem: 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint',
                  deployment_id: 'https://purl.imsglobal.org/spec/lti/claim/deployment_id',
-                 user_launch_data: 'https://purl.imsglobal.org/spec/lti/claim/lti1p1' }.freeze
+                 user_id: 'sub' }.freeze
   LTI_ROLES = { learner: 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner',
                 test_user: 'http://purl.imsglobal.org/vocab/lti/system/person#TestUser',
                 ta: 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant',

--- a/spec/support/lti_controller_examples.rb
+++ b/spec/support/lti_controller_examples.rb
@@ -142,9 +142,7 @@ shared_examples 'lti deployment controller' do
               course_id: 1,
               user_id: 1
             },
-            LtiDeployment::LTI_CLAIMS[:user_launch_data] => {
-              user_id: 'lti_user_id'
-            } }
+            LtiDeployment::LTI_CLAIMS[:user_id] => 'some_user_id' }
         end
         let(:pub_jwk) { JWT::JWK.new(OpenSSL::PKey::RSA.new(1024)) }
         let(:lti_jwt) { JWT.encode(payload, pub_jwk.keypair, 'RS256', { kid: pub_jwk.kid }) }


### PR DESCRIPTION
## Proposed Changes
LTI launch from canvas is using LTI v1.1 for it's lti_user_id attribute. We need to use LTI v1.3 one as Roster sync uses this one, which is found under the subject attribute, "sub". LTI v1.1 and LTI v1.3 both have different values for lti_user_id. 

If an instructor logs in from canvas and then does an Roster sync, other users who then launches from Canvas will get the following log error:

Couldn't find LtiUser with [WHERE "lti_users"."user_id" = $1 AND "lti_users"."lti_client_id" = $2 AND "lti_users"."lti_user_id" = $3] 

On production mode, they will see a 404 error on the browser but we will see the same error in the logs.

The reason this errors comes about is that when during the Launch, the following code is run in lti_deployments_controller.rb:

LtiUser.find_or_create_by(user: @real_user, lti_client: lti_client,
                              lti_user_id: lti_data[:lti_user_id])

It will first try to find this user, which they would not because of the different LTI versions, it would then try to create the user, but the DB would not allow it because of the unique index that requires User_id and lti_client_id combined has to be unique. So it would then raise the above error.

To test this locally:

1) Empty out lti_users table in DB
2) Launch from Canvas to MarkUs as an instructor
3) Do Roster sync
4) On Canvas, act as another user in that course and launch MarkUs
5) You will now be able to log in without the above error

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |      x    |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
