### PR TITLE
fix: navbar navigation inconsistency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Add case-sensitive search toggle to group name filters in graders, groups, submissions, and annotation usage tables (#7938)
 
 ### 🐛 Bug fixes
+- Fixed bug where clicking MarkUs logo in navbar on mobile would open the sidebar instead of redirecting to courses page (#7990)
 - Fixed bug where merge commits were incorrectly flagged as making a new assignment submission when no assignment files were changed (#7988)
 - Fixed shift+up/shift+down keybinding being suppressed when a criterion input had focus; active criterion now scrolls into view when navigated to via keyboard (#7989)
 

--- a/app/assets/stylesheets/common/_navigation.scss
+++ b/app/assets/stylesheets/common/_navigation.scss
@@ -74,7 +74,7 @@ nav {
     background-image: url('markus_logo_dark.svg');
   }
 
-  #mobile_menu {
+  #mobile_menu #mobile-logo {
     background-image: url('markus_logo_dark.svg');
   }
 }
@@ -132,7 +132,7 @@ nav {
 }
 
 #mobile_menu {
-  background: $background-support url('markus_logo.svg') no-repeat center center / 90px 30px;
+  background: $background-support;
   border-bottom: 1px solid $primary-three;
   display: none;
   height: 3.5em;
@@ -145,12 +145,26 @@ nav {
     display: block;
   }
 
+  #mobile-logo {
+    background: transparent url('markus_logo.svg') no-repeat center center / 90px 30px;
+    display: block;
+    height: 3.5em;
+    left: 50%;
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    width: 90px;
+  }
+
   #menu_icon {
+    background: transparent;
     cursor: pointer;
     display: inline-block;
     height: 2em;
     margin: 0.5em 0 0 0.5em;
+    position: relative;
     width: 2em;
+    z-index: 1;
 
     &::before,
     &::after {

--- a/app/javascript/common/menu.js
+++ b/app/javascript/common/menu.js
@@ -4,9 +4,10 @@ function hideMenu() {
 
 function initMenu() {
   /* Menu toggle for mobile views */
-  document.getElementById("mobile_menu").addEventListener(
+  document.getElementById("menu_icon").addEventListener(
     "click",
-    () => {
+    event => {
+      event.preventDefault();
       document.body.classList.toggle("show_menu");
     },
     false

--- a/app/views/layouts/assignment_content.html.erb
+++ b/app/views/layouts/assignment_content.html.erb
@@ -15,6 +15,7 @@
 <div id='<%= controller.action_name == "login" ? "loggedOut" : "loggedIn" %>'>
   <div id='mobile_menu'>
     <a id='menu_icon'></a>
+    <a href='<%= root_path %>' id='mobile-logo' aria-label='<%= t('menu.home') %>'></a>
   </div>
   <div id='wrapper'>
     <nav id='menus'>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -15,6 +15,7 @@
 <div id='<%= controller.action_name == "login" ? "loggedOut" : "loggedIn" %>'>
   <div id='mobile_menu'>
     <a id='menu_icon'></a>
+    <a href='<%= root_path %>' id='mobile-logo' aria-label='<%= t('menu.home') %>'></a>
   </div>
   <div id='wrapper'>
     <nav id='menus'>

--- a/app/views/layouts/result_content.erb
+++ b/app/views/layouts/result_content.erb
@@ -15,6 +15,7 @@
 <div id='<%= controller.action_name == "login" ? "loggedOut" : "loggedIn" %>'>
   <div id='mobile_menu'>
     <a id='menu_icon'></a>
+    <a href='<%= root_path %>' id='mobile-logo' aria-label='<%= t('menu.home') %>'></a>
   </div>
   <div id='wrapper' class='flex-col'>
     <nav id='menus'>


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

This PR fixes an inconsistency in the mobile navbar where tapping the centered MarkUs logo opened the mobile course menu instead of navigating home. Fixes #7421.

Changes:
- Adds a real `root_path` link for the MarkUs logo in the mobile navbar.
- Updates the mobile menu click handler so only the hamburger icon toggles the menu.
- Moves the mobile logo background styling from the navbar container to the new logo link.
- Preserves the existing desktop behavior, where the MarkUs logo returns users to the home route.

This makes mobile behavior consistent with desktop and gives students, TAs, and instructors a clear way to return to the course list from course pages.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |      x    |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
