### PR TITLE
feat: refactor polling to websocket

### DIFF
--- a/app/channels/groups_channel.rb
+++ b/app/channels/groups_channel.rb
@@ -1,0 +1,20 @@
+class GroupsChannel < ApplicationCable::Channel
+  def subscribed
+    course = Course.find_by(id: params[:course_id])
+    assignment = course&.assignments&.find_by(id: params[:assignment_id])
+    role = Role.find_by(user: current_user, course: course)
+    if assignment.nil? || role.nil?
+      reject
+      return
+    end
+    unless allowed_to?(:manage?, assignment, context: { real_user: current_user, role: role })
+      reject
+      return
+    end
+    stream_for current_user
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -326,13 +326,14 @@ class GroupsController < ApplicationController
                            .where(hidden: false)
                            .pluck('users.user_name')
                            .map { |user_name| [user_name, user_name] }
-      @current_job = CreateGroupsJob.perform_later @assignment, data
-      session[:job_id] = @current_job.job_id
+      enqueuing_user = current_user
+      current_job = CreateGroupsJob.perform_later @assignment, data,
+                                                  enqueuing_user: enqueuing_user,
+                                                  notify_socket: true
+      GroupsChannel.broadcast_to(enqueuing_user, ActiveJob::Status.get(current_job).to_h) if enqueuing_user
     end
 
-    respond_to do |format|
-      format.js { render 'shared/_poll_job' }
-    end
+    head :ok
   end
 
   def download

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -308,8 +308,7 @@ class GroupsController < ApplicationController
       end
 
       if result[:invalid_lines].empty?
-        @current_job = CreateGroupsJob.perform_later assignment, group_rows
-        session[:job_id] = @current_job.job_id
+        create_groups_with_socket(assignment, group_rows)
       else
         flash_message(:error, result[:invalid_lines])
       end
@@ -326,11 +325,7 @@ class GroupsController < ApplicationController
                            .where(hidden: false)
                            .pluck('users.user_name')
                            .map { |user_name| [user_name, user_name] }
-      enqueuing_user = current_user
-      current_job = CreateGroupsJob.perform_later @assignment, data,
-                                                  enqueuing_user: enqueuing_user,
-                                                  notify_socket: true
-      GroupsChannel.broadcast_to(enqueuing_user, ActiveJob::Status.get(current_job).to_h) if enqueuing_user
+      create_groups_with_socket(@assignment, data)
     end
 
     head :ok
@@ -628,6 +623,14 @@ class GroupsController < ApplicationController
   end
 
   private
+
+  def create_groups_with_socket(assignment, data)
+    enqueuing_user = current_user
+    current_job = CreateGroupsJob.perform_later assignment, data,
+                                                enqueuing_user: enqueuing_user,
+                                                notify_socket: true
+    GroupsChannel.broadcast_to(enqueuing_user, ActiveJob::Status.get(current_job).to_h) if enqueuing_user
+  end
 
   # These methods are called through global actions.
 

--- a/app/javascript/Components/__tests__/groups_manager.test.jsx
+++ b/app/javascript/Components/__tests__/groups_manager.test.jsx
@@ -3,6 +3,22 @@ import {GroupsManager} from "../groups_manager";
 import {beforeEach, describe, expect, it} from "@jest/globals";
 import {getTimeExtension} from "../Helpers/table_helpers";
 
+const mockCreateSubscription = jest.fn();
+const mockRenderFlashMessages = jest.fn();
+
+jest.mock("../../channels/consumer", () => ({
+  __esModule: true,
+  default: {
+    subscriptions: {
+      create: (...args) => mockCreateSubscription(...args),
+    },
+  },
+}));
+
+jest.mock("../../common/flash", () => ({
+  renderFlashMessages: (...args) => mockRenderFlashMessages(...args),
+}));
+
 jest.mock("@fortawesome/react-fontawesome", () => ({
   FontAwesomeIcon: () => {
     return null;
@@ -66,6 +82,11 @@ const studentMock = [
   },
 ];
 
+beforeEach(() => {
+  mockCreateSubscription.mockClear();
+  mockRenderFlashMessages.mockClear();
+});
+
 describe("GroupsManager", () => {
   let filter_method = null;
   let wrapper = React.createRef();
@@ -94,6 +115,66 @@ describe("GroupsManager", () => {
     // wait for page to load and render content
     await screen.findByText("abcd").catch(err => err);
     // to view screen render: screen.debug(undefined, 300000)
+  });
+
+  describe("websocket updates", () => {
+    it("subscribes to group creation job status updates", () => {
+      expect(mockCreateSubscription).toHaveBeenCalledWith(
+        {channel: "GroupsChannel", course_id: 1, assignment_id: 2},
+        expect.objectContaining({
+          connected: expect.any(Function),
+          disconnected: expect.any(Function),
+          received: expect.any(Function),
+        })
+      );
+
+      const callbacks = mockCreateSubscription.mock.calls[0][1];
+      callbacks.connected();
+      callbacks.disconnected();
+    });
+
+    it("renders flash messages from websocket status updates", () => {
+      const callbacks = mockCreateSubscription.mock.calls[0][1];
+      const cases = [
+        [{status: "queued"}, {notice: I18n.t("job.status.queued")}],
+        [{status: "completed"}, {success: I18n.t("job.status.completed")}],
+        [{status: "failed"}, {error: I18n.t("job.status.failed.no_message")}],
+        [
+          {status: "failed", exception: {message: "boom"}},
+          {error: I18n.t("job.status.failed.message", {error: "boom"})},
+        ],
+        [
+          {status: "working", progress: 1, total: 2, warning_message: "warn"},
+          {notice: I18n.t("poll_job.create_groups_job", {progress: 1, total: 2}), warning: "warn"},
+        ],
+      ];
+
+      cases.forEach(([data, expectedMessage]) => {
+        mockRenderFlashMessages.mockClear();
+        callbacks.received(data);
+        expect(mockRenderFlashMessages).toHaveBeenCalledWith(expectedMessage);
+      });
+    });
+
+    it("refreshes data when the websocket update requests a table update", () => {
+      const callbacks = mockCreateSubscription.mock.calls[0][1];
+      wrapper.current.fetchData = jest.fn();
+
+      callbacks.received({update_table: true});
+
+      expect(wrapper.current.fetchData).toHaveBeenCalled();
+      expect(mockRenderFlashMessages).not.toHaveBeenCalled();
+    });
+
+    it("requests individual group creation without eagerly refreshing data", () => {
+      const getSpy = jest.spyOn($, "get").mockReturnValue({});
+      wrapper.current.createAllGroups();
+
+      expect(getSpy).toHaveBeenCalledWith({
+        url: Routes.create_groups_when_students_work_alone_course_assignment_groups_path(1, 2),
+      });
+      getSpy.mockRestore();
+    });
   });
 
   describe("DueDateExtensions", () => {

--- a/app/javascript/Components/groups_manager.jsx
+++ b/app/javascript/Components/groups_manager.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import {createRoot} from "react-dom/client";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
+import consumer from "../channels/consumer";
+import {renderFlashMessages} from "../common/flash";
 import {withSelection, CheckboxTable} from "./markus_with_selection_hoc";
 import ExtensionModal from "./Modals/extension_modal";
 import {
@@ -42,6 +44,7 @@ class GroupsManager extends React.Component {
 
   componentDidMount() {
     this.fetchData();
+    this.createChannelSubscriptions();
   }
 
   fetchData = () => {
@@ -105,7 +108,29 @@ class GroupsManager extends React.Component {
         this.props.course_id,
         this.props.assignment_id
       ),
-    }).then(this.fetchData);
+    });
+  };
+
+  createChannelSubscriptions = () => {
+    consumer.subscriptions.create(
+      {
+        channel: "GroupsChannel",
+        course_id: this.props.course_id,
+        assignment_id: this.props.assignment_id,
+      },
+      {
+        connected: () => {},
+        disconnected: () => {},
+        received: data => {
+          if (data["status"] != null) {
+            renderFlashMessages(generateMessage(data));
+          }
+          if (data["update_table"] != null) {
+            this.fetchData();
+          }
+        },
+      }
+    );
   };
 
   deleteGroups = () => {
@@ -846,6 +871,36 @@ export function makeGroupsManager(elem, props) {
   const component = React.createRef();
   root.render(<GroupsManager {...props} ref={component} />);
   return component;
+}
+
+function generateMessage(status_data) {
+  let message_data = {};
+  switch (status_data["status"]) {
+    case "failed":
+      if (!status_data["exception"] || !status_data["exception"]["message"]) {
+        message_data["error"] = I18n.t("job.status.failed.no_message");
+      } else {
+        message_data["error"] = I18n.t("job.status.failed.message", {
+          error: status_data["exception"]["message"],
+        });
+      }
+      break;
+    case "completed":
+      message_data["success"] = I18n.t("job.status.completed");
+      break;
+    case "queued":
+      message_data["notice"] = I18n.t("job.status.queued");
+      break;
+    default: {
+      let progress = status_data["progress"];
+      let total = status_data["total"];
+      message_data["notice"] = I18n.t("poll_job.create_groups_job", {progress, total});
+    }
+  }
+  if (status_data["warning_message"]) {
+    message_data["warning"] = status_data["warning_message"];
+  }
+  return message_data;
 }
 
 export {GroupsManager};

--- a/app/jobs/create_groups_job.rb
+++ b/app/jobs/create_groups_job.rb
@@ -8,7 +8,8 @@ class CreateGroupsJob < ApplicationJob
     I18n.t('poll_job.create_groups_job', progress: status[:progress], total: status[:total])
   end
 
-  def perform(assignment, data)
+  def perform(assignment, data, enqueuing_user: nil, notify_socket: false)
+    job_failed = false
     progress.total = data.length
     Repository.get_class.update_permissions_after(only_on_request: true) do
       data.each do |(group_name, *members)|
@@ -45,10 +46,38 @@ class CreateGroupsJob < ApplicationJob
           end
         end
         progress.increment
+        broadcast_status(enqueuing_user, notify_socket)
       end
     end
     m_logger = MarkusLogger.instance
     m_logger.log('Creating all individual groups completed',
                  MarkusLogger::INFO)
+  rescue StandardError => e
+    job_failed = true
+    status.catch_exception(e)
+    raise e
+  ensure
+    broadcast_final_status(enqueuing_user, notify_socket, job_failed)
+  end
+
+  private
+
+  def broadcast_status(enqueuing_user, notify_socket)
+    return unless notify_socket && enqueuing_user
+
+    GroupsChannel.broadcast_to(enqueuing_user, status.to_h)
+  end
+
+  def broadcast_final_status(enqueuing_user, notify_socket, job_failed)
+    return unless notify_socket && enqueuing_user
+
+    message = if job_failed
+                status.to_h
+              else
+                { status: :completed }.tap do |options|
+                  options[:warning_message] = status[:warning_message] if status[:warning_message].present?
+                end
+              end
+    GroupsChannel.broadcast_to(enqueuing_user, message.merge({ update_table: true }))
   end
 end

--- a/spec/channels/groups_channel_spec.rb
+++ b/spec/channels/groups_channel_spec.rb
@@ -1,0 +1,69 @@
+describe GroupsChannel do
+  let(:course) { create(:course) }
+  let(:assignment) { create(:assignment, course: course) }
+
+  context 'when a user can manage the assignment' do
+    let(:role) { create(:instructor, course: course) }
+    let(:user) { role.user }
+
+    before do
+      stub_connection(current_user: user)
+      subscribe(course_id: course.id, assignment_id: assignment.id)
+    end
+
+    it 'subscribes to the channel' do
+      expect(subscription).to be_confirmed
+    end
+
+    it 'streams for the current user' do
+      expect(subscription).to have_stream_for(user)
+    end
+  end
+
+  context 'when a user cannot manage the assignment' do
+    let(:role) { create(:student, course: course) }
+    let(:user) { role.user }
+
+    before do
+      stub_connection(current_user: user)
+      subscribe(course_id: course.id, assignment_id: assignment.id)
+    end
+
+    it 'does not subscribe to the channel' do
+      expect(subscription).to be_rejected
+    end
+  end
+
+  context 'when a user cannot manage the course for this assignment' do
+    let(:other_course) { create(:course) }
+    let(:role) { create(:ta, manage_assessments: true, course: other_course) }
+    let(:user) { role.user }
+
+    before do
+      stub_connection(current_user: user)
+      subscribe(course_id: course.id, assignment_id: assignment.id)
+    end
+
+    it 'does not subscribe to the channel' do
+      expect(subscription).to be_rejected
+    end
+  end
+
+  context 'when a ta can manage assessments in the course' do
+    let(:role) { create(:ta, manage_assessments: true, course: course) }
+    let(:user) { role.user }
+
+    before do
+      stub_connection(current_user: user)
+      subscribe(course_id: course.id, assignment_id: assignment.id)
+    end
+
+    it 'subscribes to the channel' do
+      expect(subscription).to be_confirmed
+    end
+
+    it 'streams for the current user' do
+      expect(subscription).to have_stream_for(user)
+    end
+  end
+end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -561,7 +561,39 @@ describe GroupsController do
         end
       end
 
+      it 'enqueues the create groups job with websocket notifications' do
+        post_as instructor, :upload, params: {
+          course_id: course.id,
+          assignment_id: @assignment.id,
+          upload_file: fixture_file_upload('groups/form_good.csv', 'text/csv')
+        }
+
+        expected_args = ->(job_args) do
+          assignment_arg, data_arg, kwargs = job_args
+          expect(assignment_arg).to eq(@assignment)
+          expect(data_arg).to match_array([%w[group1 c8shosta c5bennet]])
+          expect(kwargs).to include(enqueuing_user: instructor.user, notify_socket: true)
+        end
+
+        assert_enqueued_with(job: CreateGroupsJob, args: expected_args)
+        expect(flash[:error]).to be_blank
+      end
+
+      it 'broadcasts the initial job status to the current user' do
+        expect(GroupsChannel).to receive(:broadcast_to) do |enqueuing_user, _|
+          expect(enqueuing_user).to eq(instructor.user)
+        end
+
+        post_as instructor, :upload, params: {
+          course_id: course.id,
+          assignment_id: @assignment.id,
+          upload_file: fixture_file_upload('groups/form_good.csv', 'text/csv')
+        }
+      end
+
       it 'does not accept files with invalid columns' do
+        expect(GroupsChannel).not_to receive(:broadcast_to)
+
         post_as instructor, :upload, params: { course_id: course.id,
                                                assignment_id: @assignment.id,
                                                upload_file: fixture_file_upload('groups/form_invalid_column.csv',

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -649,20 +649,24 @@ describe GroupsController do
                  format: 'js'
 
           expected_args = ->(job_args) do
-            assignment_arg, data_arg = job_args
+            assignment_arg, data_arg, kwargs = job_args
             expect(assignment_arg).to eq(assignment)
             expect(data_arg).to match_array(data)
+            expect(kwargs).to include(enqueuing_user: instructor.user, notify_socket: true)
           end
 
           assert_enqueued_with(job: CreateGroupsJob, args: expected_args)
           expect(flash[:error]).to be_blank
         end
 
-        it 'responds with _poll_job template' do
+        it 'broadcasts the initial job status to the current user' do
+          expect(GroupsChannel).to receive(:broadcast_to) do |enqueuing_user, _|
+            expect(enqueuing_user).to eq(instructor.user)
+          end
+
           get_as instructor, :create_groups_when_students_work_alone,
                  params: { course_id: course.id, assignment_id: assignment.id },
                  format: 'js'
-          expect(response).to render_template('shared/_poll_job')
         end
 
         it 'responds with appropriate status' do
@@ -670,6 +674,13 @@ describe GroupsController do
                  params: { course_id: course.id, assignment_id: assignment.id },
                  format: 'js'
           expect(response).to have_http_status(:ok)
+        end
+
+        it 'does not render the polling template' do
+          get_as instructor, :create_groups_when_students_work_alone,
+                 params: { course_id: course.id, assignment_id: assignment.id },
+                 format: 'js'
+          expect(response).not_to render_template('shared/_poll_job')
         end
       end
 
@@ -690,11 +701,18 @@ describe GroupsController do
           expect(response).to have_http_status(:ok)
         end
 
-        it 'responds with _poll_job template' do
+        it 'does not broadcast a job status' do
+          expect(GroupsChannel).not_to receive(:broadcast_to)
           get_as instructor, :create_groups_when_students_work_alone,
                  params: { course_id: course.id, assignment_id: assignment.id },
                  format: 'js'
-          expect(response).to render_template('shared/_poll_job')
+        end
+
+        it 'does not render the polling template' do
+          get_as instructor, :create_groups_when_students_work_alone,
+                 params: { course_id: course.id, assignment_id: assignment.id },
+                 format: 'js'
+          expect(response).not_to render_template('shared/_poll_job')
         end
       end
     end

--- a/spec/jobs/create_groups_job_spec.rb
+++ b/spec/jobs/create_groups_job_spec.rb
@@ -93,6 +93,61 @@ describe CreateGroupsJob do
     it_behaves_like 'create objects', 2, 2, 2
   end
 
+  context 'when notify_socket flag is set to true and enqueuing_user contains a valid user' do
+    let(:student1) { create(:student, course: assignment.course) }
+    let(:student2) { create(:student, course: assignment.course) }
+    let(:instructor) { create(:instructor, course: assignment.course) }
+
+    before do
+      @data = [[student1.user_name, student1.user_name],
+               [student2.user_name, student2.user_name]]
+    end
+
+    it 'broadcasts status updates and one table update on completion' do
+      (1..2).each do |i|
+        expect(GroupsChannel).to receive(:broadcast_to) do |enqueuing_user, options|
+          expect(enqueuing_user).to eq(instructor.user)
+          expect(options[:status]).to be(:working)
+          expect(options[:progress]).to eq(i)
+          expect(options[:total]).to eq(2)
+        end
+      end
+      expect(GroupsChannel).to receive(:broadcast_to) do |enqueuing_user, options|
+        expect(enqueuing_user).to eq(instructor.user)
+        expect(options[:status]).to be(:completed)
+        expect(options[:update_table]).to be true
+      end
+
+      CreateGroupsJob.perform_now(assignment, @data, enqueuing_user: instructor.user, notify_socket: true)
+    end
+
+    it 'broadcasts warning messages if present' do
+      @data = [['group1', "#{student1.user_name}_bad_padding"],
+               [student2.user_name, student2.user_name]]
+
+      expect(GroupsChannel).to receive(:broadcast_to) do |_, options|
+        expect(options[:warning_message]).to include(
+          I18n.t('groups.upload.errors.unknown_students', student_names: "#{student1.user_name}_bad_padding")
+        )
+      end.exactly(3).times
+
+      CreateGroupsJob.perform_now(assignment, @data, enqueuing_user: instructor.user, notify_socket: true)
+    end
+  end
+
+  context 'when notify_socket flag is not set' do
+    let(:instructor) { create(:instructor, course: assignment.course) }
+
+    before do
+      @data = [[student1.user_name, student1.user_name]]
+    end
+
+    it "doesn't broadcast a message" do
+      expect { CreateGroupsJob.perform_now(assignment, @data, enqueuing_user: instructor.user) }
+        .to have_broadcasted_to(instructor.user).from_channel(GroupsChannel).exactly 0
+    end
+  end
+
   context 'when creating one good and one bad group' do
     context 'when the bad one is first' do
       before do


### PR DESCRIPTION
## Proposed Changes
*(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)*

This PR refactors both `GroupsController#create_groups_when_students_work_alone` and `GroupsController#upload` to use ActionCable websockets instead of polling to report `CreateGroupsJob` status.

Previously, these actions enqueued `CreateGroupsJob`, stored the job id in the session, and relied on the shared polling partial so the frontend could repeatedly request job status. This change follows the existing websocket patterns used elsewhere in MarkUs for background jobs and makes both uses of `CreateGroupsJob` consistent.
<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

<details>
<summary>Associated <a href="https://github.com/MarkUsProject/Wiki">documentation repository</a> pull request (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |     X     |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*

I added tests after seeing the Coveralls comment, the CI/CD test for Coveralls passed after I pushed new tests.
