### PR TITLE
Add tests to #edit and #update when user is trying to change criteria when marks have already been released

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         - id: prettier
           types_or: [javascript, jsx, css, scss, html]
   -   repo: https://github.com/thibaudcolas/pre-commit-stylelint
-      rev: v16.18.0
+      rev: v16.19.1
       hooks:
         - id: stylelint
           additional_dependencies: [
@@ -39,7 +39,7 @@ repos:
               app/assets/stylesheets/common/_reset.scss
             )$
   - repo: https://github.com/rubocop/rubocop
-    rev: v1.75.2
+    rev: v1.75.5
     hooks:
       - id: rubocop
         args: ["--autocorrect"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Remove `activerecord-session_store` gem (#7517)
 - Upgrade to Rails 8 (#7504)
 - Add tests for `#new` and `#create` actions in `CriteriaController` (#7521)
+- Add tests for `#edit` and `#update` when user is trying to change criteria in `CriteriaController` (#7526)
 
 ## [v2.7.0]
 

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -192,6 +192,7 @@ Shion Kashimura
 Simon Lavigne-Giroux
 Sohee Goo
 Stephen Tsimicalis
+Steven Lin
 Su Zhang
 Tanveer Gill
 Tara Clark

--- a/spec/controllers/criteria_controller_spec.rb
+++ b/spec/controllers/criteria_controller_spec.rb
@@ -271,7 +271,6 @@ describe CriteriaController do
         context 'when assignment marks have been released' do
           let!(:released_assignment) do
             create(:assignment, course: course).tap do |assignment|
-              # create one criterion *before* release
               create(:flexible_criterion, assignment: assignment, name: 'Pre-release Criterion')
 
               grouping = create(:grouping,  assignment: assignment)
@@ -468,7 +467,6 @@ describe CriteriaController do
         context 'when assignment marks have been released' do
           let!(:released_assignment) do
             create(:assignment, course: course).tap do |assignment|
-              # create one criterion *before* release
               create(:flexible_criterion, assignment: assignment, name: 'Pre-release Criterion')
 
               grouping = create(:grouping,  assignment: assignment)


### PR DESCRIPTION
## Proposed Changes

The PR adds new test coverage for the #edit and #update methods for CriteriaController. When the user is authenticated and authorised, and tries to edit/update the criteria after marks have not been released, there should be a flash message with an error, and the appropriate response code is returned. This PR adds two tests for these two methods. 
...
<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |     X     |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
