### PR TITLE
Issue 7854

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
+- Added a confirm dialog to the Upload Scans form that appears when no template divisions are assigned to the selected exam template.
 - Migrated `MarkingSchemesTable` component to React Table V8 (#7985)
 - Removed Graders Subcomponent and added a Graders column in the Assignment Grades tab (#7967)
 - Added GET and PATCH /overall_comment API routes (#7963)

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
-- Added a confirm dialog to the Upload Scans form that appears when no template divisions are assigned to the selected exam template.
+- Added a confirm dialog to the Upload Scans form that appears when no template divisions are assigned to the selected exam template (#7993)
 - Migrated `MarkingSchemesTable` component to React Table V8 (#7985)
 - Removed Graders Subcomponent and added a Graders column in the Assignment Grades tab (#7967)
 - Added GET and PATCH /overall_comment API routes (#7963)

--- a/app/views/exam_templates/_boot.js.erb
+++ b/app/views/exam_templates/_boot.js.erb
@@ -252,9 +252,10 @@ function _round_down_to_nearest_hundred(num) {
  * The event listener checks the template divisions count of the template that was selected from the form dropdown
  * and shows a confirmation dialog on submission of the form if the selected template has no divisions assigned to it.
  * This function runs after the form is injected in view_logs.js.erb.
+ * @param {Array} examTemplateData contains exam template ids and matching template division counts.
  * @returns {void}
  */
-function init_upload_scans_form() {
+function init_upload_scans_form(examTemplateData) {
   const uploadScansForm = document.getElementById('upload_scans_form');
   const dropdown = document.getElementById('exam_template_dropdown');
 
@@ -262,10 +263,8 @@ function init_upload_scans_form() {
     return;
   }
 
-  const examTemplates = JSON.parse(uploadScansForm.dataset.examTemplates);
-
   uploadScansForm.addEventListener('submit', (e) => {
-    const selectedExamTemplate = examTemplates.find(template => String(template.exam_template_id) === dropdown.value);
+    const selectedExamTemplate = examTemplateData.find(template => String(template.exam_template_id) === dropdown.value);
 
     if (selectedExamTemplate && selectedExamTemplate.template_division_count === 0) {
       const proceed = confirm('The selected exam template has no template divisions assigned to it. Are you sure you would like to proceed?');

--- a/app/views/exam_templates/_boot.js.erb
+++ b/app/views/exam_templates/_boot.js.erb
@@ -246,3 +246,26 @@ function set_crop_selection(crop_target, form, id, jcrop_api) {
 function _round_down_to_nearest_hundred(num) {
   return Math.floor(num / 100) * 100;
 }
+
+function init_upload_scans_form() {
+  const uploadScansForm = document.getElementById('upload_scans_form');
+  const dropdown = document.getElementById('exam_template_dropdown');
+
+  if (!uploadScansForm || !dropdown) {
+    return;
+  }
+
+  const examTemplates = JSON.parse(uploadScansForm.dataset.examTemplates);
+
+  uploadScansForm.addEventListener('submit', (e) => {
+    const selectedExamTemplate = examTemplates.find(template => String(template.exam_template_id) === dropdown.value);
+
+    if (!selectedExamTemplate || selectedExamTemplate.template_division_count === 0) {
+      const proceed = confirm('The selected exam template has no template divisions assigned to it. Are you sure you would like to proceed?');
+      if (!proceed) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+  }, true);
+}

--- a/app/views/exam_templates/_boot.js.erb
+++ b/app/views/exam_templates/_boot.js.erb
@@ -267,7 +267,7 @@ function init_upload_scans_form(examTemplateData) {
     const selectedExamTemplate = examTemplateData.find(template => String(template.exam_template_id) === dropdown.value);
 
     if (selectedExamTemplate && selectedExamTemplate.template_division_count === 0) {
-      const proceed = confirm('The selected exam template has no template divisions assigned to it. Are you sure you would like to proceed?');
+      const proceed = confirm(I18n.t('exam_templates.upload_scans.confirmation_dialog'));
       if (!proceed) {
         e.preventDefault();
         e.stopPropagation();

--- a/app/views/exam_templates/_boot.js.erb
+++ b/app/views/exam_templates/_boot.js.erb
@@ -247,6 +247,13 @@ function _round_down_to_nearest_hundred(num) {
   return Math.floor(num / 100) * 100;
 }
 
+/**
+ * Adds a submit event listener to the upload scans form.
+ * The event listener checks the template divisions count of the template that was selected from the form dropdown
+ * and shows a confirmation dialog on submission of the form if the selected template has no divisions assigned to it.
+ * This function runs after the form is injected in view_logs.js.erb.
+ * @returns {void}
+ */
 function init_upload_scans_form() {
   const uploadScansForm = document.getElementById('upload_scans_form');
   const dropdown = document.getElementById('exam_template_dropdown');

--- a/app/views/exam_templates/_boot.js.erb
+++ b/app/views/exam_templates/_boot.js.erb
@@ -260,7 +260,7 @@ function init_upload_scans_form() {
   uploadScansForm.addEventListener('submit', (e) => {
     const selectedExamTemplate = examTemplates.find(template => String(template.exam_template_id) === dropdown.value);
 
-    if (!selectedExamTemplate || selectedExamTemplate.template_division_count === 0) {
+    if (selectedExamTemplate && selectedExamTemplate.template_division_count === 0) {
       const proceed = confirm('The selected exam template has no template divisions assigned to it. Are you sure you would like to proceed?');
       if (!proceed) {
         e.preventDefault();

--- a/app/views/exam_templates/_split_form.html.erb
+++ b/app/views/exam_templates/_split_form.html.erb
@@ -1,4 +1,11 @@
-<%= form_with url: split_course_assignment_exam_templates_path(@current_course),
+<% exam_template_data = @exam_templates.map{
+  |exam_template|
+    { exam_template_id: exam_template.id, template_division_count: exam_template.template_divisions.size }
+} %>
+
+<%= form_with id: 'upload_scans_form',
+              url: split_course_assignment_exam_templates_path(@current_course),
+              html: {data: { exam_templates: exam_template_data }},
               method: :patch,
               authenticity_token: true,
               multipart: true do |f| %>
@@ -6,7 +13,8 @@
     <%= f.label :exam_template_id, ExamTemplate.model_name.human %>
     <%= f.select :exam_template_id,
                  options_from_collection_for_select(@exam_templates, 'id', 'name'),
-                 required: true %>
+                 {required: true},
+                 {id: 'exam_template_dropdown'} %>
     <%= f.label :pdf_to_split, t('exam_templates.upload_scans.instruction') %>
     <%= f.file_field :pdf_to_split, required: true, accept: 'application/pdf' %>
   </div>

--- a/app/views/exam_templates/_split_form.html.erb
+++ b/app/views/exam_templates/_split_form.html.erb
@@ -1,11 +1,5 @@
-<% exam_template_data = @exam_templates.map{
-  |exam_template|
-    { exam_template_id: exam_template.id, template_division_count: exam_template.template_divisions.size }
-} %>
-
 <%= form_with id: 'upload_scans_form',
               url: split_course_assignment_exam_templates_path(@current_course),
-              html: {data: { exam_templates: exam_template_data }},
               method: :patch,
               authenticity_token: true,
               multipart: true do |f| %>

--- a/app/views/exam_templates/view_logs.js.erb
+++ b/app/views/exam_templates/view_logs.js.erb
@@ -3,3 +3,5 @@ document.getElementById('editing_pane_menu').innerHTML =
 
 makeExamScanLogTable(document.getElementById('exam_scan_log_table'),
   {course_id: <%= @current_course.id %>, assignment_id: <%= @assignment.id %>});
+
+init_upload_scans_form();

--- a/app/views/exam_templates/view_logs.js.erb
+++ b/app/views/exam_templates/view_logs.js.erb
@@ -4,4 +4,11 @@ document.getElementById('editing_pane_menu').innerHTML =
 makeExamScanLogTable(document.getElementById('exam_scan_log_table'),
   {course_id: <%= @current_course.id %>, assignment_id: <%= @assignment.id %>});
 
-init_upload_scans_form();
+<% exam_template_data = @exam_templates.map{
+  |exam_template|
+    { exam_template_id: exam_template.id, template_division_count: exam_template.template_divisions.size }
+} %>
+
+let examTemplateData = <%= exam_template_data.to_json.html_safe %>;
+
+init_upload_scans_form(examTemplateData);

--- a/config/locales/views/exam_templates/en.yml
+++ b/config/locales/views/exam_templates/en.yml
@@ -98,6 +98,7 @@ en:
       instruction: Replace template file
       success: Exam Template has been successfully updated
     upload_scans:
+      confirmation_dialog: The selected exam template has no template divisions assigned to it. Are you sure you would like to proceed?
       failure: Scans failed to upload
       instruction: Papers to upload (.pdf)
       invalid: Invalid file type

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -349,11 +349,10 @@ describe ExamTemplatesController do
 
       it('should respond with 200') { expect(response).to have_http_status :ok }
 
-      it 'embeds template division data on the upload form' do
-        expect(response.body).to include('data-exam-templates')
+      it 'passes template division data to init_upload_scans_form' do
         expect(response.body).to include('upload_scans_form')
         expect(response.body).to include('template_division_count')
-        expect(response.body).to include('init_upload_scans_form()')
+        expect(response.body).to include('init_upload_scans_form(examTemplateData)')
         expect(response.body).to include(exam_template.id.to_s)
       end
     end

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -342,9 +342,20 @@ describe ExamTemplatesController do
     end
 
     describe '#view_logs' do
-      before { get_as user, :view_logs, params: { assignment_id: exam_template.assignment.id, course_id: course.id } }
+      render_views
+      before do
+ get_as user, :view_logs, format: 'js', params: { assignment_id: exam_template.assignment.id, course_id: course.id }
+      end
 
       it('should respond with 200') { expect(response).to have_http_status :ok }
+
+      it 'embeds template division data on the upload form' do
+        expect(response.body).to include('data-exam-templates')
+        expect(response.body).to include('upload_scans_form')
+        expect(response.body).to include('template_division_count')
+        expect(response.body).to include('init_upload_scans_form()')
+        expect(response.body).to include(exam_template.id.to_s)
+      end
     end
 
     describe '#download_generate' do


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

**The issue:** If no template divisions are assigned to an exam template and then the user goes to upload a scan with that same exam template, there is no easy way for them to go back and add template divisions afterwords. 

**The fix:** As requested, I added a confirmation dialog on submit of the Upload Scans form. This dialog will warn the user when no template divisions are assigned to the selected exam template and ask them if it's okay to proceed.

**The implementation:** In _split_form.html.erb I wrote embedded ruby code to build an array of { exam_template_id, template_division_count } using the @exam_templates variable which was initialized in exam_templates_controller#view_logs. Then I embedded this array into the form via the data-exam-templates HTML attribute.

When view_logs.js.erb gets returned to the browser after the AJAX request, the JavaScript inside this file gets executed to first build and inject the Upload Scans into #editing_pane_menu, and then call the new function I defined called init_upload_scans_form(). 

The init_upload_scans_form() was defined in _boot.js.erb. This function reads template division counts from the form's data-eexam-templates attribute, and listens for the form's submit event in the capture phase. If the selected template has template_division_count === 0 then we show the confirm dialog. On cancel, we prevent submission so that the user can configure template divisions first.

**Tests:** Added controller specs for #view_logs (JS format, with render_views) to verify that the form embeds template division data and calls init_upload_scans_form().

**Documentation:** Updated the relevant wiki page to mention the confirmation dialog when uploading without template divisions and further emphasize the need for them.

closes #7854 

<details>
<summary>Screenshots of your changes (if applicable)</summary>
<img width="1710" height="1107" alt="Screenshot 2026-06-08 at 4 59 51 PM" src="https://github.com/user-attachments/assets/8c77a4f1-eb45-47d0-abff-56074c2bbb44" />


</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>
https://github.com/MarkUsProject/Wiki/pull/265

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |    X      |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
