### PR TITLE
Display mark last updated by

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 ### 🚨 Breaking changes
 
 ### ✨ New features and improvements
+- Displayed who last updated a mark to TAs and instructors in the grading view (#8131)
 - Added support for inviting students to groups by email (case-insensitive), in addition to user name (#8106)
 - Added row numbers to the course summaries table (#8108)
 - Added an option to rotate sideways scanned exam pages by 90 degrees when fixing scan errors (#8103)

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -141,6 +141,13 @@
   }
 }
 
+.last-updated-by {
+  color: $line;
+  font-style: italic;
+  margin-top: 0.2em;
+  opacity: 0.65;
+}
+
 .criterion-description {
   float: left;
 }

--- a/app/assets/stylesheets/grader.scss
+++ b/app/assets/stylesheets/grader.scss
@@ -146,6 +146,7 @@
   font-style: italic;
   margin-top: 0.2em;
   opacity: 0.65;
+  padding-left: 20px;
 }
 
 .criterion-description {

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -21,6 +21,7 @@ class ResultsController < ApplicationController
         original_result = remark_submitted ? submission.get_original_result : nil
         is_review = result.is_a_review?
         is_reviewer = current_role.student? && current_role.is_reviewer_for?(assignment.pr_assignment, result)
+        can_view_grader_info = current_role.instructor? || current_role.ta? || is_reviewer
         pr_assignment = is_review ? assignment.pr_assignment : nil
 
         grouping = submission.grouping
@@ -29,7 +30,7 @@ class ResultsController < ApplicationController
           grouping_id: is_reviewer ? nil : submission.grouping_id,
           marking_state: result.marking_state,
           released_to_students: result.released_to_students,
-          detailed_annotations: current_role.instructor? || current_role.ta? || is_reviewer,
+          detailed_annotations: can_view_grader_info,
           revision_identifier: submission.revision_identifier,
           instructor_run: true,
           allow_remarks: is_review ? pr_assignment.allow_remarks : assignment.allow_remarks,
@@ -93,11 +94,11 @@ class ResultsController < ApplicationController
         end
 
         data[:annotations] = all_annotations.map do |annotation|
-          annotation.get_data(include_creator: current_role.instructor? || current_role.ta? || is_reviewer)
+          annotation.get_data(include_creator: can_view_grader_info)
         end
 
         # Annotation categories
-        if current_role.instructor? || current_role.ta? || is_reviewer
+        if can_view_grader_info
           annotation_categories = AnnotationCategory.visible_categories(is_review ? pr_assignment : assignment,
                                                                         current_role)
                                                     .includes(:annotation_texts)
@@ -160,13 +161,20 @@ class ResultsController < ApplicationController
         marks_map = [CheckboxCriterion, FlexibleCriterion, RubricCriterion].flat_map do |klass|
           criteria = klass.where(**criteria_query)
           criteria_info = criteria.pluck_to_hash(*fields)
-          marks_info = criteria.joins(:marks)
-                               .where('marks.result_id': result.id)
-                               .pluck_to_hash(*fields,
-                                              'marks.mark AS mark',
-                                              'marks.override AS override',
-                                              'criteria.bonus AS bonus')
-                               .group_by { |h| h[:id] }
+          marks_relation = criteria.joins(:marks).where('marks.result_id': result.id)
+          marks_fields = [*fields,
+                          'marks.mark as mark',
+                          'marks.override AS override',
+                          'criteria.bonus AS bonus']
+          if can_view_grader_info
+            marks_relation = marks_relation
+                               .joins('LEFT OUTER JOIN roles last_updated_by_roles ' \
+                                      'ON last_updated_by_roles.id = marks.last_updated_by_id')
+                               .joins('LEFT OUTER JOIN users last_updated_by_users ' \
+                                      'ON last_updated_by_users.id = last_updated_by_roles.user_id')
+            marks_fields << 'last_updated_by_users.display_name AS last_updated_by'
+          end
+          marks_info = marks_relation.pluck_to_hash(*marks_fields).group_by { |h| h[:id] }
           # adds a criterion type to each of the marks info hashes
           criteria_info.map do |cr|
             info = marks_info[cr[:id]]&.first || cr.merge(mark: nil)
@@ -473,6 +481,7 @@ class ResultsController < ApplicationController
         num_marked: num_marked,
         mark: result_mark.reload.mark,
         mark_override: result_mark.override,
+        last_updated_by: current_role.display_name,
         subtotal: result.get_subtotal,
         total: result.get_total_mark
       }

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -167,12 +167,8 @@ class ResultsController < ApplicationController
                           'marks.override AS override',
                           'criteria.bonus AS bonus']
           if can_view_grader_info
-            marks_relation = marks_relation
-                               .joins('LEFT OUTER JOIN roles last_updated_by_roles ' \
-                                      'ON last_updated_by_roles.id = marks.last_updated_by_id')
-                               .joins('LEFT OUTER JOIN users last_updated_by_users ' \
-                                      'ON last_updated_by_users.id = last_updated_by_roles.user_id')
-            marks_fields << 'last_updated_by_users.display_name AS last_updated_by'
+            marks_relation = marks_relation.left_outer_joins(marks: { last_updated_by: :user })
+            marks_fields << 'users.display_name AS last_updated_by'
           end
           marks_info = marks_relation.pluck_to_hash(*marks_fields).group_by { |h| h[:id] }
           # adds a criterion type to each of the marks info hashes

--- a/app/javascript/Components/Result/checkbox_criterion_input.jsx
+++ b/app/javascript/Components/Result/checkbox_criterion_input.jsx
@@ -121,7 +121,7 @@ export default function CheckboxCriterionInput({
             oldMark.mark
           })`}</div>
         )}
-        {!released_to_students && last_updated_by && (
+        {last_updated_by && (
           <div className="last-updated-by">
             {I18n.t("results.last_updated_by", {name: last_updated_by})}
           </div>

--- a/app/javascript/Components/Result/checkbox_criterion_input.jsx
+++ b/app/javascript/Components/Result/checkbox_criterion_input.jsx
@@ -11,6 +11,7 @@ export default function CheckboxCriterionInput({
   destroyMark,
   expanded,
   id,
+  last_updated_by,
   mark,
   max_mark,
   name,
@@ -120,6 +121,11 @@ export default function CheckboxCriterionInput({
             oldMark.mark
           })`}</div>
         )}
+        {!released_to_students && last_updated_by && (
+          <div className="last-updated-by">
+            {I18n.t("results.last_updated_by", {name: last_updated_by})}
+          </div>
+        )}
         <div
           className="criterion-description"
           dangerouslySetInnerHTML={{__html: safe_marked(description)}}
@@ -134,6 +140,7 @@ CheckboxCriterionInput.propTypes = {
   destroyMark: PropTypes.func.isRequired,
   expanded: PropTypes.bool.isRequired,
   id: PropTypes.number.isRequired,
+  last_updated_by: PropTypes.string,
   mark: PropTypes.number,
   max_mark: PropTypes.number.isRequired,
   oldMark: PropTypes.object,

--- a/app/javascript/Components/Result/flexible_criterion_input.jsx
+++ b/app/javascript/Components/Result/flexible_criterion_input.jsx
@@ -13,6 +13,7 @@ export default function FlexibleCriterionInput({
   expanded,
   findDeductiveAnnotation,
   id,
+  last_updated_by,
   mark,
   max_mark,
   name,
@@ -216,6 +217,11 @@ export default function FlexibleCriterionInput({
         </span>
         {listDeductions()}
         {renderOldMark()}
+        {!released_to_students && last_updated_by && (
+          <div className="last-updated-by">
+            {I18n.t("results.last_updated_by", {name: last_updated_by})}
+          </div>
+        )}
       </div>
     </li>
   );
@@ -229,6 +235,7 @@ FlexibleCriterionInput.propTypes = {
   expanded: PropTypes.bool.isRequired,
   findDeductiveAnnotation: PropTypes.func.isRequired,
   id: PropTypes.number.isRequired,
+  last_updated_by: PropTypes.string,
   mark: PropTypes.number,
   max_mark: PropTypes.number.isRequired,
   oldMark: PropTypes.object,

--- a/app/javascript/Components/Result/flexible_criterion_input.jsx
+++ b/app/javascript/Components/Result/flexible_criterion_input.jsx
@@ -217,7 +217,7 @@ export default function FlexibleCriterionInput({
         </span>
         {listDeductions()}
         {renderOldMark()}
-        {!released_to_students && last_updated_by && (
+        {last_updated_by && (
           <div className="last-updated-by">
             {I18n.t("results.last_updated_by", {name: last_updated_by})}
           </div>

--- a/app/javascript/Components/Result/result.jsx
+++ b/app/javascript/Components/Result/result.jsx
@@ -633,6 +633,7 @@ class Result extends React.Component {
           let newMark = {...markData};
           newMark.mark = data.mark;
           newMark.override = data.mark_override;
+          newMark.last_updated_by = data.last_updated_by;
           return newMark;
         } else {
           return markData;

--- a/app/javascript/Components/Result/rubric_criterion_input.jsx
+++ b/app/javascript/Components/Result/rubric_criterion_input.jsx
@@ -161,7 +161,7 @@ export default function RubricCriterionInput({
         <table className="rubric-levels">
           <tbody>{rubricLevels}</tbody>
         </table>
-        {!released_to_students && last_updated_by && (
+        {last_updated_by && (
           <div className="last-updated-by">
             {I18n.t("results.last_updated_by", {name: last_updated_by})}
           </div>

--- a/app/javascript/Components/Result/rubric_criterion_input.jsx
+++ b/app/javascript/Components/Result/rubric_criterion_input.jsx
@@ -11,6 +11,7 @@ export default function RubricCriterionInput({
   destroyMark,
   expanded,
   id,
+  last_updated_by,
   levels,
   mark,
   max_mark,
@@ -160,6 +161,11 @@ export default function RubricCriterionInput({
         <table className="rubric-levels">
           <tbody>{rubricLevels}</tbody>
         </table>
+        {!released_to_students && last_updated_by && (
+          <div className="last-updated-by">
+            {I18n.t("results.last_updated_by", {name: last_updated_by})}
+          </div>
+        )}
       </div>
     </li>
   );
@@ -170,6 +176,7 @@ RubricCriterionInput.propTypes = {
   destroyMark: PropTypes.func.isRequired,
   expanded: PropTypes.bool.isRequired,
   id: PropTypes.number.isRequired,
+  last_updated_by: PropTypes.string,
   levels: PropTypes.array,
   mark: PropTypes.number,
   max_mark: PropTypes.number,

--- a/config/locales/views/results/en.yml
+++ b/config/locales/views/results/en.yml
@@ -56,6 +56,7 @@ en:
       previous_level: Select previous level
       toggle_compact: Toggle fullscreen
       when_rubric: "(When on rubric) "
+    last_updated_by: Last updated by %{name}
     late_submission_warning_html: This group <a href="%{url}">submitted work</a> after the due date.
     marks_chart: Marks Chart
     marks_released: The marks have been released. You cannot change the grades.

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1444,6 +1444,23 @@ describe ResultsController do
      :update_view_token_expiry,
      :download_view_tokens].each { |route_name| test_unauthorized(route_name) }
     it_behaves_like 'showing json data', true
+
+    context 'when a criterion has been graded' do
+      let(:criterion) { create(:rubric_criterion, assignment: assignment) }
+      let(:mark) { create(:rubric_mark, result: complete_result, criterion: criterion, last_updated_by: instructor) }
+
+      before do
+        allow_any_instance_of(Result).to receive(:released_to_students?).and_return true
+        mark
+        get :show, params: { course_id: complete_result.course.id, id: complete_result.id, format: :json }
+      end
+
+      it 'does not include the name of the grader who last updated the mark' do
+        mark_data = response.parsed_body['marks'].find { |m| m['id'] == criterion.id }
+        expect(mark_data).not_to have_key('last_updated_by')
+      end
+    end
+
     describe '#view_token_check' do
       subject { get :view_token_check, params: params }
 
@@ -2228,6 +2245,19 @@ describe ResultsController do
       create(:ta_membership, role: ta, grouping: grouping)
       get :show, params: { course_id: course.id, id: incomplete_result.id }, format: :json
       expect(response.parsed_body['can_manage_submissions']).to be false
+    end
+
+    context 'when a criterion has been graded' do
+      before do
+        create(:ta_membership, role: ta, grouping: grouping)
+        rubric_mark.update!(last_updated_by: ta)
+        get :show, params: { course_id: course.id, id: incomplete_result.id }, format: :json
+      end
+
+      it 'includes the name of the grader who last updated the mark' do
+        mark_data = response.parsed_body['marks'].find { |m| m['id'] == rubric_criterion.id }
+        expect(mark_data['last_updated_by']).to eq ta.display_name
+      end
     end
 
     context 'with manage submissions permission' do


### PR DESCRIPTION
## Proposed Changes

Displays who last graded (updated the mark for) a criterion in the grading view, visible only to TAs and instructors. This mirrors the existing "creator"/"last editor" pattern already used for annotations.

The `last_updated_by` association on `Mark` already existed on the backend (#7878, #7885) but wasn't exposed anywhere in the UI. This PR:
- Adds `last_updated_by` to the `marks` payload returned by `ResultsController#show`, gated behind the same TA/instructor/reviewer check already used for annotation creator visibility (`can_view_grader_info`), so students never receive this data at all.
- Updates `ResultsController#update_mark`'s JSON response to include `last_updated_by`, and patches local React state in `result.jsx` so the UI updates immediately after a mark change, without a reload.
- Displays a small caption ("Last updated by <name>") under the mark for checkbox, flexible, and rubric criteria, hidden once results are released to students.

### Screenshots

<img width="531" height="448" alt="Screenshot 2026-08-19 at 6 54 29 PM" src="https://github.com/user-attachments/assets/248483c2-682e-4314-a045-d0df4ea09c34" />

## Type of Change
*(Write an `X` or a brief description next to the type or types that best describe your changes.)*

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |     X     |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  |          |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |    X      |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         |          |


## Checklist
*(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)*

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [N/A] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [N/A] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [X] I have updated the project Changelog (this is required for all changes).
- [X] I have verified that the pre-commit.ci checks have passed.
- [X] I have verified that the CI tests have passed.
- [X] I have reviewed the test coverage changes reported by Coveralls.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.