### PR TITLE
feat: add R Markdown HTML preview support (WIP)

### DIFF
--- a/app/javascript/Components/test_run_table.jsx
+++ b/app/javascript/Components/test_run_table.jsx
@@ -387,7 +387,7 @@ class TestGroupFeedbackFileTable extends React.Component {
         Header: I18n.t("activerecord.attributes.submission.feedback_files"),
         accessor: "filename",
         Cell: row => {
-          const { filename, id } = row.original;
+          const {filename, id} = row.original;
           const isHtml = filename.toLowerCase().endsWith(".html");
           const url = Routes.course_feedback_file_path(this.props.course_id, id);
 

--- a/app/javascript/Components/test_run_table.jsx
+++ b/app/javascript/Components/test_run_table.jsx
@@ -386,6 +386,19 @@ class TestGroupFeedbackFileTable extends React.Component {
       {
         Header: I18n.t("activerecord.attributes.submission.feedback_files"),
         accessor: "filename",
+        Cell: row => {
+          const { filename, id } = row.original;
+          const isHtml = filename.toLowerCase().endsWith(".html");
+          const url = Routes.course_feedback_file_path(this.props.course_id, id);
+
+          return isHtml ? (
+            <a href={url} target="_blank" rel="noopener noreferrer">
+              {I18n.t("automated_tests.view_html_preview") || "View HTML Preview"}
+            </a>
+          ) : (
+            filename
+          );
+        },
       },
     ];
 

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -24,7 +24,7 @@ class AutotestRunJob < AutotestJob
           File.write(file_path, file.download_file)
           output_path = file_path.sub_ext('.html')
 
-          script = Rails.root.join('lib', 'tasks', 'render_rmd.sh')
+          script = Rails.root.join('lib/tasks/render_rmd.sh')
           system("bash #{script} #{Shellwords.escape(file_path.to_s)} #{Shellwords.escape(output_path.to_s)}")
 
           if File.exist?(output_path)

--- a/app/jobs/autotest_run_job.rb
+++ b/app/jobs/autotest_run_job.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 # Job to run autotest tests
 class AutotestRunJob < AutotestJob
   def self.show_status(_status)
@@ -11,6 +13,30 @@ class AutotestRunJob < AutotestJob
     assignment = Assignment.find(assignment_id)
 
     group_ids.each_slice(Settings.autotest.max_batch_size) do |group_id_slice|
+      group_id_slice.each do |group_id|
+        grouping = Grouping.find_by(group_id: group_id, assignment: assignment)
+        submission = grouping&.current_submission_used
+        next unless submission
+
+        rmd_files = submission.submission_files.select { |f| f.filename.end_with?('.Rmd') }
+        rmd_files.each do |file|
+          file_path = Rails.root.join('tmp', "#{file.id}.Rmd")
+          File.write(file_path, file.download_file)
+          output_path = file_path.sub_ext('.html')
+
+          script = Rails.root.join('lib', 'tasks', 'render_rmd.sh')
+          system("bash #{script} #{Shellwords.escape(file_path.to_s)} #{Shellwords.escape(output_path.to_s)}")
+
+          if File.exist?(output_path)
+            submission.feedback_files.create!(
+              filename: File.basename(output_path),
+              mime_type: 'text/html',
+              file_content: File.open(output_path)
+            )
+          end
+        end
+      end
+
       run_tests(assignment, host_with_port, group_id_slice, role, collected: collected, batch: test_batch)
     end
     AutotestResultsJob.perform_later

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
     not_enqueued: No job was enqueued
     queued: Queued
     split_pdf_job: Processing page %{progress} out of %{total} for %{exam_name}
-    uncollect_submissions_job: 'Uncollecting assignments ... '
+    uncollect_submissions_job: "Uncollecting assignments ... "
     update_repo_max_file_size_job: "%{progress}/%{total} Student repositories updated with new maximum file size"
     update_repo_required_files_job: "%{progress}/%{total} Student repositories updated with new required files"
     working_message: "%{progress} out of %{total}"
@@ -35,11 +35,13 @@ en:
       conflicts: Conflicts
       empty_file_warning: "%{file_name} is empty"
       external_submit_only: MarkUs is only accepting external submits
-      file_conflicts: 'Your changes have not been made.  The following file conflicts were detected:'
+      file_conflicts: "Your changes have not been made.  The following file conflicts were detected:"
       file_extension_mismatch: The contents of the uploaded file do not match the file extension %{extension}.
       file_too_large: The size of the uploaded file %{file_name} exceeds the maximum of %{max_size} MB.
-      invalid_file_name: 'Invalid file name on submitted file: %{file_name}'
-      invalid_folder_name: 'Invalid folder name on submitted folder: %{folder_name}'
+      invalid_file_name: "Invalid file name on submitted file: %{file_name}"
+      invalid_folder_name: "Invalid folder name on submitted folder: %{folder_name}"
       missing_file: Could not download %{file_name}.  File may be missing.
-      missing_files: 'You still need to submit %{file} required file(s) for this assignment:'
+      missing_files: "You still need to submit %{file} required file(s) for this assignment:"
       no_action_detected: No actions were detected in the last submit.  Nothing was changed.
+  automated_tests:
+    view_html_preview: "View HTML Preview"

--- a/lib/tasks/render_rmd.sh
+++ b/lib/tasks/render_rmd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+input_file="$1"
+output_file="$2"
+
+if [[ ! -f "$input_file" ]]; then
+  echo "Error: input file '$input_file' does not exist" >&2
+  exit 1
+fi
+
+Rscript -e "rmarkdown::render('$input_file', output_file = '$output_file')"


### PR DESCRIPTION
## What this does

This PR begins implementing HTML preview support for .Rmd (R Markdown) files using the existing Autotester infrastructure.

So far, I’ve done the following:

FE: Added a “View HTML Preview” link in the test results table for feedback files ending in .html
BE:  - Updated the AutotestRunJob to both detect .Rmd files submitted by students and write them to disk and call a shell script for rendering
- Created a shell script (render_rmd.sh) that uses Rscript and knitr::render to convert .Rmd to .html.

This work is in response to issue #7424 

## What is left

If I had more time, I would complete the following:

Autotester integration:
Set up the Flask server inside the Autotester container and expose the rendering route properly (e.g., /register, /run, etc.). The current WIP Python service was not fully hooked up.

Test coverage:
Add spec and frontend tests to confirm that .Rmd files are processed and the .html file appears in feedback.

Production readiness:
Ensure this only runs on the Autotester, not on the Rails host

## What I’d need from the team

- Guidance on whether rendering .Rmd inside the Rails job is acceptable, or if it should be moved entirely into the Autotester’s Python service.
- Feedback on whether the test preview link should always be shown, or conditionally based on a flag.
