### PR TITLE
Fix tester spec upload when spec contains non-existent criterion, closes 7528

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Fixed bug where clicking MarkUs logo in navbar on mobile would open the sidebar instead of redirecting to courses page (#7990)
 - Fixed bug where merge commits were incorrectly flagged as making a new assignment submission when no assignment files were changed (#7988)
 - Fixed shift+up/shift+down keybinding being suppressed when a criterion input had focus; active criterion now scrolls into view when navigated to via keyboard (#7989)
+- Fixed autotester spec upload when spec contains non-existent criterion (#7998)
 
 ### 🔧 Internal changes
 - Moved rubric criterion keyboard navigation (up/down/enter) from a global jQuery-based keybinding into `RubricCriterionInput`, replacing DOM class mutation with React state (`hoveredLevelIndex`); moved criterion navigation (shift+up/shift+down) into `MarksPanel`, eliminating the `window.marksPanel` global (#7989)

--- a/app/helpers/automated_tests_helper.rb
+++ b/app/helpers/automated_tests_helper.rb
@@ -69,7 +69,7 @@ module AutomatedTestsHelper
         criterion_name = extra_data_specs['criterion']
         criterion = assignment.ta_criteria.find_by(name: criterion_name)
         if criterion_name.present? && criterion.nil?
-          flash_message(:warning, I18n.t('automated_tests.no_criteria', name: criterion_name))
+          raise I18n.t('automated_tests.no_criteria', name: criterion_name)
         end
         fields = { name: test_group_name, display_output: display_output,
                    criterion_id: criterion&.id, autotest_settings: test_group_specs,

--- a/spec/helpers/automated_tests_helper_spec.rb
+++ b/spec/helpers/automated_tests_helper_spec.rb
@@ -12,14 +12,12 @@ describe AutomatedTestsHelper do
           'test_data' => [{
             'extra_info' => {
               'test_group_id' => test_group_id,
-              'criterion' => criterion.name
+              'criterion' => nil
             }
           }]
         }
       ] }
     end
-
-    before { allow(AutomatedTestsHelper).to receive(:flash_message) }
 
     context 'when the test group exists' do
       let!(:test_group_id) { create(:test_group, assignment: assignment).id }
@@ -49,6 +47,18 @@ describe AutomatedTestsHelper do
 
     context 'when the criterion exists' do
       let(:test_group_id) { create(:test_group, assignment: assignment).id }
+      let(:specs) do
+        { 'testers' => [
+          {
+            'test_data' => [{
+              'extra_info' => {
+                'test_group_id' => test_group_id,
+                'criterion' => criterion.name
+              }
+            }]
+          }
+        ] }
+      end
 
       before { criterion.save }
 
@@ -59,12 +69,32 @@ describe AutomatedTestsHelper do
     end
 
     context 'when the criterion does not exist' do
-      let(:test_group_id) { create(:test_group, assignment: assignment).id }
+      let!(:test_group_id) { create(:test_group, assignment: assignment).id }
+      let(:specs_with_bad_criterion) do
+        { 'testers' => [
+          {
+            'test_data' => [{
+              'extra_info' => {
+                'test_group_id' => test_group_id,
+                'criterion' => 'nonexistent_criterion'
+              }
+            }]
+          }
+        ] }
+      end
 
-      before { subject }
+      it 'raises with the invalid criterion name' do
+        expect { update_test_groups_from_specs(assignment, specs_with_bad_criterion) }
+          .to raise_error(/Unable to find a criterion with name/)
+      end
 
-      it 'should not set the criterion on the test group' do
-        expect(assignment.test_groups.first.criterion).to be_nil
+      it 'does not persist any changes' do
+        begin
+          update_test_groups_from_specs(assignment, specs_with_bad_criterion)
+        rescue StandardError
+          nil
+        end
+        expect(assignment.reload.autotest_settings).to be_nil
       end
     end
   end

--- a/spec/jobs/autotest_specs_job_spec.rb
+++ b/spec/jobs/autotest_specs_job_spec.rb
@@ -84,6 +84,28 @@ describe AutotestSpecsJob do
 
         it_behaves_like 'autotest specs job'
       end
+
+      context 'when the spec contains an invalid criterion name' do
+        subject { AutotestSpecsJob.perform_now(host_with_port, assignment, bad_specs) }
+
+        let(:bad_specs) do
+          { 'testers' => [{ 'test_data' => [{ 'extra_info' => {
+            'criterion' => 'nonexistent_criterion'
+          } }] }] }
+        end
+
+        it 'raises with the invalid criterion name' do
+          expect { subject }.to raise_error(/Unable to find a criterion with name/)
+        end
+
+        it 'does not persist any test groups' do
+          expect do
+                     subject
+          rescue StandardError
+                     nil
+          end.not_to(change { assignment.test_groups.count })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #7528.

## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

If `update_test_groups_from_specs` were to fail, it would call `flash_message` which requires the request-scoped `flash` object to be present in the given context. This object is not present in the context of autotest spec job, which is why the error message in the issue says `undefined method 'flash_message' for an instance of AutotestSpecsJob`.

We replace `flash_message` with `raise`, which allows for `AutotestSpecsJob` to correctly propagate the error message up to the front end.

Furthermore, tests in `automated_test_helper_spec.rb` were silently swallowing the `NoMethodError` by mocking the call to `flash_message`. We also restructure the way `criterion` is defined in these tests, allowing for appropriate overrides depending on the test case.


<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>
<img width="791" height="481" alt="Screenshot 2026-06-10 at 1 50 31 PM" src="https://github.com/user-attachments/assets/65b8d23e-5fdd-45b4-bd95-1c1baca13963" />


<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |     x     |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
