### PR TITLE
bugfix: random assignment after grader filtering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 - Added GET /test_runs API route (#8055)
 
 ### 🐛 Bug fixes
+- Ensured random grader assignment excludes ineligible roles and recalculates weights using eligible graders (#8073)
 - Fixed Assign Scans returning a raw 404 instead of redirecting back to the Groups page once all groups have been assigned (#8059)
 - Fixed Assignments Index page dropdown menu not redirecting users to the selected assignment (#8043)
 - Fixed broken checkbox in the header of the selection column for tables with row selection enabled. (#8037)

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -142,17 +142,17 @@ class Grouping < ApplicationRecord
   # which is a parallel array to +ta_ids+. The groupings
   # must belong to the given assignment +assignment+.
   def self.randomly_assign_tas(grouping_ids, ta_ids, weightings_arr, assignment)
-    # Create a hash of TA's to the number of groups they are supposed to mark
-    total = weightings_arr.sum
-    weightings = {}
-    ta_ids.each_with_index do |group, index|
-      weightings[group] = (weightings_arr[index].to_f / total * grouping_ids.length).round
-    end
+    weightings = Array(ta_ids).map(&:to_i).zip(weightings_arr).to_h
 
-    assign_tas(grouping_ids, ta_ids, assignment) do |grouping_ids_, _|
-      # Create 1 TA for each group they are supposed to be assigned to
-      ta_ids = ta_ids.sort_by { |ta| weightings[ta] }
-      ta_ids_ = ta_ids.flat_map { |ta_id| [ta_id] * weightings[ta_id] }
+    assign_tas(grouping_ids, ta_ids, assignment) do |grouping_ids_, ta_ids_|
+      total = ta_ids_.sum { |ta_id| weightings[ta_id] || 0 }
+      next [] if total.zero?
+
+      assignment_counts = ta_ids_.index_with do |ta_id|
+        ((weightings[ta_id] || 0).to_f / total * grouping_ids_.length).round
+      end
+      ta_ids_ = ta_ids_.sort_by { |ta_id| assignment_counts[ta_id] }
+                       .flat_map { |ta_id| [ta_id] * assignment_counts[ta_id] }
       # Assign TAs in a round-robin fashion to a list of random groupings.
       grouping_ids_.shuffle.zip(ta_ids_.cycle).reject { |pair| pair.include?(nil) }
     end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -120,6 +120,16 @@ describe Grouping do
         end
       end
 
+      it 'uses only TAs retained by assign_tas when calculating weights' do
+        student = create(:student, course: assignment.course)
+
+        Grouping.randomly_assign_tas(grouping_ids, [ta_ids.first, student.id], [1, 3], assignment)
+
+        groupings.each do |grouping|
+          expect(grouping.reload.tas).to contain_exactly(tas.first)
+        end
+      end
+
       it 'can randomly bulk assign TAs with weighting' do
         weightings = [3, 1]
         Grouping.randomly_assign_tas(grouping_ids, ta_ids, weightings, assignment)


### PR DESCRIPTION
## Proposed Changes

Ensure random grader assignment uses only the TA IDs accepted by `Grouping.assign_tas`.

Previously, `randomly_assign_tas` calculated assignment counts from the original submitted IDs and ignored the filtered TA IDs yielded by `assign_tas`. A filtered-out role, such as a student, could therefore be reintroduced into the generated membership pairs. Its requested weight also remained part of the workload calculation.

This PR:

- preserves each submitted weight by role ID;
- calculates the total and assignment counts after `assign_tas` filters the IDs;
- constructs membership pairs using only the filtered IDs;
- returns no assignments when no eligible weighted TAs remain; and
- adds a regression test confirming that an invalid role with a larger weight is excluded and the valid TA receives all selected groups.

Valid random-assignment requests retain the existing relative weighting behavior. This is a focused follow-up to the review discussion in #8060 and is independent of #8072.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

| Type | Applies? |
|---|---|
| 🚨 Breaking change | |
| ✨ New feature | |
| 🐛 Bug fix | X |
| 🎨 User interface change | |
| ♻️ Refactoring | |
| 🚦 Test update | |
| 📦 Dependency update | |
| 📖 Documentation update | |
| 🔧 Internal | |

## Checklist

Before opening this pull request:

- [x] I have performed a self-review of my changes.
- [x] I have added tests for my changes.
- [x] I have updated the project documentation, if applicable.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening this pull request:

- [x] I have updated the project Changelog.
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have requested a review from a project maintainer.

## Questions and Comments