### PR TITLE
Release script plain ruby fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
             db/migrate/.*|
             db/schema.rb|
             lib/repo/test/.*|
+            release/.*|
             Vagrantfile
           )$
         additional_dependencies:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'db/migrate/.*'
     - 'db/schema.rb'
     - 'lib/repo/test/.*'
+    - 'release/.*'
     - 'Vagrantfile'
   NewCops: enable
   SuggestExtensions: false

--- a/release/changelog.rb
+++ b/release/changelog.rb
@@ -19,6 +19,7 @@ CATEGORIES = [
   "### \u{1F6A8} Breaking changes",
   "### \u{2728} New features and improvements",
   "### \u{1F41B} Bug fixes",
+  "### \u{1F4DA} Documentation changes",
   "### \u{1F527} Internal changes"
 ].freeze
 
@@ -81,10 +82,8 @@ def emit_old_sections_verbatim(out, raw_text, skip:)
   emitting = false
   raw_text.each_line do |line|
     line = line.chomp
-    if line =~ /^## \[(unreleased|v[\d.]+)\]/i
-      ver = Regexp.last_match(1).downcase == 'unreleased' ? 'unreleased' : Regexp.last_match(1)
-      emitting = skip.exclude?(ver)
-    end
+    ver = parse_version_header(line)
+    emitting = !skip.include?(ver) if ver
     out << line if emitting
   end
 end
@@ -138,7 +137,11 @@ if ARGV.empty? || ARGV.intersect?(['-h', '--help'])
 end
 
 args = {}
-ARGV.each { |a| args[Regexp.last_match(1)] = Regexp.last_match(2) if a =~ /^--(\w[\w-]*)=(.+)$/ }
+ARGV.each do |arg|
+  next unless (match = arg.match(/^--(\w[\w-]*)=(.+)$/))
+
+  args[match[1]] = match[2]
+end
 
 mode = args['mode']
 version = args['version']

--- a/release/cherry-pick.sh
+++ b/release/cherry-pick.sh
@@ -49,6 +49,14 @@ stop() {
   exit 1
 }
 
+# Abort the in-progress cherry-pick and record the current $PR as skipped.
+# Caller must `continue` the loop afterwards.
+skip_pr() {
+  git cherry-pick --skip 2>/dev/null
+  success "#$PR — already on release, skipped"
+  SKIPPED="${SKIPPED:+$SKIPPED,}$PR"
+}
+
 # Show hook diff and stop for user review
 stop_for_hook_review() {
   local hook_diff="$1"
@@ -111,9 +119,7 @@ while IFS= read -r entry; do
   CHERRY_OUT=$(git cherry-pick -m1 "$SHA" 2>&1) || {
     # Empty commit — PR already on release via different path
     if [[ "$CHERRY_OUT" =~ (empty|nothing.*to\ commit) ]]; then
-      git cherry-pick --skip 2>/dev/null
-      success "#$PR — already on release, skipped"
-      SKIPPED="${SKIPPED:+$SKIPPED,}$PR"
+      skip_pr
       continue
     fi
 
@@ -124,9 +130,7 @@ while IFS= read -r entry; do
       HOOK_DIFF=$(git diff 2>/dev/null)
       [[ -n "$HOOK_DIFF" ]] && stop_for_hook_review "$HOOK_DIFF"
       # No conflicts, no hook changes — truly empty commit
-      git cherry-pick --skip 2>/dev/null
-      success "#$PR — already on release, skipped"
-      SKIPPED="${SKIPPED:+$SKIPPED,}$PR"
+      skip_pr
       continue
     fi
 
@@ -172,9 +176,7 @@ while IFS= read -r entry; do
       [[ -n "$HOOK_DIFF" ]] && stop_for_hook_review "$HOOK_DIFF"
       # No hook changes — commit became empty after resolution (PR already applied)
       git checkout -- . 2>/dev/null
-      git cherry-pick --skip 2>/dev/null
-      success "#$PR — already on release, skipped"
-      SKIPPED="${SKIPPED:+$SKIPPED,}$PR"
+      skip_pr
       continue
     fi
     success "#$PR — auto-resolved ($(echo "$CONFLICTED_FILES" | paste -sd, -))"

--- a/release/recon-format.rb
+++ b/release/recon-format.rb
@@ -14,7 +14,7 @@
 require 'json'
 
 data = JSON.parse($stdin.read)
-prs = data['milestone_prs'].index_by { |p| p['number'] }
+prs = data['milestone_prs'].to_h { |p| [p['number'], p] }
 order = data['proposed_cherry_pick_order']
 skipped = data['skipped']
 
@@ -42,7 +42,7 @@ when '--order'
   order.each { |item| puts "#{item['number']}:#{item['ref']}" }
 
 when '--pr-list'
-  puts order.pluck('number').join(',')
+  puts order.map { |o| o['number'] }.join(',')
 
 when '--pr-body'
   puts "## Release #{data['version']}"

--- a/release/recon.rb
+++ b/release/recon.rb
@@ -30,17 +30,45 @@ def enrich_pr(pull)
   pull['files_changed'] = fetch_pr_files(pull['number'])
   sha = pull.dig('mergeCommit', 'oid')
   pull['merge_commit'] = sha
-  pull['already_in_release'] = sha.present? && ancestor_of_release?(sha)
+  pull['already_in_release'] = !sha.to_s.empty? && ancestor_of_release?(sha)
 end
 
+# Query the milestone's PRs directly from GitHub's database via GraphQL rather
+# than `gh pr list --search`, whose backing search index can lag hours behind
+# milestone edits. Shape mirrors the old gh output: number, title, mergedAt,
+# mergeCommit{oid}, author{login}.
+MILESTONE_QUERY = <<~GRAPHQL
+  query($owner: String!, $name: String!, $milestone: String!) {
+    repository(owner: $owner, name: $name) {
+      milestones(query: $milestone, first: 10) {
+        nodes {
+          title
+          pullRequests(first: 100, states: MERGED) {
+            nodes {
+              number
+              title
+              mergedAt
+              mergeCommit { oid }
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+GRAPHQL
+
 def fetch_milestone_prs(version)
+  owner, name = ReleaseHelpers::REPO.split('/')
   raw = ReleaseHelpers.run_stripped(
-    'gh', 'pr', 'list', '--repo', ReleaseHelpers::REPO,
-    '--state', 'merged', '--search', "milestone:#{version}",
-    '--json', 'number,title,mergedAt,mergeCommit,author',
-    '--jq', 'sort_by(.mergedAt)', '--limit', '100'
+    'gh', 'api', 'graphql', '-f', "query=#{MILESTONE_QUERY}",
+    '-F', "owner=#{owner}", '-F', "name=#{name}", '-F', "milestone=#{version}"
   )
-  prs = JSON.parse(raw)
+  nodes = JSON.parse(raw).dig('data', 'repository', 'milestones', 'nodes') || []
+  milestone = nodes.find { |m| m['title'] == version }
+  pr_nodes = milestone&.dig('pullRequests', 'nodes') || []
+  warn "Warning: milestone #{version} hit the 100-PR query cap — some PRs may be missing" if pr_nodes.length >= 100
+  prs = pr_nodes.sort_by { |pr| pr['mergedAt'] }
   warn "Warning: No merged PRs found in milestone #{version}" if prs.empty?
   prs.each { |pr| enrich_pr(pr) }
 end
@@ -64,7 +92,7 @@ def earlier_prs(prs, current, timestamps)
 end
 
 def detect_dependencies(pending_prs)
-  timestamps = pending_prs.to_h { |pr| [pr['number'], Time.zone.parse(pr['mergedAt'])] }
+  timestamps = pending_prs.to_h { |pr| [pr['number'], Time.parse(pr['mergedAt'])] }
   pending_prs.each do |pr|
     earlier = earlier_prs(pending_prs, pr, timestamps)
     overlapping = earlier.select { |o| pr['files_changed'].intersect?(o['files_changed']) }
@@ -96,8 +124,8 @@ def build_order(remaining, by_num)
 end
 
 def topo_sort(pending_prs)
-  by_num = pending_prs.index_by { |pr| pr['number'] }
-  remaining = pending_prs.pluck('number')
+  by_num = pending_prs.to_h { |pr| [pr['number'], pr] }
+  remaining = pending_prs.map { |pr| pr['number'] }
   build_order(remaining, by_num)
 end
 
@@ -105,6 +133,44 @@ end
 def build_cherry_pick_order(pending_prs)
   detect_dependencies(pending_prs)
   topo_sort(pending_prs)
+end
+
+def diff_release_to_master(*paths)
+  ReleaseHelpers.run_stripped('git', 'diff', 'origin/release..origin/master', '--', *paths)
+end
+
+def dependency_changes
+  dep_diff = diff_release_to_master('Gemfile', 'Gemfile.lock', 'package.json', 'package-lock.json')
+  settings_diff = diff_release_to_master('markus.control', 'config/settings.yml')
+  dep_line_count = dep_diff.lines.count { |l| l.start_with?('+', '-') }
+  {
+    'summary' => dep_diff.empty? ? 'No dependency changes' : "Dependency files changed (#{dep_line_count} lines)",
+    'settings' => settings_diff.empty? ? 'No settings changes' : 'Settings files changed — notify sysadmin'
+  }
+end
+
+def pr_summary(pull)
+  { 'number' => pull['number'], 'title' => pull['title'], 'author' => pull.dig('author', 'login'),
+    'merged_at' => pull['mergedAt'], 'merge_commit' => pull['merge_commit'],
+    'files_changed' => pull['files_changed'], 'already_in_release' => pull['already_in_release'],
+    'dependencies' => pull['dependencies'] || [] }
+end
+
+def skipped_entry(pull)
+  { 'ref' => pull['merge_commit'], 'number' => pull['number'], 'reason' => 'Already ancestor of release branch' }
+end
+
+def build_result(version, prs, order)
+  {
+    'version' => version,
+    'timestamp' => Time.now.utc.iso8601,
+    'release_branch_tip' => ReleaseHelpers.run_stripped('git', 'log', 'origin/release', '--oneline', '-1'),
+    'milestone_prs' => prs.map { |pr| pr_summary(pr) },
+    'non_pr_commits' => find_non_pr_commits,
+    'proposed_cherry_pick_order' => order,
+    'skipped' => prs.select { |pr| pr['already_in_release'] }.map { |pr| skipped_entry(pr) },
+    'dependency_changes' => dependency_changes
+  }
 end
 
 # --- Main ---
@@ -126,36 +192,4 @@ prs = fetch_milestone_prs(version)
 pending = prs.reject { |pr| pr['already_in_release'] }
 order = build_cherry_pick_order(pending)
 
-dep_diff = ReleaseHelpers.run_stripped(
-  'git', 'diff', 'origin/release..origin/master', '--',
-  'Gemfile', 'Gemfile.lock', 'package.json', 'package-lock.json'
-)
-settings_diff = ReleaseHelpers.run_stripped(
-  'git', 'diff', 'origin/release..origin/master', '--',
-  'markus.control', 'config/settings.yml'
-)
-
-dep_line_count = dep_diff.lines.count { |l| l.start_with?('+', '-') }
-
-result = {
-  'version' => version,
-  'timestamp' => Time.now.utc.iso8601,
-  'release_branch_tip' => ReleaseHelpers.run_stripped('git', 'log', 'origin/release', '--oneline', '-1'),
-  'milestone_prs' => prs.map do |pr|
-    { 'number' => pr['number'], 'title' => pr['title'], 'author' => pr.dig('author', 'login'),
-      'merged_at' => pr['mergedAt'], 'merge_commit' => pr['merge_commit'],
-      'files_changed' => pr['files_changed'], 'already_in_release' => pr['already_in_release'],
-      'dependencies' => pr['dependencies'] || [] }
-  end,
-  'non_pr_commits' => find_non_pr_commits,
-  'proposed_cherry_pick_order' => order,
-  'skipped' => prs.select { |pr| pr['already_in_release'] }.map do |pr|
-    { 'ref' => pr['merge_commit'], 'number' => pr['number'], 'reason' => 'Already ancestor of release branch' }
-  end,
-  'dependency_changes' => {
-    'summary' => dep_diff.empty? ? 'No dependency changes' : "Dependency files changed (#{dep_line_count} lines)",
-    'settings' => settings_diff.empty? ? 'No settings changes' : 'Settings files changed — notify sysadmin'
-  }
-}
-
-puts JSON.pretty_generate(result)
+puts JSON.pretty_generate(build_result(version, prs, order))

--- a/release/test/test_helpers.rb
+++ b/release/test/test_helpers.rb
@@ -110,8 +110,8 @@ def build_order(remaining, by_num)
 end
 
 def topological_sort(pending_prs)
-  by_num = pending_prs.index_by { |pr| pr['number'] }
-  remaining = pending_prs.pluck('number')
+  by_num = pending_prs.to_h { |pr| [pr['number'], pr] }
+  remaining = pending_prs.map { |pr| pr['number'] }
   build_order(remaining, by_num)
 end
 
@@ -217,7 +217,7 @@ linear = [
   { 'number' => 2, 'mergedAt' => '2026-01-02', 'merge_commit' => 'b', 'dependencies' => [1] },
   { 'number' => 3, 'mergedAt' => '2026-01-03', 'merge_commit' => 'c', 'dependencies' => [2] }
 ]
-assert_eq 'linear: 1,2,3', topological_sort(linear).pluck('number'), [1, 2, 3]
+assert_eq 'linear: 1,2,3', topological_sort(linear).map { |o| o['number'] }, [1, 2, 3]
 
 diamond = [
   { 'number' => 1, 'mergedAt' => '2026-01-01', 'merge_commit' => 'a', 'dependencies' => [] },
@@ -225,7 +225,7 @@ diamond = [
   { 'number' => 3, 'mergedAt' => '2026-01-03', 'merge_commit' => 'c', 'dependencies' => [1] },
   { 'number' => 4, 'mergedAt' => '2026-01-04', 'merge_commit' => 'd', 'dependencies' => [2, 3] }
 ]
-nums = topological_sort(diamond).pluck('number')
+nums = topological_sort(diamond).map { |o| o['number'] }
 assert_eq 'diamond: first is 1', nums[0], 1
 assert_eq 'diamond: last is 4', nums[3], 4
 assert 'diamond: 2 before 4', nums.index(2) < nums.index(4)
@@ -236,7 +236,7 @@ independent = [
   { 'number' => 1, 'mergedAt' => '2026-01-01', 'merge_commit' => 'a', 'dependencies' => [] },
   { 'number' => 2, 'mergedAt' => '2026-01-02', 'merge_commit' => 'b', 'dependencies' => [] }
 ]
-assert_eq 'independent: date order', topological_sort(independent).pluck('number'), [1, 2, 3]
+assert_eq 'independent: date order', topological_sort(independent).map { |o| o['number'] }, [1, 2, 3]
 
 cycle = [
   { 'number' => 1, 'mergedAt' => '2026-01-01', 'merge_commit' => 'a', 'dependencies' => [2] },
@@ -244,10 +244,10 @@ cycle = [
 ]
 result = topological_sort(cycle)
 assert_eq 'cycle: 2 items', result.length, 2
-assert_eq 'cycle: chronological fallback', result.pluck('number'), [1, 2]
+assert_eq 'cycle: chronological fallback', result.map { |o| o['number'] }, [1, 2]
 
 single = [{ 'number' => 1, 'mergedAt' => '2026-01-01', 'merge_commit' => 'a', 'dependencies' => [] }]
-assert_eq 'single PR', topological_sort(single).pluck('number'), [1]
+assert_eq 'single PR', topological_sort(single).map { |o| o['number'] }, [1]
 
 assert_eq 'empty input', topological_sort([]), []
 
@@ -272,7 +272,7 @@ diff = <<~DIFF
 DIFF
 
 assert 'file1 extraction', extract_file_diff(diff, 'file1.rb').include?('+added')
-assert 'file1 excludes file2', extract_file_diff(diff, 'file1.rb').exclude?('+new')
+assert 'file1 excludes file2', !extract_file_diff(diff, 'file1.rb').include?('+new')
 assert 'file2 extraction', extract_file_diff(diff, 'file2.rb').include?('+new')
 assert_eq 'missing file', extract_file_diff(diff, 'nope.rb'), ''
 

--- a/release/verify.rb
+++ b/release/verify.rb
@@ -34,6 +34,14 @@ def change_lines(diff_text)
            .reject { |l| l.start_with?('+++', '---') }
 end
 
+# Gemfile.lock base versions differ between release and master, so removed
+# lines always mismatch — compare additions only for those files.
+def comparable_lines(lines, file)
+  return lines.select { |l| l.start_with?('+') } if ADDITIONS_ONLY_FILES.include?(file)
+
+  lines
+end
+
 # --- Main ---
 
 pr_number = ARGV[0]
@@ -58,16 +66,11 @@ missing = pr_files - cherry_files
 shared = cherry_files & pr_files
 
 pr_full_diff = ReleaseHelpers.run('gh', 'pr', 'diff', pr_number, '--repo', ReleaseHelpers::REPO)
-comparable_lines = ->(lines, file) do
-  return lines.select { |l| l.start_with?('+') } if ADDITIONS_ONLY_FILES.include?(file)
-
-  lines
-end
 
 mismatched = shared.reject do |file|
   cherry = change_lines(ReleaseHelpers.run('git', 'diff', 'HEAD~1..HEAD', '--', file))
   original = change_lines(extract_file_diff(pr_full_diff, file))
-  comparable_lines.call(cherry, file).sort == comparable_lines.call(original, file).sort
+  comparable_lines(cherry, file).sort == comparable_lines(original, file).sort
 end
 
 if [extra, missing, mismatched].any? { |s| !s.empty? }


### PR DESCRIPTION
## Proposed Changes 🐛 *Bug fix*
The `release/*` scripts crash when run outside Rails. This PR converts them to plain Ruby so they run, and exempts `release/` from rubocop check to prevent reintroducing the crash.

The scripts run as standalone `ruby`. The cherry-pick loop and the release playbook invoke them without Rails. They call ActiveSupport methods that load with Rails:
  - `pluck` / `index_by`
  - `present?`
  - `Time.zone.parse`
  - `String#exclude?`
 
Under plain `ruby`, each raises `NoMethodError`. Master's `recon.rb` dies with `undefined method 'present?' for an instance of String`. Rubocop masks this. The repo runs `rubocop-rails`, whose cops prefer those methods. `Rails/Pluck` demands `pluck`. `Rails/NegateInclude` demands `.exclude?`. The scripts pass lint and crash at runtime.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |      X    |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
*(Include any questions or comments you have regarding your changes.)*
