### PR TITLE
Maintain font size in grading view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ### ✨ New features and improvements
 - Improved layout and labeling in the assignment settings form for both standard and timed assessments. (#7531)
 - Improved Assignment view for students (#7533)
+- Maintain font size in grading view (#7525)
 
 ### 🐛 Bug fixes
 

--- a/app/javascript/Components/Result/text_viewer.jsx
+++ b/app/javascript/Components/Result/text_viewer.jsx
@@ -106,6 +106,10 @@ export class TextViewer extends React.PureComponent {
     if (content && (content !== prevContent || this.props.annotations !== prevProps.annotations)) {
       this.ready_annotations();
       this.setState({copy_success: false});
+
+      if (localStorage.getItem("text_viewer_font_size") != null) {
+        this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
+      }
     } else if (this.props.focusLine !== prevProps.focusLine) {
       this.scrollToLine(this.props.focusLine);
     }
@@ -178,7 +182,9 @@ export class TextViewer extends React.PureComponent {
   };
 
   change_font_size = delta => {
-    this.setState({font_size: Math.max(this.state.font_size + delta, 0.25)});
+    let font_size = Math.max(this.state.font_size + delta, 0.25);
+    this.setState({font_size: font_size});
+    localStorage.setItem("text_viewer_font_size", font_size);
   };
 
   display_annotation = annotation => {

--- a/app/javascript/Components/Result/text_viewer.jsx
+++ b/app/javascript/Components/Result/text_viewer.jsx
@@ -37,6 +37,10 @@ export class TextViewer extends React.PureComponent {
   componentDidMount() {
     this.highlight_root = this.raw_content.current.parentNode;
 
+    if (localStorage.getItem("text_viewer_font_size") != null) {
+      this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
+    }
+
     // Fetch content from a URL if it is passed as a prop. The URL should point to plaintext data.
     if (this.props.url) {
       this.props.setLoadingCallback(true);
@@ -106,10 +110,6 @@ export class TextViewer extends React.PureComponent {
     if (content && (content !== prevContent || this.props.annotations !== prevProps.annotations)) {
       this.ready_annotations();
       this.setState({copy_success: false});
-
-      if (localStorage.getItem("text_viewer_font_size") != null) {
-        this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
-      }
     } else if (this.props.focusLine !== prevProps.focusLine) {
       this.scrollToLine(this.props.focusLine);
     }

--- a/app/javascript/Components/Result/text_viewer.jsx
+++ b/app/javascript/Components/Result/text_viewer.jsx
@@ -37,8 +37,13 @@ export class TextViewer extends React.PureComponent {
   componentDidMount() {
     this.highlight_root = this.raw_content.current.parentNode;
 
-    if (localStorage.getItem("text_viewer_font_size") != null) {
-      this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
+    if (localStorage.getItem("text_viewer_font_size") !== null) {
+      try {
+        this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
+      } catch (error) {
+        localStorage.removeItem("text_viewer_font_size");
+        console.error("An error occurred:", error.message);
+      }
     }
 
     // Fetch content from a URL if it is passed as a prop. The URL should point to plaintext data.

--- a/app/javascript/Components/Result/text_viewer.jsx
+++ b/app/javascript/Components/Result/text_viewer.jsx
@@ -37,9 +37,13 @@ export class TextViewer extends React.PureComponent {
   componentDidMount() {
     this.highlight_root = this.raw_content.current.parentNode;
 
-    if (localStorage.getItem("text_viewer_font_size") !== null) {
+    let textViewerFontSize = localStorage.getItem("text_viewer_font_size");
+    if (textViewerFontSize !== null) {
       try {
-        this.setState({font_size: Number(localStorage.getItem("text_viewer_font_size"))});
+        if (isNaN(textViewerFontSize) || textViewerFontSize.trim() === "") {
+          throw new Error("Local storage item 'text_viewer_font_size' is not a number.");
+        }
+        this.setState({font_size: Number(textViewerFontSize)});
       } catch (error) {
         localStorage.removeItem("text_viewer_font_size");
         console.error("An error occurred:", error.message);

--- a/app/javascript/Components/__tests__/text_viewer.test.jsx
+++ b/app/javascript/Components/__tests__/text_viewer.test.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import {TextViewer} from "../Result/text_viewer";
 import fetchMock from "jest-fetch-mock";
+import userEvent from "@testing-library/user-event";
+
 import {BinaryViewer} from "../Result/binary_viewer";
 
 describe("TextViewer", () => {
@@ -19,6 +21,17 @@ describe("TextViewer", () => {
   afterEach(() => {
     jest.clearAllMocks();
     fetchMock.resetMocks();
+  });
+
+  it("should save font size to localStorage when font size change", async () => {
+    jest.spyOn(Storage.prototype, "getItem");
+
+    render(<TextViewer {...props} />);
+    userEvent.click(screen.getByText("+A"));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("text_viewer_font_size")).toBe("1.25");
+    });
   });
 
   it("should render its text content when the content ends with a new line", () => {

--- a/app/javascript/Components/__tests__/text_viewer.test.jsx
+++ b/app/javascript/Components/__tests__/text_viewer.test.jsx
@@ -3,7 +3,6 @@ import {render, screen, waitFor} from "@testing-library/react";
 import {TextViewer} from "../Result/text_viewer";
 import fetchMock from "jest-fetch-mock";
 import userEvent from "@testing-library/user-event";
-
 import {BinaryViewer} from "../Result/binary_viewer";
 
 describe("TextViewer", () => {

--- a/app/javascript/Components/__tests__/text_viewer.test.jsx
+++ b/app/javascript/Components/__tests__/text_viewer.test.jsx
@@ -10,6 +10,7 @@ describe("TextViewer", () => {
   const successfulFetchResp = "File content";
   const loadingCallback = jest.fn();
   const errorCallback = jest.fn();
+  const getItemMock = jest.spyOn(Storage.prototype, "getItem");
   const props = {
     annotations: [],
     focusLine: null,
@@ -21,16 +22,28 @@ describe("TextViewer", () => {
   afterEach(() => {
     jest.clearAllMocks();
     fetchMock.resetMocks();
+    getItemMock.mockReset();
   });
 
   it("should save font size to localStorage when font size change", async () => {
-    jest.spyOn(Storage.prototype, "getItem");
+    jest.spyOn(Storage.prototype, "setItem");
 
     render(<TextViewer {...props} />);
     userEvent.click(screen.getByText("+A"));
 
     await waitFor(() => {
-      expect(localStorage.getItem("text_viewer_font_size")).toBe("1.25");
+      expect(localStorage.setItem).toHaveBeenCalledWith("text_viewer_font_size", 1.25);
+    });
+  });
+
+  it("should render using font size from localStorage", async () => {
+    getItemMock.mockReturnValue("3");
+
+    const {container} = render(<TextViewer {...props} />);
+    const element = container.querySelector(".line-numbers");
+
+    await waitFor(() => {
+      expect(element).toHaveStyle("font-size: 3em");
     });
   });
 

--- a/app/javascript/Components/__tests__/text_viewer.test.jsx
+++ b/app/javascript/Components/__tests__/text_viewer.test.jsx
@@ -21,7 +21,6 @@ describe("TextViewer", () => {
   afterEach(() => {
     jest.clearAllMocks();
     fetchMock.resetMocks();
-    getItemMock.mockReset();
   });
 
   it("should save font size to localStorage when font size change", async () => {
@@ -32,6 +31,16 @@ describe("TextViewer", () => {
 
     await waitFor(() => {
       expect(localStorage.setItem).toHaveBeenCalledWith("text_viewer_font_size", 1.25);
+    });
+  });
+
+  it("should remove local storage text_viewer_font_size when it is not a number", async () => {
+    localStorage.setItem("text_viewer_font_size", "not a number");
+
+    render(<TextViewer {...props} />);
+
+    await waitFor(() => {
+      expect(localStorage.getItem("text_viewer_font_size")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Proposed Changes
When the font size is modified by the user in the grading view for the editor, we want to maintain that size even when the browser is refreshed. To do this we store the font size in the browser's local storage, where we check for and apply it when the browser is refreshed.


...

<details>
<summary>Screenshots of your changes (if applicable)</summary>
This image shows where the editor's font size buttons are located:

<img width="1661" alt="editor font size buttons" src="https://github.com/user-attachments/assets/2f92077e-10a8-48f8-b046-6e8a7e41e60f" />


</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |     x     |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [ ] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
