### PR TITLE
render (hidden) label for assignments according to visibility setting (#7785)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 - Fix version mismatch between container client and database server (#7916)
 - Fixed filter Canvas Test Student from roster sync (#7926)
 - Fix: include original total mark in JSON response for remark requests (#7945)
+- Fixed `(hidden)` assignment labeling for assignments with `visible_on` and/or `visible_until` set (#7944)
 
 ### 🔧 Internal changes
 - Fixed flaky test `can bulk assign duplicated TAs to grade entry students` in `/spec/models/grade_entry_student_spec.rb` (#7958)

--- a/app/helpers/assessments_helper.rb
+++ b/app/helpers/assessments_helper.rb
@@ -1,0 +1,7 @@
+module AssessmentsHelper
+  def formatted_assessment_visibility_label(assessment, base_text)
+    return t('assignments.hidden', assignment_text: base_text) if assessment.currently_hidden?
+
+    base_text
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -89,6 +89,14 @@ class Assessment < ApplicationRecord
     self.due_date > Time.current
   end
 
+  def currently_hidden?
+    return true if is_hidden
+    return true if visible_on.present? && Time.current < visible_on
+    return true if visible_until.present? && Time.current > visible_until
+
+    false
+  end
+
   # Returns grade distribution histogram bins of the grades for this assessment, using the grades in
   # self.completed_result_marks.
   def grade_distribution_array(intervals = 20)

--- a/app/views/assignments/_list_manage.html.erb
+++ b/app/views/assignments/_list_manage.html.erb
@@ -20,7 +20,7 @@
         <% assignments.each do |assignment| %>
           <% route = { controller: 'assignments', action: action, id: assignment.id } %>
           <% assignment_text = "#{h(assignment.short_identifier)}: #{h(assignment.description)}" %>
-          <% assignment_text = t('assignments.hidden', assignment_text: assignment_text) if assignment.is_hidden %>
+          <% assignment_text = formatted_assessment_visibility_label(assignment, assignment_text) %>
           <tr>
             <td>
               <%= link_to assignment_text, route %>

--- a/app/views/courses/_dashboard_list.html.erb
+++ b/app/views/courses/_dashboard_list.html.erb
@@ -14,19 +14,12 @@
         <% @assignments.each do |assignment| -%>
           <tr>
             <td>
-              <% if assignment.is_hidden %>
-                <%= link_to truncate(t('assignments.hidden',
-                                       assignment_text:
-                                         "#{h(assignment.short_identifier)}: #{h(assignment.description)}")),
-                            view_summary_course_assignment_path(@current_course, assignment.id),
-                            data: { remote: true, id: assignment.short_identifier },
-                            class: (assignment.id == @current_assignment.id ? "inactive" : "") %>
-              <% else %>
-                <%= link_to assignment.short_identifier + ': ' + assignment.description,
-                            view_summary_course_assignment_path(@current_course, assignment.id),
-                            data: { remote: true, id: assignment.short_identifier },
-                            class: (assignment.id == @current_assignment.id ? "inactive" : "") %>
-              <% end %>
+              <% assignment_text = formatted_assessment_visibility_label(assignment,
+                                                                        "#{h(assignment.short_identifier)}: #{h(assignment.description)}") %>
+              <%= link_to truncate(assignment_text),
+                          view_summary_course_assignment_path(@current_course, assignment.id),
+                          data: { remote: true, id: assignment.short_identifier },
+                          class: (assignment.id == @current_assignment.id ? "inactive" : "") %>
             </td>
 
             <td>

--- a/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
+++ b/app/views/layouts/menus/_instructor_ta_sub_menu_assessments.html.erb
@@ -11,9 +11,7 @@
         <% if assessment.is_a?(Assignment) && assessment.is_peer_review? %>
           <% title = "#{assessment.parent_assignment.short_identifier} #{PeerReview.model_name.human}" %>
         <% end %>
-        <% if assessment.is_hidden %>
-          <% title = t('assignments.hidden', assignment_text: title) %>
-        <% end %>
+        <% title = formatted_assessment_visibility_label(assessment, title) %>
         <%= title %>
       <% end %>
       <ul>

--- a/app/views/shared/_assignment_dropdown_link.html.erb
+++ b/app/views/shared/_assignment_dropdown_link.html.erb
@@ -1,8 +1,6 @@
 <li class="<%= active_id == assignment.id ? 'active' : '' %>">
   <% link_text = assignment.short_identifier %>
-  <% if assignment.is_hidden %>
-    <% link_text = t('assignments.hidden', assignment_text: link_text) %>
-  <% end %>
+  <% link_text = formatted_assessment_visibility_label(assignment, link_text) %>
 
   <%= link_to link_text,
               switch_course_assignment_path(@current_course, assignment.id),

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -177,6 +177,7 @@ Parker Hutcheson
 Partoo Vafaeikia
 Paymahn Moghadasian
 Peter Guanjie Zhao
+Philip Kukulak
 Pranav Rao
 Rafael Padilha
 Raine Yang

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1,5 +1,6 @@
 describe AssignmentsController do
   include AutomatedTestsHelper
+  include ActiveSupport::Testing::TimeHelpers
 
   # TODO: add 'role is from a different course' shared tests to each route test below
 
@@ -407,6 +408,83 @@ describe AssignmentsController do
           expect(response).to have_http_status(:success)
         end
       end
+    end
+  end
+
+  describe '#index rendered visibility labels' do
+    render_views
+
+    let(:role) { create(:instructor) }
+    let(:course) { role.course }
+    let(:current_time) { Time.zone.local(2026, 5, 9, 12, 0, 0) }
+
+    visibility_cases = [
+      { label: 'explicitly hidden', options: -> { { is_hidden: true } }, hidden: true },
+      { label: 'future start', options: -> { { visible_on: 1.day.from_now } }, hidden: true },
+      { label: 'past end', options: -> { { visible_until: 1.day.ago } }, hidden: true },
+      { label: 'window future',
+        options: -> { { visible_on: 1.day.from_now, visible_until: 2.days.from_now } }, hidden: true },
+      { label: 'window expired',
+        options: -> { { visible_on: 2.days.ago, visible_until: 1.day.ago } }, hidden: true },
+      { label: 'plain visible', options: -> { {} }, hidden: false },
+      { label: 'past start', options: -> { { visible_on: 1.day.ago } }, hidden: false },
+      { label: 'future end', options: -> { { visible_until: 1.day.from_now } }, hidden: false },
+      { label: 'window current',
+        options: -> { { visible_on: 1.day.ago, visible_until: 1.day.from_now } }, hidden: false },
+      { label: 'starts now', options: -> { { visible_on: Time.current } }, hidden: false },
+      { label: 'ends now', options: -> { { visible_until: Time.current } }, hidden: false }
+    ]
+
+    before { travel_to current_time }
+
+    visibility_cases.each do |vc|
+      it "renders #{vc[:hidden] ? 'the hidden label' : 'no hidden label'} for #{vc[:label]}" do
+        assignment = create(:assignment, course: course, **vc[:options].call)
+        get_as role, :index, params: { course_id: course.id }
+
+        base_text = "#{assignment.short_identifier}: #{assignment.description}"
+        hidden_text = I18n.t('assignments.hidden', assignment_text: base_text)
+
+        if vc[:hidden]
+          expect(response.body).to include(hidden_text)
+        else
+          expect(response.body).to include(base_text)
+          expect(response.body).not_to include(hidden_text)
+        end
+      end
+    end
+  end
+
+  describe '#edit rendered visibility labels' do
+    render_views
+
+    let(:role) { create(:instructor) }
+    let(:course) { role.course }
+    let(:current_time) { Time.zone.local(2026, 5, 9, 12, 0, 0) }
+    let(:scheduled_target) { create(:assignment, course: course, visible_on: 1.day.from_now) }
+    let(:currently_visible) { create(:assignment, course: course, visible_until: 1.day.from_now) }
+
+    before do
+      travel_to current_time
+      scheduled_target
+      currently_visible
+    end
+
+    it 'renders the hidden label in both the current assignment submenu title and the dropdown list item' do
+      get_as role, :edit, params: { course_id: course.id, id: scheduled_target.id }
+
+      current_title = I18n.t('assignments.hidden', assignment_text: scheduled_target.short_identifier)
+      doc = response.parsed_body
+      dropdown = doc.at_css('li#dropdown > div.dropdown')
+      dropdown_text = dropdown.children.find { |node| node.text? && !node.text.strip.empty? }.text.strip
+      target_path = switch_course_assignment_path(course, scheduled_target.id)
+      visible_path = switch_course_assignment_path(course, currently_visible.id)
+      target_link = dropdown.at_css("ul a[href='#{target_path}'][title='#{scheduled_target.description}']")
+      visible_link = dropdown.at_css("ul a[href='#{visible_path}'][title='#{currently_visible.description}']")
+
+      expect(dropdown_text).to eq(current_title)
+      expect(target_link.text).to eq(current_title)
+      expect(visible_link.text).to eq(currently_visible.short_identifier)
     end
   end
 

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -1,4 +1,6 @@
 describe CoursesController do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:instructor) { create(:instructor) }
   let(:course) { instructor.course }
   let(:student) { create(:student, course: course) }
@@ -353,6 +355,53 @@ describe CoursesController do
           let(:user) { create(:student) }
 
           it_behaves_like 'cannot update course'
+        end
+      end
+    end
+  end
+
+  describe '#show rendered visibility labels' do
+    render_views
+
+    let(:current_time) { Time.zone.local(2026, 5, 9, 12, 0, 0) }
+
+    # short_identifier and description keep text short so (hidden) is never truncated in _dashboard_list
+    visibility_cases = [
+      { label: 'future start',
+        options: -> { { short_identifier: 'A1', description: 'a', visible_on: 1.day.from_now } },
+        hidden: true },
+      { label: 'past end',
+        options: -> { { short_identifier: 'A2', description: 'a', visible_until: 1.day.ago } },
+        hidden: true },
+      { label: 'plain visible',
+        options: -> { { short_identifier: 'A3', description: 'a' } },
+        hidden: false },
+      { label: 'future end',
+        options: -> { { short_identifier: 'A4', description: 'a', visible_until: 1.day.from_now } },
+        hidden: false },
+      { label: 'starts now',
+        options: -> { { short_identifier: 'A5', description: 'a', visible_on: Time.current } },
+        hidden: false },
+      { label: 'ends now',
+        options: -> { { short_identifier: 'A6', description: 'a', visible_until: Time.current } },
+        hidden: false }
+    ]
+
+    before { travel_to current_time }
+
+    visibility_cases.each do |vc|
+      it "renders #{vc[:hidden] ? 'the hidden label' : 'no hidden label'} for #{vc[:label]}" do
+        assignment = create(:assignment, course: course, **vc[:options].call)
+        get_as instructor, :show, params: { id: course }
+
+        base_text = "#{assignment.short_identifier}: #{assignment.description}"
+        hidden_text = I18n.t('assignments.hidden', assignment_text: base_text)
+
+        if vc[:hidden]
+          expect(response.body).to include(hidden_text)
+        else
+          expect(response.body).to include(base_text)
+          expect(response.body).not_to include(hidden_text)
         end
       end
     end


### PR DESCRIPTION

## Proposed Changes
From an instructor/TA view, the visibility of an assignment is not correctly displayed if visible-from and/or visible-until settings are set because the labelling logic only covers the binary "visible or hidden" settings. The proposed changes correctly labels assignments based on whether or not they are visible to students in the dashboard view, the instructor/TA assignment list view, and the instructor/TA assignment list view dropdown menu.


<details>
<summary>Screenshots of your changes (if applicable)</summary>

<img width="796" height="699" alt="Screenshot 2026-05-11 at 11 35 25 AM" src="https://github.com/user-attachments/assets/2769e790-4f2c-4a7b-9024-114d1e75c0f1" />
<img width="798" height="661" alt="Screenshot 2026-05-11 at 11 35 16 AM" src="https://github.com/user-attachments/assets/bb3650fc-1f88-4fef-a11d-7f929e7155ea" />
<img width="796" height="701" alt="Screenshot 2026-05-11 at 11 35 04 AM" src="https://github.com/user-attachments/assets/8f17ee5c-e453-4f41-82c9-d18a9ed7cdf6" />
<img width="804" height="704" alt="Screenshot 2026-05-11 at 11 34 32 AM" src="https://github.com/user-attachments/assets/75dd328d-d351-4f28-b92a-bb0aaaa73603" />



</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |     X     |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |    X     |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [X] I have verified that the pre-commit.ci checks have passed.
- [X] I have verified that the CI tests have passed.
- [X] I have reviewed the test coverage changes reported by Coveralls.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
n/a
