### PR TITLE
Fix production JS builds compiling JSX in development mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ### ✨ New features and improvements
 
 ### 🐛 Bug fixes
+- Fixed production webpack builds compiling JSX in development mode (#8150)
 
 ### 🔧 Internal changes
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -33,7 +33,12 @@ module.exports = function (api) {
           exclude: ["transform-typeof-symbol"],
         },
       ],
-      require("@babel/preset-react").default,
+      [
+        require("@babel/preset-react").default,
+        {
+          development: isDevelopmentEnv || isTestEnv,
+        },
+      ],
     ].filter(Boolean),
     plugins: [
       (isProductionEnv || isDevelopmentEnv) && [

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,3 +1,9 @@
+// Babel reads BABEL_ENV/NODE_ENV from the build process, not from webpack's
+// mode. Without this, @babel/preset-react compiles JSX in development mode
+// (jsxDEV calls), which React's production build does not provide.
+process.env.BABEL_ENV = process.env.BABEL_ENV || "production";
+process.env.NODE_ENV = process.env.NODE_ENV || "production";
+
 const {merge} = require("webpack-merge");
 const common = require("./webpack.common.js");
 


### PR DESCRIPTION
Cherry-picks #8150 onto `release` so the branch builds a correct production bundle on its own.

### Why

v2.10.2 shipped without this fix. `@babel/preset-react` compiled JSX in development mode, so the production bundle called `jsxDEV`, which React's production build does not provide. The bundle died on its first component and pages lost their React tables.

The workaround on the servers was an asset rebuild with `NODE_ENV=production` exported by hand. This commit makes the build set it itself.

### Scope

| File | Change |
|---|---|
| `babel.config.js` | `preset-react` receives `development: isDevelopmentEnv \|\| isTestEnv` |
| `webpack.production.js` | sets `BABEL_ENV` and `NODE_ENV` before webpack loads |
| `Changelog.md` | one bug-fix line under `[unreleased]` |

### Verification

- Clean cherry-pick of `ec4bf2b` from master. Zero conflicts.
- `babel.config.js` and `webpack.production.js` md5-match master byte for byte.
- Both files also md5-match the copies running on `ben` and `tiny`, where the rebuilt bundle carries zero `jsxDEV` calls.
- Original PR #8150 passed jest, rspec, brakeman, CodeQL, and pre-commit on master.

### Tag

The `v2.10.2` tag stays where it is. This commit lands on `release` only, so deployed boxes stop being a hand patch. #8150 keeps its v2.10.3 milestone.
