### PR TITLE
Fix merge commit incorrectly attributed as latest submission (fixes #4534)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Add case-sensitive search toggle to group name filters in graders, groups, submissions, and annotation usage tables (#7938)
 
 ### 🐛 Bug fixes
+- Fixed bug where merge commits were incorrectly flagged as making a new assignment submission when no assignment files were changed (#7988)
 
 ### 🔧 Internal changes
 - Refactored `Group` creation to reserve the next id from `groups_id_seq` in a `before_validation` callback that populates `id`, `group_name`, and `repo_name` before validation (#7975)

--- a/app/lib/git_revision.rb
+++ b/app/lib/git_revision.rb
@@ -65,21 +65,28 @@ class GitRevision < Repository::AbstractRevision
     if parents.empty?
       return !entry.nil?
     end
+
     # check each parent commit (a merge has 2+ parents)
-    parents.each do |parent|
+    parent_diffs = parents.map do |parent|
       parent_entry = get_entry_hash(path, parent)
       # neither exists, no change
       if !entry && !parent_entry
-        next
-        # only in one of them, change
+        false
+      # only in one of them, change
       elsif !entry || !parent_entry
-        return true
-        # otherwise it's changed if their ids aren't the same
-      elsif entry[:oid] != parent_entry[:oid]  # rubocop:disable Lint/DuplicateBranch
-        return true
+        true
+      # otherwise it's changed if their oids aren't the same
+      else
+        entry[:oid] != parent_entry[:oid]
       end
     end
-    false
+
+    # For merge commits, only consider the path changed if it differs from ALL parents.
+    # If the result matches any parent, the merge was trivial for this path (it just
+    # carried that parent's version forward). Treating such a merge as a change would
+    # incorrectly attribute an instructor's merge commit as the latest student submission
+    # (see https://github.com/MarkUsProject/Markus/issues/4534).
+    parent_diffs.all?
   end
 
   def changes_at_path?(path)

--- a/spec/lib/repo/git_revision_spec.rb
+++ b/spec/lib/repo/git_revision_spec.rb
@@ -71,5 +71,75 @@ describe GitRevision do
         expect(repo.stringify(test_file)).to eq 'testdata'
       end
     end
+
+    describe '#entry_changed?' do
+      let(:revision) { repo.get_latest_revision }
+
+      def make_tree_double(file_oid)
+        tree = instance_double(Rugged::Tree)
+        if file_oid
+          allow(tree).to receive(:path).and_return({ oid: file_oid })
+        else
+          allow(tree).to receive(:path).and_raise(Rugged::TreeError)
+        end
+        tree
+      end
+
+      def make_commit_double(file_oid, parents)
+        instance_double(Rugged::Commit,
+                        tree: make_tree_double(file_oid),
+                        tree_id: file_oid,
+                        parents: parents)
+      end
+
+      context 'for a regular (non-merge) commit' do
+        it 'returns true when the file differs from the parent' do
+          parent = make_commit_double('old_oid', [])
+          commit = make_commit_double('new_oid', [parent])
+          expect(revision.entry_changed?('file.txt', commit)).to be true
+        end
+
+        it 'returns false when the file is unchanged from the parent' do
+          parent = make_commit_double('same_oid', [])
+          commit = make_commit_double('same_oid', [parent])
+          expect(revision.entry_changed?('file.txt', commit)).to be false
+        end
+
+        it 'returns true when the file is added (parent has no file)' do
+          parent = make_commit_double(nil, [])
+          commit = make_commit_double('new_oid', [parent])
+          expect(revision.entry_changed?('file.txt', commit)).to be true
+        end
+      end
+
+      context 'for a merge commit' do
+        # Regression test for https://github.com/MarkUsProject/Markus/issues/4534:
+        # when an instructor merges a student's commit into their own local branch and
+        # pushes the merge commit, that merge commit should not be treated as the latest
+        # "submission" for the student's files (which would inflate late penalties).
+        it 'returns false when the result matches one parent (trivial merge)' do
+          # parent_instructor has no student file; parent_student has the file;
+          # the merge result simply carries forward parent_student's version.
+          parent_instructor = make_commit_double(nil, [])
+          parent_student = make_commit_double('student_file_oid', [])
+          merge_commit = make_commit_double('student_file_oid', [parent_instructor, parent_student])
+          expect(revision.entry_changed?('assignment/file.txt', merge_commit)).to be false
+        end
+
+        it 'returns true when the result differs from all parents (genuine conflict resolution)' do
+          parent1 = make_commit_double('version_a', [])
+          parent2 = make_commit_double('version_b', [])
+          merge_commit = make_commit_double('version_c', [parent1, parent2])
+          expect(revision.entry_changed?('assignment/file.txt', merge_commit)).to be true
+        end
+
+        it 'returns false when both parents have the same content' do
+          parent1 = make_commit_double('same_oid', [])
+          parent2 = make_commit_double('same_oid', [])
+          merge_commit = make_commit_double('same_oid', [parent1, parent2])
+          expect(revision.entry_changed?('assignment/file.txt', merge_commit)).to be false
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Proposed Changes

Fixes #4534.

When an instructor clones a student's repository, adds a local commit (e.g. converting a file to PDF), then merges the student's push and pushes the resulting merge commit, MarkUs was treating that merge commit as the latest submission for the student's files. This caused two problems:

1. The repository browser showed the instructor as the file author ("Revised by") instead of the student.
2. The late penalty was calculated from the instructor's push timestamp rather than the student's original push timestamp, inflating the penalty.

**Root cause:** `entry_changed?` in `GitRevision` returned `true` if the file differed from *any* parent of a merge commit. For a merge commit where one parent (the instructor's branch) simply lacked the student's file, this always flagged the merge as having changed the file — even when the merge result was identical to the student's parent.

**Fix:** For merge commits (2+ parents), only return `true` if the file differs from *all* parents. If the merged content matches at least one parent, the merge was trivial for that path and should be skipped. This is consistent with how `git log -- <path>` handles merge commits.

## Type of Change

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  | X        |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

The fix is entirely in `entry_changed?`. The `get_revision_by_timestamp` and `add_entries_info` methods both use `entry_changed?` (via `changes_at_path?`), so both the late-penalty timestamp and the repository browser's "Revised by" / "Last modified" columns are corrected by this single change.