### PR TITLE
Reviewed and updated CSP rules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -55,6 +55,7 @@
 - Replaced custom `HTMLElement` class methods with native versions and removed `application.js` (#7951)
 - Moved annotation-related Javascript to be bundled with webpack (#7953)
 - Upgraded `react-jsonschema-form` to v6.5.2 (#7954)
+- Fixed CSP warnings and updated CSP config. Switched webpack development source map to `eval-source-map`. (#7956)
 
 ## [v2.9.6]
 

--- a/app/assets/stylesheets/common/_table.scss
+++ b/app/assets/stylesheets/common/_table.scss
@@ -651,3 +651,7 @@
   padding: 10px 0;
   text-align: center;
 }
+
+.grid-wrapper {
+  justify-content: center;
+}

--- a/app/javascript/Components/Result/image_viewer.jsx
+++ b/app/javascript/Components/Result/image_viewer.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import heic2any from "heic2any";
 import {ImageAnnotationManager} from "../../common/annotations/image_annotation_manager";
 
 export class ImageViewer extends React.PureComponent {
@@ -41,7 +40,9 @@ export class ImageViewer extends React.PureComponent {
       // Returns a promise containing an object URL for a JPEG image converted from the HEIC/HEIF format.
       return fetch(this.props.url)
         .then(res => res.blob())
-        .then(blob => heic2any({blob, toType: "image/jpeg"}))
+        .then(blob =>
+          import("heic2any").then(({default: heic2any}) => heic2any({blob, toType: "image/jpeg"}))
+        )
         .then(conversionResult => URL.createObjectURL(conversionResult))
         .then(JPEGObjectURL => this.setState({url: JPEGObjectURL}));
     } else {

--- a/app/javascript/Components/autotest_manager.jsx
+++ b/app/javascript/Components/autotest_manager.jsx
@@ -11,9 +11,6 @@ import FileUploadModal from "./Modals/file_upload_modal";
 import AutotestSpecsUploadModal from "./Modals/autotest_specs_upload_modal";
 import {flashMessage} from "../common/flash";
 
-const ajvOptionsOverrides = {discriminator: true};
-const validator = customizeValidator({ajvOptionsOverrides});
-
 class AutotestManager extends React.Component {
   constructor(props) {
     super(props);
@@ -493,7 +490,7 @@ class AutotestManager extends React.Component {
             uiSchema={this.state.uiSchema}
             formData={this.state.formData}
             onChange={this.handleFormChange}
-            validator={validator}
+            validator={this.props.validator}
             templates={{
               ErrorListTemplate: AutotestErrorList,
               ButtonTemplates: {
@@ -630,8 +627,9 @@ function MoveUpButton(props) {
 }
 
 export function makeAutotestManager(elem, props) {
+  const validator = customizeValidator({ajvOptionsOverrides: {discriminator: true}});
   const root = createRoot(elem);
   const component = React.createRef();
-  root.render(<AutotestManager {...props} ref={component} />);
+  root.render(<AutotestManager {...props} validator={validator} ref={component} />);
   return component;
 }

--- a/app/views/groups/assign_scans.html.erb
+++ b/app/views/groups/assign_scans.html.erb
@@ -139,7 +139,7 @@
       </form>
 
       <!-- OCR Suggestions Section -->
-      <div id="ocr_suggestions" class="ocr-suggestions-container" style="display: none;">
+      <div id="ocr_suggestions" class="ocr-suggestions-container no-display">
         <!-- Will be populated by JavaScript -->
       </div>
 

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -4,6 +4,9 @@
 <%= action_cable_meta_tag %>
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>
+<!-- The following meta tag is used by the styled-components dependency.
+     See https://styled-components.com/docs/advanced#security -->
+<meta property="csp-nonce" content="<%= content_security_policy_nonce %>">
 <%= stylesheet_link_tag 'application' %>
 <%= stylesheet_link_tag 'application_webpack' %>
 <% if @current_user&.theme == 'dark' %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,23 +6,39 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    # Rails defaults:
-    # policy.default_src :self, :https
-    # policy.font_src    :self, :https, :data
-    # policy.img_src     :self, :https, :data
-    # policy.object_src  :none
-    # policy.script_src  :self, :https
-    # policy.style_src   :self, :https
-
     policy.default_src :self
-    policy.script_src :self, "'strict-dynamic'"
+    policy.font_src :self
     policy.form_action :self
-    # Safari doesn't support worker-src and defaults to child-src, blob is required because of the way Safari
-    # handles dynamically generated images
+
+    # img_src is overridden in specific controller methods. Rails default:
+    # policy.img_src     :self, :https, :data
+
+    policy.object_src :none
+    policy.style_src_elem :self   # <style> elements and <link> stylesheets; nonce added below
+    policy.style_src_attr :unsafe_inline  # style="..." attributes (required by Jcrop, jQuery UI, etc.)
+
+    # child-src is the worker-src fallback for Safari < 16; blob: is required for heic2any's blob Worker
+    # and for blob: image URLs created by URL.createObjectURL on those same pages.
     policy.child_src :self, :blob
-    # required for Safari < 16
-    policy.connect_src :self, :wss
-    unless Rails.env.production?
+    policy.worker_src :self, :blob
+
+    # Notes:
+    # 1. The following dependencies still require script-src 'unsafe-eval' on specific pages;
+    #    these are overridden per action in the relevant controllers:
+    #     - heic2any (results, submissions) - libheif compiled via Emscripten uses new Function()
+    #     - @rjsf/validator-ajv8 (automated_tests#manage) - ajv compiles JSON schemas via new Function()
+    # 2. @rails/ujs dynamically inserts <script> tags when a controller responses with render js: ...
+    #    These require 'strict-dynamic' to execute.
+    if Rails.env.production?
+      policy.script_src :self, "'strict-dynamic'"
+    else
+      # Allow eval for use in Webpack-generated source maps
+      policy.script_src :self, "'strict-dynamic'", :unsafe_eval
+    end
+
+    if Rails.env.production?
+      policy.connect_src :self, :wss
+    else
       # http and ws are required so that webpack-dev-server can serve assets
       policy.connect_src :self, :http, :ws
     end
@@ -34,15 +50,8 @@ Rails.application.configure do
   # Rails default:
   # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-  config.content_security_policy_nonce_directives = %w[script-src style-src]
+  config.content_security_policy_nonce_directives = %w[script-src style-src-elem]
 
   # Report violations without enforcing the policy.
   # config.content_security_policy_report_only = true
 end
-
-# TODO: - at the moment, the following dependencies require unsafe configurations:
-#          heic2any: requires script-src 'unsafe-eval'
-#          bullet: requires style-src 'unsafe-inline'
-#          react-jsonschema-form: required script-src 'unsafe-eval'
-#       - These are set as needed in controllers. Eventually we should update
-#         all code and dependencies so that these unsafe configs are not needed

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -3,7 +3,7 @@ const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
   mode: "development",
-  devtool: "inline-source-map",
+  devtool: "eval-source-map",
   watch: true,
   watchOptions: {
     ignored: /node_modules/,


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

This pull request makes a few modifications to the codebase to improve our use of Content Security Policies (CSP).

### Fixed violations

There were two existing violations of the `script-src` policy, in which a Javascript eval was used.

- `heic2any` was creating workers on module load (see https://github.com/alexcorvi/heic2any/blob/master/build/build.ts#L29), which triggered on every page. I modified this to import `heic2any` lazily when it is required, on the pages which already have a CSP exception built in (e.g., `ResultsController#edit`).
- `ajv` was creating a validator at the module top-level, which triggered on every page load. I modified this to only create the validator when the `AutotestManager` component is used.
- Our table loading spinner was using `styled-components`, which needed [a nonce to be set](https://styled-components.com/docs/advanced#security). I added the nonce as a `<meta>` tag in the `_head.html.erb` layout. 
    - This had the effect of causing the spinner to animate correctly in Firefox; I also added a `justify-content` rule to ensure that the spinner was centered in the table.
- In `app/views/groups/assign_scans.html.erb`, inline style was used. I replaced this with a class.
- However, other libraries also use inline styles. I enabled `policy.style_src_attr :unsafe_inline`, allowing for inline `style` attributes to be added to HTML elements.

### Webpack source maps

We currently use Webpack's [`inline-source-map`](https://webpack.js.org/configuration/devtool/) format for generating source maps in development. This was causing issues loading the source maps on Firefox. I changed this to `eval-source-map`, which avoids the loading issue and is faster to rebuild when changes are made. This required adding `policy.script_src :unsafe_eval` to the development environment.

### Other changes

In `config/initializers/content_security_policy.rb` I added the rules `policy.font_src :self` and `policy.object_src :none` (Rails defaults), and `policy.worker_src :self, :blob` (rather than rely on the `child-src` fallback).

I also updated the comments to remove the reference to Bullet (as we are not using Bullet to inject HTML) and provide an explanation for the use of `policy.script_src "'strict-dynamic'"` due to `@rails/ujs`.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          | X        |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         | X        |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
