### PR TITLE
Add data-testid for the name search input

### DIFF
--- a/app/javascript/Components/__tests__/graders_manager.test.jsx
+++ b/app/javascript/Components/__tests__/graders_manager.test.jsx
@@ -132,7 +132,6 @@ describe("For the GradersManager's name search", () => {
       }),
     });
     render(<GradersManager sections={{}} course_id={1} assignment_id={1} />);
-
     await screen.findByText("Severin Gehwolf");
   });
 
@@ -143,7 +142,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("filters by first name correctly", async () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {target: {value: "Severin"}});
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: "Severin"}});
 
     expect(screen.getByText("Severin Gehwolf")).toBeInTheDocument();
     expect(screen.queryByText("Mark Rada")).not.toBeInTheDocument();
@@ -151,7 +151,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("filters by last name correctly", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {target: {value: "Rada"}});
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: "Rada"}});
 
     expect(screen.getByText("Mark Rada")).toBeInTheDocument();
     expect(screen.queryByText("Severin Gehwolf")).not.toBeInTheDocument();
@@ -159,9 +160,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("filters by full name correctly", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {
-      target: {value: "Nelle Varoquaux"},
-    });
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: "Nelle Varoquaux"}});
 
     expect(screen.getByText("Nelle Varoquaux")).toBeInTheDocument();
     expect(screen.queryByText("Severin Gehwolf")).not.toBeInTheDocument();
@@ -169,7 +169,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("is case insensitive when filtering", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {target: {value: "mark"}});
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: "mark"}});
 
     expect(screen.getByText("Mark Rada")).toBeInTheDocument();
     expect(screen.queryByText("Severin Gehwolf")).not.toBeInTheDocument();
@@ -177,7 +178,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("handles partial matches", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {target: {value: "ver"}});
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: "ver"}});
 
     expect(screen.getByText("Severin Gehwolf")).toBeInTheDocument();
     expect(screen.queryByText("Mark Rada")).not.toBeInTheDocument();
@@ -185,7 +187,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("shows all graders when filter is cleared", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {target: {value: ""}});
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {target: {value: ""}});
 
     expect(screen.getByText("Severin Gehwolf")).toBeInTheDocument();
     expect(screen.getByText("Mark Rada")).toBeInTheDocument();
@@ -193,7 +196,8 @@ describe("For the GradersManager's name search", () => {
   });
 
   it("shows no results when filter matches nothing", () => {
-    fireEvent.change(screen.getByTestId("grader-name-search"), {
+    const nameSearch = screen.getByRole("textbox", {name: `${I18n.t("search")} Name`});
+    fireEvent.change(nameSearch, {
       target: {value: "NonexistentName"},
     });
 

--- a/app/javascript/Components/graders_manager.jsx
+++ b/app/javascript/Components/graders_manager.jsx
@@ -4,7 +4,7 @@ import {Tab, Tabs, TabList, TabPanel} from "react-tabs";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 import {withSelection, CheckboxTable} from "./markus_with_selection_hoc";
-import {selectFilter} from "./Helpers/table_helpers";
+import {selectFilter, textFilter} from "./Helpers/table_helpers";
 import {GraderDistributionModal} from "./Modals/graders_distribution_modal";
 import {SectionDistributionModal} from "./Modals/section_distribution_modal";
 
@@ -495,17 +495,7 @@ class RawGradersTable extends React.Component {
       accessor: "full_name",
       id: "full_name",
       filterable: true,
-      Filter: ({filter, onChange}) => (
-        <input
-          placeholder={I18n.t("table.search")}
-          type="text"
-          onChange={e => onChange(e.target.value)}
-          value={filter ? filter.value : ""}
-          style={{width: "100%"}}
-          aria-label={I18n.t("table.search")}
-          data-testid="grader-name-search"
-        />
-      ),
+      Filter: textFilter,
       Cell: row => `${row.original.first_name} ${row.original.last_name}`,
       filterMethod: (filter, row) => {
         if (filter.value) {


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*
Replaced the hard-coded textbox index (screen.getAllByRole("textbox")[2]) in test cases with a stable data-testid selector to improve test reliability.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |     X     |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [ ] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
I wasn’t fully sure if adding a custom Filter input directly within the RawGradersTable column definition is the best approach, since this table still uses the older React Table (v6) API and doesn’t appear to be using the newer SearchFilter (v8-style) implementation yet.
I added a custom filter input only for the full_name column in order to include the data-testid attribute for testing. However, I’m not certain if this is the most appropriate or maintainable solution, and would appreciate feedback on whether there’s a better pattern for this in the current setup.
