### PR TITLE
Support all annotation types in add_annotations API (#7999)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Added GET and PATCH /overall_comment API routes (#7963)
 - Add case-sensitive search toggle to group name filters in graders, groups, submissions, and annotation usage tables (#7938)
 - Add pagination to Admin Users table for performance (#7997)
+- Added support for all annotation types for POST /add_annotations (#8007)
 
 ### 🐛 Bug fixes
 - Fixed bug where clicking MarkUs logo in navbar on mobile would open the sidebar instead of redirecting to courses page (#7990)

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -5,7 +5,6 @@ class AnnotationsController < ApplicationController
     result = Result.find(params[:result_id])
     submission = result.submission
     submission_file = submission.submission_files.find(params[:submission_file_id])
-    rmd_convert = submission_file.is_rmd? && Rails.application.config.rmd_convert_enabled
 
     base_attributes = {
       submission_file_id: submission_file.id,
@@ -16,44 +15,12 @@ class AnnotationsController < ApplicationController
       result_id: params[:result_id]
     }
 
-    if submission_file.is_supported_image?
-      @annotation = result.annotations.create(
-        type: 'ImageAnnotation',
-        x1: params[:x1],
-        y1: params[:y1],
-        x2: params[:x2],
-        y2: params[:y2],
-        **base_attributes
-      )
-    elsif submission_file.is_pdf?
-      @annotation = result.annotations.create(
-        type: 'PdfAnnotation',
-        x1: params[:x1],
-        y1: params[:y1],
-        x2: params[:x2],
-        y2: params[:y2],
-        page: params[:page],
-        **base_attributes
-      )
-    elsif submission_file.is_pynb? || rmd_convert
-      @annotation = result.annotations.create!(
-        type: 'HtmlAnnotation',
-        start_node: params[:start_node],
-        start_offset: params[:start_offset],
-        end_node: params[:end_node],
-        end_offset: params[:end_offset],
-        **base_attributes
-      )
-    else
-      @annotation = result.annotations.create(
-        type: 'TextAnnotation',
-        line_start: params[:line_start],
-        line_end: params[:line_end],
-        column_start: params[:column_start],
-        column_end: params[:column_end],
-        **base_attributes
-      )
-    end
+    annotation_type = submission_file.annotation_type
+    @annotation = result.annotations.create!(
+      type: annotation_type,
+      **type_specific_annotation_attributes(annotation_type),
+      **base_attributes
+    )
     render :create
   end
 
@@ -61,7 +28,6 @@ class AnnotationsController < ApplicationController
     result = Result.find(params[:result_id])
     submission = result.submission
     submission_file = submission.submission_files.find(params[:submission_file_id])
-    rmd_convert = submission_file.is_rmd? && Rails.application.config.rmd_convert_enabled
 
     d = result.grouping.assignment.annotation_categories.find_by(id: params[:category_id])&.flexible_criterion_id
 
@@ -90,44 +56,12 @@ class AnnotationsController < ApplicationController
       is_remark: !result.remark_request_submitted_at.nil?,
       submission_file_id: submission_file.id
     }
-    if submission_file.is_supported_image?
-      @annotation = result.annotations.create!(
-        type: 'ImageAnnotation',
-        x1: params[:x1],
-        x2: params[:x2],
-        y1: params[:y1],
-        y2: params[:y2],
-        **base_attributes
-      )
-    elsif submission_file.is_pdf?
-      @annotation = result.annotations.create!(
-        type: 'PdfAnnotation',
-        x1: params[:x1],
-        x2: params[:x2],
-        y1: params[:y1],
-        y2: params[:y2],
-        page: params[:page],
-        **base_attributes
-      )
-    elsif submission_file.is_pynb? || rmd_convert
-      @annotation = result.annotations.create!(
-        type: 'HtmlAnnotation',
-        start_node: params[:start_node],
-        start_offset: params[:start_offset],
-        end_node: params[:end_node],
-        end_offset: params[:end_offset],
-        **base_attributes
-      )
-    else
-      @annotation = result.annotations.create!(
-        type: 'TextAnnotation',
-        line_start: params[:line_start],
-        line_end: params[:line_end],
-        column_start: params[:column_start],
-        column_end: params[:column_end],
-        **base_attributes
-      )
-    end
+    annotation_type = submission_file.annotation_type
+    @annotation = result.annotations.create!(
+      type: annotation_type,
+      **type_specific_annotation_attributes(annotation_type),
+      **base_attributes
+    )
   end
 
   def destroy
@@ -186,5 +120,24 @@ class AnnotationsController < ApplicationController
 
   def identification_params
     params.permit(:id, :result_id)
+  end
+
+  private
+
+  # The type-specific coordinate attributes (read from params) for the given annotation
+  # class. The non-type-specific attributes are supplied separately by each action.
+  def type_specific_annotation_attributes(annotation_type)
+    case annotation_type
+    when 'ImageAnnotation'
+      { x1: params[:x1], y1: params[:y1], x2: params[:x2], y2: params[:y2] }
+    when 'PdfAnnotation'
+      { x1: params[:x1], y1: params[:y1], x2: params[:x2], y2: params[:y2], page: params[:page] }
+    when 'HtmlAnnotation'
+      { start_node: params[:start_node], start_offset: params[:start_offset],
+        end_node: params[:end_node], end_offset: params[:end_offset] }
+    else
+      { line_start: params[:line_start], line_end: params[:line_end],
+        column_start: params[:column_start], column_end: params[:column_end] }
+    end
   end
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -15,10 +15,10 @@ class AnnotationsController < ApplicationController
       result_id: params[:result_id]
     }
 
-    annotation_type = submission_file.annotation_type
+    annotation_class = submission_file.annotation_class
     @annotation = result.annotations.create!(
-      type: annotation_type,
-      **type_specific_annotation_attributes(annotation_type),
+      type: annotation_class.name,
+      **params.to_unsafe_h.slice(*annotation_class.required_fields).symbolize_keys,
       **base_attributes
     )
     render :create
@@ -56,10 +56,10 @@ class AnnotationsController < ApplicationController
       is_remark: !result.remark_request_submitted_at.nil?,
       submission_file_id: submission_file.id
     }
-    annotation_type = submission_file.annotation_type
+    annotation_class = submission_file.annotation_class
     @annotation = result.annotations.create!(
-      type: annotation_type,
-      **type_specific_annotation_attributes(annotation_type),
+      type: annotation_class.name,
+      **params.to_unsafe_h.slice(*annotation_class.required_fields).symbolize_keys,
       **base_attributes
     )
   end
@@ -120,24 +120,5 @@ class AnnotationsController < ApplicationController
 
   def identification_params
     params.permit(:id, :result_id)
-  end
-
-  private
-
-  # The type-specific coordinate attributes (read from params) for the given annotation
-  # class. The non-type-specific attributes are supplied separately by each action.
-  def type_specific_annotation_attributes(annotation_type)
-    case annotation_type
-    when 'ImageAnnotation'
-      { x1: params[:x1], y1: params[:y1], x2: params[:x2], y2: params[:y2] }
-    when 'PdfAnnotation'
-      { x1: params[:x1], y1: params[:y1], x2: params[:x2], y2: params[:y2], page: params[:page] }
-    when 'HtmlAnnotation'
-      { start_node: params[:start_node], start_offset: params[:start_offset],
-        end_node: params[:end_node], end_offset: params[:end_offset] }
-    else
-      { line_start: params[:line_start], line_end: params[:line_end],
-        column_start: params[:column_start], column_end: params[:column_end] }
-    end
   end
 end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -5,6 +5,17 @@ module Api
     # Define default fields to display for index and show methods
     DEFAULT_FIELDS = [:id, :group_name].freeze
 
+    # The annotation types accepted by add_annotations (single-table-inheritance class names,
+    # matching the values reported by the annotations endpoint), mapped to the fields that must
+    # be present for each. Mirrors each subclass's model validations, enforced in add_annotations
+    # because insert_all bypasses them.
+    REQUIRED_ANNOTATION_FIELDS = {
+      'TextAnnotation' => %i[line_start line_end column_start column_end],
+      'ImageAnnotation' => %i[x1 y1 x2 y2],
+      'PdfAnnotation' => %i[x1 y1 x2 y2 page],
+      'HtmlAnnotation' => %i[start_node start_offset end_node end_offset]
+    }.freeze
+
     # Create an assignment's group
     # Requires: assignment_id
     # Optional: filter, fields
@@ -238,12 +249,45 @@ module Api
         return page_not_found('Marking for that submission is already completed')
       end
 
+      annots = annotations_params
+      submission_files = result.submission.submission_files.index_by(&:filename)
+
+      # Validation pass: insert_all bypasses model validations, so guard the input here
+      # before writing anything to the database. The annotation type is derived from the
+      # file; a caller-supplied type is optional but must agree with it.
+      annots.each do |annot_params|
+        submission_file = submission_files[annot_params[:filename]]
+        if submission_file.nil?
+          return add_annotations_error("Submission file not found: #{annot_params[:filename]}")
+        end
+
+        expected_type = submission_file.annotation_type
+
+        requested = annot_params[:type].presence
+        if requested
+          unless REQUIRED_ANNOTATION_FIELDS.key?(requested)
+            return add_annotations_error("Invalid annotation type: #{requested}")
+          end
+          if requested != expected_type
+            return add_annotations_error(
+              "Annotation type '#{requested}' does not match the type of file '#{annot_params[:filename]}'"
+            )
+          end
+        end
+
+        missing = REQUIRED_ANNOTATION_FIELDS[expected_type].select { |field| annot_params[field].blank? }
+        next if missing.empty?
+
+        return add_annotations_error(
+          "Missing required fields for #{expected_type}: #{missing.join(', ')}"
+        )
+      end
+
       annotation_texts = []
       annotations = []
       count = result.submission.annotations.count + 1
       annotation_category = nil
-      submission_file = nil
-      params[:annotations].each_with_index do |annot_params, i|
+      annots.each_with_index do |annot_params, i|
         if annot_params[:annotation_category_name].nil?
           annotation_category_id = nil
         else
@@ -255,10 +299,8 @@ module Api
           end
           annotation_category_id = annotation_category.id
         end
-        if submission_file.nil? || submission_file.filename != annot_params[:filename]
-          submission_file = result.submission.submission_files.find_by(filename: annot_params[:filename])
-        end
 
+        submission_file = submission_files[annot_params[:filename]]
         annotation_texts << {
           content: annot_params[:content],
           annotation_category_id: annotation_category_id,
@@ -266,10 +308,20 @@ module Api
           last_editor_id: current_role.id
         }
         annotations << {
+          type: submission_file.annotation_type,
           line_start: annot_params[:line_start],
           line_end: annot_params[:line_end],
           column_start: annot_params[:column_start],
           column_end: annot_params[:column_end],
+          x1: annot_params[:x1],
+          y1: annot_params[:y1],
+          x2: annot_params[:x2],
+          y2: annot_params[:y2],
+          page: annot_params[:page],
+          start_node: annot_params[:start_node],
+          start_offset: annot_params[:start_offset],
+          end_node: annot_params[:end_node],
+          end_offset: annot_params[:end_offset],
           annotation_text_id: nil,
           submission_file_id: submission_file.id,
           creator_id: current_role.id,
@@ -283,7 +335,7 @@ module Api
       imported.rows.zip(annotations) do |t, a|
         a[:annotation_text_id] = t[0]
       end
-      TextAnnotation.insert_all! annotations
+      Annotation.insert_all! annotations
       render 'shared/http_status', locals: { code: '200', message:
         HttpStatusHelper::ERROR_CODE['message']['200'] }, status: :ok
     end
@@ -507,15 +559,31 @@ module Api
     end
 
     def annotations_params
-      params.require(annotations: [
+      params.permit(annotations: [
         :annotation_category_name,
-        :column_end,
-        :column_start,
         :content,
         :filename,
+        :type,
+        :line_start,
         :line_end,
-        :line_start
-      ])
+        :column_start,
+        :column_end,
+        :x1,
+        :y1,
+        :x2,
+        :y2,
+        :page,
+        :start_node,
+        :start_offset,
+        :end_node,
+        :end_offset
+      ])[:annotations] || []
+    end
+
+    def add_annotations_error(message)
+      render 'shared/http_status',
+             locals: { code: '422', message: message },
+             status: :unprocessable_content
     end
 
     def time_delta_params

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -5,17 +5,6 @@ module Api
     # Define default fields to display for index and show methods
     DEFAULT_FIELDS = [:id, :group_name].freeze
 
-    # The annotation types accepted by add_annotations (single-table-inheritance class names,
-    # matching the values reported by the annotations endpoint), mapped to the fields that must
-    # be present for each. Mirrors each subclass's model validations, enforced in add_annotations
-    # because insert_all bypasses them.
-    REQUIRED_ANNOTATION_FIELDS = {
-      'TextAnnotation' => %i[line_start line_end column_start column_end],
-      'ImageAnnotation' => %i[x1 y1 x2 y2],
-      'PdfAnnotation' => %i[x1 y1 x2 y2 page],
-      'HtmlAnnotation' => %i[start_node start_offset end_node end_offset]
-    }.freeze
-
     # Create an assignment's group
     # Requires: assignment_id
     # Optional: filter, fields
@@ -252,90 +241,86 @@ module Api
       annots = annotations_params
       submission_files = result.submission.submission_files.index_by(&:filename)
 
-      # Validation pass: insert_all bypasses model validations, so guard the input here
-      # before writing anything to the database. The annotation type is derived from the
-      # file; a caller-supplied type is optional but must agree with it.
-      annots.each do |annot_params|
-        submission_file = submission_files[annot_params[:filename]]
-        if submission_file.nil?
-          return add_annotations_error("Submission file not found: #{annot_params[:filename]}")
-        end
-
-        expected_type = submission_file.annotation_type
-
-        requested = annot_params[:type].presence
-        if requested
-          unless REQUIRED_ANNOTATION_FIELDS.key?(requested)
-            return add_annotations_error("Invalid annotation type: #{requested}")
-          end
-          if requested != expected_type
-            return add_annotations_error(
-              "Annotation type '#{requested}' does not match the type of file '#{annot_params[:filename]}'"
-            )
-          end
-        end
-
-        missing = REQUIRED_ANNOTATION_FIELDS[expected_type].select { |field| annot_params[field].blank? }
-        next if missing.empty?
-
-        return add_annotations_error(
-          "Missing required fields for #{expected_type}: #{missing.join(', ')}"
-        )
-      end
-
       annotation_texts = []
       annotations = []
       count = result.submission.annotations.count + 1
       annotation_category = nil
-      annots.each_with_index do |annot_params, i|
-        if annot_params[:annotation_category_name].nil?
-          annotation_category_id = nil
-        else
-          name = annot_params[:annotation_category_name]
-          if annotation_category.nil? || annotation_category.annotation_category_name != name
-            annotation_category = assignment.annotation_categories.find_or_create_by(
-              annotation_category_name: name
-            )
+      error_message = nil
+
+      ActiveRecord::Base.transaction do
+        annots.each_with_index do |annot_params, i|
+          submission_file = submission_files[annot_params[:filename]]
+          if submission_file.nil?
+            error_message = "Submission file not found: #{annot_params[:filename]}"
+            raise ActiveRecord::Rollback
           end
-          annotation_category_id = annotation_category.id
+
+          expected_class = submission_file.annotation_class
+          requested = annot_params[:type].presence
+          if requested && requested != expected_class.name
+            error_message = "Annotation type '#{requested}' does not match the type " \
+                            "of file '#{annot_params[:filename]}'"
+            raise ActiveRecord::Rollback
+          end
+
+          missing = expected_class.required_fields.select { |field| annot_params[field].blank? }
+          if missing.any?
+            error_message = "Missing required fields for #{expected_class.name}: #{missing.join(', ')}"
+            raise ActiveRecord::Rollback
+          end
+
+          if annot_params[:annotation_category_name].nil?
+            annotation_category_id = nil
+          else
+            name = annot_params[:annotation_category_name]
+            if annotation_category.nil? || annotation_category.annotation_category_name != name
+              annotation_category = assignment.annotation_categories.find_or_create_by(
+                annotation_category_name: name
+              )
+            end
+            annotation_category_id = annotation_category.id
+          end
+
+          annotation_texts << {
+            content: annot_params[:content],
+            annotation_category_id: annotation_category_id,
+            creator_id: current_role.id,
+            last_editor_id: current_role.id
+          }
+          annotations << {
+            type: expected_class.name,
+            line_start: annot_params[:line_start],
+            line_end: annot_params[:line_end],
+            column_start: annot_params[:column_start],
+            column_end: annot_params[:column_end],
+            x1: annot_params[:x1],
+            y1: annot_params[:y1],
+            x2: annot_params[:x2],
+            y2: annot_params[:y2],
+            page: annot_params[:page],
+            start_node: annot_params[:start_node],
+            start_offset: annot_params[:start_offset],
+            end_node: annot_params[:end_node],
+            end_offset: annot_params[:end_offset],
+            annotation_text_id: nil,
+            submission_file_id: submission_file.id,
+            creator_id: current_role.id,
+            creator_type: current_role.type,
+            is_remark: !result.remark_request_submitted_at.nil?,
+            annotation_number: count + i,
+            result_id: result.id
+          }
         end
 
-        submission_file = submission_files[annot_params[:filename]]
-        annotation_texts << {
-          content: annot_params[:content],
-          annotation_category_id: annotation_category_id,
-          creator_id: current_role.id,
-          last_editor_id: current_role.id
-        }
-        annotations << {
-          type: submission_file.annotation_type,
-          line_start: annot_params[:line_start],
-          line_end: annot_params[:line_end],
-          column_start: annot_params[:column_start],
-          column_end: annot_params[:column_end],
-          x1: annot_params[:x1],
-          y1: annot_params[:y1],
-          x2: annot_params[:x2],
-          y2: annot_params[:y2],
-          page: annot_params[:page],
-          start_node: annot_params[:start_node],
-          start_offset: annot_params[:start_offset],
-          end_node: annot_params[:end_node],
-          end_offset: annot_params[:end_offset],
-          annotation_text_id: nil,
-          submission_file_id: submission_file.id,
-          creator_id: current_role.id,
-          creator_type: current_role.type,
-          is_remark: !result.remark_request_submitted_at.nil?,
-          annotation_number: count + i,
-          result_id: result.id
-        }
+        imported = AnnotationText.insert_all! annotation_texts
+        imported.rows.zip(annotations) do |t, a|
+          a[:annotation_text_id] = t[0]
+        end
+        Annotation.insert_all! annotations
       end
-      imported = AnnotationText.insert_all! annotation_texts
-      imported.rows.zip(annotations) do |t, a|
-        a[:annotation_text_id] = t[0]
-      end
-      Annotation.insert_all! annotations
+
+      return add_annotations_error(error_message) if error_message
+
       render 'shared/http_status', locals: { code: '200', message:
         HttpStatusHelper::ERROR_CODE['message']['200'] }, status: :ok
     end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -256,6 +256,7 @@ module Api
           end
 
           expected_class = submission_file.annotation_class
+          required = expected_class.required_fields
           requested = annot_params[:type].presence
           if requested && requested != expected_class.name
             error_message = "Annotation type '#{requested}' does not match the type " \
@@ -263,9 +264,15 @@ module Api
             raise ActiveRecord::Rollback
           end
 
-          missing = expected_class.required_fields.select { |field| annot_params[field].blank? }
+          missing = required.select { |field| annot_params[field].blank? }
           if missing.any?
             error_message = "Missing required fields for #{expected_class.name}: #{missing.join(', ')}"
+            raise ActiveRecord::Rollback
+          end
+
+          extra = (Annotation.location_fields - required).select { |field| annot_params[field].present? }
+          if extra.any?
+            error_message = "Unexpected fields for #{expected_class.name}: #{extra.join(', ')}"
             raise ActiveRecord::Rollback
           end
 
@@ -289,19 +296,7 @@ module Api
           }
           annotations << {
             type: expected_class.name,
-            line_start: annot_params[:line_start],
-            line_end: annot_params[:line_end],
-            column_start: annot_params[:column_start],
-            column_end: annot_params[:column_end],
-            x1: annot_params[:x1],
-            y1: annot_params[:y1],
-            x2: annot_params[:x2],
-            y2: annot_params[:y2],
-            page: annot_params[:page],
-            start_node: annot_params[:start_node],
-            start_offset: annot_params[:start_offset],
-            end_node: annot_params[:end_node],
-            end_offset: annot_params[:end_offset],
+            **annot_params.slice(*required).to_h.symbolize_keys,
             annotation_text_id: nil,
             submission_file_id: submission_file.id,
             creator_id: current_role.id,
@@ -316,7 +311,11 @@ module Api
         imported.rows.zip(annotations) do |t, a|
           a[:annotation_text_id] = t[0]
         end
-        Annotation.insert_all! annotations
+        # Each annotation type has a different set of location columns, and insert_all! requires
+        # uniform keys, so insert one type at a time.
+        annotations.group_by { |annotation| annotation[:type] }.each_value do |rows|
+          Annotation.insert_all!(rows)
+        end
       end
 
       return add_annotations_error(error_message) if error_message
@@ -544,7 +543,7 @@ module Api
     end
 
     def annotations_params
-      params.permit(annotations: [
+      params.expect(annotations: [[
         :annotation_category_name,
         :content,
         :filename,
@@ -562,7 +561,7 @@ module Api
         :start_offset,
         :end_node,
         :end_offset
-      ])[:annotations] || []
+      ]])
     end
 
     def add_annotations_error(message)

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -66,6 +66,12 @@ class Annotation < ApplicationRecord
   before_destroy :check_if_released
   after_destroy :modify_mark_with_deduction, unless: ->(a) { [nil, 0].include? a.annotation_text.deduction }
 
+  # The union of every annotation subclass's location fields, used to detect annotation
+  # params that belong to a different type than the one being created.
+  def self.location_fields
+    [TextAnnotation, ImageAnnotation, PdfAnnotation, HtmlAnnotation].flat_map(&:required_fields).uniq
+  end
+
   def modify_mark_with_deduction
     criterion = self.annotation_text.annotation_category.flexible_criterion
     self.result.marks.find_or_create_by(criterion: criterion).update_deduction unless self.is_remark

--- a/app/models/html_annotation.rb
+++ b/app/models/html_annotation.rb
@@ -43,6 +43,10 @@ class HtmlAnnotation < Annotation
   validates :end_node, presence: true
   validates :end_offset, presence: true
 
+  def self.required_fields
+    %i[start_node start_offset end_node end_offset]
+  end
+
   def get_data(include_creator: false)
     data = super
     data.merge({ start_node: start_node, start_offset: start_offset, end_node: end_node, end_offset: end_offset })

--- a/app/models/image_annotation.rb
+++ b/app/models/image_annotation.rb
@@ -43,6 +43,10 @@ class ImageAnnotation < Annotation
   validates :x1, :x2, :y1, :y2, presence: true
   validates :x1, :x2, :y1, :y2, numericality: true
 
+  def self.required_fields
+    %i[x1 y1 x2 y2]
+  end
+
   # Return a hash containing the coordinates of the rectangle containing the
   # annotation.
   #

--- a/app/models/pdf_annotation.rb
+++ b/app/models/pdf_annotation.rb
@@ -43,6 +43,10 @@ class PdfAnnotation < Annotation
   validates :x1, :x2, :y1, :y2, :page, presence: true
   validates :x1, :x2, :y1, :y2, :page, numericality: true
 
+  def self.required_fields
+    %i[x1 y1 x2 y2 page]
+  end
+
   # Return a hash containing the coordinates of the rectangle containing the
   # annotation and the page.
   #

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -53,6 +53,17 @@ class SubmissionFile < ApplicationRecord
     File.extname(filename).casecmp('.rmd')&.zero?
   end
 
+  # The annotation class (single-table-inheritance type) appropriate for this file,
+  # derived from its type. Mirrors the logic used when creating annotations in the UI
+  # (see AnnotationsController), and is the single source of truth for that mapping.
+  def annotation_type
+    return 'ImageAnnotation' if is_supported_image?
+    return 'PdfAnnotation' if is_pdf?
+    return 'HtmlAnnotation' if is_pynb? || (is_rmd? && Rails.application.config.rmd_convert_enabled)
+
+    'TextAnnotation'
+  end
+
   # Taken from http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/44936
   def self.is_binary?(file_contents)
     file_contents.size == 0 ||

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -53,15 +53,15 @@ class SubmissionFile < ApplicationRecord
     File.extname(filename).casecmp('.rmd')&.zero?
   end
 
-  # The annotation class (single-table-inheritance type) appropriate for this file,
+  # The annotation class (single-table-inheritance subclass) appropriate for this file,
   # derived from its type. Mirrors the logic used when creating annotations in the UI
   # (see AnnotationsController), and is the single source of truth for that mapping.
-  def annotation_type
-    return 'ImageAnnotation' if is_supported_image?
-    return 'PdfAnnotation' if is_pdf?
-    return 'HtmlAnnotation' if is_pynb? || (is_rmd? && Rails.application.config.rmd_convert_enabled)
+  def annotation_class
+    return ImageAnnotation if is_supported_image?
+    return PdfAnnotation if is_pdf?
+    return HtmlAnnotation if is_pynb? || (is_rmd? && Rails.application.config.rmd_convert_enabled)
 
-    'TextAnnotation'
+    TextAnnotation
   end
 
   # Taken from http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/44936

--- a/app/models/text_annotation.rb
+++ b/app/models/text_annotation.rb
@@ -43,6 +43,10 @@ class TextAnnotation < Annotation
   validates :column_start, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :column_end, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
+  def self.required_fields
+    %i[line_start line_end column_start column_end]
+  end
+
   def get_data(include_creator: false)
     data = super
     data.merge({

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -115,6 +115,17 @@ describe AnnotationsController do
         expect(response).to have_http_status(:success)
         expect(result.annotations.reload.size).to eq 1
       end
+
+      it 'raises when required annotation attributes are missing' do
+        expect do
+          post_as user,
+                  :add_existing_annotation,
+                  params: { annotation_text_id: annotation_text.id, submission_file_id: submission_file.id,
+                            result_id: result.id, course_id: course.id },
+                  format: :js
+        end.to raise_error(ActiveRecord::RecordInvalid)
+        expect(result.annotations.reload).to be_empty
+      end
     end
 
     describe '#create' do

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -922,6 +922,20 @@ describe Api::GroupsController do
           expect(response).to have_http_status :unprocessable_content
           expect(submission.current_result.annotations).to be_empty
         end
+
+        it 'rolls back categories created earlier in the batch when a later annotation is invalid' do
+          annotation_data = [
+            { type: 'TextAnnotation', filename: submission_file.filename, content: 'ok',
+              annotation_category_name: 'New Category',
+              line_start: 1, line_end: 1, column_start: 0, column_end: 5 },
+            { type: 'TextAnnotation', filename: pdf_file.filename, content: 'bad', # mismatched type/file
+              line_start: 1, line_end: 1, column_start: 0, column_end: 5 }
+          ]
+
+          expect { post_annotations(annotation_data) }.not_to(change { assignment.annotation_categories.count })
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
       end
     end
 

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -784,8 +784,21 @@ describe Api::GroupsController do
       let(:assignment) { create(:assignment) }
       let(:grouping) { create(:grouping, assignment: assignment) }
       let(:submission) { create(:version_used_submission, grouping: grouping) }
-      let(:submission_file) { create(:submission_file, submission: submission) }
+      let!(:submission_file) { create(:submission_file, submission: submission) }
+      let!(:image_file) { create(:image_submission_file, submission: submission) }
+      let!(:pdf_file) { create(:pdf_submission_file, submission: submission) }
+      let!(:notebook_file) { create(:notebook_submission_file, submission: submission) }
       let(:response_type) { 'application/xml' }
+
+      def post_annotations(annotation_data)
+        request.env['HTTP_ACCEPT'] = response_type
+        post :add_annotations, params: {
+          assignment_id: assignment.id,
+          id: grouping.group_id,
+          course_id: course.id,
+          annotations: annotation_data
+        }
+      end
 
       it 'creates new annotations for a submission file that exists' do
         annotation_data = [
@@ -808,18 +821,107 @@ describe Api::GroupsController do
             column_end: 15
           }
         ]
-        request.env['HTTP_ACCEPT'] = response_type
-        post :add_annotations, params: {
-          assignment_id: assignment.id,
-          id: grouping.group_id,
-          course_id: course.id,
-          annotations: annotation_data
-        }
+        post_annotations(annotation_data)
 
         expect(response).to have_http_status :success
 
         annotation_contents = submission.current_result.annotations.map { |a| a.annotation_text.content }
         expect(annotation_contents).to contain_exactly('Content 1', 'Content 2')
+      end
+
+      it "creates a TextAnnotation for type 'TextAnnotation' on a text file" do
+        post_annotations([{ type: 'TextAnnotation', filename: submission_file.filename, content: 'c',
+                            line_start: 1, line_end: 2, column_start: 0, column_end: 5 }])
+
+        expect(response).to have_http_status :success
+        expect(submission.current_result.annotations.first).to be_a(TextAnnotation)
+      end
+
+      it "creates an ImageAnnotation for type 'ImageAnnotation' on an image file" do
+        post_annotations([{ type: 'ImageAnnotation', filename: image_file.filename, content: 'c',
+                            x1: 1, y1: 2, x2: 3, y2: 4 }])
+
+        expect(response).to have_http_status :success
+        annotation = submission.current_result.annotations.first
+        expect(annotation).to be_a(ImageAnnotation)
+        expect([annotation.x1, annotation.y1, annotation.x2, annotation.y2]).to eq([1, 2, 3, 4])
+      end
+
+      it "creates a PdfAnnotation for type 'PdfAnnotation' on a pdf file" do
+        post_annotations([{ type: 'PdfAnnotation', filename: pdf_file.filename, content: 'c',
+                            x1: 1, y1: 2, x2: 3, y2: 4, page: 7 }])
+
+        expect(response).to have_http_status :success
+        annotation = submission.current_result.annotations.first
+        expect(annotation).to be_a(PdfAnnotation)
+        expect(annotation.page).to eq(7)
+      end
+
+      it "creates an HtmlAnnotation for type 'HtmlAnnotation' on a notebook file" do
+        post_annotations([{ type: 'HtmlAnnotation', filename: notebook_file.filename, content: 'c',
+                            start_node: 'p:nth-child(1)', start_offset: 0,
+                            end_node: 'p:nth-child(2)', end_offset: 10 }])
+
+        expect(response).to have_http_status :success
+        annotation = submission.current_result.annotations.first
+        expect(annotation).to be_a(HtmlAnnotation)
+        expect(annotation.start_node).to eq('p:nth-child(1)')
+      end
+
+      it 'derives the type from the file when type is omitted' do
+        post_annotations([{ filename: pdf_file.filename, content: 'c',
+                            x1: 1, y1: 2, x2: 3, y2: 4, page: 1 }])
+
+        expect(response).to have_http_status :success
+        expect(submission.current_result.annotations.first).to be_a(PdfAnnotation)
+      end
+
+      it 'creates annotations of mixed types across files in a single request' do
+        annotation_data = [
+          { type: 'TextAnnotation', filename: submission_file.filename, content: 'text',
+            line_start: 1, line_end: 1, column_start: 0, column_end: 5 },
+          { type: 'PdfAnnotation', filename: pdf_file.filename, content: 'pdf',
+            x1: 1, y1: 2, x2: 3, y2: 4, page: 1 }
+        ]
+        post_annotations(annotation_data)
+
+        expect(response).to have_http_status :success
+        types = submission.current_result.annotations.map { |a| a.class.name }
+        expect(types).to contain_exactly('TextAnnotation', 'PdfAnnotation')
+      end
+
+      context 'with invalid input' do
+        it 'returns 422 when the asserted type does not match the file' do
+          post_annotations([{ type: 'TextAnnotation', filename: pdf_file.filename, content: 'c',
+                              line_start: 1, line_end: 1, column_start: 0, column_end: 5 }])
+
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
+
+        it 'returns 422 for an unknown annotation type' do
+          post_annotations([{ type: 'bogus', filename: submission_file.filename, content: 'c',
+                              line_start: 1, line_end: 1, column_start: 0, column_end: 5 }])
+
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
+
+        it 'returns 422 when the submission file does not exist' do
+          post_annotations([{ type: 'TextAnnotation', filename: 'does_not_exist.txt', content: 'c',
+                              line_start: 1, line_end: 1, column_start: 0, column_end: 5 }])
+
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
+
+        it 'returns 422 when a required field is missing for the derived type' do
+          post_annotations([{ filename: pdf_file.filename, content: 'c',
+                              x1: 1, y1: 2, x2: 3, y2: 4 }]) # missing page
+
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
       end
     end
 

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -891,6 +891,14 @@ describe Api::GroupsController do
       end
 
       context 'with invalid input' do
+        it 'raises ParameterMissing when the annotations key is absent' do
+          request.env['HTTP_ACCEPT'] = response_type
+          expect do
+            post :add_annotations, params: { assignment_id: assignment.id, id: grouping.group_id,
+                                             course_id: course.id }
+          end.to raise_error(ActionController::ParameterMissing)
+        end
+
         it 'returns 422 when the asserted type does not match the file' do
           post_annotations([{ type: 'TextAnnotation', filename: pdf_file.filename, content: 'c',
                               line_start: 1, line_end: 1, column_start: 0, column_end: 5 }])
@@ -918,6 +926,15 @@ describe Api::GroupsController do
         it 'returns 422 when a required field is missing for the derived type' do
           post_annotations([{ filename: pdf_file.filename, content: 'c',
                               x1: 1, y1: 2, x2: 3, y2: 4 }]) # missing page
+
+          expect(response).to have_http_status :unprocessable_content
+          expect(submission.current_result.annotations).to be_empty
+        end
+
+        it 'returns 422 when fields belonging to a different type are included' do
+          post_annotations([{ filename: pdf_file.filename, content: 'c',
+                              x1: 1, y1: 2, x2: 3, y2: 4, page: 1,
+                              line_start: 5 }]) # line_start belongs to a TextAnnotation
 
           expect(response).to have_http_status :unprocessable_content
           expect(submission.current_result.annotations).to be_empty

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -335,4 +335,36 @@ describe SubmissionFile do
       expect(file.retrieve_file.include?(deductive_info)).to be true
     end
   end
+
+  describe '#annotation_type' do
+    it 'returns ImageAnnotation for an image file' do
+      expect(build(:image_submission_file).annotation_type).to eq('ImageAnnotation')
+    end
+
+    it 'returns PdfAnnotation for a pdf file' do
+      expect(build(:pdf_submission_file).annotation_type).to eq('PdfAnnotation')
+    end
+
+    it 'returns HtmlAnnotation for a notebook file' do
+      expect(build(:notebook_submission_file).annotation_type).to eq('HtmlAnnotation')
+    end
+
+    it 'returns TextAnnotation for a plaintext file' do
+      expect(build(:submission_file, filename: 'foo.py').annotation_type).to eq('TextAnnotation')
+    end
+
+    context 'for an RMarkdown file' do
+      let(:rmd_file) { build(:rmd_submission_file) }
+
+      it 'returns HtmlAnnotation when rmd_convert_enabled is true' do
+        allow(Rails.application.config).to receive(:rmd_convert_enabled).and_return(true)
+        expect(rmd_file.annotation_type).to eq('HtmlAnnotation')
+      end
+
+      it 'returns TextAnnotation when rmd_convert_enabled is false' do
+        allow(Rails.application.config).to receive(:rmd_convert_enabled).and_return(false)
+        expect(rmd_file.annotation_type).to eq('TextAnnotation')
+      end
+    end
+  end
 end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -336,21 +336,21 @@ describe SubmissionFile do
     end
   end
 
-  describe '#annotation_type' do
+  describe '#annotation_class' do
     it 'returns ImageAnnotation for an image file' do
-      expect(build(:image_submission_file).annotation_type).to eq('ImageAnnotation')
+      expect(build(:image_submission_file).annotation_class).to eq(ImageAnnotation)
     end
 
     it 'returns PdfAnnotation for a pdf file' do
-      expect(build(:pdf_submission_file).annotation_type).to eq('PdfAnnotation')
+      expect(build(:pdf_submission_file).annotation_class).to eq(PdfAnnotation)
     end
 
     it 'returns HtmlAnnotation for a notebook file' do
-      expect(build(:notebook_submission_file).annotation_type).to eq('HtmlAnnotation')
+      expect(build(:notebook_submission_file).annotation_class).to eq(HtmlAnnotation)
     end
 
     it 'returns TextAnnotation for a plaintext file' do
-      expect(build(:submission_file, filename: 'foo.py').annotation_type).to eq('TextAnnotation')
+      expect(build(:submission_file, filename: 'foo.py').annotation_class).to eq(TextAnnotation)
     end
 
     context 'for an RMarkdown file' do
@@ -358,12 +358,12 @@ describe SubmissionFile do
 
       it 'returns HtmlAnnotation when rmd_convert_enabled is true' do
         allow(Rails.application.config).to receive(:rmd_convert_enabled).and_return(true)
-        expect(rmd_file.annotation_type).to eq('HtmlAnnotation')
+        expect(rmd_file.annotation_class).to eq(HtmlAnnotation)
       end
 
       it 'returns TextAnnotation when rmd_convert_enabled is false' do
         allow(Rails.application.config).to receive(:rmd_convert_enabled).and_return(false)
-        expect(rmd_file.annotation_type).to eq('TextAnnotation')
+        expect(rmd_file.annotation_class).to eq(TextAnnotation)
       end
     end
   end


### PR DESCRIPTION
## Proposed Changes


The API endpoint `POST add_annotations` now supports all annotation types. Co-authored with Claude. Closes #7999.

In achieving this, it was found that there was no validation of annotation type to file type for which we are seeking to annotate. This means a request to apply a `PdfAnnotation` to a `.py` file would succeed, which would break rendering in the UI. To resolve this, some pre-existing type derivation logic was lifted out of the UI `AnnotationsController` and is now being used in both the UI and API controllers; the API also uses it as a part of the validation chain. 

As a side effect of this change, `add_existing_annotation`'s specs were lacking coverage due to a mix in record creation between annotation types: `HtmlAnnotation` used `create!`, and all other annotations used `create`. This is now consolidated. There was no coverage of the failure path for this record creation, so this was added here for good measure.

Another small bug that was fixed is that prior to this change, `POST`ing a `TextAnnotation` to a non-text file could create an annotation that would never be displayed on that file. Users will now see a `422` response if they try to do this.

The API endpoint itself now either accepts an explicit annotation type, or derives it implicitly. In the former case, it expects a match between the annotation type and the file being annotated. In the latter, it simply reconciles it from the file being annotated.



<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

https://github.com/MarkUsProject/Wiki/pull/267

</details>

## Type of Change


| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |     x     |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Here's a summary of the smoke tests for the changes to the endpoint:

### Smoke test — `add_annotations` API

Local server (`/csc108`), authenticated instructor API key. Seeded one file per type on a
version-used submission: `hello.py`, `nemo.jpg`, `possimus.pdf`, `ipsa.ipynb`. Each result
confirmed by reading back through `GET …/groups/:id/annotations`. The `type` field uses the
full STI class names (`TextAnnotation`/`ImageAnnotation`/`PdfAnnotation`/`HtmlAnnotation`).

| # | Scenario | `type` sent | Target file | Expected | Result |
|---|----------|-------------|-------------|----------|--------|
| 1 | Text annotation | `TextAnnotation` | `hello.py` | 200, `TextAnnotation` | ✅ 200 — `TextAnnotation`, line/col persisted |
| 2 | Image annotation | `ImageAnnotation` | `nemo.jpg` | 200, `ImageAnnotation` | ✅ 200 — `ImageAnnotation`, x/y persisted |
| 3 | PDF annotation | `PdfAnnotation` | `possimus.pdf` | 200, `PdfAnnotation` | ✅ 200 — `PdfAnnotation`, page 2 |
| 4 | HTML annotation | `HtmlAnnotation` | `ipsa.ipynb` | 200, `HtmlAnnotation` | ✅ 200 — `HtmlAnnotation`, nodes persisted |
| 5 | Type omitted → derived from file | *(none)* | `possimus.pdf` | 200, `PdfAnnotation` | ✅ 200 — `PdfAnnotation`, page 3 |
| 6 | Type ↔ file mismatch | `TextAnnotation` | `possimus.pdf` | 422 | ✅ 422 — `Annotation type 'TextAnnotation' does not match the type of file 'possimus.pdf'` |
| 7 | Unknown / invalid type | `bogus` | `hello.py` | 422 | ✅ 422 — `Invalid annotation type: bogus` |
| 8 | Missing required field | *(derived pdf)* | `possimus.pdf` (no `page`) | 422 | ✅ 422 — `Missing required fields for PdfAnnotation: page` |
| 9 | Nonexistent file | `TextAnnotation` | `nope.txt` | 422 | ✅ 422 — `Submission file not found: nope.txt` |
| 10 | Batch atomicity (1 valid + 1 invalid) | `TextAnnotation`, `TextAnnotation` | `hello.py`, `possimus.pdf` | 422, nothing written | ✅ 422 — DB count unchanged; valid item not written |
| 11 | Empty annotations array | — | — | (edge) | ✅ 200 — no-op, nothing written |

**Net:** all 5 valid writes persisted with the correct STI type on the correct file; all 4
bad-input paths failed closed with specific 422 messages and left the DB unchanged; batch
validation is atomic (rejects the whole request before any insert).

> Note: `type` accepts the STI class names; a short code such as `"text"` is rejected as
> `Invalid annotation type: text` (consistent with the `add_test_results` endpoint).

> Note: API error `description` values are HTML-escaped (e.g. `&#39;` for `'`) by the shared
> `shared/http_status.json.erb` renderer — pre-existing, app-wide behavior, not introduced by
> this change.
