### PR TITLE
Fix content shift on input focus

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
+- Fix front-end content shift when an input element is focused (#7384)
 
 ### 🐛 Bug fixes
 

--- a/app/assets/stylesheets/common/_markus.scss
+++ b/app/assets/stylesheets/common/_markus.scss
@@ -186,8 +186,8 @@ textarea {
 
   &:focus {
     background-color: $background-main;
-    border-color: $primary-three;
-    border-width: 3px;
+    border-color: transparent;
+    box-shadow: 0 0 0 3px $primary-three;
   }
 
   &:invalid {


### PR DESCRIPTION
## Proposed Changes
This PR aims to remove the DOM content shift that occurs when an input is focused. This is done by replacing the border with a box shadow. Unlike a border, a box shadow doesn't get factored into the component size calculation, so it doesn't cause content to shift.

There is no change to appearance. The border style and animation match the previous implementation.

### Before and after:

![image](https://github.com/user-attachments/assets/3590dfee-2dea-435f-bc07-6aa35e69de8e)

![image](https://github.com/user-attachments/assets/dce9738c-a8a5-40ab-b54d-13e009d94f33)


## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |   x      |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [ ] I have updated the project Changelog (this is required for all changes).
- [ ] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
