### PR TITLE
Implement GET and PATCH /overall_comment API routes, closes #7708

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 - Added term-based suffixes to course names created via LTI to ensure uniqueness across academic years (#7881)
 - Added `db:populate_course_dates` rake task to backfill `start_at`/`end_at` for existing courses, and permit those fields when creating courses through the admin UI (#7925)
 - Sync due date when creating or updating LTI gradebook line items, and re-sync automatically when an assessment is edited (#7872)
+- Added GET and PATCH /overall_comment API routes (#7963)
 
 ### 🐛 Bug fixes
 - Prevent "No rows found" message from displaying in tables when data is loading (#7790)

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -466,6 +466,34 @@ module Api
       end
     end
 
+    def overall_comment
+      result = grouping&.current_result
+      return page_not_found('No submission exists for that group') if result.nil?
+
+      case request.method
+      when 'GET'
+        respond_to do |format|
+          format.xml do
+            render xml: { overall_comment: result.overall_comment }.to_xml(root: 'result', skip_types: 'true')
+          end
+          format.json { render json: { overall_comment: result.overall_comment } }
+        end
+      when 'PATCH'
+        if has_missing_params?([:overall_comment])
+          render 'shared/http_status', locals: { code: '422', message:
+              HttpStatusHelper::ERROR_CODE['message']['422'] }, status: :unprocessable_content
+          return
+        end
+        if result.update(overall_comment: params[:overall_comment])
+          head :ok
+        else
+          render 'shared/http_status',
+                 locals: { code: '422', message: result.errors.full_messages.first },
+                 status: :unprocessable_content
+        end
+      end
+    end
+
     private
 
     def assignment

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -444,11 +444,17 @@ class Result < ApplicationRecord
 
   private
 
-  # Do not allow the marking state to be changed to incomplete if the result is released
+  # Do not allow certain fields to be changed when the result is released
   def check_for_released
-    if released_to_students && marking_state_changed?(to: Result::MARKING_STATES[:incomplete])
-      errors.add(:base, :marks_released)
-      throw(:abort)
+    if released_to_students
+      if marking_state_changed?(to: Result::MARKING_STATES[:incomplete])
+        errors.add(:base, :marks_released)
+        throw(:abort)
+      end
+      if overall_comment_changed?
+        errors.add(:overall_comment, :marks_released)
+        throw(:abort)
+      end
     end
     true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@
 #                                                                   PATCH    /api/courses/:course_id/assignments/:assignment_id/groups/:group_id/feedback_files/:id(.:format)              api/feedback_files#update
 #                                                                   PUT      /api/courses/:course_id/assignments/:assignment_id/groups/:group_id/feedback_files/:id(.:format)              api/feedback_files#update
 #                                                                   DELETE   /api/courses/:course_id/assignments/:assignment_id/groups/:group_id/feedback_files/:id(.:format)              api/feedback_files#destroy
+#                       overall_comment_api_course_assignment_group GET      /api/courses/:course_id/assignments/:assignment_id/groups/:id/overall_comment(.:format)                       api/groups#overall_comment
+#                                                                   PATCH    /api/courses/:course_id/assignments/:assignment_id/groups/:id/overall_comment(.:format)                       api/groups#overall_comment
 #                           annotations_api_course_assignment_group GET      /api/courses/:course_id/assignments/:assignment_id/groups/:id/annotations(.:format)                           api/groups#annotations
 #                       add_annotations_api_course_assignment_group POST     /api/courses/:course_id/assignments/:assignment_id/groups/:id/add_annotations(.:format)                       api/groups#add_annotations
 #                           add_members_api_course_assignment_group POST     /api/courses/:course_id/assignments/:assignment_id/groups/:id/add_members(.:format)                           api/groups#add_members
@@ -619,6 +621,10 @@ Rails.application.routes.draw do
             post 'extension'
             patch 'extension'
             delete 'extension'
+          end
+          member do
+            get 'overall_comment'
+            patch 'overall_comment'
           end
         end
         resources :starter_file_groups, only: [:index, :create]

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -52,6 +52,16 @@ describe Api::GroupsController do
            params: { assignment_id: assignment.id, course_id: course.id, id: group.id, extension: extension_params }
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'should fail to authenticate a GET overall_comment request' do
+      get :overall_comment, params: { assignment_id: assignment.id, id: group.id, course_id: course.id }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'should fail to authenticate a PATCH overall_comment request' do
+      patch :overall_comment, params: { assignment_id: assignment.id, id: group.id, course_id: course.id }
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 
   context 'An authenticated request requesting' do
@@ -1457,6 +1467,112 @@ describe Api::GroupsController do
           expect(test_results.length).to eq(1)
           expect(test_results.first['test_result_name']).to eq('New Test')
           expect(test_results.first['marks_earned']).to eq(4.0)
+        end
+      end
+    end
+
+    context 'Overall Comment' do
+      let!(:grouping) { create(:grouping, group: group, assignment: assignment) }
+
+      before { request.env['HTTP_ACCEPT'] = 'application/json' }
+
+      context 'when no submission/result exists' do
+        it 'GET returns 404' do
+          get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'PATCH returns 404' do
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                            id: group.id, overall_comment: 'hello' }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context 'when a result exists' do
+        let(:submission) { create(:version_used_submission, grouping: grouping) }
+
+        before { submission }
+
+        context 'expecting a json response' do
+          it 'GET returns 200 with the overall_comment' do
+            grouping.current_result.update!(overall_comment: 'existing comment')
+            get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['overall_comment']).to eq('existing comment')
+          end
+
+          it 'GET returns 200 with null overall_comment when none set' do
+            get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['overall_comment']).to be_nil
+          end
+
+          it_behaves_like 'for a different course' do
+            before do
+              get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            end
+          end
+        end
+
+        context 'expecting an xml response' do
+          before { request.env['HTTP_ACCEPT'] = 'application/xml' }
+
+          it 'GET returns 200' do
+            get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'GET returns overall_comment nested under a result root element' do
+            grouping.current_result.update!(overall_comment: 'xml comment')
+            get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            parsed = Hash.from_xml(response.body)
+            expect(parsed.dig('result', 'overall_comment')).to eq('xml comment')
+          end
+
+          it 'GET returns null overall_comment as empty element when none set' do
+            get :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+            parsed = Hash.from_xml(response.body)
+            expect(parsed.dig('result', 'overall_comment')).to be_nil
+          end
+        end
+
+        it 'PATCH updates overall_comment and returns 200' do
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                            id: group.id, overall_comment: 'new comment' }
+          expect(response).to have_http_status(:ok)
+          expect(grouping.current_result.reload.overall_comment).to eq('new comment')
+        end
+
+        it 'PATCH returns 422 when result is released' do
+          grouping.current_result.update!(released_to_students: true)
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                            id: group.id, overall_comment: 'blocked' }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'PATCH returns 422 when overall_comment param is missing' do
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id, id: group.id }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'PATCH returns 422 when overall_comment param is nil' do
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                            id: group.id, overall_comment: nil }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'PATCH returns 422 when overall_comment param is empty string' do
+          patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                            id: group.id, overall_comment: '' }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it_behaves_like 'for a different course' do
+          before do
+            patch :overall_comment, params: { course_id: course.id, assignment_id: assignment.id,
+                                              id: group.id, overall_comment: 'hello' }
+          end
         end
       end
     end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -67,6 +67,26 @@ describe Result do
         end
       end
     end
+
+    context 'check_for_released' do
+      before { result.update!(released_to_students: true) }
+
+      it 'does not allow marking_state to be changed to incomplete' do
+        result.marking_state = Result::MARKING_STATES[:incomplete]
+        expect(result.save).to be false
+        expect(result.errors[:base]).to be_present
+      end
+
+      it 'does not allow overall_comment to be changed' do
+        result.overall_comment = 'new comment'
+        expect(result.save).to be false
+        expect(result.errors[:overall_comment]).to be_present
+      end
+
+      it 'allows other fields to be updated' do
+        expect { result.regenerate_view_token }.not_to raise_error
+      end
+    end
   end
 
   shared_context 'get subtotal context' do


### PR DESCRIPTION
## Proposed Changes
Implements `GET` and `PATCH` `/overall_comment`, allowing for API retrieval and updating of the `overall_comment` field in the `results` table. Closes #7708.

  - `GET` `/api/courses/:course_id/assignments/:assignment_id/groups/:id/overall_comment` — returns the current overall comment for a group's result
  - `PATCH` `/api/courses/:course_id/assignments/:assignment_id/groups/:id/overall_comment` — sets or clears the overall comment

  Both endpoints return JSON or XML depending on the Accept header, consistent with the rest of the API.


<details>
<summary>Screenshots of your changes (if applicable)</summary>
n/a
</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>
https://github.com/MarkUsProject/Wiki/pull/263
</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |     x     |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Detailed description of smoke tests:

# Smoke Test: `GET/PATCH .../groups/:id/overall_comment`

## Setup

### Prerequisites

- Dev server running: `docker compose up -d rails`
- App is mounted under a course prefix — all API routes live at `http://localhost:3000/csc108/api/...`
- An instructor API key for course 1. Reset it if needed:

```bash
docker compose run --rm rails bundle exec rails runner "
u = Instructor.where(course_id: 1).first.user
u.reset_api_key
puts u.api_key
"
```

- A group with a submission (group_id=1, used below)

### Variables used in all commands below

```bash
KEY="<instructor api key>"
URL="http://localhost:3000/csc108/api/courses/1/assignments/1/groups/1/overall_comment"
```

Reset to a known state before running:

```bash
curl -s -X PATCH -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  -d "overall_comment=baseline" "$URL"
```

---

## Test Cases

### Auth

```bash
# No auth header → 403
curl -s -o /dev/null -w "%{http_code}" -H "Accept: application/json" "$URL"

# Garbage token → 403
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth BADTOKEN" -H "Accept: application/json" "$URL"

# Wrong scheme (Bearer) → 403
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $KEY" -H "Accept: application/json" "$URL"
```

### Format

```bash
# No Accept header → 200 (defaults to XML)
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" "$URL"

# JSON Accept → 200
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"

# XML Accept → 200
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/xml" "$URL"

# Unsupported Accept (text/html) → 406
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: text/html" "$URL"

# JSON body shape contains 'overall_comment' key
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: {"overall_comment":"..."}

# XML body shape contains <result><overall-comment> structure
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/xml" "$URL"
# Expected: <result><overall-comment>...</overall-comment></result>
```

### Routing

```bash
# Non-existent course_id → 404
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  "http://localhost:3000/csc108/api/courses/9999/assignments/1/groups/1/overall_comment"

# Non-existent assignment_id → 404
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  "http://localhost:3000/csc108/api/courses/1/assignments/9999/groups/1/overall_comment"

# Non-existent group_id → 404
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  "http://localhost:3000/csc108/api/courses/1/assignments/1/groups/9999/overall_comment"
```

### GET

```bash
# Returns current value
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: {"overall_comment":"baseline"}
```

### PATCH

```bash
# Plain string — set and verify
curl -s -o /dev/null -w "%{http_code}" -X PATCH \
  -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  -d "overall_comment=hello" "$URL"
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: 200, {"overall_comment":"hello"}

# Empty string — clears to ""
curl -s -o /dev/null -w "%{http_code}" -X PATCH \
  -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  -d "overall_comment=" "$URL"
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: 200, {"overall_comment":""}

# No body param — clears to null
curl -s -o /dev/null -w "%{http_code}" -X PATCH \
  -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: 200, {"overall_comment":null}

# PATCH twice — second write wins
curl -s -o /dev/null -w "%{http_code}" -X PATCH \
  -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  -d "overall_comment=first" "$URL"
curl -s -o /dev/null -w "%{http_code}" -X PATCH \
  -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" \
  -d "overall_comment=final" "$URL"
curl -s -H "Authorization: MarkUsAuth $KEY" -H "Accept: application/json" "$URL"
# Expected: 200, {"overall_comment":"final"}
```

---

## Results (2026-05-22)

| # | Category | Test | Expected | Result |
|---|----------|------|----------|--------|
| 1 | Auth | No auth header | 403 | ✅ 403 |
| 2 | Auth | Garbage token | 403 | ✅ 403 |
| 3 | Auth | Wrong scheme (Bearer) | 403 | ✅ 403 |
| 4 | Format | No Accept header | 200 XML | ✅ 200 |
| 5 | Format | JSON Accept | 200 JSON | ✅ 200 |
| 6 | Format | XML Accept | 200 XML | ✅ 200 |
| 7 | Format | Unsupported Accept | 406 | ✅ 406 |
| 8 | Format | JSON body shape | `{"overall_comment":...}` | ✅ |
| 9 | Format | XML body shape | `<result><overall-comment>` | ✅ |
| 10 | Routing | Bad course_id | 404 | ✅ 404 |
| 11 | Routing | Bad assignment_id | 404 | ✅ 404 |
| 12 | Routing | Bad group_id | 404 | ✅ 404 |
| 13 | GET | Returns current value | 200 + value | ✅ |
| 14 | PATCH | Plain string | 200 + persisted | ✅ |
| 15 | PATCH | Empty string | 200 + `""` | ✅ |
| 16 | PATCH | No body param → null | 200 + `null` | ✅ |
| 17 | PATCH | Second write wins | 200 + final value | ✅ |
