### PR TITLE
Fixed spacing issue for the remote authentication login button

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 - Fixed group member filtering in assignment summary table (#7644)
+- Fixed spacing issue for the remote authentication login button (#7646)
 
 ### 🔧 Internal changes
 - Updated the assignment summary table to use `@tanstack/react-table` v8 (#7630)

--- a/app/views/main/login.html.erb
+++ b/app/views/main/login.html.erb
@@ -62,10 +62,8 @@
     <% if Settings.remote_auth_login_url %>
       <div class="login-selector">
         <a class="button"
-           href="<%= login_remote_auth_main_index_path %>">
-          <%= t('main.login_with',
-               name: Settings.remote_auth_login_name || t('main.external_authentication_default_name') ) %>
-        </a>
+           href="<%= login_remote_auth_main_index_path %>"><%= t('main.login_with',
+               name: Settings.remote_auth_login_name || t('main.external_authentication_default_name') ) %></a>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

This fixes a UI issue on the login page, where previously the remote authentication button had extra whitespace (due to a CSS rule `white-space: pre-wrap` and HTML formatting in the source code). I preserved the CSS rule but modified the formatting.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

Before:

<img width="904" height="635" alt="image" src="https://github.com/user-attachments/assets/80f9074f-be3a-4eea-be53-a9fdc54ecaa7" />


After:

<img width="828" height="582" alt="image" src="https://github.com/user-attachments/assets/2ab1ccfc-2663-4890-bfc0-1879083f840a" />

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              | X        |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
