### PR TITLE
Automatically collect scanned submissions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 
 ### ✨ New features and improvements
 - Decreased size of QR codes on scanned assessments and ignored whitespace in OCR of page labels (#8076)
+- Added automatic collection of scanned exam submissions once a paper's pages are all present and error-free (#8069)
 - Added support for assigning instructors as graders through the assignment Graders tab and CSV imports (#8060)
 - Improved the Assign Scans page: OCR suggestions now appear above the manual entry form and clicking one assigns the student directly, "Skip group" is now a button instead of a checkbox, the Members list is hidden when empty, and the progress bar shows "x of y assigned" (#8059)
 - Added an assignment summary table filter that lets graders with manage submissions permission view either all submissions or only their assigned submissions (#8052)

--- a/app/controllers/exam_templates_controller.rb
+++ b/app/controllers/exam_templates_controller.rb
@@ -256,12 +256,7 @@ class ExamTemplatesController < ApplicationController
   def error_pages
     exam_template = record
     exam_group = current_course.groups.find_by(group_name: "#{exam_template.name}_paper_#{params[:exam_number]}")
-    expected_pages = [*1..exam_template.num_pages]
-    if exam_group.nil?
-      pages = expected_pages
-    else
-      pages = expected_pages - exam_group.split_pages.pluck(:exam_page_number)
-    end
+    pages = exam_group.nil? ? [*1..exam_template.num_pages] : exam_template.missing_pages(exam_group)
     render json: pages
   end
 

--- a/app/jobs/split_pdf_job.rb
+++ b/app/jobs/split_pdf_job.rb
@@ -349,6 +349,7 @@ class SplitPdfJob < ApplicationJob
         repo.reload_non_bare_repo  # Unclear why, but this is needed to prevent a "bare index" error for new groups
         repo.commit(txn)
       end
+      exam_template.collect_if_complete(grouping)
     end
     num_complete
   end

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -316,6 +316,12 @@ class ExamTemplate < ApplicationRecord
   def collect_if_complete(grouping)
     return if grouping.is_collected?
     return unless paper_complete?(grouping.group)
+    group = grouping.group
+    begin
+      Repository.get_class.access(group.repo_path) { |_repo| nil }
+    rescue StandardError
+      group.build_repository
+    end
     SubmissionsJob.perform_now([grouping], apply_late_penalty: false)
   end
 

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -317,11 +317,7 @@ class ExamTemplate < ApplicationRecord
     return if grouping.is_collected?
     return unless paper_complete?(grouping.group)
     group = grouping.group
-    begin
-      Repository.get_class.access(group.repo_path) { |_repo| nil }
-    rescue StandardError
-      group.build_repository
-    end
+    group.build_repository unless Repository.get_class.repository_exists?(group.repo_path)
     SubmissionsJob.perform_now([grouping], apply_late_penalty: false)
   end
 

--- a/app/models/exam_template.rb
+++ b/app/models/exam_template.rb
@@ -254,6 +254,7 @@ class ExamTemplate < ApplicationRecord
 
         repo.commit(txn)
       end
+      collect_if_complete(grouping)
     end
   end
 
@@ -302,6 +303,20 @@ class ExamTemplate < ApplicationRecord
   # any changes to template divisions should be rejected once exams have been uploaded
   def exam_been_uploaded?
     self.split_pdf_logs.exists?
+  end
+
+  def missing_pages(group)
+    (1..num_pages).to_a - group.split_pages.pluck(:exam_page_number)
+  end
+
+  def paper_complete?(group)
+    missing_pages(group).empty?
+  end
+
+  def collect_if_complete(grouping)
+    return if grouping.is_collected?
+    return unless paper_complete?(grouping.group)
+    SubmissionsJob.perform_now([grouping], apply_late_penalty: false)
   end
 
   private

--- a/docs/docs/instructors/scanned-exams.md
+++ b/docs/docs/instructors/scanned-exams.md
@@ -219,11 +219,12 @@ After your test is complete, you should scan all test papers (saving the scans a
 
 ### Finalizing submissions
 
-When you are done uploading all scanned files and fixing all QR code parsing errors, you are ready to finalize the scanned files for grading.
-This is done by *collecting* the submissions:
+As soon as all pages for a paper are accounted for (either via bulk upload or by fixing the last pending error for that paper), MarkUs will automatically collect the submission for that group. Grading for this paper can begin without any additional action.
 
-1. Go to the "Submissions" tab and select all rows.
-2. Press the "Collect Submissions" button (do this only *after* you are sure you've scanned all test papers and fixed all parsing errors).
+If a paper is still missing pages, or you need to recollect one after fixing an error on it *after* it was collected, you can still collect submissions manually:
+
+1. Go to the "Submissions" tab and select relevant rows.
+2. Press the "Collect Submissions" button. If a paper was previously collected, check "Recollect previously collected submissions?" in the dialog, or it will be silently skipped.
 
     ![Scanned Exam Collect All](/images/scanned-exam-collect-all.png)
 

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -262,6 +262,12 @@ describe ExamTemplatesController do
                           page_number: page_number }
       end
 
+      it 'does not collect the submission when the paper is still incomplete' do
+        group = Group.find_by(group_name: "#{exam_template.name}_paper_#{copy_number}")
+        grouping = exam_template.assignment.groupings.find_by(group_id: group.id)
+        expect(grouping.is_collected?).to be false
+      end
+
       context 'when the split page id does not exist' do
         let(:split_page_id) { -1 }
 
@@ -338,6 +344,61 @@ describe ExamTemplatesController do
           expect(flash[:error]).not_to be_empty
           expect(response.body).to eq("#{split_page_id}.pdf")
         end
+      end
+    end
+
+    describe '#fix_error completing a paper' do
+      let(:copy_number) { 1 }
+      let(:page_number) { 1 }
+      let(:group) do
+ create(:group, group_name: "#{exam_template.name}_paper_#{copy_number}",
+                repo_name: "#{exam_template.name}_paper_#{copy_number}", course: course)
+      end
+      let(:grouping) { create(:grouping, group: group, assignment: exam_template.assignment) }
+      let(:split_pdf_log) { create(:split_pdf_log, exam_template: exam_template) }
+      let(:split_page) do
+ create(:split_page, split_pdf_log: split_pdf_log, group: group, exam_page_number: page_number)
+      end
+      let(:split_page_id) { split_page.id }
+
+      before do
+        grouping
+        (2..6).each do |n|
+          create(:split_page, split_pdf_log: split_pdf_log, group: group,
+                              exam_page_number: n, status: 'Saved to incomplete directory')
+        end
+
+        filename = "#{split_page_id}.pdf"
+        error_file = File.join(exam_template.base_path, 'error', filename)
+        complete_page = File.join(exam_template.base_path, 'complete', copy_number.to_s, page_number.to_s)
+        incomplete_page = File.join(exam_template.base_path, 'incomplete', copy_number.to_s, page_number.to_s)
+        incomplete_dir = File.join(exam_template.base_path, 'incomplete', copy_number.to_s)
+        renamed_page_pdf = File.join(incomplete_dir, "#{page_number}.pdf")
+
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(error_file).and_return(true)
+
+        allow(File).to receive(:exist?).with(complete_page).and_return(false)
+        allow(File).to receive(:exist?).with(incomplete_page).and_return(false)
+        allow(File).to receive(:exist?).with(renamed_page_pdf).and_return(false)
+
+        allow(FileUtils).to receive(:mv).and_call_original
+        allow(FileUtils).to receive(:mv).with(error_file, incomplete_dir)
+        allow(File).to receive(:rename).and_call_original
+        allow(File).to receive(:rename).with(File.join(incomplete_dir, filename), renamed_page_pdf)
+
+        post_as user, :fix_error,
+                params: { course_id: course.id,
+                          id: exam_template.id,
+                          commit: 'Save',
+                          split_page_id: split_page_id,
+                          copy_number: copy_number,
+                          page_number: page_number,
+                          split_pdf_log_id: split_pdf_log.id }
+      end
+
+      it 'automatically collects the submission' do
+        expect(grouping.reload.is_collected?).to be true
       end
     end
 

--- a/spec/controllers/exam_templates_controller_spec.rb
+++ b/spec/controllers/exam_templates_controller_spec.rb
@@ -263,8 +263,8 @@ describe ExamTemplatesController do
       end
 
       it 'does not collect the submission when the paper is still incomplete' do
-        group = Group.find_by(group_name: "#{exam_template.name}_paper_#{copy_number}")
-        grouping = exam_template.assignment.groupings.find_by(group_id: group.id)
+        group = Group.find_by!(group_name: "#{exam_template.name}_paper_#{copy_number}")
+        grouping = exam_template.assignment.groupings.find_by!(group_id: group.id)
         expect(grouping.is_collected?).to be false
       end
 
@@ -354,7 +354,7 @@ describe ExamTemplatesController do
  create(:group, group_name: "#{exam_template.name}_paper_#{copy_number}",
                 repo_name: "#{exam_template.name}_paper_#{copy_number}", course: course)
       end
-      let(:grouping) { create(:grouping, group: group, assignment: exam_template.assignment) }
+      let!(:grouping) { create(:grouping, group: group, assignment: exam_template.assignment) }
       let(:split_pdf_log) { create(:split_pdf_log, exam_template: exam_template) }
       let(:split_page) do
  create(:split_page, split_pdf_log: split_pdf_log, group: group, exam_page_number: page_number)
@@ -362,7 +362,6 @@ describe ExamTemplatesController do
       let(:split_page_id) { split_page.id }
 
       before do
-        grouping
         (2..6).each do |n|
           create(:split_page, split_pdf_log: split_pdf_log, group: group,
                               exam_page_number: n, status: 'Saved to incomplete directory')

--- a/spec/jobs/split_pdf_job_spec.rb
+++ b/spec/jobs/split_pdf_job_spec.rb
@@ -63,8 +63,14 @@ describe SplitPdfJob do
     expect(Group.count).to eq 1
     expect(split_pdf_log.num_groups_in_complete).to eq 1
     expect(split_pdf_log.num_pages_qr_scan_error).to eq 0
+    expect(split_pdf_log.split_pages.where(status: 'Saved to complete directory').count).to eq 6
+
+    group = Group.find_by!(group_name: 'midterm1-v2-test_paper_100')
+    grouping = exam_template.assignment.groupings.find_by!(group_id: group.id)
+    expect(grouping.is_collected?).to be true
+
     completed_page_numbers = split_pdf_log.split_pages.where(status: 'Saved to complete directory')
-                                           .pluck(:exam_page_number)
+                                          .pluck(:exam_page_number)
     expect(completed_page_numbers).to contain_exactly(1, 2, 3, 4, 5, 6)
   end
 
@@ -202,9 +208,7 @@ describe SplitPdfJob do
                      File.join(exam_template.base_path, 'raw', "raw_upload_#{split_pdf_log2.id}.pdf")
         SplitPdfJob.perform_now(exam_template, '', split_pdf_log2, filename, instructor, 'ignore', user)
 
-        ignored_page_numbers = split_pdf_log2.split_pages.where(status: 'Duplicate page ignored')
-                                              .pluck(:exam_page_number)
-        expect(ignored_page_numbers).to contain_exactly(1, 2, 3, 4, 5, 6)
+        expect(split_pdf_log2.split_pages.where(status: 'Duplicate page ignored').size).to eq 6
         error_dir_entries = Dir.entries(File.join(exam_template.base_path, 'error')) - %w[. ..]
         expect(error_dir_entries.length).to eq 0
       end

--- a/spec/models/exam_template_spec.rb
+++ b/spec/models/exam_template_spec.rb
@@ -1,0 +1,65 @@
+describe ExamTemplate do
+  let(:exam_template) { create(:exam_template_midterm) }
+  let(:group) { create(:group, course: exam_template.course) }
+  let(:grouping) { create(:grouping, group: group, assignment: exam_template.assignment) }
+
+  describe '#missing_pages' do
+    it 'returns all page numbers when no pages have been scanned' do
+      expect(exam_template.missing_pages(group)).to eq (1..6).to_a
+    end
+
+    it 'returns only the unscanned page numbers when some pages exist' do
+      create(:split_page, group: group, exam_page_number: 2)
+      create(:split_page, group: group, exam_page_number: 4)
+      expect(exam_template.missing_pages(group)).to eq [1, 3, 5, 6]
+    end
+
+    it 'returns an empty array when all pages have been scanned' do
+      (1..6).each { |n| create(:split_page, group: group, exam_page_number: n) }
+      expect(exam_template.missing_pages(group)).to eq []
+    end
+  end
+
+  describe '#paper_complete?' do
+    it 'is false when pages are missing' do
+      expect(exam_template.paper_complete?(group)).to be false
+    end
+
+    it 'is true when every page has been scanned' do
+      (1..6).each { |n| create(:split_page, group: group, exam_page_number: n) }
+      expect(exam_template.paper_complete?(group)).to be true
+    end
+  end
+
+  describe '#collect_if_complete' do
+    context 'when the paper is complete and not yet collected' do
+      before { (1..6).each { |n| create(:split_page, group: group, exam_page_number: n) } }
+
+      it 'collects the submission' do
+        exam_template.collect_if_complete(grouping)
+        expect(grouping.reload.is_collected?).to be true
+      end
+    end
+
+    context 'when the paper is incomplete' do
+      before { create(:split_page, group: group, exam_page_number: 1) }
+
+      it 'does not collect the submission' do
+        exam_template.collect_if_complete(grouping)
+        expect(grouping.reload.is_collected?).to be false
+      end
+    end
+
+    context 'when the paper is complete but already collected' do
+      before do
+        (1..6).each { |n| create(:split_page, group: group, exam_page_number: n) }
+        grouping.update!(is_collected: true)
+      end
+
+      it 'does not attempt to recollect' do
+        expect(SubmissionsJob).not_to receive(:perform_now)
+        exam_template.collect_if_complete(grouping)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Proposed Changes

This adds automatic submission collection for scanned exam papers. Currently, once all of a paper's pages have been scanned and matched (or matched after manually fixing any error pages), an instructor still has to go to the Submissions tab and manually collect it before grading can begin. With this change, MarkUs collects the submission automatically as soon as a paper is complete and hasn't already been collected, so this manual step is no longer needed for the common case.

Completion can happen in two different places, so autocollection is triggered from both: when a batch of scans is uploaded and a paper's pages all match successfully on the first pass (`SplitPdfJob`), and when an instructor manually fixes the last missing or erroring page for a paper through "Fix Errors" (`ExamTemplate#fix_error`). To support this, the `ExamTemplate` model now contains methods `#missing_pages` and `#paper_complete?` to determine whether a paper is done, and `#collect_if_complete`, which performs the actual collection once it is.

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |    X      |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [N/A] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [X] I have verified that the pre-commit.ci checks have passed.
- [X] I have verified that the CI tests have passed.
- [X] I have reviewed the test coverage changes reported by Coveralls.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Hi @david-yz-liu, I wanted to ask whether or not we should have some sort of UI feedback telling instructors that some submissions were automatically collected when they upload scans in bulk (something like "X submissions are now complete and were automatically collected")? 
