### PR TITLE
Report incomplete scanned exam groups

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 - Added GET /test_runs API route (#8055)
 
 ### 🐛 Bug fixes
+- Fixed issue with exam scans where instructors were unable to identify which groups have missing pages in their exam scan (#8051)
 - Fixed Assignments Index page dropdown menu not redirecting users to the selected assignment (#8043)
 - Fixed broken checkbox in the header of the selection column for tables with row selection enabled.
 - Fixed bug where clicking a file link in the annotations tab would show a blank or oversized error for PDF files (#8017)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### ✨ New features and improvements
 - Added an assignment summary table filter that lets graders with manage submissions permission view either all submissions or only their assigned submissions (#8052)
+- Added a table showing incomplete papers and their missing page numbers when uploading exam scans (#8051)
 - Updated links to refer to new documentation website (#8049)
 - Added a submissions table filter option that lets graders with manage submissions permission view either all submissions or only their assigned submissions (#8047)
 - Added a submission scope filter to the grading view so TAs with manage submissions permission can navigate either all submissions or only their assigned submissions (#8046)
@@ -27,7 +28,6 @@
 - Added GET /test_runs API route (#8055)
 
 ### 🐛 Bug fixes
-- Fixed issue with exam scans where instructors were unable to identify which groups have missing pages in their exam scan (#8051)
 - Fixed Assignments Index page dropdown menu not redirecting users to the selected assignment (#8043)
 - Fixed broken checkbox in the header of the selection column for tables with row selection enabled.
 - Fixed bug where clicking a file link in the annotations tab would show a blank or oversized error for PDF files (#8017)

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -201,8 +201,18 @@ class ExamTemplatesController < ApplicationController
             end
 
             next if page.group_id.nil?
-            group_data[page.group_id] ||= { group: page.group.group_name, complete: false }
-            group_data[page.group_id][:complete] ||= page.status&.include?('Saved to complete directory') || false
+            group_data[page.group_id] ||= { group: page.group.group_name, pages_seen: Set.new }
+            group_data[page.group_id][:pages_seen] << page.exam_page_number if page.exam_page_number
+          end
+
+          num_pages = log.exam_template.num_pages
+          group_data = group_data.values.map do |group|
+            missing_pages = num_pages - group[:pages_seen].size
+            {
+              group: group[:group],
+              complete: missing_pages == 0,
+              missing_pages: missing_pages
+            }
           end
 
           {
@@ -217,7 +227,7 @@ class ExamTemplatesController < ApplicationController
             num_pages_qr_scan_error: log.num_pages_qr_scan_error,
             # number_of_pages_fixed: log.split_pages.where(status: 'FIXED').length
             page_data: page_data,
-            group_data: group_data.values
+            group_data: group_data
           }
         end
         render json: data

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -190,6 +190,7 @@ class ExamTemplatesController < ApplicationController
           group_data = {}
 
           log.split_pages.each do |page|
+            # TODO: make status non-nil.
             if page.status == 'FIXED' || page.status&.start_with?('ERROR')
               page_data << {
                 raw_page_number: page.raw_page_number,
@@ -201,18 +202,14 @@ class ExamTemplatesController < ApplicationController
             end
 
             next if page.group_id.nil?
-            group_data[page.group_id] ||= { group: page.group.group_name, pages_seen: Set.new }
-            group_data[page.group_id][:pages_seen] << page.exam_page_number if page.exam_page_number
+            group_data[page.group.group_name] ||= Set.new
+            group_data[page.group.group_name] << page.exam_page_number if page.exam_page_number
           end
 
           num_pages = log.exam_template.num_pages
-          group_data = group_data.values.map do |group|
-            missing_pages = num_pages - group[:pages_seen].size
-            {
-              group: group[:group],
-              complete: missing_pages == 0,
-              missing_pages: missing_pages
-            }
+          group_data = group_data.filter_map do |group_name, pages_seen|
+            missing_pages = (1..num_pages).to_a - pages_seen.to_a
+            { group: group_name, missing_pages: missing_pages } unless missing_pages.empty?
           end
 
           {

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -186,20 +186,25 @@ class ExamTemplatesController < ApplicationController
                                     .includes(split_pages: :group)
 
         data = split_pdf_logs.map do |log|
-          pages = log.split_pages.select do |p|
-            # TODO: make status non-nil.
-            p.status == 'FIXED' || p.status&.start_with?('ERROR')
+          page_data = []
+          group_data = {}
+
+          log.split_pages.each do |page|
+            if page.status == 'FIXED' || page.status&.start_with?('ERROR')
+              page_data << {
+                raw_page_number: page.raw_page_number,
+                exam_page_number: page.exam_page_number,
+                status: page.status,
+                group: page.group_id.nil? ? nil : page.group.group_name,
+                id: page.id
+              }
+            end
+
+            next if page.group_id.nil?
+            group_data[page.group_id] ||= { group: page.group.group_name, complete: false }
+            group_data[page.group_id][:complete] ||= page.status&.include?('Saved to complete directory') || false
           end
 
-          page_data = pages.map do |page|
-            {
-              raw_page_number: page.raw_page_number,
-              exam_page_number: page.exam_page_number,
-              status: page.status,
-              group: page.group_id.nil? ? nil : page.group.group_name,
-              id: page.id
-            }
-          end
           {
             date: I18n.l(log.uploaded_when),
             exam_template: log.exam_template.name,
@@ -211,7 +216,8 @@ class ExamTemplatesController < ApplicationController
             original_num_pages: log.original_num_pages,
             num_pages_qr_scan_error: log.num_pages_qr_scan_error,
             # number_of_pages_fixed: log.split_pages.where(status: 'FIXED').length
-            page_data: page_data
+            page_data: page_data,
+            group_data: group_data.values
           }
         end
         render json: data

--- a/app/javascript/Components/exam_scan_log_table.jsx
+++ b/app/javascript/Components/exam_scan_log_table.jsx
@@ -136,7 +136,7 @@ class ExamScanLogTable extends React.Component {
               split_pdf_log_id={row.original.file_id}
               assignment_id={this.props.assignment_id}
             />
-            <h4>{I18n.t("split_pdf_logs.papers_found")}</h4>
+            <h4>{I18n.t("split_pdf_logs.incomplete_papers_found")}</h4>
             <ExamScanGroupsTable data={row.original.group_data} />
           </div>
         )}
@@ -212,25 +212,15 @@ class ExamScanErrorsTable extends React.Component {
 }
 
 class ExamScanGroupsTable extends React.Component {
-  constructor() {
-    super();
-  }
-
   columns = [
     {
-      Header: I18n.t("activerecord.models.group.one"),
+      Header: I18n.t("split_pdf_logs.paper"),
       accessor: "group",
-    },
-    {
-      Header: "Status",
-      accessor: "complete",
-      Cell: row =>
-        row.value ? I18n.t("submissions.state.complete") : I18n.t("submissions.state.incomplete"),
     },
     {
       Header: I18n.t("split_pdf_logs.missing_pages"),
       accessor: "missing_pages",
-      className: "number",
+      Cell: row => row.value.join(", "),
     },
   ];
 
@@ -239,7 +229,7 @@ class ExamScanGroupsTable extends React.Component {
       <ReactTable
         data={this.props.data}
         columns={this.columns}
-        style={{maxWidth: "800px", marginTop: "5px", marginBottom: "5px"}}
+        style={{maxWidth: "500px", marginTop: "5px", marginBottom: "5px"}}
         minRows={1}
       />
     );

--- a/app/javascript/Components/exam_scan_log_table.jsx
+++ b/app/javascript/Components/exam_scan_log_table.jsx
@@ -127,13 +127,18 @@ class ExamScanLogTable extends React.Component {
         filterable
         defaultSorted={[{id: "date", desc: true}]}
         SubComponent={row => (
-          <ExamScanErrorsTable
-            course_id={this.props.course_id}
-            data={row.original.page_data}
-            exam_template_id={row.original.exam_template_id}
-            split_pdf_log_id={row.original.file_id}
-            assignment_id={this.props.assignment_id}
-          />
+          <div>
+            <h4>{I18n.t("split_pdf_logs.pages_error")}</h4>
+            <ExamScanErrorsTable
+              course_id={this.props.course_id}
+              data={row.original.page_data}
+              exam_template_id={row.original.exam_template_id}
+              split_pdf_log_id={row.original.file_id}
+              assignment_id={this.props.assignment_id}
+            />
+            <h4>{I18n.t("split_pdf_logs.papers_found")}</h4>
+            <ExamScanGroupsTable data={row.original.group_data} />
+          </div>
         )}
         loading={this.state.loading}
       />
@@ -191,6 +196,36 @@ class ExamScanErrorsTable extends React.Component {
       accessor: "exam_page_number",
       maxWidth: 120,
       className: "number",
+    },
+  ];
+
+  render() {
+    return (
+      <ReactTable
+        data={this.props.data}
+        columns={this.columns}
+        style={{maxWidth: "800px", marginTop: "5px", marginBottom: "5px"}}
+        minRows={1}
+      />
+    );
+  }
+}
+
+class ExamScanGroupsTable extends React.Component {
+  constructor() {
+    super();
+  }
+
+  columns = [
+    {
+      Header: I18n.t("activerecord.models.group.one"),
+      accessor: "group",
+    },
+    {
+      Header: "Status",
+      accessor: "complete",
+      Cell: row =>
+        row.value ? I18n.t("submissions.state.complete") : I18n.t("submissions.state.incomplete"),
     },
   ];
 

--- a/app/javascript/Components/exam_scan_log_table.jsx
+++ b/app/javascript/Components/exam_scan_log_table.jsx
@@ -227,6 +227,11 @@ class ExamScanGroupsTable extends React.Component {
       Cell: row =>
         row.value ? I18n.t("submissions.state.complete") : I18n.t("submissions.state.incomplete"),
     },
+    {
+      Header: I18n.t("split_pdf_logs.missing_pages"),
+      accessor: "missing_pages",
+      className: "number",
+    },
   ];
 
   render() {

--- a/config/locales/views/split_pdf_logs/en.yml
+++ b/config/locales/views/split_pdf_logs/en.yml
@@ -2,8 +2,10 @@
 en:
   split_pdf_logs:
     file_information: File information
-    missing_pages: Missing pages
+    incomplete_papers_found: Incomplete papers found
+    missing_pages: Missing page numbers
     pages: Pages
     pages_error: Pending errors
     pages_fixed: Number fixed
+    paper: Paper
     papers_found: Papers found

--- a/config/locales/views/split_pdf_logs/en.yml
+++ b/config/locales/views/split_pdf_logs/en.yml
@@ -2,6 +2,7 @@
 en:
   split_pdf_logs:
     file_information: File information
+    missing_pages: Missing pages
     pages: Pages
     pages_error: Pending errors
     pages_fixed: Number fixed

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -377,10 +377,9 @@ describe ExamTemplatesController do
                                      params: { assignment_id: exam_template.assignment.id, course_id: course.id }
           end
 
-          it 'reports the group as complete with 0 missing pages' do
+          it 'excludes the group from group_data since it has no missing pages' do
             entry = group_data_for(response).find { |g| g['group'] == group.group_name }
-            expect(entry['complete']).to be true
-            expect(entry['missing_pages']).to eq 0
+            expect(entry).to be_nil
           end
         end
 
@@ -396,10 +395,9 @@ describe ExamTemplatesController do
                                      params: { assignment_id: exam_template.assignment.id, course_id: course.id }
           end
 
-          it 'reports the group as incomplete with the correct missing page count' do
+          it 'reports the group with the correct missing page numbers' do
             entry = group_data_for(response).find { |g| g['group'] == group.group_name }
-            expect(entry['complete']).to be false
-            expect(entry['missing_pages']).to eq(exam_template.num_pages - pages_scanned)
+            expect(entry['missing_pages']).to eq(((pages_scanned + 1)..exam_template.num_pages).to_a)
           end
         end
       end

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -364,7 +364,7 @@ describe ExamTemplatesController do
         let(:group) { create(:group, course: course) }
 
         def group_data_for(response)
-          response.parsed_body['group_data']
+          response.parsed_body.first['group_data']
         end
 
         context 'when a group has every expected page scanned' do

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -364,7 +364,7 @@ describe ExamTemplatesController do
         let(:group) { create(:group, course: course) }
 
         def group_data_for(response)
-          JSON.parse(response.body).first['group_data']
+          response.parsed_body['group_data']
         end
 
         context 'when a group has every expected page scanned' do

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -342,18 +342,66 @@ describe ExamTemplatesController do
     end
 
     describe '#view_logs' do
-      render_views
-      before do
- get_as user, :view_logs, format: 'js', params: { assignment_id: exam_template.assignment.id, course_id: course.id }
+      context 'when format is js' do
+        render_views
+        before do
+          get_as user, :view_logs, format: 'js',
+                                   params: { assignment_id: exam_template.assignment.id, course_id: course.id }
+        end
+
+        it('should respond with 200') { expect(response).to have_http_status :ok }
+
+        it 'passes template division data to init_upload_scans_form' do
+          expect(response.body).to include('upload_scans_form')
+          expect(response.body).to include('template_division_count')
+          expect(response.body).to include('init_upload_scans_form(examTemplateData)')
+          expect(response.body).to include(exam_template.id.to_s)
+        end
       end
 
-      it('should respond with 200') { expect(response).to have_http_status :ok }
+      context 'when format is json' do
+        let(:split_pdf_log) { create(:split_pdf_log, exam_template: exam_template) }
+        let(:group) { create(:group, course: course) }
 
-      it 'passes template division data to init_upload_scans_form' do
-        expect(response.body).to include('upload_scans_form')
-        expect(response.body).to include('template_division_count')
-        expect(response.body).to include('init_upload_scans_form(examTemplateData)')
-        expect(response.body).to include(exam_template.id.to_s)
+        def group_data_for(response)
+          JSON.parse(response.body).first['group_data']
+        end
+
+        context 'when a group has every expected page scanned' do
+          before do
+            (1..exam_template.num_pages).each do |page_num|
+              create(:split_page, split_pdf_log: split_pdf_log, group: group,
+                                  exam_page_number: page_num, status: 'Saved to complete directory')
+            end
+            get_as user, :view_logs, format: 'json',
+                                     params: { assignment_id: exam_template.assignment.id, course_id: course.id }
+          end
+
+          it 'reports the group as complete with 0 missing pages' do
+            entry = group_data_for(response).find { |g| g['group'] == group.group_name }
+            expect(entry['complete']).to be true
+            expect(entry['missing_pages']).to eq 0
+          end
+        end
+
+        context 'when a group is partially scanned' do
+          let(:pages_scanned) { 4 }
+
+          before do
+            (1..pages_scanned).each do |page_num|
+              create(:split_page, split_pdf_log: split_pdf_log, group: group,
+                                  exam_page_number: page_num, status: 'Saved to incomplete directory')
+            end
+            get_as user, :view_logs, format: 'json',
+                                     params: { assignment_id: exam_template.assignment.id, course_id: course.id }
+          end
+
+          it 'reports the group as incomplete with the correct missing page count' do
+            entry = group_data_for(response).find { |g| g['group'] == group.group_name }
+            expect(entry['complete']).to be false
+            expect(entry['missing_pages']).to eq(exam_template.num_pages - pages_scanned)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## Proposed Changes

Currently the exam scan log only surfaces per-page errors after scanning a batch of exam PDFs. There's no way to tell, at a glance, which student groups had all their pages successfully matched versus which are still missing pages.

This PR adds a per-group completion status, including a missing-page count, to the scan log:

### Before

<img width="1101" height="283" alt="Screenshot 2026-07-19 at 1 44 28 PM" src="https://github.com/user-attachments/assets/500deea2-68be-44a0-8191-a68bd9f861f1" />

### After

<img width="1099" height="393" alt="Screenshot 2026-07-19 at 1 43 52 PM" src="https://github.com/user-attachments/assets/985ee5b6-8614-4665-8f9f-d0b0b42cacb5" />

### Overview of Code Changes

Backend (`exam_templates_controller.rb`): while building the page-level error data, also aggregate pages by `group_id`, tracking the distinct `exam_page_numbers` scanned for each group. A group's `missing_pages` count is the difference between the exam template's expected page count and the number of distinct pages seen, and it's complete once that count reaches 0. 

Frontend (`exam_scan_log_table.jsx`): add a new `ExamScanGroupsTable` sub-component, rendered under a `"Papers found"` heading next to the existing `"Pending errors"` table, showing each group's name, Complete/Incomplete status, and missing page count.

Tests: added controller specs covering a fully-scanned group (complete, 0 missing) and a partially-scanned group (incomplete, correct missing count).

Fixes #6511.

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |    X      |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |     X     |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [N/A] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [N/A] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [X] I have verified that the pre-commit.ci checks have passed.
- [X] I have verified that the CI tests have passed.
- [X] I have reviewed the test coverage changes reported by Coveralls.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.
