### PR TITLE
test: refactored sign_in method in authentication_helper.rb to set set session variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@
 - Fixed `(hidden)` assignment labeling for assignments with `visible_on` and/or `visible_until` set (#7944)
 
 ### 🔧 Internal changes
+- Refactored `AuthenticationHelper#sign_in` to set session values directly instead of going through `MainController#login` (#7962)
 - Fixed flaky test `can bulk assign duplicated TAs to grade entry students` in `/spec/models/grade_entry_student_spec.rb` (#7958)
 - Added tests for `GroupsController` to fully cover `global_actions` (#7955)
 - Added tests for `graders_controller` to fully cover `grader_criteria_mapping` function (#7949)

--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 
 ### 🔧 Internal changes
 - Refactored `AuthenticationHelper#sign_in` to set session values directly instead of going through `MainController#login` (#7962)
+- Updated `MainController` specs to dispatch `post :login` directly in tests that assert on login's response, instead of relying on `sign_in`'s internal request (#7962)
 - Fixed flaky test `can bulk assign duplicated TAs to grade entry students` in `/spec/models/grade_entry_student_spec.rb` (#7958)
 - Added tests for `GroupsController` to fully cover `global_actions` (#7955)
 - Added tests for `graders_controller` to fully cover `grader_criteria_mapping` function (#7949)

--- a/spec/controllers/main_controller_spec.rb
+++ b/spec/controllers/main_controller_spec.rb
@@ -152,14 +152,15 @@ describe MainController do
 
     context 'logging in during an LTI launch' do
       let(:lti) { create(:lti_deployment) }
+      let(:lti_redirect_url) { redirect_login_canvas_path }
 
       before do
-        cookies.encrypted.permanent[:lti_data] = JSON.generate({ lti_redirect: redirect_login_canvas_path })
+        cookies.encrypted.permanent[:lti_data] = JSON.generate({ lti_redirect: lti_redirect_url })
       end
 
       it 'redirects to redirect_login' do
-        sign_in instructor
-        expect(response).to redirect_to action: 'redirect_login', controller: 'canvas'
+        post :login, params: { user_login: instructor.user_name, user_password: 'a' }
+        expect(response).to redirect_to lti_redirect_url
       end
 
       context 'when logged in during lti launch' do
@@ -207,7 +208,7 @@ describe MainController do
 
     context 'after logging in without remote user auth' do
       before do
-        sign_in student
+        post :login, params: { user_login: student.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'student tests'
@@ -217,7 +218,7 @@ describe MainController do
       before do
         env_hash = { HTTP_X_FORWARDED_USER: student.user_name }
         request.headers.merge! env_hash
-        sign_in student
+        post :login, params: { user_login: student.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'student tests'
@@ -233,7 +234,7 @@ describe MainController do
 
     context 'after logging in without remote user auth' do
       before do
-        sign_in ta
+        post :login, params: { user_login: ta.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'ta tests'
@@ -243,7 +244,7 @@ describe MainController do
       before do
         env_hash = { HTTP_X_FORWARDED_USER: ta.user_name }
         request.headers.merge! env_hash
-        sign_in ta
+        post :login, params: { user_login: ta.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'ta tests'
@@ -259,7 +260,7 @@ describe MainController do
 
     context 'after logging in without remote user auth' do
       before do
-        sign_in admin_user
+        post :login, params: { user_login: admin_user.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'admin tests'
@@ -269,7 +270,7 @@ describe MainController do
       before do
         env_hash = { HTTP_X_FORWARDED_USER: admin_user.user_name }
         request.headers.merge! env_hash
-        sign_in admin_user
+        post :login, params: { user_login: admin_user.user_name, user_password: 'a' }
       end
 
       it_behaves_like 'admin tests'

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,9 +1,9 @@
 module AuthenticationHelper
   def sign_in(user)
-    real_controller = @controller
-    @controller = MainController.new
-    post :login, params: { user_login: user.user_name, user_password: 'x' }
-    @controller = real_controller
+    session[:auth_type] = 'local'
+    session[:real_user_name] = user.user_name
+    session[:timeout] = Settings.session_timeout.seconds.from_now.to_s
+    session[:has_warned] = false
   end
 
   def get_as(user, action, params: {}, format: nil, session: {})


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

Refactored `AuthenticationHelper#sign_in` (in `spec/support/authentication_helper.rb`) to set the relevant session values directly instead of dispatching a real `POST /login` request to `MainController#login`.

**Motivation:** `sign_in` is a test helper whose responsibility is to *simulate* an authenticated session so that other controller tests can exercise their own controller's behavior. It is not responsible for verifying that `MainController#login` works — `MainController` has its own spec for that. Routing every test login through the real `login` action conflated those two responsibilities and, as a side effect, made every call to `sign_in` invoke `User.authenticate`, which spawns a subprocess to run the configured `validate_file` script. Because `sign_in` is called once per `get_as` / `post_as` / `put_as` / `patch_as` / `delete_as`, this added per-test overhead to a large portion of the controller suite.

The new `sign_in` writes the four session keys that `MainController#login` would have written on a successful local login:
- `session[:auth_type] = 'local'`
- `session[:real_user_name] = user.user_name`
- `session[:timeout] = Settings.session_timeout.seconds.from_now.to_s`
- `session[:has_warned] = false`

Subsequent requests in the same example still pass `SessionHandler#authenticate`'s `before_action` checks because `logged_in?` and `session_expired?` only read from these session keys.

Also updated `main_controller_spec.rb`: 7 tests were asserting on the redirect produced by `sign_in`'s internal `post :login`, which is exactly the conflation this refactor exposes. They now call `post :login` directly. One test (LTI launch) additionally needed its cookie value memoized via `let` to avoid a pre-existing locale-asymmetry bug surfaced by the change.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |     X     |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
