### PR TITLE
Fixed bugs with section-starter file group mapping across multiple assignments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bugs when assigning sections to starter file groups across multiple assignments (#7523)
+
 ### 🔧 Internal changes
 
 - Remove `activerecord-session_store` gem (#7517)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -439,13 +439,26 @@ class AssignmentsController < ApplicationController
         use_rename: g.use_rename,
         files: starter_file_group_file_data(g) }
     end
+    sections = current_course.sections.pluck(:id, :name)
     section_data = current_course.sections
-                                 .left_outer_joins(:starter_file_groups)
-                                 .order(:id)
+                                 .joins(:starter_file_groups)
+                                 .where('starter_file_groups.assessment_id': assignment.id)
                                  .pluck_to_hash('sections.id as section_id',
                                                 'sections.name as section_name',
                                                 'starter_file_groups.id as group_id',
                                                 'starter_file_groups.name as group_name')
+    section_data_ids = section_data.pluck(:section_id)
+    sections.each do |id, name|
+      unless section_data_ids.include? id
+        section_data << {
+          section_id: id,
+          section_name: name,
+          group_id: nil,
+          group_name: nil
+        }
+      end
+    end
+    section_data.sort_by! { |x| x[:section_id] }
     data = { files: file_data,
              sections: section_data,
              available_after_due: assignment.starter_files_after_due,

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -24,10 +24,11 @@ class Section < ApplicationRecord
   end
 
   def update_starter_file_group(assessment_id, starter_file_group_id)
-    return if starter_file_groups.where(assessment_id: assessment_id).first&.id == starter_file_group_id
+    starter_files_groups_for_assignment = starter_file_groups.where(assessment_id: assessment_id)
+    return if starter_files_groups_for_assignment.first&.id == starter_file_group_id
 
     # delete all old section starter file groups
-    section_starter_file_groups.where.not(starter_file_group_id: starter_file_group_id).find_each(&:destroy)
+    section_starter_file_groups.where(starter_file_group_id: starter_files_groups_for_assignment).find_each(&:destroy)
 
     unless starter_file_group_id.nil?
       SectionStarterFileGroup.find_or_create_by(section_id: self.id, starter_file_group_id: starter_file_group_id)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1033,12 +1033,37 @@ describe AssignmentsController do
         let(:params) { { course_id: assignment.course.id, id: ssfg.starter_file_group.assignment.id } }
 
         it 'should contain the right values' do
+          expect(response.parsed_body['sections'].size).to eq 1
           file_data = response.parsed_body['sections'].first
           expected = { section_id: section.id,
                        section_name: section.name,
                        group_id: starter_file_group.id,
                        group_name: starter_file_group.name }
           expect(file_data).to eq(expected.transform_keys(&:to_s))
+        end
+
+        context 'when there is another assignment with sections' do
+          let(:a2) { create(:assignment) }
+          let(:other_starter_file_group) { create(:starter_file_group, assignment: a2) }
+          let(:ssfg2) do
+            create(:section_starter_file_group, starter_file_group: other_starter_file_group, section: section)
+          end
+          let(:params) do
+            # Ensure creation of both assignments and starter file groups
+            ssfg
+            ssfg2
+            { course_id: assignment.course.id, id: ssfg.starter_file_group.assignment.id }
+          end
+
+          it 'should only contain the section data for the requested assignment' do
+            expect(response.parsed_body['sections'].size).to eq 1
+            file_data = response.parsed_body['sections'].first
+            expected = { section_id: section.id,
+                         section_name: section.name,
+                         group_id: starter_file_group.id,
+                         group_name: starter_file_group.name }
+            expect(file_data).to eq(expected.transform_keys(&:to_s))
+          end
         end
       end
     end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -102,7 +102,7 @@ describe Section do
       end
     end
 
-    context 'when a starter file group is already assigned' do
+    context 'when a starter file group is already assigned for that assignment' do
       let(:section) { sections.second }
 
       before { section.update_starter_file_group(assignment.id, starter_file_groups.first.id) }
@@ -115,6 +115,27 @@ describe Section do
       it 'should remove the old starter file group' do
         ids = section.reload.section_starter_file_groups.pluck(:starter_file_group_id)
         expect(ids).not_to include starter_file_groups.second.id
+      end
+    end
+
+    context 'when a starter file group is assigned for a different assignment' do
+      let(:assignment2) { create(:assignment) }
+      let!(:starter_file_groups2) { create_list(:starter_file_group_with_entries, 2, assignment: assignment2) }
+      let(:section) { sections.second }
+
+      before do
+        create(:section_starter_file_group, starter_file_group: starter_file_groups2.second, section: section)
+        section.update_starter_file_group(assignment.id, starter_file_groups.first.id)
+      end
+
+      it 'should assign the new starter file group' do
+        ids = section.reload.section_starter_file_groups.pluck(:starter_file_group_id)
+        expect(ids).to include starter_file_groups.first.id
+      end
+
+      it 'should not remove the starter file group for the other assignment' do
+        ids = section.reload.section_starter_file_groups.pluck(:starter_file_group_id)
+        expect(ids).to include starter_file_groups2.second.id
       end
     end
   end


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

When configuring assignment starter files, instructors can assign sections different starter file groups. However, this functionality had two problems when doing this assignment across different assignments:

1. Assigning a section in one assignment caused the section to be unassigned from starter file groups for all other assignments.
2. (after fixing the above) the configuration page would load section-starter file group mappings for all assignments, not just the currently selected assignment.

This PR fixes both of those bugs.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  | X        |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
