### PR TITLE
TICKET-583: Include due date in LTI gradebook sync

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,9 +16,9 @@
 - Add JS autotester example (#7866)
 - Return structured JSON from grade entry forms API show endpoint with optional student filter and CSV export (#7886)
 - Added term-based suffixes to course names created via LTI to ensure uniqueness across academic years (#7881)
+- Sync due date when creating or updating LTI gradebook line items, and re-sync automatically when an assessment is edited (#7872)
 
 ### 🐛 Bug fixes
-- Sync due date when creating or updating LTI gradebook line items, and re-sync automatically when an assessment is edited (#7756)
 - Prevent "No rows found" message from displaying in tables when data is loading (#7790)
 - Fixed course card link behavior on the dashboard (#7887)
 - Fixed reserved interpolation key `%{format}` in `download_errors.unrecognized_format` locale string, renamed to `%{file_format}` (#7894)

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 - Added term-based suffixes to course names created via LTI to ensure uniqueness across academic years (#7881)
 
 ### 🐛 Bug fixes
+- Sync due date when creating or updating LTI gradebook line items, and re-sync automatically when an assessment is edited (#7756)
 - Prevent "No rows found" message from displaying in tables when data is loading (#7790)
 - Fixed course card link behavior on the dashboard (#7887)
 - Fixed reserved interpolation key `%{format}` in `download_errors.unrecognized_format` locale string, renamed to `%{file_format}` (#7894)

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -190,7 +190,7 @@ module LtiHelper
       resourceId: assessment.short_identifier,
       scoreMaximum: assessment.max_mark.to_f
     }
-    payload[:dueAt] = assessment.due_date.iso8601 if assessment.due_date.present?
+    payload[:endDateTime] = assessment.due_date.iso8601 if assessment.due_date.present?
     auth_data = lti_deployment.lti_client.get_oauth_token([LtiDeployment::LTI_SCOPES[:ags_lineitem]])
     lineitem_service = lti_deployment.lti_services.find_by!(service_type: 'agslineitem')
     lineitem_uri = URI(lineitem_service.url)
@@ -200,7 +200,8 @@ module LtiHelper
     else
       req = Net::HTTP::Post.new(lineitem_uri)
     end
-    req.set_form_data(payload)
+    req.content_type = 'application/vnd.ims.lis.v2.lineitem+json'
+    req.body = payload.to_json
     res = lti_deployment.send_lti_request!(req, lineitem_uri, auth_data, [LtiDeployment::LTI_SCOPES[:ags_lineitem]])
     line_item_data = JSON.parse(res.body)
     line_item.update!(lti_line_item_id: line_item_data['id'])

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -190,6 +190,7 @@ module LtiHelper
       resourceId: assessment.short_identifier,
       scoreMaximum: assessment.max_mark.to_f
     }
+    payload[:dueAt] = assessment.due_date.iso8601 if assessment.due_date.present?
     auth_data = lti_deployment.lti_client.get_oauth_token([LtiDeployment::LTI_SCOPES[:ags_lineitem]])
     lineitem_service = lti_deployment.lti_services.find_by!(service_type: 'agslineitem')
     lineitem_uri = URI(lineitem_service.url)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -50,6 +50,8 @@ class Assessment < ApplicationRecord
 
   has_many :lti_line_items, dependent: :destroy
 
+  after_update_commit :sync_lti_line_items, if: :lti_sync_needed?
+
   # Call custom validator in order to validate the :due_date attribute
   # date: true maps to DateValidator (custom_name: true maps to CustomNameValidator)
   # Look in lib/validators/* for more info
@@ -148,6 +150,18 @@ class Assessment < ApplicationRecord
   # Returns the number of grades equal to 0 for this assessment, using all grades in self.completed_result_marks.
   def results_zeros
     self.completed_result_marks.count(&:zero?)
+  end
+
+  # Re-pushes line item metadata to any LMS that already has this assessment linked,
+  # so changes in MarkUs (notably due_date) propagate without manual re-trigger.
+  def sync_lti_line_items
+    deployment_ids = lti_line_items.distinct.pluck(:lti_deployment_id)
+    LtiLineItemJob.perform_later(deployment_ids, self)
+  end
+
+  def lti_sync_needed?
+    return false unless lti_line_items.exists?
+    saved_change_to_due_date? || saved_change_to_description?
   end
 
   # Returns the standard deviation for this assessment, using all grades in self.completed_result_marks.

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -152,18 +152,6 @@ class Assessment < ApplicationRecord
     self.completed_result_marks.count(&:zero?)
   end
 
-  # Re-pushes line item metadata to any LMS that already has this assessment linked,
-  # so changes in MarkUs (notably due_date) propagate without manual re-trigger.
-  def sync_lti_line_items
-    deployment_ids = lti_line_items.distinct.pluck(:lti_deployment_id)
-    LtiLineItemJob.perform_later(deployment_ids, self)
-  end
-
-  def lti_sync_needed?
-    return false unless lti_line_items.exists?
-    saved_change_to_due_date? || saved_change_to_description?
-  end
-
   # Returns the standard deviation for this assessment, using all grades in self.completed_result_marks.
   def results_standard_deviation
     return 0 if self.max_mark.zero?
@@ -174,5 +162,19 @@ class Assessment < ApplicationRecord
     else
       DescriptiveStatistics.standard_deviation(marks)
     end
+  end
+
+  private
+
+  # Re-pushes line item metadata to any LMS that already has this assessment linked,
+  # so changes in MarkUs (notably due_date) propagate without manual re-trigger.
+  def sync_lti_line_items
+    deployment_ids = lti_line_items.distinct.pluck(:lti_deployment_id)
+    LtiLineItemJob.perform_later(deployment_ids, self)
+  end
+
+  def lti_sync_needed?
+    return false unless lti_line_items.exists?
+    saved_change_to_due_date? || saved_change_to_description?
   end
 end

--- a/spec/helpers/lti_helper_spec.rb
+++ b/spec/helpers/lti_helper_spec.rb
@@ -887,13 +887,40 @@ describe LtiHelper do
       expect(LtiLineItem.count).to eq(1)
     end
 
-    it 'includes dueAt in the request payload' do
+    it 'sends JSON body with correct LTI AGS Content-Type' do
       allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
-        body = URI.decode_www_form(req.body).to_h
-        expect(body).to include('dueAt' => assessment.due_date.iso8601)
+        expect(req.content_type).to eq('application/vnd.ims.lis.v2.lineitem+json')
+        body = JSON.parse(req.body)
+        expect(body).to include(
+          'label' => assessment.description,
+          'resourceId' => assessment.short_identifier,
+          'scoreMaximum' => assessment.max_mark.to_f
+        )
         OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
       end
       subject
+    end
+
+    it 'includes endDateTime in the request payload' do
+      allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
+        body = JSON.parse(req.body)
+        expect(body).to include('endDateTime' => assessment.due_date.iso8601)
+        OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
+      end
+      subject
+    end
+
+    context 'when the assessment has no due date' do
+      let(:assessment) { create(:grade_entry_form, due_date: nil) }
+
+      it 'does not include endDateTime in the payload' do
+        allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
+          body = JSON.parse(req.body)
+          expect(body).not_to have_key('endDateTime')
+          OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
+        end
+        subject
+      end
     end
 
     context 'when a line item already exists' do
@@ -906,6 +933,33 @@ describe LtiHelper do
       it 'does update the line item id' do
         subject
         expect(LtiLineItem.first.lti_line_item_id).to eq('https://test.example.com/lineitems/1')
+      end
+
+      it 'sends a PUT request with JSON body and endDateTime' do
+        allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
+          expect(req).to be_a(Net::HTTP::Put)
+          expect(req.content_type).to eq('application/vnd.ims.lis.v2.lineitem+json')
+          body = JSON.parse(req.body)
+          expect(body).to include('endDateTime' => assessment.due_date.iso8601)
+          OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
+        end
+        subject
+      end
+    end
+
+    context 'when updating a line item without a due date' do
+      let(:assessment) { create(:grade_entry_form, due_date: nil) }
+
+      before { create(:lti_line_item, lti_deployment: lti_deployment, assessment: assessment) }
+
+      it 'sends a PUT request without endDateTime' do
+        allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
+          expect(req).to be_a(Net::HTTP::Put)
+          body = JSON.parse(req.body)
+          expect(body).not_to have_key('endDateTime')
+          OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
+        end
+        subject
       end
     end
   end

--- a/spec/helpers/lti_helper_spec.rb
+++ b/spec/helpers/lti_helper_spec.rb
@@ -887,6 +887,15 @@ describe LtiHelper do
       expect(LtiLineItem.count).to eq(1)
     end
 
+    it 'includes dueAt in the request payload' do
+      allow(lti_deployment).to receive(:send_lti_request!) do |req, *|
+        body = URI.decode_www_form(req.body).to_h
+        expect(body).to include('dueAt' => assessment.due_date.iso8601)
+        OpenStruct.new(body: { id: 'https://test.example.com/lineitems/1' }.to_json)
+      end
+      subject
+    end
+
     context 'when a line item already exists' do
       before { create(:lti_line_item, lti_deployment: lti_deployment, assessment: assessment) }
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -56,4 +56,35 @@ describe Assessment do
       expect(assessment.errors[:visible_until]).to include('must be after visible_on')
     end
   end
+
+  describe 'LTI line item resync on update' do
+    let(:assignment) { create(:assignment) }
+    let(:lti_deployment) { create(:lti_deployment, course: assignment.course) }
+
+    context 'when no LTI line item exists for the assessment' do
+      it 'does not enqueue a sync job on due_date change' do
+        expect(LtiLineItemJob).not_to receive(:perform_later)
+        assignment.update!(due_date: 2.days.from_now)
+      end
+    end
+
+    context 'when an LTI line item exists for the assessment' do
+      before { create(:lti_line_item, lti_deployment: lti_deployment, assessment: assignment) }
+
+      it 'enqueues a sync job when due_date changes' do
+        expect(LtiLineItemJob).to receive(:perform_later).with([lti_deployment.id], assignment)
+        assignment.update!(due_date: 3.days.from_now)
+      end
+
+      it 'enqueues a sync job when description changes' do
+        expect(LtiLineItemJob).to receive(:perform_later).with([lti_deployment.id], assignment)
+        assignment.update!(description: 'updated description')
+      end
+
+      it 'does not enqueue when only an unrelated attribute changes' do
+        expect(LtiLineItemJob).not_to receive(:perform_later)
+        assignment.update!(message: 'unrelated change')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Proposed Changes 🐛 *Bug fix* 

When creating or updating a gradebook item via LTI, MarkUs sends a line item payload to Canvas containing the assignment label, resource ID, and maximum score. The `dueAt` field supported by the LTI Assignment and Grade Services (AGS) specification was missing from this payload, and the due date set in MarkUs remained absent on the corresponding Canvas assignment. The fix adds `dueAt` as an ISO 8601 timestamp to the payload when the assessment has a due date, ensuring it is synced during both line item creation and updates.

<details>
<summary>Screenshots of your changes (if applicable)</summary>
<img width="1376" height="764" alt="Screenshot 2026-04-20 at 9 36 57 PM" src="https://github.com/user-attachments/assets/0cdb8c34-8233-4bc0-9c7d-0c042c37fc89" />

https://github.com/user-attachments/assets/d7dd6e25-e635-448f-9733-ddd13a8c49a5


</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |       X  |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
