### PR TITLE
Fix production JS builds compiling JSX in development mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Added a submission scope filter to the grading view so TAs with manage submissions permission can navigate either all submissions or only their assigned submissions (#8046)
 
 ### 🐛 Bug fixes
+- Fixed production webpack builds compiling JSX in development mode (#8150)
 
 ### 📚 Documentation changes
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -33,7 +33,12 @@ module.exports = function (api) {
           exclude: ["transform-typeof-symbol"],
         },
       ],
-      require("@babel/preset-react").default,
+      [
+        require("@babel/preset-react").default,
+        {
+          development: isDevelopmentEnv || isTestEnv,
+        },
+      ],
     ].filter(Boolean),
     plugins: [
       (isProductionEnv || isDevelopmentEnv) && [

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,3 +1,9 @@
+// Babel reads BABEL_ENV/NODE_ENV from the build process, not from webpack's
+// mode. Without this, @babel/preset-react compiles JSX in development mode
+// (jsxDEV calls), which React's production build does not provide.
+process.env.BABEL_ENV = process.env.BABEL_ENV || "production";
+process.env.NODE_ENV = process.env.NODE_ENV || "production";
+
 const {merge} = require("webpack-merge");
 const common = require("./webpack.common.js");
 


### PR DESCRIPTION
## Proposed Changes

Production webpack builds compile JSX in development mode. #8042 moved JSX to the automatic runtime. In development mode, that emits `jsxDEV` calls. Production React drops that function. The bundle then crashes on its first component. Every page loses its JavaScript after that ("Routes is not defined", empty admin Courses and Users tables). Deployed v2.10.2 instances hit this. Dev servers and Jest kept working.

Cause: Babel picks its mode from the build shell's `BABEL_ENV` or `NODE_ENV`. Webpack's `mode` plays no part. Deploy hosts leave both unset, so Babel ran in development mode.

Two changes:
- `webpack.production.js` sets `BABEL_ENV` plus `NODE_ENV` to `production` at the top. A production build now compiles right on any host.
- `babel.config.js` gives `@babel/preset-react` an explicit `development` flag. Dev and test keep `jsxDEV`.

Verification:
- Before: a production bundle contains `jsxDEV`. A headless Chromium login crashes with `(0, fF.jsxDEV) is not a function` and shows zero tables.
- After: the bundle has zero `jsxDEV`. The same headless login renders the course list with a clean console. `window.Routes` works.
- Jest passes (the test env keeps the development runtime).

## Type of Change

| Type                                                                                    | Applies? |
|-----------------------------------------------------------------------------------------|----------|
| 🚨 *Breaking change* (fix or feature that would cause existing functionality to change) |          |
| ✨ *New feature* (non-breaking change that adds functionality)                          |          |
| 🐛 *Bug fix* (non-breaking change that fixes an issue)                                  | X        |
| 🎨 *User interface change* (change to user interface; provide screenshots)              |          |
| ♻️ *Refactoring* (internal change to codebase, without changing functionality)          |          |
| 🚦 *Test update* (change that *only* adds or modifies tests)                            |          |
| 📦 *Dependency update* (change that updates a dependency)                               |          |
| 📖 *Documentation update* (change that updates documentation)                           |          |
| 🔧 *Internal* (change that *only* affects developers or continuous integration)         | X        |


## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/MarkUsProject/Markus/blob/master/doc/markus-contributors.txt).

After opening your pull request:

- [x] I have updated the project Changelog (this is required for all changes).
- [ ] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

This change is build config, so the checks above are hand-run build checks in place of unit tests. The Jest suite covers the test side of the Babel change.
