### PR TITLE
TICKET-637: Set course dates from term on LTI course creation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
+- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#7915)
 - Improved Session Timeout Logic: `check_timeout` polling paused when user is not focused on the MarkUs tab and polling stops after user session has timed out (#8074)
 - Migrated Groups Manager students and groups tables to use `react-table` v8 (#8068)
 - Decreased size of QR codes on scanned assessments and ignored whitespace in OCR of page labels (#8076)

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
-- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#7915)
+- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#8057)
 - Improved Session Timeout Logic: `check_timeout` polling paused when user is not focused on the MarkUs tab and polling stops after user session has timed out (#8074)
 - Migrated Groups Manager students and groups tables to use `react-table` v8 (#8068)
 - Decreased size of QR codes on scanned assessments and ignored whitespace in OCR of page labels (#8076)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
+- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#7915)
 - Added support for inviting students to groups by email (case-insensitive), in addition to user name (#8106)
 - Added row numbers to the course summaries table (#8108)
 - Added an option to rotate sideways scanned exam pages by 90 degrees when fixing scan errors (#8103)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
-- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#7915)
+- Automatically populate course start and end dates from the term when a course is created via Canvas LTI (#8057)
 - Added support for inviting students to groups by email (case-insensitive), in addition to user name (#8106)
 - Added row numbers to the course summaries table (#8108)
 - Added an option to rotate sideways scanned exam pages by 90 degrees when fixing scan errors (#8103)

--- a/app/controllers/canvas_controller.rb
+++ b/app/controllers/canvas_controller.rb
@@ -40,6 +40,7 @@ class CanvasController < LtiDeploymentsController
         user_id: '$Canvas.user.id',
         course_id: '$Canvas.course.id',
         course_name: '$Canvas.course.name',
+        term_name: '$Canvas.term.name',
         student_number: '$Canvas.user.sisIntegrationId'
       }
     }

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -225,7 +225,9 @@ class LtiDeploymentsController < ApplicationController
       redirect_to choose_course_lti_deployment_path
       return
     end
-    new_course.update!(display_name: params['display_name'], is_hidden: true)
+    start_at, end_at = LtiConfig.get_course_dates(record) if LtiConfig.respond_to?(:get_course_dates)
+    new_course.update!(display_name: params['display_name'], is_hidden: true,
+                       start_at: start_at, end_at: end_at)
     if current_user.admin_user?
       AdminRole.find_or_create_by(user: current_user, course: new_course)
     else

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -223,7 +223,9 @@ class LtiDeploymentsController < ApplicationController
       redirect_to choose_course_lti_deployment_path
       return
     end
-    new_course.update!(display_name: params['display_name'], is_hidden: true)
+    start_at, end_at = LtiConfig.get_course_dates(record) if LtiConfig.respond_to?(:get_course_dates)
+    new_course.update!(display_name: params['display_name'], is_hidden: true,
+                       start_at: start_at, end_at: end_at)
     if current_user.admin_user?
       AdminRole.find_or_create_by(user: current_user, course: new_course)
     else

--- a/app/controllers/lti_deployments_controller.rb
+++ b/app/controllers/lti_deployments_controller.rb
@@ -223,7 +223,7 @@ class LtiDeploymentsController < ApplicationController
       redirect_to choose_course_lti_deployment_path
       return
     end
-    start_at, end_at = LtiConfig.get_course_dates(record) if LtiConfig.respond_to?(:get_course_dates)
+    start_at, end_at = LtiConfig.respond_to?(:get_course_dates) ? LtiConfig.get_course_dates(record) : nil
     new_course.update!(display_name: params['display_name'], is_hidden: true,
                        start_at: start_at, end_at: end_at)
     if current_user.admin_user?

--- a/config/dummy_lti_config.rb
+++ b/config/dummy_lti_config.rb
@@ -23,18 +23,47 @@ module LtiConfig
     clean_term = term_string.to_s.strip
     return Time.current.year.to_s if clean_term.blank?
     is_scs = clean_term.downcase.include?('scs')
-    # Regex: find 4 digits (2024) or 2 digits (24)
-    year_match = clean_term.match(/\d{4}|\d{2}/).to_s
-    month = case clean_term
-            when /Fall/i then '9'
-            when /Summer|Spring/i then '5'
-            when /Winter/i then '1'
-            end
-    if !year_match.empty? && month
-      year = year_match.length == 2 ? "20#{year_match}" : year_match
+    year, month = parse_term_year_month(clean_term)
+    if year
       suffix = "#{year}#{month}"
       return is_scs ? "SCS-#{suffix}" : suffix
     end
     clean_term.upcase.gsub(/[^A-Z0-9]+/, '-').chomp('-').delete_prefix('-')
+  end
+
+  # Returns [start_at, end_at] for a course created from this deployment,
+  # or nil when no term information can be parsed.
+  # Terms span 4 months, from the first day of the start month to the last
+  # day of the final month (e.g. Fall: Sep 1 - Dec 31).
+  def self.get_course_dates(lti_deployment)
+    year, month = get_term_start(lti_deployment)
+    return if year.nil?
+    start_date = Date.new(year, month, 1)
+    [start_date.beginning_of_day, (start_date + 3.months).end_of_month.end_of_day]
+  end
+
+  # Returns the term start as [year, month], or nil. The SIS ID term code
+  # takes precedence over the term name; a code is only trusted when its
+  # month is a real month (guards against Date.new raising Date::Error).
+  def self.get_term_start(lti_deployment)
+    sis_id = lti_deployment.lms_course_sourcedid
+    match = sis_id&.match(/\A[a-zA-Z0-9]+-[a-zA-Z]-LEC\d{4}-(\d{4})(\d{1,2})\z/)
+    return [match[1].to_i, match[2].to_i] if match && match[2].to_i.between?(1, 12)
+    parse_term_year_month(lti_deployment.lms_term_name)
+  end
+
+  def self.parse_term_year_month(term_string)
+    clean_term = term_string.to_s.strip
+    return if clean_term.blank?
+    # Regex: find 4 digits (2024) or 2 digits (24)
+    year_match = clean_term.match(/\d{4}|\d{2}/).to_s
+    month = case clean_term
+            when /Fall/i then 9
+            when /Summer|Spring/i then 5
+            when /Winter/i then 1
+            end
+    return if year_match.empty? || month.nil?
+    year = year_match.length == 2 ? "20#{year_match}" : year_match
+    [year.to_i, month]
   end
 end

--- a/config/dummy_lti_config.rb
+++ b/config/dummy_lti_config.rb
@@ -1,4 +1,9 @@
 module LtiConfig
+  SINGLE_TERM_MONTHS = 4
+  YEAR_LONG_MONTHS = 8
+  # Terms a year-long course may be registered under: Winter (1) and Fall (9).
+  YEAR_LONG_TERM_MONTHS = [1, 9].freeze
+
   # Implement LtiConfig.allowed_to_create_course? to set a filter for LTI deployments that are
   # permitted to trigger course creation for MarkUs.
   def self.allowed_to_create_course?(lti_deployment)
@@ -33,22 +38,36 @@ module LtiConfig
 
   # Returns [start_at, end_at] for a course created from this deployment,
   # or nil when no term information can be parsed.
-  # Terms span 4 months, from the first day of the start month to the last
-  # day of the final month (e.g. Fall: Sep 1 - Dec 31).
+  # A single term spans 4 months, from the first day of the start month to the
+  # last day of the final month (e.g. Fall: Sep 1 - Dec 31). A year-long course
+  # spans Sep 1 to Apr 30 of the following year, matching the date ranges used
+  # by the db:populate_course_dates rake task.
   def self.get_course_dates(lti_deployment)
-    year, month = get_term_start(lti_deployment)
+    year, month, year_long = get_term_start(lti_deployment)
     return if year.nil?
-    start_date = Date.new(year, month, 1)
-    [start_date.beginning_of_day, (start_date + 3.months).end_of_month.end_of_day]
+    return year_long_dates(year, month) if year_long && YEAR_LONG_TERM_MONTHS.include?(month)
+    dates_spanning(Date.new(year, month, 1), SINGLE_TERM_MONTHS)
   end
 
-  # Returns the term start as [year, month], or nil. The SIS ID term code
-  # takes precedence over the term name; a code is only trusted when its
-  # month is a real month (guards against Date.new raising Date::Error).
+  # A year-long course registered under a Winter term began the previous September.
+  def self.year_long_dates(year, month)
+    start_year = month == 1 ? year - 1 : year
+    dates_spanning(Date.new(start_year, 9, 1), YEAR_LONG_MONTHS)
+  end
+
+  # Returns [start_at, end_at] covering whole months from the first day of start_date.
+  def self.dates_spanning(start_date, months)
+    [start_date.beginning_of_day, (start_date + months.months - 1.day).end_of_day]
+  end
+
+  # Returns the term as [year, month, year_long], or nil. The SIS ID takes
+  # precedence over the term name; it is only trusted when its term code month
+  # is a real month (guards against Date.new raising Date::Error).
   def self.get_term_start(lti_deployment)
     sis_id = lti_deployment.lms_course_sourcedid
-    match = sis_id&.match(/\A[a-zA-Z0-9]+-[a-zA-Z]-LEC\d{4}-(\d{4})(\d{1,2})\z/)
-    return [match[1].to_i, match[2].to_i] if match && match[2].to_i.between?(1, 12)
+    # Session (Y) marks a year-long course: (CourseCode)-(Session)-(Lecture)-(Term)
+    match = sis_id&.match(/\A[a-zA-Z0-9]+-([a-zA-Z])-LEC\d{4}-(\d{4})(\d{1,2})\z/)
+    return [match[2].to_i, match[3].to_i, match[1].casecmp?('Y')] if match && match[3].to_i.between?(1, 12)
     parse_term_year_month(lti_deployment.lms_term_name)
   end
 
@@ -64,6 +83,11 @@ module LtiConfig
             end
     return if year_match.empty? || month.nil?
     year = year_match.length == 2 ? "20#{year_match}" : year_match
-    [year.to_i, month]
+    [year.to_i, month, year_long_term?(clean_term)]
+  end
+
+  # A term naming both Fall and Winter covers a year-long course (e.g. '2026 Fall-Winter').
+  def self.year_long_term?(term_string)
+    term_string.match?(/Fall/i) && term_string.match?(/Winter/i)
   end
 end

--- a/spec/config/lti_config_spec.rb
+++ b/spec/config/lti_config_spec.rb
@@ -35,6 +35,132 @@ describe LtiConfig do
     end
   end
 
+  describe '.get_course_dates' do
+    subject(:dates) { LtiConfig.get_course_dates(deployment) }
+
+    context 'when parsing the term name' do
+      it 'spans Fall from Sep 1 to Dec 31' do
+        deployment.lms_term_name = 'Fall 2025'
+        expect(dates).to eq([Time.zone.local(2025, 9, 1), Time.zone.local(2025, 12, 31).end_of_day])
+      end
+
+      it 'spans Winter from Jan 1 to Apr 30' do
+        deployment.lms_term_name = 'Winter 2026'
+        expect(dates).to eq([Time.zone.local(2026, 1, 1), Time.zone.local(2026, 4, 30).end_of_day])
+      end
+
+      it 'spans Summer from May 1 to Aug 31' do
+        deployment.lms_term_name = 'Summer 2025'
+        expect(dates).to eq([Time.zone.local(2025, 5, 1), Time.zone.local(2025, 8, 31).end_of_day])
+      end
+
+      it 'parses SCS-prefixed terms like the plain term' do
+        deployment.lms_term_name = 'SCS Fall 2025'
+        expect(dates).to eq([Time.zone.local(2025, 9, 1), Time.zone.local(2025, 12, 31).end_of_day])
+      end
+
+      it 'expands a 2-digit Fall year' do
+        deployment.lms_term_name = 'Fall 25'
+        expect(dates).to eq([Time.zone.local(2025, 9, 1), Time.zone.local(2025, 12, 31).end_of_day])
+      end
+
+      it 'expands a 2-digit Winter year' do
+        deployment.lms_term_name = 'Winter 26'
+        expect(dates).to eq([Time.zone.local(2026, 1, 1), Time.zone.local(2026, 4, 30).end_of_day])
+      end
+
+      it 'returns times in the application time zone' do
+        deployment.lms_term_name = 'Fall 2025'
+        expect(dates.first.utc_offset).to eq(Time.zone.local(2025, 9, 1).utc_offset)
+      end
+    end
+
+    context 'when the term name is unparseable' do
+      it 'returns nil for a season-less term name' do
+        deployment.lms_term_name = 'Default Term'
+        expect(dates).to be_nil
+      end
+
+      it 'returns nil for a blank term name' do
+        deployment.lms_term_name = ''
+        expect(dates).to be_nil
+      end
+
+      it 'returns nil for a whitespace-only term name' do
+        deployment.lms_term_name = '   '
+        expect(dates).to be_nil
+      end
+
+      it 'returns nil for an unexpanded Canvas variable' do
+        deployment.lms_term_name = '$Canvas.term.name'
+        expect(dates).to be_nil
+      end
+
+      it 'returns nil for a year without a season' do
+        deployment.lms_term_name = '2025'
+        expect(dates).to be_nil
+      end
+    end
+
+    context 'when parsing the SIS ID term code' do
+      it 'decodes a Fall term code' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20259'
+        expect(dates).to eq([Time.zone.local(2025, 9, 1), Time.zone.local(2025, 12, 31).end_of_day])
+      end
+
+      it 'decodes a Winter term code' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20261'
+        expect(dates).to eq([Time.zone.local(2026, 1, 1), Time.zone.local(2026, 4, 30).end_of_day])
+      end
+
+      it 'decodes a 2-digit month and crosses the year boundary' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-202511'
+        expect(dates).to eq([Time.zone.local(2025, 11, 1), Time.zone.local(2026, 2, 28).end_of_day])
+      end
+
+      it 'wins over a disagreeing term name' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20259'
+        deployment.lms_term_name = 'Winter 2030'
+        expect(dates.first).to eq(Time.zone.local(2025, 9, 1))
+      end
+    end
+
+    context 'when the SIS ID term code is malformed' do
+      before { deployment.lms_term_name = 'Winter 2026' }
+
+      it 'falls through to the term name for a month of zero' do
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-20250'
+        expect(dates.first).to eq(Time.zone.local(2026, 1, 1))
+      end
+
+      it 'falls through to the term name for a month over twelve' do
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-202590'
+        expect(dates.first).to eq(Time.zone.local(2026, 1, 1))
+      end
+
+      it 'falls through to the term name for a year-only code' do
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-2025'
+        expect(dates.first).to eq(Time.zone.local(2026, 1, 1))
+      end
+
+      it 'falls through to the term name for a 2-digit code' do
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-99'
+        expect(dates.first).to eq(Time.zone.local(2026, 1, 1))
+      end
+
+      it 'falls through to the term name for an unexpanded variable' do
+        deployment.lms_course_sourcedid = '$CourseSection.sourcedId'
+        expect(dates.first).to eq(Time.zone.local(2026, 1, 1))
+      end
+
+      it 'returns nil when the term name is also unparseable' do
+        deployment.lms_term_name = nil
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-20250'
+        expect(dates).to be_nil
+      end
+    end
+  end
+
   describe '.get_course_suffix' do
     it 'handles standard Fall term' do
       expect(LtiConfig.get_course_suffix('Fall 2025')).to eq('20259')

--- a/spec/config/lti_config_spec.rb
+++ b/spec/config/lti_config_spec.rb
@@ -104,24 +104,80 @@ describe LtiConfig do
 
     context 'when parsing the SIS ID term code' do
       it 'decodes a Fall term code' do
-        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20259'
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-20259'
         expect(dates).to eq([Time.zone.local(2025, 9, 1), Time.zone.local(2025, 12, 31).end_of_day])
       end
 
       it 'decodes a Winter term code' do
-        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20261'
+        deployment.lms_course_sourcedid = 'ABC123H1-S-LEC0101-20261'
         expect(dates).to eq([Time.zone.local(2026, 1, 1), Time.zone.local(2026, 4, 30).end_of_day])
       end
 
       it 'decodes a 2-digit month and crosses the year boundary' do
-        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-202511'
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-202511'
         expect(dates).to eq([Time.zone.local(2025, 11, 1), Time.zone.local(2026, 2, 28).end_of_day])
       end
 
       it 'wins over a disagreeing term name' do
-        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20259'
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-20259'
         deployment.lms_term_name = 'Winter 2030'
         expect(dates.first).to eq(Time.zone.local(2025, 9, 1))
+      end
+    end
+
+    context 'when the course spans a full year' do
+      it 'spans Sep to Apr for a Y session with a Fall term code' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20269'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2027, 4, 30).end_of_day])
+      end
+
+      it 'starts the previous Sep for a Y session with a Winter term code' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20251'
+        expect(dates).to eq([Time.zone.local(2024, 9, 1), Time.zone.local(2025, 4, 30).end_of_day])
+      end
+
+      it 'matches a lowercase y session' do
+        deployment.lms_course_sourcedid = 'lsm999y1-y-LEC0101-20269'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2027, 4, 30).end_of_day])
+      end
+
+      it 'keeps a Y session Summer term to a single term' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20255'
+        expect(dates).to eq([Time.zone.local(2025, 5, 1), Time.zone.local(2025, 8, 31).end_of_day])
+      end
+
+      it 'spans Sep to Apr for a Fall-Winter term name' do
+        deployment.lms_term_name = '2026 Fall-Winter'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2027, 4, 30).end_of_day])
+      end
+
+      it 'spans Sep to Apr for a Fall/Winter term name' do
+        deployment.lms_term_name = 'Fall/Winter 2026'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2027, 4, 30).end_of_day])
+      end
+
+      it 'reads the year-long session from the SIS ID over a single-term term name' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20269'
+        deployment.lms_term_name = 'Fall 2026'
+        expect(dates.last).to eq(Time.zone.local(2027, 4, 30).end_of_day)
+      end
+
+      it 'falls back to a Fall-Winter term name when the SIS ID is malformed' do
+        deployment.lms_course_sourcedid = '$CourseSection.sourcedId'
+        deployment.lms_term_name = '2026 Fall-Winter'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2027, 4, 30).end_of_day])
+      end
+
+      it 'ignores a Fall-Winter term name when the SIS ID reports a single term' do
+        deployment.lms_course_sourcedid = 'ABC123H1-F-LEC0101-20269'
+        deployment.lms_term_name = '2026 Fall-Winter'
+        expect(dates.last).to eq(Time.zone.local(2026, 12, 31).end_of_day)
+      end
+
+      it 'ignores a Y session when a malformed term code sends it to the term name' do
+        deployment.lms_course_sourcedid = 'LSM999Y1-Y-LEC0101-20250'
+        deployment.lms_term_name = 'Fall 2026'
+        expect(dates).to eq([Time.zone.local(2026, 9, 1), Time.zone.local(2026, 12, 31).end_of_day])
       end
     end
 

--- a/spec/controllers/lti_deployments_controller_spec.rb
+++ b/spec/controllers/lti_deployments_controller_spec.rb
@@ -102,6 +102,16 @@ describe LtiDeploymentsController do
         lti_deployment.reload
         expect(lti_deployment.resource_link_id).to eq(test_rlid)
       end
+
+      it 'populates the course start date from the term' do
+        expect(Course.find_by(name: expected_name).start_at).to eq(Time.zone.local(2026, 9, 1))
+      end
+
+      it 'populates the course end date from the term' do
+        # Column is timestamp(6): end_of_day nanoseconds are truncated to microseconds on write
+        expect(Course.find_by(name: expected_name).end_at)
+          .to be_within(1.second).of(Time.zone.local(2026, 12, 31).end_of_day)
+      end
     end
 
     context 'with an SCS term' do
@@ -130,6 +140,30 @@ describe LtiDeploymentsController do
         }
         expect(Course.find_by(name: 'CSC108-DEFAULT-TERM')).not_to be_nil
       end
+
+      it 'creates the course with unset dates' do
+        post_as instructor, :create_course, params: {
+          id: lti_deployment.id,
+          name: 'csc108',
+          display_name: 'CSC108'
+        }
+        course = Course.find_by(name: 'CSC108-DEFAULT-TERM')
+        expect([course.start_at, course.end_at]).to eq([nil, nil])
+      end
+    end
+
+    context 'when the adapter file does not implement get_course_dates' do
+      before do
+        allow(LtiConfig).to receive(:respond_to?).and_call_original
+        allow(LtiConfig).to receive(:respond_to?).with(:get_course_dates).and_return(false)
+        session[:lti_deployment_id] = lti_deployment.id
+        post_as instructor, :create_course, params: course_params
+      end
+
+      it 'creates the course with unset dates' do
+        course = Course.find_by(name: expected_name)
+        expect([course.start_at, course.end_at]).to eq([nil, nil])
+      end
     end
 
     context 'as an admin user' do
@@ -150,6 +184,10 @@ describe LtiDeploymentsController do
         course = Course.find_by(name: expected_name)
         expect(Role.find_by(user: admin_user, course: course, type: 'AdminRole')).not_to be_nil
       end
+
+      it 'populates the course dates from the term' do
+        expect(Course.find_by(name: expected_name).start_at).to eq(Time.zone.local(2026, 9, 1))
+      end
     end
 
     context 'when a course already exists' do
@@ -166,6 +204,12 @@ describe LtiDeploymentsController do
       it 'does redirect to choose_course' do
         post_as instructor, :create_course, params: course_params
         expect(response).to have_http_status(:found)
+      end
+
+      it 'leaves the existing course dates untouched' do
+        post_as instructor, :create_course, params: course_params
+        course = Course.find_by(name: expected_name)
+        expect([course.start_at, course.end_at]).to eq([nil, nil])
       end
     end
 

--- a/spec/controllers/lti_deployments_controller_spec.rb
+++ b/spec/controllers/lti_deployments_controller_spec.rb
@@ -114,6 +114,26 @@ describe LtiDeploymentsController do
       end
     end
 
+    context 'with a year-long term' do
+      let!(:lti_deployment) do
+        create(:lti_deployment, lms_course_name: 'csc108', lms_term_name: '2026 Fall-Winter')
+      end
+
+      before do
+        session[:lti_deployment_id] = lti_deployment.id
+        post_as instructor, :create_course, params: course_params
+      end
+
+      it 'starts the course in September' do
+        expect(Course.find_by(name: expected_name).start_at).to eq(Time.zone.local(2026, 9, 1))
+      end
+
+      it 'ends the course in April of the following year' do
+        expect(Course.find_by(name: expected_name).end_at)
+          .to be_within(1.second).of(Time.zone.local(2027, 4, 30).end_of_day)
+      end
+    end
+
     context 'with an SCS term' do
       let!(:lti_deployment) { create(:lti_deployment, :scs_winter, lms_course_name: 'csc108') }
 


### PR DESCRIPTION
## Proposed Changes - ✨ *New feature*
Courses created through the Canvas LTI flow now start with term dates filled in. Before this change, instructors set both dates by hand after every course creation.

- `LtiConfig.get_course_dates` turns the term into a four-month window. "Fall 2025" becomes Sep 1 to Dec 31, 2025.
- The SIS ID term code (`LSM999Y1-Y-LEC0101-20259`) wins over the term name when both are present.
- Canvas sends the term name through a new `term_name` custom claim.
- When no term can be parsed, both dates stay unset and instructors set them as before.
- Adapter files without `get_course_dates` keep working through a `respond_to?` guard.

<details>
<summary>Screenshots of your changes (if applicable)</summary>
<img width="788" height="745" alt="Screenshot 2026-07-13 at 10 48 00 PM" src="https://github.com/user-attachments/assets/eebeee26-ec4a-4a41-8b50-4bc76dcdbd83" />

<img width="1137" height="622" alt="Screenshot 2026-07-13 at 10 47 30 PM" src="https://github.com/user-attachments/assets/35d3e78c-96ce-4350-af30-0e251d95d036" />

</details>


## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |      X   |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
