### PR TITLE
Add python3.13-dev to Dockerfile for ARM64 wheel builds

### DIFF
--- a/.dockerfiles/Dockerfile
+++ b/.dockerfiles/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends openssh-server \
                                                                                python3.13 \
+                                                                               python3.13-dev \
                                                                                python3.13-venv \
                                                                                equivs \
                                                                                libjemalloc2

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Add an administrator action on the course settings page to refresh autotest schema (#7828)
 - Add JS autotester example (#7866)
 - Return structured JSON from grade entry forms API show endpoint with optional student filter and CSV export (#7886)
+- Update Dockerfile to include the python3.13-dev package which allows building c++ extensions from source (#7912)
 
 ### 🐛 Bug fixes
 - Prevent "No rows found" message from displaying in tables when data is loading (#7790)


### PR DESCRIPTION
## Proposed Changes

The `markus_exam_matcher==0.4.0` depends on `zxing-cpp==2.3.0` (a C++ extension). `zxing-cpp==2.3.0` exclusively publishes wheels for `x86_64` and `i686` Linux. `aarch64` wheels are missing.

Here is what is happening:

- Python packages with C/C++ code (like `zxing-cpp`) ship precompiled wheels for common platforms to reduce user effort.
- `zxing-cpp==2.3.0` publishes wheels for many `linux_x86_64` (Intel Linux) and few `linux_aarch64` (ARM Linux).
- On an Intel Mac, Docker runs `x86_64` Linux containers. pip finds a matching wheel and installs it directly. Zero compilation required.
- On Apple Silicon, Docker runs `aarch64` Linux containers. pip fails to find a matching wheel, and downloads the source tarball to try and compile the C++ extension locally.

Solution:

 - Building a C/C++ Python extension from source requires the Python C API headers (Python.h, pyconfig.h, etc.) and the shared library to link against.
 - The python3.13 package exclusively includes the interpreter runtime, enough to run Python.
 - python3.13-dev provides those headers and libraries. Without it, the C++ compiler is unable to find Python.h and the build fails.
 - With it installed, cmake/gcc can compile `zxing-cpp` from source successfully inside the container.                           

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
