### PR TITLE
Fix navigation warnings on autotest manager and starter file manager pages, closes 7641

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -45,6 +45,7 @@
 - Fixed filter Canvas Test Student from roster sync (#7926)
 - Fix: include original total mark in JSON response for remark requests (#7945)
 - Fixed `(hidden)` assignment labeling for assignments with `visible_on` and/or `visible_until` set (#7944)
+- Fixed spurious navigation warnings on autotest manager and starter file manager pages (#7968)
 
 ### 🔧 Internal changes
 - Fixed flaky test `can bulk assign duplicated TAs to grade entry students` in `/spec/models/grade_entry_student_spec.rb` (#7958)

--- a/app/javascript/Components/__tests__/autotest_manager.test.jsx
+++ b/app/javascript/Components/__tests__/autotest_manager.test.jsx
@@ -1,0 +1,114 @@
+import React from "react";
+import {render, screen, fireEvent, act} from "@testing-library/react";
+import {AutotestManager} from "../autotest_manager";
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => null,
+}));
+
+let mockFormOnChange;
+jest.mock("@rjsf/core", () => {
+  const React = require("react");
+  const MockForm = React.forwardRef((props, ref) => {
+    mockFormOnChange = props.onChange;
+    React.useImperativeHandle(ref, () => ({validateForm: () => true}));
+    return <form>{props.children}</form>;
+  });
+  MockForm.displayName = "MockForm";
+  return {__esModule: true, default: MockForm};
+});
+
+jest.mock("@rjsf/utils", () => ({TranslatableString: {}}));
+jest.mock("@rjsf/validator-ajv8", () => ({customizeValidator: () => ({})}));
+
+jest.mock("react-flatpickr", () => {
+  const React = require("react");
+  const MockFlatpickr = ({id, value}) => <input id={id} type="text" readOnly value={value || ""} />;
+  MockFlatpickr.displayName = "MockFlatpickr";
+  return {__esModule: true, default: MockFlatpickr};
+});
+
+jest.mock("flatpickr/dist/plugins/labelPlugin/labelPlugin", () => () => ({}));
+
+jest.mock("../markus_file_manager", () => ({__esModule: true, default: () => null}));
+jest.mock("../Modals/file_upload_modal", () => ({__esModule: true, default: () => null}));
+jest.mock("../Modals/autotest_specs_upload_modal", () => ({__esModule: true, default: () => null}));
+jest.mock("../../common/flash", () => ({flashMessage: jest.fn()}));
+
+const fetchPayload = {
+  files: [],
+  schema: {},
+  formData: {},
+  enable_test: true,
+  enable_student_tests: true,
+  token_start_date: "",
+  token_end_date: "",
+  tokens_per_period: 0,
+  token_period: 0,
+  non_regenerating_tokens: false,
+  unlimited_tokens: false,
+};
+
+function renderManager() {
+  return render(<AutotestManager course_id={1} assignment_id={1} validator={{}} />);
+}
+
+describe("AutotestManager navigation warning", () => {
+  beforeEach(() => {
+    fetch.mockReset();
+    fetch.mockResolvedValue({ok: true, json: jest.fn().mockResolvedValue(fetchPayload)});
+  });
+
+  afterEach(() => {
+    window.onbeforeunload = null;
+  });
+
+  it("does not warn when no changes have been made", () => {
+    renderManager();
+    expect(window.onbeforeunload()).toBeUndefined();
+  });
+
+  it("warns after a field is changed", () => {
+    renderManager();
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    expect(window.onbeforeunload()).toBe(I18n.t("uncommitted_changes_warning"));
+  });
+
+  it("clears the warning after form is saved", async () => {
+    renderManager();
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    expect(window.onbeforeunload()).toBe(I18n.t("uncommitted_changes_warning"));
+
+    fetch.mockResolvedValueOnce({ok: true, json: jest.fn().mockResolvedValue({job_id: "1"})});
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", {name: I18n.t("save")}));
+    });
+    expect(window.onbeforeunload()).toBeUndefined();
+  });
+
+  it("does not mark dirty when rjsf fires onChange before fetch resolves", () => {
+    renderManager();
+    // formData is null until fetch resolves, so onChange is suppressed
+    act(() => {
+      mockFormOnChange({formData: {}});
+    });
+    expect(window.onbeforeunload()).toBeUndefined();
+  });
+
+  it("marks dirty when rjsf fires onChange after fetch resolves", async () => {
+    renderManager();
+    await act(async () => {}); // flush fetch promise, formData is now non-null
+
+    act(() => {
+      mockFormOnChange({formData: {testers: []}});
+    });
+    expect(window.onbeforeunload()).toBe(I18n.t("uncommitted_changes_warning"));
+  });
+
+  it("restores window.onbeforeunload to null on unmount", () => {
+    const {unmount} = renderManager();
+    expect(window.onbeforeunload).not.toBeNull();
+    unmount();
+    expect(window.onbeforeunload).toBeNull();
+  });
+});

--- a/app/javascript/Components/__tests__/starter_file_manager.test.jsx
+++ b/app/javascript/Components/__tests__/starter_file_manager.test.jsx
@@ -1,5 +1,5 @@
 import {StarterFileManager} from "../starter_file_manager";
-import {render, screen} from "@testing-library/react";
+import {render, screen, fireEvent, act} from "@testing-library/react";
 
 import React from "react";
 
@@ -127,5 +127,62 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
         expect(saveButton).not.toBeDisabled();
       }
     });
+  });
+});
+
+const minimalFetchPayload = {
+  files: [],
+  sections: {},
+  available_after_due: true,
+  starterfileType: "simple",
+  defaultStarterFileGroup: "",
+};
+
+function renderManager() {
+  return render(<StarterFileManager course_id={1} assignment_id={1} read_only={false} />);
+}
+
+describe("StarterFileManager navigation warning", () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.mockResponseOnce(JSON.stringify(minimalFetchPayload));
+  });
+
+  afterEach(() => {
+    window.onbeforeunload = null;
+  });
+
+  it("does not warn when no changes have been made", () => {
+    renderManager();
+    expect(window.onbeforeunload()).toBeUndefined();
+  });
+
+  it("warns after a field is changed", async () => {
+    renderManager();
+    await screen.findByTestId("available_after_due_checkbox");
+    fireEvent.click(screen.getByTestId("available_after_due_checkbox"));
+    expect(window.onbeforeunload()).toBe(I18n.t("uncommitted_changes_warning"));
+  });
+
+  it("clears the warning after form is saved", async () => {
+    renderManager();
+    await screen.findByTestId("available_after_due_checkbox");
+    fireEvent.click(screen.getByTestId("available_after_due_checkbox"));
+    expect(window.onbeforeunload()).toBe(I18n.t("uncommitted_changes_warning"));
+
+    jest.spyOn($, "ajax").mockResolvedValue({});
+    fetch.resetMocks();
+    fetch.mockResponseOnce(JSON.stringify(minimalFetchPayload));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("save_button"));
+    });
+    expect(window.onbeforeunload()).toBeUndefined();
+  });
+
+  it("restores window.onbeforeunload to null on unmount", () => {
+    const {unmount} = renderManager();
+    expect(window.onbeforeunload).not.toBeNull();
+    unmount();
+    expect(window.onbeforeunload).toBeNull();
   });
 });

--- a/app/javascript/Components/autotest_manager.jsx
+++ b/app/javascript/Components/autotest_manager.jsx
@@ -77,7 +77,7 @@ class AutotestManager extends React.Component {
           },
         },
       },
-      formData: {},
+      formData: null,
       enable_test: true,
       enable_student_tests: true,
       token_start_date: "",
@@ -98,6 +98,16 @@ class AutotestManager extends React.Component {
 
   componentDidMount() {
     this.fetchData();
+    // takes over from _navigation_warning.js.erb to use React state as the source of truth
+    window.onbeforeunload = () => {
+      if (this.state.form_changed) {
+        return I18n.t("uncommitted_changes_warning");
+      }
+    };
+  }
+
+  componentWillUnmount() {
+    window.onbeforeunload = null;
   }
 
   fetchData = () => {
@@ -205,7 +215,10 @@ class AutotestManager extends React.Component {
   };
 
   handleFormChange = data => {
-    this.setState({formData: data.formData}, () => this.toggleFormChanged(true));
+    this.setState({formData: data.formData});
+    if (this.state.formData !== null) {
+      this.toggleFormChanged(true);
+    }
   };
 
   toggleEnableTest = () => {
@@ -488,7 +501,7 @@ class AutotestManager extends React.Component {
             disabled={!this.state.enable_test}
             schema={this.state.schema}
             uiSchema={this.state.uiSchema}
-            formData={this.state.formData}
+            formData={this.state.formData ?? {}}
             onChange={this.handleFormChange}
             validator={this.props.validator}
             templates={{
@@ -625,6 +638,8 @@ function MoveUpButton(props) {
     </button>
   );
 }
+
+export {AutotestManager};
 
 export function makeAutotestManager(elem, props) {
   const validator = customizeValidator({ajvOptionsOverrides: {discriminator: true}});

--- a/app/javascript/Components/starter_file_manager.jsx
+++ b/app/javascript/Components/starter_file_manager.jsx
@@ -31,6 +31,16 @@ class StarterFileManager extends React.Component {
 
   componentDidMount() {
     this.fetchData();
+    // takes over from _navigation_warning.js.erb to use React state as the source of truth
+    window.onbeforeunload = () => {
+      if (this.state.form_changed) {
+        return I18n.t("uncommitted_changes_warning");
+      }
+    };
+  }
+
+  componentWillUnmount() {
+    window.onbeforeunload = null;
   }
 
   toggleFormChanged = value => {

--- a/app/views/assignments/starter_file.html.erb
+++ b/app/views/assignments/starter_file.html.erb
@@ -11,10 +11,6 @@
       );
     });
   <% end %>
-
-  <%= render partial: 'shared/navigation_warning',
-             formats: [:js],
-             handlers: [:erb] %>
 <% end %>
 
 <div id='starter_file_manager'></div>

--- a/app/views/automated_tests/_form.html.erb
+++ b/app/views/automated_tests/_form.html.erb
@@ -5,9 +5,6 @@
         { course_id: <%= @current_course.id %>, assignment_id: <%= @assignment.id %>});
     });
   <% end %>
-  <%= render partial: 'shared/navigation_warning',
-             formats: [:js],
-             handlers: [:erb] %>
 <% end %>
 
 <div id='autotest-manager'></div>


### PR DESCRIPTION
## Proposed Changes
On the _Settings > Automated Tests_ page, a warning should pop up if a user attempts to navigate away from the page after making changes and before saving them.

Currently, it appears even after the user has saved their changes. This happens because the _Settings > Automated Tests_ page is rendered with `react`, which is rendered after the `jquery` click handler in `_navigation_warning.js.erb` is registered: `submit_clicked` can never be flipped to `true` because the submit button doesn't exist when that handler is registered.

Furthermore, the `window.onbeforeunload` handler as defined in the `_navigation_warning.js.erb` partial has no awareness of the _Automated Tests_ page `react` structure. The page and the partial within it are tracking 'dirtiness' in separate state variables.

With help from `claude`, the cleanest fix is to override the `window.onbeforeunload` handler in `autotest_manager.jsx` and to gate the initialization of the page so that `fetchData` doesn't instantly 'dirty' the page when `react` fires `onChange` upon first receipt of existing form data.

The fix for the _Settings -> Starter Files_ page is far simpler, since it is not rendered using `react`: we bind the handler to `.on('click', ...)` instead.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

https://github.com/user-attachments/assets/6b94ec2a-916c-451f-b92a-e9a28377850b

https://github.com/user-attachments/assets/f8eab892-e9dc-4a40-8f8a-b9d7af19f5a2



</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>
n/a
</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |     x     |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
I had the thought that we could also take this a step further and track changes to the page that are 'undone', e.g. checking a box and then unchecking it, and make sure the navigation warning doesn't pop up in that case. I came to the judgment that this would bloat the code more than we could justify an improvement so slight.

~~I also did not touch the _Settings -> Starter Files_ page (on which this bug is also present) but if it is decided upon review that we'd like to bundle that fix into this PR, I would be happy to do so.~~ Applied this fix to the _Settings -> Starter Files_ page.
