### PR TITLE
Fix API fields filtering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
 - Added GET /test_runs API route (#8055)
 
 ### 🐛 Bug fixes
+- Fixed API user and course endpoints ignoring the optional fields parameter
 - Ensured random grader assignment excludes ineligible roles and recalculates weights using eligible graders (#8073)
 - Prevented grader assignment and unassignment operations from modifying groupings belonging to other assignments (#8072)
 - Fixed the "Fix" link being clipped off the screen for long QR-scan error messages on the exam scan log table (#8070)

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -11,17 +11,19 @@ module Api
       else
         courses = get_collection(current_user.visible_courses)
       end
+      fields = get_fields || return
       respond_to do |format|
-        format.xml { render xml: courses.to_xml(only: DEFAULT_FIELDS, root: 'courses', skip_types: 'true') }
-        format.json { render json: courses.to_json(only: DEFAULT_FIELDS) }
+        format.xml { render xml: courses.to_xml(only: fields, root: 'courses', skip_types: 'true') }
+        format.json { render json: courses.to_json(only: fields) }
       end
     end
 
     def show
       course = current_course
+      fields = get_fields || return
       respond_to do |format|
-        format.xml { render xml: course.to_xml(only: DEFAULT_FIELDS, root: 'course', skip_types: 'true') }
-        format.json { render json: course.to_json(only: DEFAULT_FIELDS) }
+        format.xml { render xml: course.to_xml(only: fields, root: 'course', skip_types: 'true') }
+        format.json { render json: course.to_json(only: fields) }
       end
     end
 

--- a/app/controllers/api/main_api_controller.rb
+++ b/app/controllers/api/main_api_controller.rb
@@ -81,6 +81,20 @@ module Api
       end
     end
 
+    def get_fields
+      return self.class::DEFAULT_FIELDS if params[:fields].blank?
+
+      fields = params.permit(fields: [])[:fields]&.map { |field| field.to_s.to_sym }
+      fields = fields&.intersection(self.class::DEFAULT_FIELDS)
+      if fields.blank?
+        render 'shared/http_status', locals: { code: '422', message:
+          'Invalid or malformed parameter values' }, status: :unprocessable_content
+        false
+      else
+        fields
+      end
+    end
+
     # Checks that the symbols provided in the array aren't blank in the params
     def has_missing_params?(required_params)
       required_params.each do |param|

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -9,11 +9,12 @@ module Api
     # Optional: filter, fields
     def index
       users = get_collection(visible_users) || return
+      fields = get_fields || return
 
       respond_to do |format|
-        format.xml { render xml: users.to_xml(only: DEFAULT_FIELDS, root: :users, skip_types: true) }
+        format.xml { render xml: users.to_xml(only: fields, root: :users, skip_types: true) }
         format.json do
-          render json: users.pluck_to_hash(*DEFAULT_FIELDS)
+          render json: users.pluck_to_hash(*fields)
         end
       end
     end
@@ -70,9 +71,10 @@ module Api
         render 'shared/http_status', locals: { code: '404', message:
           'No user exists with that id' }, status: :not_found
       else
+        fields = get_fields || return
         respond_to do |format|
-          format.xml { render xml: user.to_xml(only: DEFAULT_FIELDS, root: :user, skip_types: true) }
-          format.json { render json: user.to_json(only: DEFAULT_FIELDS) }
+          format.xml { render xml: user.to_xml(only: fields, root: :user, skip_types: true) }
+          format.json { render json: user.to_json(only: fields) }
         end
       end
     end

--- a/doc/markus-contributors.txt
+++ b/doc/markus-contributors.txt
@@ -88,6 +88,7 @@ Gaëtan Girin
 Geoffrey Flores
 Ghislain Guiot
 Gillian Chesnais
+Guflly
 Hannah Li
 Hanson Wu
 Haohan David Jiang

--- a/spec/controllers/api/courses_controller_spec.rb
+++ b/spec/controllers/api/courses_controller_spec.rb
@@ -33,6 +33,12 @@ describe Api::CoursesController do
           keys = Hash.from_xml(response.body).dig('courses', 'course').keys.map(&:to_sym)
           expect(keys).to match_array Api::CoursesController::DEFAULT_FIELDS
         end
+
+        it 'should return only requested fields' do
+          get :index, params: { fields: %w[id name] }
+          keys = Hash.from_xml(response.body).dig('courses', 'course').keys
+          expect(keys).to match_array(%w[id name])
+        end
       end
 
       context 'with multiple courses' do
@@ -92,6 +98,12 @@ describe Api::CoursesController do
           get :index
           keys = response.parsed_body&.first&.keys&.map(&:to_sym)
           expect(keys).to match_array Api::CoursesController::DEFAULT_FIELDS
+        end
+
+        it 'should return only requested fields' do
+          get :index, params: { fields: %w[id name] }
+          keys = response.parsed_body&.first&.keys
+          expect(keys).to match_array(%w[id name])
         end
       end
 
@@ -185,6 +197,12 @@ describe Api::CoursesController do
 
         expect(Time.zone.parse(response.parsed_body['start_at'])).to be_within(1.second).of(start_time)
         expect(Time.zone.parse(response.parsed_body['end_at'])).to be_within(1.second).of(end_time)
+      end
+
+      it 'returns only requested fields' do
+        get :show, params: { id: course.id, fields: %w[id name] }
+
+        expect(response.parsed_body.keys).to match_array(%w[id name])
       end
     end
 

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -70,6 +70,12 @@ describe Api::UsersController do
             info = Hash.from_xml(response.body).dig('users', 'user')[0]
             expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
           end
+
+          it 'should return only requested fields' do
+            get :index, params: { fields: %w[id user_name] }
+            info = Hash.from_xml(response.body).dig('users', 'user')[0]
+            expect(info.keys).to match_array(%w[id user_name])
+          end
         end
 
         context 'expecting an json response' do
@@ -97,6 +103,12 @@ describe Api::UsersController do
             get :index
             info = response.parsed_body[0]
             expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          end
+
+          it 'should return only requested fields' do
+            get :index, params: { fields: %w[id user_name] }
+            info = response.parsed_body[0]
+            expect(info.keys).to match_array(%w[id user_name])
           end
         end
       end
@@ -134,6 +146,12 @@ describe Api::UsersController do
             info = Hash.from_xml(response.body)['user']
             expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
           end
+
+          it 'should return only requested fields' do
+            get :show, params: { id: end_users[0].id, fields: %w[id user_name] }
+            info = Hash.from_xml(response.body)['user']
+            expect(info.keys).to match_array(%w[id user_name])
+          end
         end
 
         context 'expecting an json response' do
@@ -155,6 +173,11 @@ describe Api::UsersController do
             get :show, params: { id: end_users[0].id }
             info = response.parsed_body
             expect(Set.new(info.keys.map(&:to_sym))).to eq Set.new(Api::UsersController::DEFAULT_FIELDS)
+          end
+
+          it 'should return only requested fields' do
+            get :show, params: { id: end_users[0].id, fields: %w[id user_name] }
+            expect(response.parsed_body.keys).to match_array(%w[id user_name])
           end
         end
       end


### PR DESCRIPTION
## Proposed Changes

Use the requested fields list when rendering user and course API responses instead of always returning every default field.

Closes #8071

<details>
<summary>Screenshots of your changes (if applicable)</summary>

Not applicable.

</details>

## Type of Change

| Type | Applies? |
|---|---|
| Bug fix | X |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
- [x] I have added tests for my changes, if applicable.
- [x] I have updated the project documentation, if applicable.
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have updated the project Changelog.
- [ ] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have requested a review from a project maintainer.

## Questions and Comments

Local checks: RuboCop on the changed Ruby files and Ruby syntax checks. The controller specs are included for CI.