### PR TITLE
Fix: include original total mark in JSON response for remark requests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
 - Fixed reserved interpolation key `%{format}` in `download_errors.unrecognized_format` locale string, renamed to `%{file_format}` (#7894)
 - Fix version mismatch between container client and database server (#7916)
 - Fixed filter Canvas Test Student from roster sync (#7926)
+- Fix: include original total mark in JSON response for remark requests (#7945)
 
 ### 🔧 Internal changes
 - Added seed task to assign TAs to A1 groupings and criteria (#7867)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -239,7 +239,7 @@ class ResultsController < ApplicationController
           data[:assignment_max_mark] = assignment.max_mark
         end
         data[:total] = marks_map.pluck('mark')
-        data[:old_total] = old_marks.values_at(:mark).compact.sum
+        data[:old_total] = original_result&.get_total_mark || 0
 
         # Tags
         all_tags = assignment.tags.pluck_to_hash(:id, :name)

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1401,6 +1401,28 @@ describe ResultsController do
     end
   end
 
+  shared_examples 'show result with old_total' do
+    context 'when format is json' do
+      it 'returns the total mark of the original result in old_total when it exists' do
+        original_result = create(:complete_result, submission: submission)
+        allow_any_instance_of(Submission).to receive(:remark_submitted?).and_return(true)
+        allow_any_instance_of(Submission).to receive(:get_original_result).and_return(original_result)
+        allow(original_result).to receive(:get_total_mark).and_return(85.5)
+
+        get :show, params: { course_id: course.id, id: incomplete_result.id }, format: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['old_total']).to eq(85.5)
+      end
+
+      it 'returns 0 for old_total when no original result exists' do
+        allow_any_instance_of(Submission).to receive(:remark_submitted?).and_return(false)
+        get :show, params: { course_id: course.id, id: incomplete_result.id }, format: :json
+        expect(response.parsed_body['old_total']).to eq(0)
+      end
+    end
+  end
+
   context 'A student' do
     before { sign_in student }
 
@@ -1635,6 +1657,8 @@ describe ResultsController do
 
   context 'An instructor' do
     before { sign_in instructor }
+
+    it_behaves_like 'show result with old_total'
 
     context 'accessing set_released_to_students' do
       before do
@@ -2143,6 +2167,8 @@ describe ResultsController do
 
   context 'A TA' do
     before { sign_in ta }
+
+    it_behaves_like 'show result with old_total'
 
     [:set_released_to_students].each { |route_name| test_unauthorized(route_name) }
 

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1402,6 +1402,10 @@ describe ResultsController do
   end
 
   shared_examples 'show result with old_total' do
+    before do
+      create(:ta_membership, role: ta, grouping: grouping)
+    end
+
     context 'when format is json' do
       it 'returns the total mark of the original result in old_total when it exists' do
         original_result = create(:complete_result, submission: submission)


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

Fixed a bug in `ResultsController#show` where the `old_total` (total marks prior to a remark request) was incorrectly displaying as `0`. 
 
The previous implementation attempted to calculate the total by accessing a `:mark` key on a hash (`old_marks.values_at(:mark)`). However, the `old_marks` hash is indexed by `Criterion ID` rather than a symbolic key, causing the lookup to return `nil` and the subsequent sum to result in `0`.  

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |     x     |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
